### PR TITLE
WEB-2881: Enhancement: Banner Copy

### DIFF
--- a/app/(candidate)/dashboard/components/ProSignUpAlert.js
+++ b/app/(candidate)/dashboard/components/ProSignUpAlert.js
@@ -4,9 +4,9 @@ import { MdChevronRight } from 'react-icons/md';
 export const ProSignUpAlert = () => (
   <AlertBanner
     {...{
-      title: 'Need Additional Support?',
+      title: 'Level Up Your Campaign',
       message:
-        'We have your back. Get voter data, 24/7 access to experts, and more for just $10/mo.',
+        'Access campaign essentials like text banking, voter data, and 1:1 expert support for just $10/month.',
       actionHref: '/dashboard/pro-sign-up',
       actionText: (
         <div className="flex items-center" id="pro_upgrade_alert">


### PR DESCRIPTION
Updated text on the upgrade account CTA at top of Dashboard .

Before:
<img width="1188" alt="Screenshot 2024-10-02 at 9 36 42 AM" src="https://github.com/user-attachments/assets/397d66e6-d452-47a4-aa05-2fa83d2bbc58">

After:
<img width="1169" alt="Screenshot 2024-10-02 at 9 36 24 AM" src="https://github.com/user-attachments/assets/c48f9fd4-1800-4499-88f4-bd6e0108485b">
