### PR TITLE
fix: style fix for article tags wrapping

### DIFF
--- a/app/blog/article/[slug]/components/ArticleTags.js
+++ b/app/blog/article/[slug]/components/ArticleTags.js
@@ -12,7 +12,7 @@ export default function ArticleTags({ tags }) {
         <Link
           href={`/blog/tag/${tag.slug}`}
           key={tag.slug}
-          className="rounded-md text-sm py-2 px-4 mr-2 bg-indigo-200 no-underline cursor hover:bg-indigo-300"
+          className="inline-block rounded-md text-sm py-2 px-4 mb-2 mr-2 bg-indigo-200 no-underline cursor hover:bg-indigo-300"
         >
           {tag.name}
         </Link>


### PR DESCRIPTION
Quick style fix for tag buttons at the bottom of an Article, they were overlapping each other when wrapped.

Before: 
![image](https://github.com/user-attachments/assets/6d8cde71-2f66-4538-9f22-5cfd93831bc8)

After: 
<img width="809" alt="Screenshot 2024-09-10 at 2 56 24 PM" src="https://github.com/user-attachments/assets/c6c71ccf-dcb4-48b4-9e5e-c26e9e4cec82">
