### PR TITLE
WEB-3169: [Usersnap] When I sort by a state - if state is not in view on map - I’m told...

### DIFF
--- a/app/candidates/components/CandidatesPage.js
+++ b/app/candidates/components/CandidatesPage.js
@@ -8,6 +8,7 @@ import '@shared/inputs/slick-theme.min.css';
 import CommunitySection from './CommunitySection';
 import { useEffect, useState } from 'react';
 import UserSnapScript from '@shared/scripts/UserSnapScript';
+import Script from 'next/script';
 
 const apiKey = 'AIzaSyDMcCbNUtBDnVRnoLClNHQ8hVDILY52ez8';
 
@@ -18,26 +19,16 @@ export default function CandidatesPage({
   state,
 }) {
   const [isLoaded, setIsLoaded] = useState(false);
-  const [isAdded, setIsAdded] = useState(false);
-
-  useEffect(() => {
-    if (isAdded) {
-      return;
-    }
-    setIsAdded(true);
-    const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places`;
-    script.async = true;
-    script.onload = () => setIsLoaded(true);
-    document.head.appendChild(script);
-
-    return () => {
-      document.head.removeChild(script); // Cleanup when unmounted
-    };
-  }, []);
 
   return (
     <>
+      <Script
+        src={`https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places`}
+        onReady={() => {
+          console.log('maps loaded');
+          setIsLoaded(true);
+        }}
+      />
       <Hero count={count} longState={longState} />
       <MapSection
         isLoaded={isLoaded}

--- a/app/candidates/components/CandidatesPage.js
+++ b/app/candidates/components/CandidatesPage.js
@@ -6,7 +6,7 @@ import FacesSection from './FacesSection';
 import '@shared/inputs/slick.min.css';
 import '@shared/inputs/slick-theme.min.css';
 import CommunitySection from './CommunitySection';
-import { Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import UserSnapScript from '@shared/scripts/UserSnapScript';
 
 const apiKey = 'AIzaSyDMcCbNUtBDnVRnoLClNHQ8hVDILY52ez8';
@@ -17,7 +17,6 @@ export default function CandidatesPage({
   longState,
   state,
 }) {
-  console.log('searchParams', searchParams);
   const [isLoaded, setIsLoaded] = useState(false);
   const [isAdded, setIsAdded] = useState(false);
 

--- a/app/candidates/components/CommunitySection.js
+++ b/app/candidates/components/CommunitySection.js
@@ -4,8 +4,9 @@ import Body1 from '@shared/typography/Body1';
 import MarketingH2 from '@shared/typography/MarketingH2';
 import Image from 'next/image';
 import Link from 'next/link';
+import { memo } from 'react';
 
-export default function CommunitySection() {
+export default memo(function CommunitySection() {
   return (
     <div className="bg-slate-100 py-8 lg:py-24">
       <MaxWidth>
@@ -49,4 +50,4 @@ export default function CommunitySection() {
       </MaxWidth>
     </div>
   );
-}
+});

--- a/app/candidates/components/FacesSection.js
+++ b/app/candidates/components/FacesSection.js
@@ -8,6 +8,7 @@ import MarketingH2 from '@shared/typography/MarketingH2';
 import MarketingH5 from '@shared/typography/MarketingH5';
 import Image from 'next/image';
 import Link from 'next/link';
+import { memo } from 'react';
 import Slider from 'react-slick';
 const cards = [
   {
@@ -79,7 +80,7 @@ const settings = {
   arrows: true,
 };
 
-export default function FacesSection() {
+export default memo(function FacesSection() {
   return (
     <div className="bg-primary-dark py-8 lg:py-16">
       <MaxWidth>
@@ -118,4 +119,4 @@ export default function FacesSection() {
       </MaxWidth>
     </div>
   );
-}
+});

--- a/app/candidates/components/Hero.js
+++ b/app/candidates/components/Hero.js
@@ -3,8 +3,9 @@ import MarketingH1 from '@shared/typography/MarketingH1';
 import MarketingH4 from '@shared/typography/MarketingH4';
 import { numberFormatter } from 'helpers/numberHelper';
 import Image from 'next/image';
+import { memo } from 'react';
 
-export default function Hero({ count = 0, longState }) {
+export default memo(function Hero({ count = 0, longState }) {
   return (
     <div className="bg-primary-dark py-8 lg:py-24 text-white text-center ">
       <MaxWidth>
@@ -28,4 +29,4 @@ export default function Hero({ count = 0, longState }) {
       </MaxWidth>
     </div>
   );
-}
+});

--- a/app/candidates/components/InfoSection.js
+++ b/app/candidates/components/InfoSection.js
@@ -8,7 +8,7 @@ import MarketingH2 from '@shared/typography/MarketingH2';
 import MarketingH5 from '@shared/typography/MarketingH5';
 import Modal from '@shared/utils/Modal';
 import Image from 'next/image';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { BiSolidHappy } from 'react-icons/bi';
 import { FaHeart } from 'react-icons/fa';
 import { MdPeople } from 'react-icons/md';
@@ -95,7 +95,7 @@ const cards = [
   },
 ];
 
-export default function InfoSection() {
+export default memo(function InfoSection() {
   const [modalOpen, setModalOpen] = useState(false);
   return (
     <div className="bg-indigo-100 py-8 lg:py-16">
@@ -156,4 +156,4 @@ export default function InfoSection() {
       </Modal>
     </div>
   );
-}
+});

--- a/app/candidates/components/map/CampaignPreview.js
+++ b/app/candidates/components/map/CampaignPreview.js
@@ -1,7 +1,6 @@
 'use client';
 
-import { useContext } from 'react';
-import { MapContext } from './MapSection';
+import { memo } from 'react';
 import { IoClose } from 'react-icons/io5';
 import {
   MdBeenhere,
@@ -16,8 +15,10 @@ import MarketingH5 from '@shared/typography/MarketingH5';
 import Body1 from '@shared/typography/Body1';
 import { dateUsHelper } from 'helpers/dateHelper';
 
-export default function CampaignPreview() {
-  const { selectedCampaign, onSelectCampaign } = useContext(MapContext);
+export default memo(function CampaignPreview({
+  selectedCampaign,
+  onSelectCampaign,
+}) {
   if (!selectedCampaign) {
     return null;
   }
@@ -103,4 +104,4 @@ export default function CampaignPreview() {
       </div>
     </div>
   );
-}
+});

--- a/app/candidates/components/map/CampaignSnippet.js
+++ b/app/candidates/components/map/CampaignSnippet.js
@@ -1,14 +1,15 @@
 import H3 from '@shared/typography/H3';
-import { useContext, useState } from 'react';
+import { memo, useState } from 'react';
 import { FaUserCircle } from 'react-icons/fa';
-import { MapContext } from './MapSection';
 import Subtitle2 from '@shared/typography/Subtitle2';
 import Image from 'next/image';
 
-export default function CampaignSnippet({ campaign }) {
+export default memo(function CampaignSnippet({
+  campaign,
+  onSelectCampaign,
+  selectedCampaign,
+}) {
   const { firstName, lastName, avatar, office, state } = campaign;
-
-  const { onSelectCampaign, selectedCampaign } = useContext(MapContext);
   const [imageError, setImageError] = useState(false); // State to track image load errors
 
   return (
@@ -51,4 +52,4 @@ export default function CampaignSnippet({ campaign }) {
       </div>
     </div>
   );
-}
+});

--- a/app/candidates/components/map/Filters.js
+++ b/app/candidates/components/map/Filters.js
@@ -1,12 +1,11 @@
 'use client';
 
 import { Select } from '@mui/material';
-import { useContext, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import Checkbox from '@shared/inputs/Checkbox';
 import TextField from '@shared/inputs/TextField';
 import { debounce } from 'helpers/debounceHelper';
 import { states } from 'helpers/statesHelper';
-import { MapContext } from './MapSection';
 
 const partyOptions = [
   { key: 'independent', label: 'Independent' },
@@ -24,8 +23,7 @@ const levelOptions = [
   { key: 'FEDERAL', label: 'Federal' },
 ];
 
-export default function Filters() {
-  const { filters, onChangeFilters, campaigns } = useContext(MapContext);
+export default memo(function Filters({ filters, onChangeFilters, campaigns }) {
   const [officeOptions, setOfficeOptions] = useState([]);
   const [name, setName] = useState(filters.name || ''); // Initialize with filter state
 
@@ -131,4 +129,4 @@ export default function Filters() {
       </div>
     </div>
   );
-}
+});

--- a/app/candidates/components/map/Map.js
+++ b/app/candidates/components/map/Map.js
@@ -79,7 +79,8 @@ const Map = memo(
                 //set to full bounds of campaign markers
                 const fullBounds = new window.google.maps.LatLngBounds();
                 for (const campaign of campaigns) {
-                  fullBounds.extend(campaign.position);
+                  if (campaign.position?.lat && campaign.position?.lng)
+                    fullBounds.extend(campaign.position);
                 }
                 mapRef.current.fitBounds(fullBounds);
               } else if (

--- a/app/candidates/components/map/Map.js
+++ b/app/candidates/components/map/Map.js
@@ -1,22 +1,28 @@
 'use client';
 import {
+  forwardRef,
+  memo,
   useCallback,
-  useContext,
   useEffect,
-  useMemo,
+  useImperativeHandle,
   useRef,
-  useState,
+  useMemo,
 } from 'react';
 import mapSkin from './mapSkin';
-import H3 from '@shared/typography/H3';
-import { MapContext } from './MapSection';
-
 import {
   MarkerClusterer,
   SuperClusterAlgorithm,
 } from '@googlemaps/markerclusterer';
-import { debounce, debounce2 } from 'helpers/debounceHelper';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { debounce2 } from 'helpers/debounceHelper';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { isObjectEqual } from 'helpers/objectHelper';
+
+const INITIAL_ZOOM = 5;
+const ZOOMED_IN = 14;
+const INIT_CENTER = {
+  lat: 39.8283,
+  lng: -98.5795,
+};
 
 const containerStyle = {
   width: '100%',
@@ -28,217 +34,261 @@ const mapOptions = {
   fullscreenControl: false,
   streetViewControl: false,
   styles: mapSkin,
-  minZoom: 4,
+  minZoom: 3,
 };
 
-const Map = () => {
-  const {
-    campaigns,
-    mapCenter,
-    isLoaded,
-    zoom,
-    onChangeMapBounds,
-    onSelectCampaign,
-    filters,
-  } = useContext(MapContext);
+const Map = memo(
+  forwardRef(
+    (
+      {
+        campaigns,
+        isLoaded,
+        onChangeMapBounds,
+        onSelectCampaign,
+        onClusterClick,
+      },
+      ref,
+    ) => {
+      const router = useRouter();
+      const searchParams = useSearchParams();
+      const mapContainerRef = useRef(null);
+      const mapRef = useRef(null);
+      const markersRef = useRef([]);
+      const markerClusterRef = useRef(null);
 
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const mapContainerRef = useRef(null);
-  const mapRef = useRef(null);
-  const markersRef = useRef([]);
-  const markerClusterRef = useRef(null);
+      useImperativeHandle(
+        ref,
+        () => {
+          return {
+            moveMapWithHistory: (boundsOrPoint) => {
+              // console.log(searchParams);
+              const paramsWithBounds = new URLSearchParams({
+                ...Object.fromEntries(searchParams),
+                bounds: JSON.stringify(mapRef.current.getBounds()),
+              });
 
-  // Memoize the map center to prevent unnecessary re-renders
-  const memoizedCenter = useMemo(() => mapCenter, [mapCenter]);
+              // replace current history with current map bounds for Back functionality
+              // using window.history here instead of router to replace the history instantly
+              window.history.replaceState(
+                {},
+                undefined,
+                `?${paramsWithBounds.toString()}`,
+              );
 
-  // Initialize Google Map once
-  useEffect(() => {
-    if (!isLoaded || !window.google || !mapContainerRef.current) return;
+              // set new map position
+              if (boundsOrPoint === 'full') {
+                //set to full bounds of campaign markers
+                const fullBounds = new window.google.maps.LatLngBounds();
+                for (const campaign of campaigns) {
+                  fullBounds.extend(campaign.position);
+                }
+                mapRef.current.fitBounds(fullBounds);
+              } else if (
+                boundsOrPoint instanceof window.google.maps.LatLngBounds
+              ) {
+                // bounds object
+                mapRef.current.fitBounds(boundsOrPoint);
+              } else {
+                // point object
+                mapRef.current.setZoom(ZOOMED_IN);
+                mapRef.current.setCenter(boundsOrPoint);
+              }
 
-    if (!mapRef.current) {
-      mapRef.current = new window.google.maps.Map(mapContainerRef.current, {
-        center: memoizedCenter,
-        zoom,
-        ...mapOptions,
-      });
-    }
+              // wait for map to stop moving, then update history with new bounds
+              const listener = mapRef.current.addListener('idle', () => {
+                paramsWithBounds.set(
+                  'bounds',
+                  JSON.stringify(mapRef.current.getBounds()),
+                );
 
-    const mapInstance = mapRef.current;
+                // push history with new bounds
+                router.push(`?${paramsWithBounds.toString()}`, {
+                  scroll: false,
+                  shallow: true,
+                });
 
-    const debouncedUpdateBounds = debounce2(() => {
-      const bounds = mapInstance.getBounds();
-      if (bounds) {
-        const ne = bounds.getNorthEast();
-        const sw = bounds.getSouthWest();
-        const currentCenter = mapInstance.getCenter();
-        const currentZoom = mapInstance.getZoom();
+                // remove listener, only want the callback to run once per move
+                google.maps.event.removeListener(listener);
+              });
+            },
+          };
+        },
+        [searchParams, router],
+      );
 
-        if (
-          filters.neLat != ne?.lat() ||
-          filters.neLng != ne?.lng() ||
-          filters.swLat != sw?.lat() ||
-          filters.swLng != sw?.lng()
-        ) {
-          onChangeMapBounds({
-            neLat: ne?.lat(),
-            neLng: ne?.lng(),
-            swLat: sw?.lat(),
-            swLng: sw?.lng(),
-            mapCenterLat: currentCenter?.lat(),
-            mapCenterLng: currentCenter?.lng(),
-            zoom: currentZoom,
+      // Initialize Google Map once
+      useEffect(() => {
+        if (!isLoaded || !window.google || !mapContainerRef.current) return;
+
+        if (!mapRef.current) {
+          mapRef.current = new window.google.maps.Map(mapContainerRef.current, {
+            center: INIT_CENTER,
+            zoom: INITIAL_ZOOM,
+            ...mapOptions,
           });
         }
-      }
-    }, 500);
 
-    const idleListener = mapInstance.addListener('idle', () => {
-      debouncedUpdateBounds();
-    });
-
-    return () => {
-      window.google.maps.event.removeListener(idleListener);
-    };
-  }, [isLoaded, memoizedCenter, zoom, onChangeMapBounds, filters]);
-
-  // Update map center and zoom without reinitializing the map
-  useEffect(() => {
-    if (mapRef.current) {
-      mapRef.current.setCenter(memoizedCenter);
-      mapRef.current.setZoom(zoom);
-    }
-  }, [memoizedCenter, zoom]);
-
-  const clearMarkers = () => {
-    if (markersRef.current.length > 0) {
-      markersRef.current.forEach((marker) => marker.setMap(null));
-      markersRef.current = [];
-    }
-
-    if (markerClusterRef.current) {
-      markerClusterRef.current.clearMarkers();
-      markerClusterRef.current = null;
-    }
-  };
-
-  // Memoize the createMarkers function to prevent it from changing on every render
-  const createMarkers = useCallback(() => {
-    if (!mapRef.current || !window.google) {
-      console.log('Map or Google not ready yet');
-      return [];
-    }
-
-    return campaigns.map((campaign) => {
-      const marker = new window.google.maps.Marker({
-        position: campaign.position,
-        map: mapRef.current,
-        title: campaign.name,
-        icon: {
-          url: 'https://assets.goodparty.org/gp-marker-single.png',
-          scaledSize: new window.google.maps.Size(50, 50),
-        },
-      });
-
-      marker.addListener('click', () => {
-        onSelectCampaign(campaign);
-      });
-
-      return marker;
-    });
-  }, [campaigns, onSelectCampaign]);
-
-  // Update markers when campaigns change
-  useEffect(() => {
-    if (!mapRef.current || !isLoaded || !window.google) {
-      return;
-    }
-
-    if (campaigns.length === 0) {
-      clearMarkers();
-      return;
-    }
-
-    clearMarkers();
-    const markers = createMarkers();
-    markersRef.current = markers;
-
-    if (markerClusterRef.current) {
-      markerClusterRef.current.clearMarkers();
-    }
-
-    const algorithm = new SuperClusterAlgorithm({
-      maxZoom: 15,
-      radius: 150,
-    });
-
-    const newMarkerCluster = new MarkerClusterer({
-      markers,
-      map: mapRef.current,
-      algorithm: algorithm,
-      renderer: {
-        render({ count, position }) {
-          let iconSize, labelFontSize;
-          if (count < 10) {
-            iconSize = new window.google.maps.Size(60, 60);
-            labelFontSize = '11px';
-          } else if (count < 100) {
-            iconSize = new window.google.maps.Size(80, 80);
-            labelFontSize = '11px';
-          } else {
-            iconSize = new window.google.maps.Size(100, 100);
-            labelFontSize = '11px';
+        const debouncedUpdateBounds = debounce2(() => {
+          const bounds = mapRef.current.getBounds();
+          if (bounds) {
+            onChangeMapBounds(bounds);
           }
+        }, 500);
 
-          return new window.google.maps.Marker({
-            position,
+        const idleListener = mapRef.current.addListener(
+          'bounds_changed',
+          () => {
+            debouncedUpdateBounds();
+          },
+        );
+
+        return () => {
+          window.google.maps.event.removeListener(idleListener);
+        };
+      }, [isLoaded, onChangeMapBounds]);
+
+      const clearMarkers = () => {
+        if (markersRef.current.length > 0) {
+          markersRef.current.forEach((marker) => marker.setMap(null));
+          markersRef.current = [];
+        }
+
+        if (markerClusterRef.current) {
+          markerClusterRef.current.clearMarkers();
+          markerClusterRef.current = null;
+        }
+      };
+
+      // Memoize the createMarkers function to prevent it from changing on every render
+      const createMarkers = useCallback(() => {
+        if (!mapRef.current || !window.google) {
+          console.log('Map or Google not ready yet');
+          return [];
+        }
+
+        return campaigns.map((campaign) => {
+          const marker = new window.google.maps.Marker({
+            position: campaign.position,
+            map: mapRef.current,
+            title: campaign.name,
             icon: {
-              url: 'https://assets.goodparty.org/map-cluster-icon-center.png',
-              scaledSize: iconSize,
-              labelOrigin: new window.google.maps.Point(
-                iconSize.width / 2,
-                iconSize.height / 2,
-              ),
+              url: 'https://assets.goodparty.org/gp-marker-single.png',
+              scaledSize: new window.google.maps.Size(50, 50),
             },
-            label: {
-              text: String(count),
-              color: 'white',
-              fontSize: labelFontSize,
-              className: 'cluster-label',
-            },
-            clickable: true,
           });
-        },
-      },
-    });
 
-    markerClusterRef.current = newMarkerCluster;
+          marker.addListener('click', () => {
+            onSelectCampaign(campaign);
+          });
 
-    return () => {
-      clearMarkers();
-    };
-  }, [campaigns, isLoaded, createMarkers]);
+          return marker;
+        });
+      }, [campaigns, onSelectCampaign]);
 
-  // Listen for URL changes to update the map when back button is pressed
-  useEffect(() => {
-    const lat = parseFloat(searchParams.get('mapCenterLat'));
-    const lng = parseFloat(searchParams.get('mapCenterLng'));
-    const zoomLevel = parseInt(searchParams.get('zoom'), 10);
+      // Update markers when campaigns change
+      useEffect(() => {
+        if (!mapRef.current || !isLoaded || !window.google) {
+          return;
+        }
 
-    if (mapRef.current && !isNaN(lat) && !isNaN(lng) && !isNaN(zoomLevel)) {
-      mapRef.current.setCenter({ lat, lng });
-      mapRef.current.setZoom(zoomLevel);
-    }
-  }, [searchParams.toString()]);
+        if (campaigns.length === 0) {
+          clearMarkers();
+          return;
+        }
 
-  return (
-    <div className="h-[calc(100vh-56px-220px)] md:h-[calc(100vh-56px)] relative">
-      <div ref={mapContainerRef} style={containerStyle}>
-        {/* Map will be rendered here */}
-      </div>
-    </div>
-  );
-};
+        clearMarkers();
+        const markers = createMarkers();
+        markersRef.current = markers;
+
+        if (markerClusterRef.current) {
+          markerClusterRef.current.clearMarkers();
+        }
+
+        const algorithm = new SuperClusterAlgorithm({
+          maxZoom: 15,
+          radius: 150,
+        });
+
+        const newMarkerCluster = new MarkerClusterer({
+          markers,
+          map: mapRef.current,
+          algorithm: algorithm,
+          onClusterClick: (_e, cluster) => {
+            onClusterClick(cluster);
+          },
+          renderer: {
+            render({ count, position }) {
+              let iconSize, labelFontSize;
+              if (count < 10) {
+                iconSize = new window.google.maps.Size(60, 60);
+                labelFontSize = '11px';
+              } else if (count < 100) {
+                iconSize = new window.google.maps.Size(80, 80);
+                labelFontSize = '11px';
+              } else {
+                iconSize = new window.google.maps.Size(100, 100);
+                labelFontSize = '11px';
+              }
+
+              return new window.google.maps.Marker({
+                position,
+                icon: {
+                  url: 'https://assets.goodparty.org/map-cluster-icon-center.png',
+                  scaledSize: iconSize,
+                  labelOrigin: new window.google.maps.Point(
+                    iconSize.width / 2,
+                    iconSize.height / 2,
+                  ),
+                },
+                label: {
+                  text: String(count),
+                  color: 'white',
+                  fontSize: labelFontSize,
+                  className: 'cluster-label',
+                },
+              });
+            },
+          },
+        });
+
+        markerClusterRef.current = newMarkerCluster;
+
+        return () => {
+          clearMarkers();
+        };
+      }, [campaigns, isLoaded, createMarkers]);
+
+      // Listen for URL changes to update the map when back button is pressed
+      useEffect(() => {
+        if (!searchParams.has('bounds')) return;
+        const boundsParam = searchParams.get('bounds');
+
+        try {
+          const bounds = JSON.parse(boundsParam);
+          const mapBounds = mapRef.current?.getBounds().toJSON();
+
+          if (
+            mapRef.current &&
+            typeof bounds === 'object' &&
+            !isObjectEqual(bounds, mapBounds)
+          ) {
+            mapRef.current.fitBounds(bounds);
+          }
+        } catch (e) {
+          console.error('Failed to move map bounds: ', e);
+        }
+      }, [searchParams.toString()]);
+
+      return (
+        <div className="h-[calc(100vh-56px-220px)] md:h-[calc(100vh-56px)] relative">
+          <div ref={mapContainerRef} style={containerStyle}>
+            {/* Map will be rendered here */}
+          </div>
+        </div>
+      );
+    },
+  ),
+);
 
 Map.displayName = 'Map';
 

--- a/app/candidates/components/map/Map.js
+++ b/app/candidates/components/map/Map.js
@@ -172,10 +172,11 @@ const Map = memo(
         }
 
         return campaigns.map((campaign) => {
+          const title = `${campaign.firstName} ${campaign.lastName}`;
           const marker = new window.google.maps.Marker({
             position: campaign.position,
             map: mapRef.current,
-            title: campaign.name,
+            title,
             icon: {
               url: 'https://assets.goodparty.org/gp-marker-single.png',
               scaledSize: new window.google.maps.Size(50, 50),
@@ -184,6 +185,23 @@ const Map = memo(
 
           marker.addListener('click', () => {
             onSelectCampaign(campaign);
+          });
+
+          const infowindow = new google.maps.InfoWindow({
+            headerDisabled: true,
+            content: `<h3 style="font-weight: 700">${title}</h3><p>Candidate for ${campaign.normalizedOffice}</p>`,
+            ariaLabel: campaign.name,
+          });
+
+          marker.addListener('mouseover', () => {
+            infowindow.open({
+              anchor: marker,
+              map: mapRef.current,
+            });
+          });
+
+          marker.addListener('mouseout', () => {
+            infowindow.close();
           });
 
           return marker;

--- a/app/candidates/components/map/Map.js
+++ b/app/candidates/components/map/Map.js
@@ -61,7 +61,6 @@ const Map = memo(
         () => {
           return {
             moveMapWithHistory: (boundsOrPoint) => {
-              // console.log(searchParams);
               const paramsWithBounds = new URLSearchParams({
                 ...Object.fromEntries(searchParams),
                 bounds: JSON.stringify(mapRef.current.getBounds()),
@@ -113,7 +112,7 @@ const Map = memo(
             },
           };
         },
-        [searchParams, router],
+        [searchParams, router, campaigns],
       );
 
       // Initialize Google Map once

--- a/app/candidates/components/map/MapSection.js
+++ b/app/candidates/components/map/MapSection.js
@@ -45,9 +45,8 @@ export default memo(function MapSection({ isLoaded, state, searchParams }) {
   }, [searchParams, state]);
 
   useEffect(() => {
-    if (!mapBounds) return;
     // filter visible campaigns
-    const { neLat, neLng, swLat, swLng } = mapBounds;
+    const { neLat, neLng, swLat, swLng } = mapBounds || {};
 
     if (neLat && neLng && swLat && swLng) {
       const visibleCampaigns = campaigns.filter(filterPosition);

--- a/app/candidates/components/map/MapSection.js
+++ b/app/candidates/components/map/MapSection.js
@@ -45,6 +45,7 @@ export default memo(function MapSection({ isLoaded, state, searchParams }) {
   }, [searchParams, state]);
 
   useEffect(() => {
+    if (!mapBounds) return;
     // filter visible campaigns
     const { neLat, neLng, swLat, swLng } = mapBounds;
 

--- a/app/candidates/components/map/MapSection.js
+++ b/app/candidates/components/map/MapSection.js
@@ -1,94 +1,94 @@
 'use client';
-import {
-  createContext,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import Map from './Map';
 import Results from './Results';
 import Filters from './Filters';
 import CampaignPreview from './CampaignPreview';
-import { CircularProgress, debounce } from '@mui/material';
-import H2 from '@shared/typography/H2';
 import WinnerListSection from '../winners/WinnerListSection';
 import { useMapCampaigns } from '@shared/hooks/useMapCampaigns';
 import ShareMap from './ShareMap';
 import { useRouter } from 'next/navigation';
-import { debounce2 } from 'helpers/debounceHelper';
+import { isObjectEqual } from 'helpers/objectHelper';
+import { CircularProgress } from '@mui/material';
 
-export const MapContext = createContext();
-
-const ZOOMED_IN = 14;
-const INITIAL_ZOOM = 5;
-
-const INIT_CENTER = {
-  lat: 39.8283,
-  lng: -98.5795,
-};
-
-export default function MapSection({ isLoaded, state, searchParams }) {
-  const [allCampaigns, setAllCampaigns] = useState(null); // State to store the first response
+export default memo(function MapSection({ isLoaded, state, searchParams }) {
   const router = useRouter();
   const [selectedCampaign, setSelectedCampaign] = useState(null);
+  const [visibleCampaigns, setVisibleCampaigns] = useState(null);
+  const [mapBounds, setMapBounds] = useState();
+  const mapRef = useRef(null);
   const [filters, setFilters] = useState({
     party: searchParams?.party || '',
-    state: state || '',
+    state: state || searchParams?.state || '',
     level: searchParams?.level || '',
     results: searchParams?.results === 'true',
     office: searchParams?.office || '',
     name: searchParams?.name || '',
-    neLat: searchParams?.neLat || false,
-    neLng: searchParams?.neLng || false,
-    swLat: searchParams?.swLat || false,
-    swLng: searchParams?.swLng || false,
-    zoom: searchParams?.zoom || INITIAL_ZOOM,
-    mapCenterLat: searchParams?.mapCenterLat || '',
-    mapCenterLng: searchParams?.mapCenterLng || '',
   });
+  const { campaigns, isCampaignsLoading: loading } = useMapCampaigns(filters);
+
   useEffect(() => {
-    // if (!searchParams) return;
-    setFilters({
-      party: searchParams?.party || '',
-      state: state || '',
-      level: searchParams?.level || '',
-      results: searchParams?.results === 'true',
-      office: searchParams?.office || '',
-      name: searchParams?.name || '',
-      neLat: searchParams?.neLat || false,
-      neLng: searchParams?.neLng || false,
-      swLat: searchParams?.swLat || false,
-      swLng: searchParams?.swLng || false,
-      zoom: searchParams?.zoom || INITIAL_ZOOM,
-      mapCenterLat: searchParams?.mapCenterLat || '',
-      mapCenterLng: searchParams?.mapCenterLng || '',
+    setFilters((currentFilters) => {
+      const searchParamFilters = {
+        party: searchParams?.party || '',
+        state: state || searchParams?.state || '',
+        level: searchParams?.level || '',
+        results: searchParams?.results === 'true',
+        office: searchParams?.office || '',
+        name: searchParams?.name || '',
+      };
+
+      return isObjectEqual(currentFilters, searchParamFilters)
+        ? currentFilters
+        : searchParamFilters;
     });
   }, [searchParams, state]);
 
-  const isFilterEmpty = Object.values(filters).every((val) => !val);
-  const { campaigns } = useMapCampaigns(isFilterEmpty ? null : filters);
-
   useEffect(() => {
-    // Only cache the first response
-    if (campaigns.length > 0 && !allCampaigns) {
-      setAllCampaigns(campaigns);
-    }
-  }, [campaigns, allCampaigns]);
+    // filter visible campaigns
+    const { neLat, neLng, swLat, swLng } = mapBounds;
 
-  const mapRef = useRef(null);
+    if (neLat && neLng && swLat && swLng) {
+      const visibleCampaigns = campaigns.filter(filterPosition);
+      setVisibleCampaigns(visibleCampaigns);
+      return;
+    }
+
+    setVisibleCampaigns(null);
+
+    function filterPosition(campaign) {
+      // Geolocation filtering
+      if (campaign.position.lat && campaign.position.lng) {
+        if (
+          campaign.position.lat < swLat ||
+          campaign.position.lat > neLat ||
+          campaign.position.lng < swLng ||
+          campaign.position.lng > neLng
+        ) {
+          return false;
+        }
+        return true;
+      } else {
+        return true;
+      }
+    }
+  }, [campaigns, mapBounds]);
 
   const onChangeFilters = useCallback(
     (key, val) => {
-      // add the filters to the url query only if they are not empty
+      setFilters((currentFilters) => {
+        // return same filter object if no filters values changed
+        if (currentFilters[key] === val) {
+          return currentFilters;
+        }
 
-      setFilters((prev) => {
         const updatedFilters = {
-          ...prev,
+          ...searchParams,
+          ...currentFilters,
           [key]: val,
         };
 
+        // add the filters to the url query only if they are not empty
         const query = Object.entries(updatedFilters).reduce(
           (acc, [key, val]) => {
             if (val) {
@@ -99,116 +99,102 @@ export default function MapSection({ isLoaded, state, searchParams }) {
           {},
         );
 
-        const queryString = new URLSearchParams(query).toString();
-        router.push(`?${queryString}`, { scroll: false, shallow: true });
+        const queryString = new URLSearchParams(query);
+        router.push(`?${queryString.toString()}`, {
+          scroll: false,
+          shallow: true,
+        });
 
         return updatedFilters;
       });
     },
-    [router, filters],
+    [router, searchParams],
   );
-
-  // on Change Filters that can take multiple keys and values
-  const onChangeFiltersMultiple = (newFilters) => {
-    const query = Object.entries({
-      ...filters,
-      ...newFilters,
-    }).reduce((acc, [key, val]) => {
-      if (val) {
-        acc[key] = val;
-      }
-      return acc;
-    }, {});
-
-    setFilters((prev) => ({
-      ...prev,
-      ...newFilters,
-    }));
-
-    const queryString = new URLSearchParams(query).toString();
-    router.push(`?${queryString}`, { scroll: false, shallow: true });
-  };
 
   const onChangeMapBounds = useCallback((bounds) => {
-    onChangeFiltersMultiple(bounds);
+    const { lat: neLat, lng: neLng } = bounds.getNorthEast().toJSON();
+    const { lat: swLat, lng: swLng } = bounds.getSouthWest().toJSON();
+
+    setMapBounds({ neLat, neLng, swLat, swLng });
   }, []);
 
-  const onSelectCampaign = (campaign) => {
-    if (
-      !campaign ||
-      (selectedCampaign && selectedCampaign.slug === campaign.slug)
-    ) {
-      setSelectedCampaign(null);
-      return;
-    }
-    onChangeFiltersMultiple({
-      zoom: ZOOMED_IN,
-      mapCenterLat: campaign.position.lat,
-      mapCenterLng: campaign.position.lng,
+  const onSelectCampaign = useCallback((campaign) => {
+    if (!mapRef.current) return;
+
+    setSelectedCampaign((currentSelected) => {
+      if (
+        !campaign ||
+        (currentSelected && currentSelected.slug === campaign.slug)
+      ) {
+        return null;
+      }
+
+      mapRef.current.moveMapWithHistory(campaign.position);
+
+      return campaign;
     });
+  }, []);
 
-    setSelectedCampaign(campaign);
-  };
-  const center = {
-    lat: filters.mapCenterLat
-      ? parseFloat(filters.mapCenterLat)
-      : INIT_CENTER.lat,
-    lng: filters.mapCenterLng
-      ? parseFloat(filters.mapCenterLng)
-      : INIT_CENTER.lng,
-  };
+  const onClusterClick = useCallback((cluster) => {
+    if (!mapRef.current) return;
 
-  const zoom = filters.zoom ? parseInt(filters.zoom, 10) : INITIAL_ZOOM;
-  // Memoized childProps to prevent unnecessary re-renders
-  const childProps = useMemo(
-    () => ({
-      campaigns,
-      filters,
-      onChangeFilters,
-      mapCenter: center,
-      isLoaded,
-      zoom,
-      mapRef,
-      onSelectCampaign,
-      selectedCampaign,
-      onChangeMapBounds,
-    }),
-    [
-      campaigns,
-      filters,
-      center,
-      isLoaded,
-      selectedCampaign,
-      onChangeFilters,
-      onChangeMapBounds,
-    ],
-  );
+    mapRef.current.moveMapWithHistory(cluster.bounds);
+  }, []);
 
-  if (selectedCampaign) {
-    console.log('selectedCampaign', selectedCampaign);
-  }
+  const onZoomOut = useCallback(() => {
+    if (!mapRef.current) return;
+
+    mapRef.current.moveMapWithHistory('full');
+  }, []);
 
   return (
     <>
-      <MapContext.Provider value={childProps}>
-        <div className="bg-primary-dark">
-          <section className="md:h-[calc(100vh-56px)] bg-primary-dark px-4 lg:px-8 overflow-hidden relative">
-            <div className="md:flex flex-row-reverse rounded-2xl overflow-hidden">
-              <div className="flex-1 h-3/4 md:h-auto">
-                <Map />
-              </div>
-              <div className="flex flex-col shadow-lg md:relative z-20">
-                <Filters />
-                <Results />
-                <CampaignPreview />
-              </div>
+      <div className="bg-primary-dark">
+        <section className="md:h-[calc(100vh-56px)] bg-primary-dark px-4 lg:px-8 overflow-hidden relative">
+          <div className="md:flex flex-row-reverse rounded-2xl overflow-hidden">
+            <div className="relative flex-1 h-3/4 md:h-auto">
+              {loading && (
+                <div className="absolute inset-0 z-50 bg-black/[0.6] pointer-events-none flex justify-center items-center">
+                  <CircularProgress
+                    size={80}
+                    variant="indeterminate"
+                    disableShrink
+                  />
+                </div>
+              )}
+              <Map
+                ref={mapRef}
+                campaigns={campaigns}
+                isLoaded={isLoaded}
+                onChangeMapBounds={onChangeMapBounds}
+                onSelectCampaign={onSelectCampaign}
+                onClusterClick={onClusterClick}
+              />
             </div>
-          </section>
-          <ShareMap />
-          <div className="h-4 md:h-8 bg-primary-dark">&nbsp;</div>
-        </div>
-      </MapContext.Provider>
-      <WinnerListSection allCampaigns={allCampaigns} />
+            <div className="flex flex-col shadow-lg md:relative z-20">
+              <Filters
+                campaigns={campaigns}
+                filters={filters}
+                onChangeFilters={onChangeFilters}
+              />
+              <Results
+                onZoomOut={onZoomOut}
+                totalNumCampaigns={campaigns.length}
+                campaigns={visibleCampaigns || campaigns}
+                onSelectCampaign={onSelectCampaign}
+                selectedCampaign={selectedCampaign}
+              />
+              <CampaignPreview
+                selectedCampaign={selectedCampaign}
+                onSelectCampaign={onSelectCampaign}
+              />
+            </div>
+          </div>
+        </section>
+        <ShareMap />
+        <div className="h-4 md:h-8 bg-primary-dark">&nbsp;</div>
+      </div>
+      <WinnerListSection />
     </>
   );
-}
+});

--- a/app/candidates/components/map/Results.js
+++ b/app/candidates/components/map/Results.js
@@ -1,22 +1,50 @@
 'use client';
 
-import { useContext } from 'react';
+import { memo } from 'react';
 import CampaignSnippet from './CampaignSnippet';
-import { MapContext } from './MapSection';
 import H5 from '@shared/typography/H5';
 import H3 from '@shared/typography/H3';
 import Body1 from '@shared/typography/Body1';
 import Button from '@shared/buttons/Button';
 import { useUser } from '@shared/hooks/useUser';
+import { ZoomOutMapRounded } from '@mui/icons-material';
 
-export default function Results(props) {
-  const { campaigns } = useContext(MapContext);
+export default memo(function Results({
+  campaigns,
+  totalNumCampaigns,
+  onSelectCampaign,
+  selectedCampaign,
+  onZoomOut,
+}) {
   const user = useUser();
+  const viewingSubset = campaigns.length < totalNumCampaigns;
+
   return (
     <div className="md:w-[400px] lg:w-[500px] h-80  md:h-[calc(100vh-56px-298px)] border-r border-gray-300 md:overflow-y-auto bg-indigo-100 overflow-auto">
-      <H5 className="p-6">{campaigns.length} candidates</H5>
+      <H5 className="p-6 flex gap-2 items-center">
+        Viewing {campaigns.length} candidates
+        {viewingSubset && (
+          <>
+            <span className="font-normal">({totalNumCampaigns} total)</span>
+            <Button
+              onClick={onZoomOut}
+              size="small"
+              color="white"
+              className="ml-auto flex gap-2 items-center"
+            >
+              <ZoomOutMapRounded className="text-sm" />
+              Zoom Out
+            </Button>
+          </>
+        )}
+      </H5>
       {campaigns.map((campaign) => (
-        <CampaignSnippet key={campaign.slug} campaign={campaign} />
+        <CampaignSnippet
+          key={campaign.slug}
+          campaign={campaign}
+          onSelectCampaign={onSelectCampaign}
+          selectedCampaign={selectedCampaign}
+        />
       ))}
       {campaigns.length === 0 && (
         <div className="px-4">
@@ -37,4 +65,4 @@ export default function Results(props) {
       )}
     </div>
   );
-}
+});

--- a/app/candidates/components/map/ShareMap.js
+++ b/app/candidates/components/map/ShareMap.js
@@ -4,12 +4,12 @@ import H2 from '@shared/typography/H2';
 import Modal from '@shared/utils/Modal';
 import { appBase } from 'gpApi';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { FaLinkedin } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
 import { MdFacebook, MdShare } from 'react-icons/md';
 
-export default function ShareMap() {
+export default memo(function ShareMap() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
   const url = appBase + pathname;
@@ -77,4 +77,4 @@ export default function ShareMap() {
       </Modal>
     </div>
   );
-}
+});

--- a/app/candidates/components/winners/WinnerListSection.js
+++ b/app/candidates/components/winners/WinnerListSection.js
@@ -4,8 +4,9 @@ import MarketingH4 from '@shared/typography/MarketingH4';
 import Image from 'next/image';
 import WinnerFilters from './WinnerFilters';
 import MaxWidth from '@shared/layouts/MaxWidth';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import FilteredWinnerList from './FilteredWinnerList';
+import { useMapCampaigns } from '@shared/hooks/useMapCampaigns';
 
 // const tempCampaigns = [
 //   {
@@ -155,7 +156,8 @@ import FilteredWinnerList from './FilteredWinnerList';
 //   },
 // ];
 
-export default function WinnerListSection({ allCampaigns = [] }) {
+export default memo(function WinnerListSection() {
+  const { campaigns: allCampaigns } = useMapCampaigns(null);
   const [campaigns, setCampaigns] = useState([]);
   const [offices, setOffices] = useState([]);
 
@@ -222,4 +224,4 @@ export default function WinnerListSection({ allCampaigns = [] }) {
       </MaxWidth>
     </div>
   );
-}
+});

--- a/app/shared/hooks/useMapCampaigns.js
+++ b/app/shared/hooks/useMapCampaigns.js
@@ -30,15 +30,18 @@ export const useMapCampaigns = (filters) => {
   const [isCampaignsLoading, setIsCampaignsLoading] = useState(false);
 
   useEffect(() => {
+    const isFilterEmpty =
+      !filters || Object.values(filters).every((val) => !val);
     setIsCampaignsLoading(true);
-    loadCampaigns(filters);
+    loadCampaigns(isFilterEmpty ? null : filters);
   }, [filters]);
 
-  const loadCampaigns = async (filters) => {
+  async function loadCampaigns(filters) {
+    console.log('loading map campaigns');
     const { campaigns } = await fetchCampaigns(filters);
     setCampaigns(campaigns || []);
     setIsCampaignsLoading(false);
-  };
+  }
 
   return { campaigns, isCampaignsLoading, setIsCampaignsLoading };
 };

--- a/app/shared/hooks/useMapCampaigns.js
+++ b/app/shared/hooks/useMapCampaigns.js
@@ -37,7 +37,6 @@ export const useMapCampaigns = (filters) => {
   }, [filters]);
 
   async function loadCampaigns(filters) {
-    console.log('loading map campaigns');
     const { campaigns } = await fetchCampaigns(filters);
     setCampaigns(campaigns || []);
     setIsCampaignsLoading(false);

--- a/helpers/objectHelper.js
+++ b/helpers/objectHelper.js
@@ -1,0 +1,19 @@
+/**
+ * Helper for checking equality between two objects
+ * @param {object} x
+ * @param {object} y
+ * @param {boolean} deepCompare pass to recursively check deep equality
+ * @returns {boolean}
+ */
+
+export function isObjectEqual(x, y, deepCompare = false) {
+  const ok = Object.keys,
+    tx = typeof x,
+    ty = typeof y;
+  return x && y && tx === 'object' && tx === ty
+    ? ok(x).length === ok(y).length &&
+        ok(x).every((key) =>
+          deepCompare ? deepEqual(x[key], y[key]) : x[key] === y[key],
+        )
+    : x === y;
+}


### PR DESCRIPTION
This PR updates the candidates map page to do the viewport filtering on the front end, this allows us to show the user how many campaigns are outside the current view, and give a button to zoom out to see all loaded campaigns. 

The rest of the filters are done on the backend still.

This also improves performance a little by avoiding some unnecessary re-renders, and simplifies keeping map bounds in query params for back button functionality on relevant map navigations.