### PR TITLE
Fix map history when moving around

### DIFF
--- a/app/candidates/components/map/Map.js
+++ b/app/candidates/components/map/Map.js
@@ -54,21 +54,17 @@ const Map = () => {
 
   // Initialize Google Map once
   useEffect(() => {
-    if (
-      !isLoaded ||
-      !window.google ||
-      !mapContainerRef.current ||
-      mapRef.current
-    )
-      return;
+    if (!isLoaded || !window.google || !mapContainerRef.current) return;
 
-    const mapInstance = new window.google.maps.Map(mapContainerRef.current, {
-      center: memoizedCenter,
-      zoom,
-      ...mapOptions,
-    });
+    if (!mapRef.current) {
+      mapRef.current = new window.google.maps.Map(mapContainerRef.current, {
+        center: memoizedCenter,
+        zoom,
+        ...mapOptions,
+      });
+    }
 
-    mapRef.current = mapInstance;
+    const mapInstance = mapRef.current;
 
     const debouncedUpdateBounds = debounce2(() => {
       const bounds = mapInstance.getBounds();
@@ -79,10 +75,10 @@ const Map = () => {
         const currentZoom = mapInstance.getZoom();
 
         if (
-          filters.neLat !== ne?.lat() ||
-          filters.neLng !== ne?.lng() ||
-          filters.swLat !== sw?.lat() ||
-          filters.swLng !== sw?.lng()
+          filters.neLat != ne?.lat() ||
+          filters.neLng != ne?.lng() ||
+          filters.swLat != sw?.lat() ||
+          filters.swLng != sw?.lng()
         ) {
           onChangeMapBounds({
             neLat: ne?.lat(),


### PR DESCRIPTION
Follow up on the earlier fix I did, this one should fix updating the URL search params when moving the map around, and the back button should properly work to step back through those changes