### PR TITLE
WEB-2716: Update headline on /Run-for-office

### DIFF
--- a/app/(landing)/run-for-office/components/Hero.js
+++ b/app/(landing)/run-for-office/components/Hero.js
@@ -15,7 +15,7 @@ export default function Hero() {
         <div className="grid grid-cols-12 gap-4 items-center">
           <div className="col-span-12 lg:col-span-6">
             <h1 className="font-semibold text-6xl md:text-7xl mb-7">
-              Free tools and tactics for your campaign
+              Supercharge your local campaign
             </h1>
             <H3>
               GoodParty.org helps people-powered candidates run viable campaigns


### PR DESCRIPTION
Small update to hero text on `/run-for-office` landing page.

Before: 
<img width="1405" alt="Screenshot 2024-08-19 at 9 00 39 AM" src="https://github.com/user-attachments/assets/03bd1ab6-7a26-4961-9824-c82b3da101ab">

After:
<img width="1421" alt="Screenshot 2024-08-19 at 9 00 44 AM" src="https://github.com/user-attachments/assets/396b55ae-afdd-4f39-ae55-ca2d9a08d986">
