### PR TITLE
[WEB-2370] - Properly encodes url search query strings

### DIFF
--- a/gpApi/gpFetch.js
+++ b/gpApi/gpFetch.js
@@ -14,7 +14,7 @@ async function gpFetch(
     url = `${url}?`;
     for (const key in data) {
       if ({}.hasOwnProperty.call(data, key)) {
-        url += `${key}=${data[key]}&`;
+        url += `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}&`;
       }
     }
     url = url.slice(0, -1);


### PR DESCRIPTION
Addresses the problem in https://goodparty.atlassian.net/browse/WEB-2370 where `+` signs in email search query params are being encoded as `%20` (space) instead of `%2B` (`+`), breaking the email being searched for.