### PR TITLE
WEB-3302: Text Campaign Schedule image upload allows users to move forward when Image is too large

### DIFF
--- a/app/(candidate)/dashboard/shared/DashboardMenu.js
+++ b/app/(candidate)/dashboard/shared/DashboardMenu.js
@@ -22,6 +22,13 @@ const CAMPAIGN_TEAM_MENU_ITEM = {
   id: 'campaign-team-dashboard',
 };
 
+const VOTER_DATA_UPGRADE_ITEM = {
+  label: 'Voter Data',
+  icon: <GiProgression />,
+  link: '/dashboard/upgrade-to-pro',
+  id: 'upgrade-pro-dashboard',
+};
+
 const DEFAULT_MENU_ITEMS = [
   {
     label: 'Campaign Tracker',
@@ -35,13 +42,7 @@ const DEFAULT_MENU_ITEMS = [
   //   link: '/dashboard/campaign-assistant',
   //   id: 'campaign-assistant-dashboard',
   // },
-  {
-    label: 'Voter Data',
-    icon: <GiProgression />,
-    link: '/dashboard/upgrade-to-pro',
-    id: 'upgrade-pro-dashboard',
-  },
-
+  VOTER_DATA_UPGRADE_ITEM,
   {
     label: 'AI Campaign Plan',
     icon: <TbBrain />,
@@ -81,7 +82,8 @@ const VOTER_RECORDS_MENU_ITEM = {
 const getDashboardMenuItems = (campaign, user) => {
   const menuItems = [...DEFAULT_MENU_ITEMS];
   if (campaign?.isPro) {
-    menuItems[2] = VOTER_RECORDS_MENU_ITEM;
+    const index = menuItems.indexOf(VOTER_DATA_UPGRADE_ITEM);
+    menuItems[index] = VOTER_RECORDS_MENU_ITEM;
   }
 
   return menuItems;

--- a/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowImageStep.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowImageStep.js
@@ -18,6 +18,7 @@ export default function ScheduleFlowImageStep({
   backCallback,
 }) {
   const [file, setFile] = useState(image);
+  const fileTooLarge = file?.size > MAX_FILE_SIZE;
 
   function handleOnChange(newFile) {
     setFile(newFile);
@@ -35,7 +36,7 @@ export default function ScheduleFlowImageStep({
       <Body1 className="text-center my-8">
         Attach your image below.
         <br />
-        <span className={file?.size > MAX_FILE_SIZE ? 'text-error' : ''}>
+        <span className={fileTooLarge ? 'text-error' : ''}>
           Max file size:&nbsp;
           {file ? `${(Number(file.size) / 1000).toLocaleString()} kB / ` : ''}
           {(MAX_FILE_SIZE / 1000).toLocaleString()} kB
@@ -54,7 +55,7 @@ export default function ScheduleFlowImageStep({
       )}
       <div className="mt-8 flex justify-between">
         <SecondaryButton onClick={backCallback}>Back</SecondaryButton>
-        <PrimaryButton disabled={!file} onClick={nextCallback}>
+        <PrimaryButton disabled={!file || fileTooLarge} onClick={nextCallback}>
           Next
         </PrimaryButton>
       </div>


### PR DESCRIPTION
This fixes a weird edge case where cropping an image ends up with a larger file size than the original image. A user was able to continue the scheduling process even though the image was too large, and the submit failed silently for them.

It also fixes the duplicate `Voter Data` dashboard menu link in a more permanent way