### PR TITLE
WEB-2637: Update link destinations on candidate pages

### DIFF
--- a/app/candidate/[name]/[office]/components/CTA.js
+++ b/app/candidate/[name]/[office]/components/CTA.js
@@ -64,7 +64,7 @@ export default function CTA({ children, id }) {
         if (user) {
           router.push('/dashboard');
         } else {
-          router.push('/login');
+          router.push('/run-for-office');
         }
         break;
       case 'help':


### PR DESCRIPTION
Updates `claim` call to action button to link to `/run-for-office` instead of `/login`