### PR TITLE
WEB-1838: Add frontend validation for Campaign Website field in My Details

### DIFF
--- a/app/(candidate)/dashboard/details/components/CampaignSection.js
+++ b/app/(candidate)/dashboard/details/components/CampaignSection.js
@@ -6,12 +6,7 @@ import { useEffect, useState } from 'react';
 import PrimaryButton from '@shared/buttons/PrimaryButton';
 import { updateCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions';
 import { CircularProgress } from '@mui/material';
-
-const isValidUrl = (url) => {
-  const regex =
-    /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
-  return regex.test(String(url).toLowerCase());
-};
+import { isValidUrl } from 'helpers/linkhelper';
 
 const fields = [
   {


### PR DESCRIPTION
This PR finishes up the remaining work for adding front end validation for the Campaign Website field on a candidate's details page `/dashboard/details`

This is a kind of messy way to handle it, but I didn't want to change more things than I needed to.

https://github.com/user-attachments/assets/d5a4330d-170d-45c8-85ad-10774155143b
