### PR TITLE
WEB-3119: try setting max duration for all /admin routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
       "path": "/api/v1/campaign/election-events",
       "schedule": "0 16 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "app/admin/**/*.js": {
+      "maxDuration": 60
+    }
+  }
 }


### PR DESCRIPTION
Trying to increase `maxDuration` timeout for admin routes