### PR TITLE
WEB-3049: Run for Office page style fixes

### DIFF
--- a/app/(landing)/run-for-office/components/KeyFeatures.js
+++ b/app/(landing)/run-for-office/components/KeyFeatures.js
@@ -25,7 +25,7 @@ function CardWrapper({ children, className }) {
 function CTALink({ id, href = '/sign-up' }) {
   return (
     <Link id={id} href={href} className="no-underline">
-      <Button variant="text" size="large" className="flex items-center gap-2">
+      <Button size="medium" className="flex items-center gap-2">
         Get Started
         <MdArrowForward className="text-2xl" />
       </Button>
@@ -43,8 +43,8 @@ export default function KeyFeatures() {
         Save time and cut costs with free campaign software.
       </Body1>
       <div className="pt-16 grid grid-cols-1 md:grid-cols-12 gap-6">
-        <CardWrapper className="pt-8 md:pt-12 pb-0 col-span-12 md:col-span-5">
-          <hgroup className="px-6">
+        <CardWrapper className="pt-8 md:pt-12 pb-0 col-span-12 md:col-span-5 flex flex-col">
+          <hgroup>
             <MarketingH4 className="mb-4">
               Create winning content in seconds
             </MarketingH4>
@@ -54,13 +54,15 @@ export default function KeyFeatures() {
               endorsement pitches.
             </Body1>
           </hgroup>
-          <CTALink id="tools-winning-content" />
-          <Image src={contentImg} alt="content" className="mt-10" />
+          <div className="pb-10">
+            <CTALink id="tools-winning-content" />
+          </div>
+          <Image src={contentImg} alt="content" className="mt-auto" />
         </CardWrapper>
 
         <CardWrapper className="col-span-12 md:col-span-7">
           <Image src={trackerImg} alt="content" className="mt-0 md:mt-8" />
-          <hgroup className="px-6">
+          <hgroup>
             <MarketingH4 className="mt-6 mb-4">
               Run a data-driven campaign
             </MarketingH4>
@@ -78,7 +80,7 @@ export default function KeyFeatures() {
             alt="content"
             className="mt-0 md:mt-10 mb-8"
           />
-          <hgroup className="px-6">
+          <hgroup>
             <MarketingH4 className="mb-4">
               Access to real campaign experts
             </MarketingH4>
@@ -92,7 +94,7 @@ export default function KeyFeatures() {
         <div className="col-span-12 md:col-span-5">
           <CardWrapper className="mb-6">
             <Image src={mapImg} alt="content" className="mb-8" />
-            <hgroup className="px-6">
+            <hgroup>
               <MarketingH4 className="mb-4">
                 Devoted volunteer network
               </MarketingH4>
@@ -104,7 +106,7 @@ export default function KeyFeatures() {
             <CTALink id="tools-volunteer-network" />
           </CardWrapper>
           <CardWrapper>
-            <hgroup className="px-6">
+            <hgroup>
               <MarketingH4 className="mb-4">
                 Dedicated resource library{' '}
               </MarketingH4>

--- a/app/(landing)/run-for-office/components/Testimonials.js
+++ b/app/(landing)/run-for-office/components/Testimonials.js
@@ -36,10 +36,16 @@ export default function Testimonials({ testimonials }) {
   useEffect(() => {
     function handleResize() {
       const windowWidth = window.innerWidth;
-      if (windowWidth <= LG_MIN) {
-        setPageSize(windowWidth <= MD_MIN ? SM_PAGE_SIZE : MD_PAGE_SIZE);
-      } else {
-        setPageSize(LG_PAGE_SIZE);
+      const newPageSize =
+        windowWidth > LG_MIN
+          ? LG_PAGE_SIZE
+          : windowWidth <= MD_MIN
+          ? SM_PAGE_SIZE
+          : MD_PAGE_SIZE;
+
+      if (pageSize !== newPageSize) {
+        setPageSize(newPageSize);
+        setCurrentPage(0);
       }
     }
 
@@ -48,7 +54,7 @@ export default function Testimonials({ testimonials }) {
     handleResize();
 
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [pageSize]);
 
   if (!testimonials || testimonials.length <= 0) return null;
 

--- a/app/blog/article/[slug]/components/RelatedArticles.js
+++ b/app/blog/article/[slug]/components/RelatedArticles.js
@@ -30,7 +30,7 @@ export default function RelatedArticles({ articles }) {
   }
 
   return (
-    <div className="p-24 bg-mint-50 grid grid-cols-1 lg:grid-cols-3 gap-8">
+    <div className="py-24 px-6 lg:px-24 bg-mint-50 grid grid-cols-1 lg:grid-cols-3 gap-8">
       <MarketingH2 className="col-span-1 lg:col-span-3 mb-2">
         You may also like...
       </MarketingH2>


### PR DESCRIPTION
These were some small style fixes that came from demo feedback for the Run for Office page at the previous cycle demos. I had forgotten to push them up before I was out.


**Run for Office**
|Before|After|
|-|-|
|![BEFORE-goodparty org_run-for-office](https://github.com/user-attachments/assets/bb2e13bc-f637-421f-96fd-be1baddb523e)|![AFTER-localhost_4000_run-for-office](https://github.com/user-attachments/assets/2aae1eab-7553-45e3-aabf-e23435a52ccd)|



**Blog Article - Related Articles** 
Screenshot from `/blog/article/meet-lyn-leddy-independent-district-rockingham-24-nh`
|Before|After|
|-|-|
|<img width="1019" alt="Screenshot 2024-10-02 at 9 06 43 AM" src="https://github.com/user-attachments/assets/085242bc-5c11-4714-a8a2-71dbf72f939f">|<img width="1017" alt="Screenshot 2024-10-02 at 9 06 35 AM" src="https://github.com/user-attachments/assets/7d809aaf-9619-4214-8532-fd7c49058f44">|




