### PR TITLE
WEB-3208: Custom Voter File Settings saved and displayed.

### DIFF
--- a/app/(candidate)/dashboard/voter-records/[type]/components/DownloadFile.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/DownloadFile.js
@@ -1,9 +1,8 @@
 'use client';
-import PrimaryButton from '@shared/buttons/PrimaryButton';
 import { useState } from 'react';
 import { fetchVoterFile } from '../../components/VoterRecordsPage';
 import { trackEvent } from 'helpers/fullStoryHelper';
-import { CircularProgress } from '@mui/material';
+import Button from '@shared/buttons/Button';
 
 export default function DownloadFile(props) {
   const [loading, setLoading] = useState(false);
@@ -49,14 +48,15 @@ export default function DownloadFile(props) {
 
   return (
     <div className="mt-3 md:mt-0">
-      <PrimaryButton
+      <Button
+        size="large"
+        className="w-full"
         disabled={loading}
         onClick={handleDownload}
-        fullWidth
         loading={loading}
       >
         Download CSV
-      </PrimaryButton>
+      </Button>
     </div>
   );
 }

--- a/app/(candidate)/dashboard/voter-records/[type]/components/Hero.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/Hero.js
@@ -1,42 +1,49 @@
+'use client';
+
+import { useMemo, useState } from 'react';
 import Paper from '@shared/utils/Paper';
 import VoterFileTypes from '../../components/VoterFileTypes';
 import H2 from '@shared/typography/H2';
 import Body2 from '@shared/typography/Body2';
-import PrimaryButton from '@shared/buttons/PrimaryButton';
 import Overline from '@shared/typography/Overline';
 import RecordCount from './RecordCount';
 import Chip from '@shared/utils/Chip';
 import slugify from 'slugify';
 import DownloadFile from './DownloadFile';
+import ViewAudienceFiltersModal from '../../components/ViewAudienceFiltersModal';
 
 export default function Hero(props) {
-  const { type, campaign, fileName } = props;
-  if (
-    campaign.data?.customVoterFiles &&
-    campaign.data?.customVoterFiles.length > 0 &&
-    VoterFileTypes.length === 6
-  ) {
-    campaign.data?.customVoterFiles.forEach((file, i) => {
-      VoterFileTypes.push({
-        key: `custom-${slugify(file.name)}`,
-        index: i,
-        isCustom: true,
-        name: file.name,
-        fields: [
-          file.channel,
-          file.name,
-          file.purpose || '',
-          <Chip
-            key="custom"
-            className="bg-orange-700 text-white"
-            label="CUSTOM VOTER FILE"
-          />,
-        ],
+  const { type, campaign, fileName, customFile } = props;
+  const [modalOpen, setModalOpen] = useState();
+  const voterFileTypes = useMemo(() => {
+    const dupedFileTypes = [...VoterFileTypes];
+
+    if (
+      campaign.data?.customVoterFiles &&
+      campaign.data?.customVoterFiles.length > 0 &&
+      dupedFileTypes.length === 6
+    ) {
+      campaign.data?.customVoterFiles.forEach((file, i) => {
+        dupedFileTypes.push({
+          key: `custom-${slugify(file.name)}`,
+          index: i,
+          isCustom: true,
+          name: file.name,
+          fields: [
+            file.channel,
+            file.name,
+            file.purpose || '',
+            'Custom Voter File',
+          ],
+        });
       });
-    });
-  }
+    }
+
+    return dupedFileTypes;
+  }, [campaign.data?.customVoterFiles]);
+
   const fileByKey = {};
-  VoterFileTypes.forEach((file) => {
+  voterFileTypes.forEach((file) => {
     fileByKey[file.key.toLowerCase()] = file;
   });
 
@@ -46,12 +53,24 @@ export default function Hero(props) {
   return (
     <Paper className="mt-4">
       <div className="md:flex justify-between">
-        <div>
+        <div className="grow">
           <H2>{fileName}</H2>
           <Body2 className="mt-2">
             Key data associated with this voter file.
           </Body2>
         </div>
+        {isCustom && (
+          <div className="mt-3 md:mt-0 mr-2">
+            <ViewAudienceFiltersModal
+              buttonType="button"
+              size="large"
+              open={modalOpen}
+              file={customFile}
+              onOpen={() => setModalOpen(true)}
+              onClose={() => setModalOpen(false)}
+            />
+          </div>
+        )}
         <DownloadFile {...props} isCustom={isCustom} index={index} />
       </div>
       <div className="mt-6 grid grid-cols-12 gap-4">

--- a/app/(candidate)/dashboard/voter-records/[type]/components/VoterFileDetailPage.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/VoterFileDetailPage.js
@@ -9,20 +9,27 @@ import { slugify } from 'helpers/articleHelper';
 import H2 from '@shared/typography/H2';
 import Body2 from '@shared/typography/Body2';
 
-const getCustomVoterFileName = (customVoterFiles = [], type) =>
-  customVoterFiles.find((file) => `custom-${slugify(file.name, true)}` === type)
-    ?.name;
+const getCustomVoterFile = (customVoterFiles = [], type) =>
+  customVoterFiles.find(
+    (file) => `custom-${slugify(file.name, true)}` === type,
+  );
 
 export default function VoterFileDetailPage(props) {
   const { type, campaign, isCustom } = props;
-  const fileName = isCustom
-    ? getCustomVoterFileName(campaign.data?.customVoterFiles, type)
-    : getDefaultVoterFileName(type);
+  const customFile = isCustom
+    ? getCustomVoterFile(campaign.data?.customVoterFiles, type)
+    : null;
+  const fileName = isCustom ? customFile?.name : getDefaultVoterFileName(type);
 
   return (
     <DashboardLayout {...props}>
       <BackToAllFiles />
-      <Hero {...props} fileName={fileName} />
+      <Hero
+        type={type}
+        campaign={campaign}
+        fileName={fileName}
+        customFile={customFile}
+      />
       {!isCustom && type !== 'full' && (
         <>
           <Paper className="my-4">

--- a/app/(candidate)/dashboard/voter-records/components/CustomVoterAudienceFilters.js
+++ b/app/(candidate)/dashboard/voter-records/components/CustomVoterAudienceFilters.js
@@ -92,6 +92,7 @@ export default function CustomVoterAudienceFilters({
   showAudienceRequest,
   prevStepValues,
   onChangeCallback,
+  readOnly = false,
 }) {
   // set initial state to all false
   const [state, setState] = useState({
@@ -121,6 +122,8 @@ export default function CustomVoterAudienceFilters({
   }, [purpose]);
 
   const handleChangeAudience = (option, val) => {
+    if (readOnly) return;
+
     const newState = {
       ...state,
       [option]: val,
@@ -146,6 +149,7 @@ export default function CustomVoterAudienceFilters({
                 }}
                 checked={state[option.key] ?? false}
                 color="secondary"
+                disabled={readOnly}
               />
             </div>
           ))}

--- a/app/(candidate)/dashboard/voter-records/components/CustomVoterFile.js
+++ b/app/(candidate)/dashboard/voter-records/components/CustomVoterFile.js
@@ -6,6 +6,7 @@ import H1 from '@shared/typography/H1';
 import Modal from '@shared/utils/Modal';
 import { useState } from 'react';
 import CustomVoterAudience from './CustomVoterAudience';
+import Button from '@shared/buttons/Button';
 
 const fields = [
   {
@@ -61,14 +62,16 @@ export default function CustomVoterFile({ campaign, reloadCampaignCallback }) {
 
   return (
     <>
-      <PrimaryButton
+      <Button
+        size="large"
+        className="w-full md:w-auto"
         onClick={() => {
           setOpen(true);
         }}
-        className="w-full md:w-auto"
       >
         Create a custom voter file
-      </PrimaryButton>
+      </Button>
+
       <Modal closeCallback={handleClose} open={open}>
         {!showAudience ? (
           <div className="w-[80vw] max-w-xl p-2 md:p-8">

--- a/app/(candidate)/dashboard/voter-records/components/NeedHelp.js
+++ b/app/(candidate)/dashboard/voter-records/components/NeedHelp.js
@@ -8,6 +8,7 @@ import gpApi from 'gpApi';
 import gpFetch from 'gpApi/gpFetch';
 import { useState } from 'react';
 import NeedHelpSuccess from './NeedHelpSuccess';
+import Button from '@shared/buttons/Button';
 
 export async function sendMessage(type, message) {
   try {
@@ -68,14 +69,16 @@ export default function NeedHelp() {
   };
   return (
     <>
-      <SecondaryButton
+      <Button
+        size="large"
+        color="neutral"
         onClick={() => {
           setOpen(true);
         }}
         className="mr-4 mb-4 md:mb-0 w-full md:w-auto"
       >
         Need Help?
-      </SecondaryButton>
+      </Button>
       <Modal closeCallback={handleClose} open={open}>
         <div className="w-[80vw] max-w-xl p-2 md:p-8">
           {showSuccess ? (

--- a/app/(candidate)/dashboard/voter-records/components/ViewAudienceFiltersModal.js
+++ b/app/(candidate)/dashboard/voter-records/components/ViewAudienceFiltersModal.js
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import Button from '@shared/buttons/Button';
+import IconButton from '@shared/buttons/IconButton';
+import Modal from '@shared/utils/Modal';
+import CustomVoterAudienceFilters from './CustomVoterAudienceFilters';
+import H2 from '@shared/typography/H2';
+import Body1 from '@shared/typography/Body1';
+import { InfoRounded } from '@mui/icons-material';
+
+export default function ViewAudienceFiltersModal({
+  open,
+  onOpen,
+  onClose,
+  file,
+  buttonType = 'icon', // 'icon' or 'button'
+  size = 'small',
+  className = '',
+}) {
+  const audienceFilters = useMemo(
+    () =>
+      file == null || file.filters == null
+        ? null
+        : file.filters.reduce((acc, filterKey) => {
+            acc[filterKey] = true;
+            return acc;
+          }, {}),
+    [file],
+  );
+
+  return (
+    <>
+      {buttonType === 'icon' ? (
+        <IconButton
+          size={size}
+          color="info"
+          title="View Audience Filters"
+          className={`flex items-center ${className}`}
+          onClick={onOpen}
+        >
+          <InfoRounded />
+        </IconButton>
+      ) : (
+        <Button
+          size={size}
+          color="neutral"
+          title="View Audience Filters"
+          className={`flex gap-2 items-center ${className}`}
+          onClick={onOpen}
+        >
+          <InfoRounded /> View Audience Filters
+        </Button>
+      )}
+
+      <Modal open={open} closeCallback={onClose}>
+        {file ? (
+          <div className="w-[80vw] max-w-4xl p-2 md:p-8">
+            <H2 className="text-center">
+              Custom Voter File: <br />
+              {file.name}
+            </H2>
+            <Body1 className="text-center mb-4 mt-2">
+              Viewing your custom audience filters
+            </Body1>
+            <CustomVoterAudienceFilters audience={audienceFilters} readOnly />
+          </div>
+        ) : (
+          <Body1>No file selected</Body1>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/app/(candidate)/dashboard/voter-records/components/VoterRecordsPage.js
+++ b/app/(candidate)/dashboard/voter-records/components/VoterRecordsPage.js
@@ -4,21 +4,18 @@ import DashboardLayout from '../../shared/DashboardLayout';
 import gpApi from 'gpApi';
 import gpFetch from 'gpApi/gpFetch';
 import Paper from '@shared/utils/Paper';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import H2 from '@shared/typography/H2';
 import Body2 from '@shared/typography/Body2';
 import Overline from '@shared/typography/Overline';
-import { FaDownload } from 'react-icons/fa';
-import { trackEvent } from 'helpers/fullStoryHelper';
-import Chip from '@shared/utils/Chip';
 import CustomVoterFile from './CustomVoterFile';
 import { getCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions';
-import { CircularProgress } from '@mui/material';
 import CantDownload from './CantDownload';
 import Link from 'next/link';
 import { slugify } from 'helpers/articleHelper';
 import voterFileTypes from './VoterFileTypes';
 import NeedHelp from './NeedHelp';
+import ViewAudienceFiltersModal from './ViewAudienceFiltersModal';
 
 const tableHeaders = ['NAME', 'CHANNEL', 'PURPOSE', 'AUDIENCE'];
 
@@ -48,6 +45,8 @@ async function wakeUp() {
 
 export default function VoterRecordsPage(props) {
   const [campaign, setCampaign] = useState(props.campaign);
+  const [modalFileKey, setModalFileKey] = useState(null);
+
   const addCustomVoterFiles = () => {
     if (
       campaign.data?.customVoterFiles &&
@@ -66,6 +65,7 @@ export default function VoterRecordsPage(props) {
             file.purpose || '',
             'Custom Voter File',
           ],
+          filters: file.filters,
         });
       });
       return updatedFiles;
@@ -118,9 +118,9 @@ export default function VoterRecordsPage(props) {
                     index === 0 ? 'rounded-tl-lg' : ''
                   } ${
                     index === tableHeaders.length - 1 ? 'rounded-tr-lg ' : ''
-                  } ${index === 2 ? 'rounded-tr-lg lg:rounded-none' : ''} ${
-                    index === 1 ? 'rounded-tr-lg md:rounded-none' : ''
-                  } ${index === 0 ? 'rounded-tr-lg sm:rounded-none' : ''} ${
+                  } ${index === 2 ? 'rounded-tr-lg lg:rounded-tr-none' : ''} ${
+                    index === 1 ? 'rounded-tr-lg md:rounded-tr-none' : ''
+                  } ${index === 0 ? 'rounded-tr-lg sm:rounded-tr-none' : ''} ${
                     index === 2 ? 'col-span-1' : 'col-span-2'
                   } ${header === 'AUDIENCE' ? 'hidden lg:block' : ''}
               
@@ -137,31 +137,42 @@ export default function VoterRecordsPage(props) {
                   {file.fields.map((field, index2) => (
                     <div
                       key={`${file.key}-${index2}`}
-                      className={`p-4 border-b border-b-gray-200 ${
+                      className={`p-4 border-b border-b-gray-200 flex items-center ${
                         index % 2 !== 0 ? ' bg-indigo-50' : ''
                       } ${index2 === 2 ? 'col-span-1' : 'col-span-2'}
                   
-                  ${index2 === 3 ? 'hidden lg:block ' : ''} ${
-                        index2 === 2 ? 'hidden md:block ' : ''
-                      }${index2 === 1 ? 'hidden sm:block' : ''}`}
+                  ${index2 === 3 ? 'hidden lg:flex ' : ''} ${
+                        index2 === 2 ? 'hidden md:flex ' : ''
+                      }${index2 === 1 ? 'hidden sm:flex' : ''}`}
                     >
-                      <Link
-                        href={
-                          file.isCustom
-                            ? `/dashboard/voter-records/custom-${slugify(
-                                file.name,
-                                true,
-                              )}`
-                            : `/dashboard/voter-records/${file.key.toLowerCase()}`
-                        }
-                        className={`${
-                          index2 === 0
-                            ? 'text-info underline hover:text-info-dark'
-                            : ''
-                        }`}
-                      >
-                        {field}
-                      </Link>
+                      {index2 === 0 ? (
+                        <Link
+                          href={
+                            file.isCustom
+                              ? `/dashboard/voter-records/custom-${slugify(
+                                  file.name,
+                                  true,
+                                )}`
+                              : `/dashboard/voter-records/${file.key.toLowerCase()}`
+                          }
+                          className="text-info underline hover:text-info-dark"
+                        >
+                          {field}
+                        </Link>
+                      ) : (
+                        <>
+                          {field}
+                          {file.isCustom && index2 === 3 && (
+                            <ViewAudienceFiltersModal
+                              open={modalFileKey === file.key}
+                              file={file}
+                              onOpen={() => setModalFileKey(file.key)}
+                              onClose={() => setModalFileKey(null)}
+                              className="ml-1 self-center"
+                            />
+                          )}
+                        </>
+                      )}
                     </div>
                   ))}
                 </Fragment>


### PR DESCRIPTION
Adds modals + buttons to let a user view their set audience filters for custom voter files.



Voter File List page:
<img width="1444" alt="Screenshot 2024-10-23 at 10 51 14 AM" src="https://github.com/user-attachments/assets/a104146b-97a4-4599-87d4-66f8e2a9fdb4">
<img width="1452" alt="Screenshot 2024-10-23 at 10 51 21 AM" src="https://github.com/user-attachments/assets/2d18c15a-a54d-423a-ba5e-018fa1a20cc4">


Voter File Detail page:
<img width="1459" alt="Screenshot 2024-10-23 at 10 51 30 AM" src="https://github.com/user-attachments/assets/e6ea655b-ae8a-41c0-a6ae-d4fa2e30c864">
<img width="1452" alt="Screenshot 2024-10-23 at 10 51 34 AM" src="https://github.com/user-attachments/assets/4b60f1d9-0834-4b1b-bb85-61e4ebedba34">

