### PR TITLE
[WEB-1925] - Fixes hydration erros due to invalid-structured HTML

### DIFF
--- a/app/shared/utils/Tabs.js
+++ b/app/shared/utils/Tabs.js
@@ -58,6 +58,7 @@ export default function Tabs({
               sx={{
                 '&.MuiButtonBase-root': { padding: 0 },
               }}
+              component="div"
               label={
                 <SecondaryButton variant="text" size={size}>
                   <span


### PR DESCRIPTION
Fixes this in DEV:
<img width="1247" alt="image" src="https://github.com/thegoodparty/gp-webapp/assets/496983/97457fbc-258a-49dd-b4c5-8fc7ba38af71">

In PROD:
<img width="549" alt="image" src="https://github.com/thegoodparty/gp-webapp/assets/496983/19c2ac69-cd44-444a-84e9-74a727fbf657">
