### PR TITLE
WEB-2752: UI Fixes

### DIFF
--- a/app/blog/article/[slug]/components/BlogArticle.js
+++ b/app/blog/article/[slug]/components/BlogArticle.js
@@ -46,7 +46,7 @@ export default function BlogArticle({ sections, article }) {
         wrapText={true}
       />
       {mainImage && (
-        <div className="relative min-h-[280px] lg:min-h-[350px] w-full my-8">
+        <div className="relative min-h-[270px] w-full my-8">
           <Image
             style={{
               borderRadius: '10px',
@@ -64,16 +64,18 @@ export default function BlogArticle({ sections, article }) {
       <Overline className="inline-block bg-purple-500 text-white px-2 py-1 rounded">
         {section.fields?.title}
       </Overline>
-      <MarketingH2 className="mt-8 mb-4" asH1>
+      <MarketingH2 className="mt-8 mb-4 !text-4xl" asH1>
         {title}
       </MarketingH2>
-      <BlogAuthor
-        imageUrl={author.fields.image?.url}
-        name={author.fields.name}
-        publishDate={publishDate}
-        // updateDate={publishDate}
-      />
-      <ShareBlog />
+      <div class="md:flex items-center justify-between">
+        <BlogAuthor
+          imageUrl={author.fields.image?.url}
+          name={author.fields.name}
+          publishDate={publishDate}
+          // updateDate={publishDate}
+        />
+        <ShareBlog />
+      </div>
       <div className="border-t-[1px] border-b-[1px] border-gray-200 py-8">
         <div>
           <CmsContentWrapper>{contentfulHelper(body)}</CmsContentWrapper>

--- a/app/blog/shared/BlogWrapper.js
+++ b/app/blog/shared/BlogWrapper.js
@@ -42,11 +42,6 @@ export default function BlogWrapper({
     { label: sectionTitle },
   ];
 
-  // ensure sections are ordered correctly
-  const sortedSections = sections.sort(
-    (a, b) => Number(a.fields?.order) - Number(b.fields?.order),
-  );
-
   return (
     <>
       <StickersCallout />

--- a/app/blog/shared/BlogWrapper.js
+++ b/app/blog/shared/BlogWrapper.js
@@ -42,6 +42,11 @@ export default function BlogWrapper({
     { label: sectionTitle },
   ];
 
+  // ensure sections are ordered correctly
+  const sortedSections = sections.sort(
+    (a, b) => Number(a.fields?.order) - Number(b.fields?.order),
+  );
+
   return (
     <>
       <StickersCallout />
@@ -63,7 +68,7 @@ export default function BlogWrapper({
             </CategoryButton>
           </Link>
 
-          {sections.map((section, index) => (
+          {sortedSections.map((section, index) => (
             <Link
               key={section.fields.slug}
               href={`/blog/section/${section.fields.slug}`}

--- a/app/blog/shared/BlogWrapper.js
+++ b/app/blog/shared/BlogWrapper.js
@@ -42,6 +42,11 @@ export default function BlogWrapper({
     { label: sectionTitle },
   ];
 
+  // ensure sections are ordered correctly
+  const sortedSections = sections.sort(
+    (a, b) => Number(a.fields?.order) - Number(b.fields?.order),
+  );
+
   return (
     <>
       <StickersCallout />


### PR DESCRIPTION
Fixes a few small issues with the new Blog pages:
- Ensures top-level category links are remain sorted by their defined orders
- Fixed spacing issues on header of Article pages to pull content above the fold.

Before:
<img width="1703" alt="Screenshot 2024-08-29 at 11 42 17 AM" src="https://github.com/user-attachments/assets/68b87139-7d7d-4c69-8349-5604c433e28c">
After:
<img width="1705" alt="Screenshot 2024-08-29 at 11 42 33 AM" src="https://github.com/user-attachments/assets/9ed98d58-d1fb-476b-bf21-c336f198cd17">
