### PR TITLE
WEB-3090: Add a free texts message under Voter Contact Methods: texting

### DIFF
--- a/app/(candidate)/dashboard/components/contactMethods/ContactMethodsSection.js
+++ b/app/(candidate)/dashboard/components/contactMethods/ContactMethodsSection.js
@@ -10,6 +10,7 @@ import {
   MdPeopleAlt,
   MdShare,
 } from 'react-icons/md';
+import { StyledAlert } from '@shared/alerts/StyledAlert';
 
 const methods = [
   {
@@ -41,6 +42,12 @@ const methods = [
     voterFileKey: 'sms',
     perc: 20,
     percText: 'text messages',
+    specialCallout: (
+      <StyledAlert severity="info" className="flex items-center">
+        <span className="font-bold">Maximize your reach:</span> Get 5,000 texts
+        for free on your first texting campaign
+      </StyledAlert>
+    ),
   },
   {
     key: 'calls',

--- a/app/(candidate)/dashboard/components/contactMethods/MethodRow.js
+++ b/app/(candidate)/dashboard/components/contactMethods/MethodRow.js
@@ -18,6 +18,7 @@ export default function MethodRow(props) {
     voterFileKey,
     perc,
     percText,
+    specialCallout,
   } = method;
   const { isPro } = campaign || {};
 
@@ -25,9 +26,17 @@ export default function MethodRow(props) {
   voterContactGoal = voterContactGoal || 0;
   const perNumber = numberFormatter((voterContactGoal * perc) / 100);
 
+  // Check campaign viability to show special callout
+  const hbViability = campaign.data?.hubSpotUpdates?.final_viability_rating;
+  const showSpecialCallout =
+    typeof hbViability === 'string' &&
+    ['has a chance', 'likely to win', 'frontrunner'].includes(
+      hbViability.toLowerCase(),
+    );
+
   return (
     <div className="border border-gray-200 p-4 rounded-lg mt-4">
-      <div className="grid grid-cols-12 gap-8">
+      <div className="grid grid-cols-12 gap-8 items-center">
         <div className="col-span-12  flex  2xl:col-span-5">
           <div className="mr-4 text-xl mt-1">{icon}</div>
           <div>
@@ -63,7 +72,9 @@ export default function MethodRow(props) {
                       </PrimaryButton>
                     ) : (
                       <Link href={`/dashboard/voter-records/${voterFileKey}`}>
-                        <PrimaryButton fullWidth>{cta}</PrimaryButton>
+                        <PrimaryButton className="whitespace-nowrap" fullWidth>
+                          {cta}
+                        </PrimaryButton>
                       </Link>
                     )}
                   </>
@@ -85,6 +96,9 @@ export default function MethodRow(props) {
           </div>
         </div>
       </div>
+      {specialCallout && showSpecialCallout && (
+        <div className="mt-4">{specialCallout}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Adds a callout message underneath Texting in the Campaign Tracker's Voter Contact Methods section, depending on the User's Campaign viability

Before:
<img width="896" alt="Screenshot 2024-10-08 at 3 56 24 PM" src="https://github.com/user-attachments/assets/f602df47-5eb1-4a1d-ba5d-91e1bae7fc3d">

After:
<img width="867" alt="Screenshot 2024-10-08 at 3 56 38 PM" src="https://github.com/user-attachments/assets/40590857-4347-4720-9719-fde383360543">
