### PR TITLE
WEB-3251: Clicking back from Add a Script breaks the text scheduling flow

### DIFF
--- a/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleAddScriptFlow/ScheduleAddScriptFlow.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleAddScriptFlow/ScheduleAddScriptFlow.js
@@ -31,7 +31,7 @@ export default function ScheduleAddScriptFlow({
 
   const Screens = {
     [ADD_SCRIPT_FLOW.CHOOSE_FLOW]: (
-      <ChooseScriptAddFlow onBack={onBack} onNext={onNext} />
+      <ChooseScriptAddFlow onBack={() => onBack()} onNext={onNext} />
     ),
     [ADD_SCRIPT_FLOW.SELECT_SMS]: (
       <SelectSmSScriptScreen


### PR DESCRIPTION
Callback was getting the event as the first arg instead of getting no arg