### PR TITLE
WEB-3094: Prevent close confirmation from showing after a complete schedule

### DIFF
--- a/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlow.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlow.js
@@ -75,7 +75,7 @@ export default function ScheduleFlow({
   };
 
   const handleClose = () => {
-    if (isObjectEqual(state, DEFAULT_STATE)) {
+    if (isObjectEqual(state, DEFAULT_STATE) || stepName === 'complete') {
       handleCloseConfirm();
       return;
     }
@@ -119,7 +119,7 @@ export default function ScheduleFlow({
       ...state,
       type,
     };
-    await scheduleVoterMessagingCampaign(updatedState);
+    return await scheduleVoterMessagingCampaign(updatedState);
   };
 
   const handleAddScriptOnComplete = (scriptKeyOrText) => {

--- a/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowScheduleStep.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowScheduleStep.js
@@ -52,11 +52,11 @@ export default function ScheduleFlowScheduleStep({
     const resp = await submitCallback();
 
     if (resp.ok === false) {
-      errorSnackbar('Failed to schedule campaign.');
+      errorSnackbar('Failed to submit request.');
       return;
     }
 
-    successSnackbar('Campaign scheduled successfully.');
+    successSnackbar('Request submitted successfully.');
     nextCallback();
   };
   const isTel = type === 'telemarketing';

--- a/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowScheduleStep.js
+++ b/app/(candidate)/dashboard/voter-records/[type]/components/ScheduleFlowScheduleStep.js
@@ -7,6 +7,7 @@ import H1 from '@shared/typography/H1';
 import { buildTrackingAttrs } from 'helpers/fullStoryHelper';
 import { useState, useMemo } from 'react';
 import { getDefaultVoterFileName } from '../../components/VoterFileTypes';
+import { useSnackbar } from 'helpers/useSnackbar';
 
 export default function ScheduleFlowScheduleStep({
   onChangeCallback,
@@ -17,6 +18,7 @@ export default function ScheduleFlowScheduleStep({
   type,
   schedule,
 }) {
+  const { errorSnackbar, successSnackbar } = useSnackbar();
   const [state, setState] = useState(
     schedule || {
       date: '',
@@ -46,9 +48,16 @@ export default function ScheduleFlowScheduleStep({
 
   const canSubmit = () => state.date != '' && state.message != '';
 
-  const handleNext = () => {
+  const handleNext = async () => {
+    const resp = await submitCallback();
+
+    if (resp.ok === false) {
+      errorSnackbar('Failed to schedule campaign.');
+      return;
+    }
+
+    successSnackbar('Campaign scheduled successfully.');
     nextCallback();
-    submitCallback();
   };
   const isTel = type === 'telemarketing';
   const today = new Date();


### PR DESCRIPTION
- Fixes an issue in the Campaign Schedule flow where the close confirmation modal window opens when trying to close out of the scheduling flow after completing it.
- Also adds snackbar messages for success/error of the actual scheduling call