### PR TITLE
WEB-2774: Double HiYa Banner on Blog article pages

### DIFF
--- a/app/blog/article/[slug]/components/BlogArticle.js
+++ b/app/blog/article/[slug]/components/BlogArticle.js
@@ -7,7 +7,6 @@ import styles from './BlogArticle.module.scss';
 import Banner from './Banner';
 import ShareBlog from 'app/blog/shared/ShareBlog';
 import BlogPopup from './BlogPopup';
-import Callout from '@shared/utils/Callout';
 import ArticleTags from './ArticleTags';
 
 export default function BlogArticle({ sections, article }) {
@@ -27,7 +26,6 @@ export default function BlogArticle({ sections, article }) {
 
   return (
     <>
-      <Callout />
       <BlogWrapper
         sections={sections}
         sectionSlug={sectionSlug}


### PR DESCRIPTION
Small bugfix to remove extra callout banner at the top of Blog pages. 

Before:
<img width="1093" alt="Screenshot 2024-08-21 at 3 01 01 PM" src="https://github.com/user-attachments/assets/561c8a78-2dbb-4a86-81fb-5037a5d534ca">

After:
<img width="1091" alt="Screenshot 2024-08-21 at 3 01 15 PM" src="https://github.com/user-attachments/assets/039a80b1-57fa-467c-b785-7c5e2a7f843d">
