### PR TITLE
WEB-3125: High marketing priority: Update Hiya Brow/Eyebrow back to Discord

### DIFF
--- a/app/homepage/HomePage.js
+++ b/app/homepage/HomePage.js
@@ -3,14 +3,14 @@ import FactsSection from './FactsSection';
 import HowSection from './HowSection';
 import ToolsSection from './ToolsSection';
 import Cta from './Cta';
-// import Callout from '@shared/utils/Callout';
-import StickersCallout from '@shared/utils/StickersCallout';
+import Callout from '@shared/utils/Callout';
+// import StickersCallout from '@shared/utils/StickersCallout';
 
 export default function HomePage(props) {
   return (
     <div className="bg-indigo-50">
-      {/* <Callout /> */}
-      <StickersCallout />
+      <Callout />
+      {/* <StickersCallout /> */}
 
       <Hero />
 

--- a/app/shared/utils/Callout.js
+++ b/app/shared/utils/Callout.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import PrimaryButton from '@shared/buttons/PrimaryButton';
 import { IoIosCloseCircle } from 'react-icons/io';
 import { useEffect, useState } from 'react';
+import { buildTrackingAttrs } from 'helpers/fullStoryHelper';
 
 export default function Callout() {
   const [showCallout, setShowCallout] = useState(true);
@@ -17,6 +18,8 @@ export default function Callout() {
       console.log(e);
     }
   }, []);
+
+  const trackingAttrs = buildTrackingAttrs('Join Discord Banner Link');
 
   return (
     showCallout && (
@@ -34,6 +37,7 @@ export default function Callout() {
                 href="https://discord.gg/invite/goodparty"
                 target="_blank"
                 aria-label="Join our Discord community - meet like-minded independents and get involved!"
+                {...trackingAttrs}
               >
                 <div className="whitespace-nowrap ml-5">
                   <PrimaryButton size="medium">Join Now</PrimaryButton>


### PR DESCRIPTION
Hides Stickers callout banner and puts the Discord callout back in. Also adds FS tracking attributes to the join Discord link

Before:
<img width="1219" alt="Screenshot 2024-10-14 at 1 42 34 PM" src="https://github.com/user-attachments/assets/ffa67bc8-2a7d-4618-8696-dfc4617f0805">

After:
<img width="1225" alt="Screenshot 2024-10-14 at 1 42 20 PM" src="https://github.com/user-attachments/assets/282addcf-3bae-43f7-a62d-e2e4bd2f27f5">
