### PR TITLE
WEB-3091, WEB-3092: Upgrade to Pro form improvements

### DIFF
--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
@@ -19,7 +19,6 @@ import {
 import { AlreadyProUserPrompt } from 'app/(candidate)/dashboard/shared/AlreadyProUserPrompt';
 import { CommitteeSupportingFilesUpload } from 'app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload';
 import Overline from '@shared/typography/Overline';
-import Checkbox from '@shared/inputs/Checkbox';
 import { Switch } from '@mui/material';
 
 const COMMITTEE_HELP_MESSAGE = (

--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
@@ -18,6 +18,9 @@ import {
 } from 'app/(candidate)/dashboard/pro-sign-up/committee-check/components/EinCheckInput';
 import { AlreadyProUserPrompt } from 'app/(candidate)/dashboard/shared/AlreadyProUserPrompt';
 import { CommitteeSupportingFilesUpload } from 'app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload';
+import Overline from '@shared/typography/Overline';
+import Checkbox from '@shared/inputs/Checkbox';
+import { Switch } from '@mui/material';
 
 const COMMITTEE_HELP_MESSAGE = (
   <span>
@@ -37,6 +40,7 @@ const CommitteeCheckPage = ({ campaign = { details: {} } }) => {
   const [einInputValue, setEinInputValue] = useState(
     campaign?.details?.einNumber || '',
   );
+  const [skipEin, setSkipEin] = useState(false);
   const [loadingEinCheck, setLoadingEinCheck] = useState(false);
   const [loadingCampaignUpdate, setLoadingCampaignUpdate] = useState(false);
   const [validatedEin, setValidatedEin] = useState(null);
@@ -99,6 +103,15 @@ const CommitteeCheckPage = ({ campaign = { details: {} } }) => {
     doCampaignUpdate();
   };
 
+  const handleSkipEinToggle = (toggleValue) => {
+    setSkipEin(toggleValue);
+
+    if (toggleValue === true) {
+      setEinInputValue('');
+      setValidatedEin(null);
+    }
+  };
+
   const onUploadSuccess = (uploadedFilename = '') =>
     uploadedFilename && setUploadedFilename(uploadedFilename);
   const onUploadError = (e) => {
@@ -107,7 +120,7 @@ const CommitteeCheckPage = ({ campaign = { details: {} } }) => {
   };
 
   const nextDisabled =
-    !(validatedEin && uploadedFilename) || loadingCampaignUpdate;
+    !((validatedEin || skipEin) && uploadedFilename) || loadingCampaignUpdate;
 
   return (
     <FocusedExperienceWrapper>
@@ -141,14 +154,23 @@ const CommitteeCheckPage = ({ campaign = { details: {} } }) => {
             }}
             fullWidth
           />
-          <EinCheckInput
-            name="ein-number"
-            loading={loadingEinCheck}
-            value={einInputValue}
-            validated={validatedEin}
-            setValidated={setValidatedEin}
-            onChange={setEinInputValue}
-          />
+          <Overline className="flex items-center">
+            My race doesn't require an EIN
+            <Switch
+              onChange={(e) => handleSkipEinToggle(e.target.checked)}
+              checked={skipEin}
+            />
+          </Overline>
+          {!skipEin && (
+            <EinCheckInput
+              name="ein-number"
+              loading={loadingEinCheck}
+              value={einInputValue}
+              validated={validatedEin}
+              setValidated={setValidatedEin}
+              onChange={setEinInputValue}
+            />
+          )}
           {validatedEin === false && (
             <Body2 className="text-error my-4 text-center">
               The provided EIN does not appear to match the given registered

--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.js
@@ -155,7 +155,7 @@ const CommitteeCheckPage = ({ campaign = { details: {} } }) => {
             fullWidth
           />
           <Overline className="flex items-center">
-            My race doesn't require an EIN
+            My race doesn&apos;t require an EIN
             <Switch
               onChange={(e) => handleSkipEinToggle(e.target.checked)}
               checked={skipEin}

--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.js
@@ -7,10 +7,14 @@ import { CircularProgress } from '@mui/material';
 import { HiddenFileUploadInput } from '@shared/inputs/HiddenFileUploadInput';
 import { useCampaign } from '@shared/hooks/useCampaign';
 import { updateCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions';
+import { InputHelpIcon } from 'app/(candidate)/dashboard/shared/InputHelpIcon';
 
 const FILE_LIMIT_MB = 10;
 
 const EIN_SUPPORT_DOCUMENT_FOLDERNAME_POSTFIX = `ein-support-documents`;
+
+const HELP_MESSAGE =
+  'A campaign filing document is the official document you filed with your election agency (e.g., Secretary of State or Board of Elections) to declare your candidacy. Common names include Statement of Candidacy, Declaration of Candidacy, or Certificate of Nomination.';
 
 const getEinSupportDocumentFolderName = (id, slug) =>
   `${id}-${slug}-${EIN_SUPPORT_DOCUMENT_FOLDERNAME_POSTFIX}`;
@@ -105,7 +109,12 @@ export const CommitteeSupportingFilesUpload = ({
         onClick={onFileBrowseClick}
         label="Upload Campaign Filing Document"
         disabled={loadingFileUpload}
-        helperText={errorMessge || `File size less than ${FILE_LIMIT_MB}MB`}
+        helperText={
+          errorMessge || `PDF file with size less than ${FILE_LIMIT_MB}MB`
+        }
+        InputProps={{
+          endAdornment: <InputHelpIcon message={HELP_MESSAGE} />,
+        }}
       />
 
       <PrimaryButton


### PR DESCRIPTION
For [WEB-3091](https://goodparty.atlassian.net/browse/WEB-3091) Adds a toggle to the Pro Signup form to let a user skip entering an EIN number. For [WEB-3092](https://goodparty.atlassian.net/browse/WEB-3092) Adds a tooltip to the `Upload Campaign Filing Document` input.

Before:
<img width="697" alt="Screenshot 2024-10-08 at 4 00 52 PM" src="https://github.com/user-attachments/assets/2fc37d72-6fd9-4789-b968-60eaceae096a">

After:
<img width="624" alt="Screenshot 2024-10-08 at 4 31 42 PM" src="https://github.com/user-attachments/assets/b5b390d4-c3cc-4dac-98de-19dc5f58b379">
<img width="615" alt="Screenshot 2024-10-08 at 4 31 48 PM" src="https://github.com/user-attachments/assets/83c11241-9056-4da4-97fe-d8e106fb549f">
<img width="673" alt="Screenshot 2024-10-08 at 4 43 55 PM" src="https://github.com/user-attachments/assets/a90f843a-0087-43f8-84c3-0b34cfb71a71">

 

[WEB-3091]: https://goodparty.atlassian.net/browse/WEB-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-3092]: https://goodparty.atlassian.net/browse/WEB-3092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ