### PR TITLE
WEB-3215: Add stories to all the components in the shared folder

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,14 @@ import '../app/globals.css';
 
 const preview = {
   parameters: {
+    backgrounds: {
+      values: [
+        { name: 'Dark', value: '#0D1528' }, // indigo-900
+        { name: 'Medium', value: '#EEF3F6' }, // indigo-100
+        { name: 'Light', value: '#F7FAFB'} // indigo-50
+      ],
+      default: 'Light',
+    },
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       matchers: {

--- a/app/shared/ModalFooter.stories.js
+++ b/app/shared/ModalFooter.stories.js
@@ -1,0 +1,10 @@
+import { ModalFooter } from './ModalFooter';
+
+export default {
+  title: 'Uncategorized/ModalFooter',
+  component: ModalFooter,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/PaymentPortalButton.stories.js
+++ b/app/shared/PaymentPortalButton.stories.js
@@ -1,0 +1,10 @@
+import { PaymentPortalButton } from './PaymentPortalButton';
+
+export default {
+  title: 'Uncategorized/PaymentPortalButton',
+  component: PaymentPortalButton,
+  tags: ['autodocs'],
+  args: { children: 'Payment Portal Button' },
+};
+
+export const Default = {};

--- a/app/shared/acknowledgements/AcknowledgementQuestion.stories.js
+++ b/app/shared/acknowledgements/AcknowledgementQuestion.stories.js
@@ -1,0 +1,60 @@
+import { PersonRounded } from '@mui/icons-material';
+import { AcknowledgementQuestion } from './AcknowledgementQuestion';
+
+export default {
+  title: 'Acknowledgements/AcknowledgementQuestion',
+  component: AcknowledgementQuestion,
+  tags: ['autodocs'],
+  args: {
+    emoticon: <PersonRounded />,
+    title: 'Independent',
+    body: `I am an independent, non-partisan, or third-party candidate. I am committed to the interests of the people above myself and partisan politics.
+
+I am NOT running as a Republican or Democrat in a partisan election. I am committed to running and serving independent of the two-major parties. I will represent people from across the political spectrum and be dedicated to advancing the priorities of my constituents.
+
+I pledge I will NOT pay membership dues to or otherwise engage in fundraising for either of the two major political party committees while in office, and will remain open to working with all sides to the benefit of my constituents.
+    `,
+    show: true,
+  },
+
+  argTypes: {
+    title: {
+      type: 'string',
+    },
+    body: {
+      type: 'string',
+    },
+    show: {
+      type: 'boolean',
+    },
+    acknowledged: {
+      type: 'boolean',
+    },
+    buttonTexts: {
+      type: {
+        name: 'array',
+        value: 'string',
+      },
+    },
+  },
+};
+
+export const Default = {};
+
+// export const Primary = {
+//   args: {
+//     variant: 'contained',
+//   },
+// };
+
+// export const Outlined = {
+//   args: {
+//     variant: 'outlined',
+//   },
+// };
+
+// export const Text = {
+//   args: {
+//     variant: 'text',
+//   },
+// };

--- a/app/shared/alerts/Alert.stories.js
+++ b/app/shared/alerts/Alert.stories.js
@@ -1,0 +1,39 @@
+import { StyledAlert } from './StyledAlert';
+
+export default {
+  title: 'Alerts/StyledAlert',
+  component: StyledAlert,
+  tags: ['autodocs'],
+  args: {
+    severity: 'success',
+  },
+  render: (args) => {
+    return (
+      <StyledAlert {...args}>
+        <h4>Alert Box Here</h4>
+        You have recieved an alert for some reason.
+      </StyledAlert>
+    );
+  },
+};
+
+export const Success = {
+  args: {
+    severity: 'success',
+  },
+};
+export const Info = {
+  args: {
+    severity: 'info',
+  },
+};
+export const Warning = {
+  args: {
+    severity: 'warning',
+  },
+};
+export const Error = {
+  args: {
+    severity: 'error',
+  },
+};

--- a/app/shared/animations/CheckmarkAnimation.stories.js
+++ b/app/shared/animations/CheckmarkAnimation.stories.js
@@ -1,0 +1,10 @@
+import CheckmarkAnimation from './CheckmarkAnimation';
+
+export default {
+  title: 'Animations/CheckmarkAnimation',
+  component: CheckmarkAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/GearsAnimation.stories.js
+++ b/app/shared/animations/GearsAnimation.stories.js
@@ -1,0 +1,10 @@
+import GearsAnimation from './GearsAnimation';
+
+export default {
+  title: 'Animations/GearsAnimation',
+  component: GearsAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/HeartAnimation.stories.js
+++ b/app/shared/animations/HeartAnimation.stories.js
@@ -1,0 +1,10 @@
+import HeartAnimation from './HeartAnimation';
+
+export default {
+  title: 'Animations/HeartAnimation',
+  component: HeartAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/LoadingDotsAnimation.stories.js
+++ b/app/shared/animations/LoadingDotsAnimation.stories.js
@@ -1,0 +1,10 @@
+import LoadingDotsAnimation from './LoadingDotsAnimation';
+
+export default {
+  title: 'Animations/LoadingDotsAnimation',
+  component: LoadingDotsAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/LoadingMapAnimation.stories.js
+++ b/app/shared/animations/LoadingMapAnimation.stories.js
@@ -1,0 +1,10 @@
+import LoadingMapAnimation from './LoadingMapAnimation';
+
+export default {
+  title: 'Animations/LoadingMapAnimation',
+  component: LoadingMapAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/PartyAnimation.stories.js
+++ b/app/shared/animations/PartyAnimation.stories.js
@@ -1,0 +1,10 @@
+import PartyAnimation from './PartyAnimation';
+
+export default {
+  title: 'Animations/PartyAnimation',
+  component: PartyAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/SadFaceAnimation.stories.js
+++ b/app/shared/animations/SadFaceAnimation.stories.js
@@ -1,0 +1,10 @@
+import SadFaceAnimation from './SadFaceAnimation';
+
+export default {
+  title: 'Animations/SadFaceAnimation',
+  component: SadFaceAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/VoteAnimation.stories.js
+++ b/app/shared/animations/VoteAnimation.stories.js
@@ -1,0 +1,10 @@
+import VoteAnimation from './VoteAnimation';
+
+export default {
+  title: 'Animations/VoteAnimation',
+  component: VoteAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/animations/WandAnimation.stories.js
+++ b/app/shared/animations/WandAnimation.stories.js
@@ -1,0 +1,10 @@
+import WandAnimation from './WandAnimation';
+
+export default {
+  title: 'Animations/WandAnimation',
+  component: WandAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/buttons/BlackButton.stories.js
+++ b/app/shared/buttons/BlackButton.stories.js
@@ -1,0 +1,17 @@
+import BlackButton from './BlackButton';
+import BlackButtonClient from './BlackButtonClient';
+
+export default {
+  title: 'Buttons/BlackButton',
+  component: BlackButton,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <div className="flex gap-3">
+      <BlackButton {...args}>Black Button</BlackButton>
+      <BlackButtonClient {...args}>Black Button Client</BlackButtonClient>
+    </div>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/buttons/BlackOutlinedButton.stories.js
+++ b/app/shared/buttons/BlackOutlinedButton.stories.js
@@ -1,0 +1,19 @@
+import BlackOutlinedButton from './BlackOutlinedButton';
+import BlackOutlinedButtonClient from './BlackOutlinedButtonClient';
+
+export default {
+  title: 'Buttons/BlackOutlinedButton',
+  component: BlackOutlinedButton,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <div className="flex gap-3">
+      <BlackOutlinedButton {...args}>Black Button</BlackOutlinedButton>
+      <BlackOutlinedButtonClient {...args}>
+        Black Button Client
+      </BlackOutlinedButtonClient>
+    </div>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/buttons/Pill.stories.js
+++ b/app/shared/buttons/Pill.stories.js
@@ -1,0 +1,18 @@
+import Pill from './Pill';
+
+export default {
+  title: 'Buttons/Pill',
+  component: Pill,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <div className="flex gap-3">
+      <Pill {...args}>Pill</Pill>
+      <Pill {...args} outlined>
+        Outlined Pill
+      </Pill>
+    </div>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/buttons/PinkButtonClient.stories.js
+++ b/app/shared/buttons/PinkButtonClient.stories.js
@@ -1,0 +1,10 @@
+import PinkButtonClient from './PinkButtonClient';
+
+export default {
+  title: 'Buttons/PinkButtonClient',
+  component: PinkButtonClient,
+  tags: ['autodocs'],
+  args: { children: 'Pink Button Client' },
+};
+
+export const Default = {};

--- a/app/shared/buttons/PurpleButton.stories.js
+++ b/app/shared/buttons/PurpleButton.stories.js
@@ -1,0 +1,10 @@
+import PurpleButton from './PurpleButton';
+
+export default {
+  title: 'Buttons/PurpleButton',
+  component: PurpleButton,
+  tags: ['autodocs'],
+  args: { children: 'Purple Button' },
+};
+
+export const Default = {};

--- a/app/shared/buttons/QuestionButton.stories.js
+++ b/app/shared/buttons/QuestionButton.stories.js
@@ -1,0 +1,10 @@
+import QuestionButton from './QuestionButton';
+
+export default {
+  title: 'Buttons/QuestionButton',
+  component: QuestionButton,
+  tags: ['autodocs'],
+  args: { children: 'Question Button' },
+};
+
+export const Default = {};

--- a/app/shared/buttons/SeverityButton.stories.js
+++ b/app/shared/buttons/SeverityButton.stories.js
@@ -1,0 +1,24 @@
+import { SeverityButton } from './SeverityButton';
+
+export default {
+  title: 'Buttons/SeverityButton',
+  component: SeverityButton,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <div className="flex gap-3">
+      <SeverityButton {...args}>Info Severity Button</SeverityButton>
+      <SeverityButton {...args} severity="warning">
+        Warning Severity Button
+      </SeverityButton>
+      <SeverityButton {...args} severity="error">
+        Error Severity Button
+      </SeverityButton>
+      <SeverityButton {...args} severity="success">
+        Success Severity Button
+      </SeverityButton>
+    </div>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/buttons/YellowButton.stories.js
+++ b/app/shared/buttons/YellowButton.stories.js
@@ -1,0 +1,17 @@
+import YellowButton from './YellowButton';
+import YellowButtonClient from './YellowButtonClient';
+
+export default {
+  title: 'Buttons/YellowButton',
+  component: YellowButton,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <div className="flex gap-3">
+      <YellowButton {...args}>Yellow Button</YellowButton>
+      <YellowButtonClient {...args}>Yellow Button Client</YellowButtonClient>
+    </div>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/candidates/CandidateAvatar.stories.js
+++ b/app/shared/candidates/CandidateAvatar.stories.js
@@ -1,0 +1,25 @@
+import CandidateAvatar from './CandidateAvatar';
+
+export default {
+  title: 'Candidates/CandidateAvatar',
+  component: CandidateAvatar,
+  tags: ['autodocs'],
+  args: {
+    candidate: {
+      firstName: 'John',
+      lastName: 'Doe',
+      image: 'https://i.pravatar.cc/100?u=goodparty123',
+    },
+  },
+};
+
+export const Default = {};
+
+export const Empty = {
+  args: {
+    candidate: {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+  },
+};

--- a/app/shared/candidates/GoalsChart.stories.js
+++ b/app/shared/candidates/GoalsChart.stories.js
@@ -1,0 +1,13 @@
+import GoalsChart from './GoalsChart';
+
+export default {
+  title: 'Candidates/GoalsChart',
+  component: GoalsChart,
+  tags: ['autodocs'],
+  args: {
+    candidate: { voterProjection: 30234, voteGoal: 18435, finalVotes: 10053 },
+    color: '#6E37FF',
+  },
+};
+
+export const Default = {};

--- a/app/shared/cards/CardPageWrapper.stories.js
+++ b/app/shared/cards/CardPageWrapper.stories.js
@@ -1,0 +1,26 @@
+import H3 from '@shared/typography/H3';
+import CardPageWrapper from './CardPageWrapper';
+import Body1 from '@shared/typography/Body1';
+
+export default {
+  title: 'Cards/CardPageWrapper',
+  component: CardPageWrapper,
+  tags: ['autodocs'],
+  args: {
+    children: (
+      <>
+        <H3>Here is your content</H3>
+        <Body1>
+          Minim eu culpa Lorem fugiat. Incididunt consequat aliquip et non
+          veniam sint et eiusmod cupidatat magna magna non ipsum dolor. Anim
+          aliqua non enim aliquip eu veniam fugiat reprehenderit. Commodo culpa
+          qui adipisicing ullamco tempor laboris tempor cillum. Officia
+          cupidatat veniam proident sunt occaecat non nisi nisi officia dolor
+          Lorem ipsum est.
+        </Body1>
+      </>
+    ),
+  },
+};
+
+export const Default = {};

--- a/app/shared/content/CmsContentWrapper.stories.js
+++ b/app/shared/content/CmsContentWrapper.stories.js
@@ -1,0 +1,41 @@
+import CmsContentWrapper from './CmsContentWrapper';
+
+const content = (
+  <>
+    <h2>
+      <b>After the Election: Tying Up Loose Ends</b>
+    </h2>
+    <p>
+      Win or lose, there are a few housekeeping details that need to be managed
+      before you officially close down your political campaign. Many of these
+      are legal requirements related to the disbursement of unspent campaign
+      funds and other assets.&nbsp;
+    </p>
+    <p>
+      The <b>Federal Election Commission (FEC)</b> has very detailed{' '}
+      <a href="https://www.fec.gov/help-candidates-and-committees/winding-down-candidate-campaign/">
+        <u>directives regarding campaign closure</u>
+      </a>
+      . States may have additional requirements for political campaigns. For
+      example, campaign statements and reports must still be filed until your
+      election committee is officially terminated in California.&nbsp;&nbsp;
+    </p>
+    <p>
+      Excess campaign funds must first be used to pay off any debts incurred
+      during the campaign. Once that is accomplished, candidates have some
+      discretion as to how to disperse the remainder of campaign funds and other
+      assets, such as office equipment.{' '}
+    </p>
+  </>
+);
+
+export default {
+  title: 'Content/CmsContentWrapper',
+  component: CmsContentWrapper,
+  tags: ['autodocs'],
+  args: {
+    children: content,
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/Checkbox.stories.js
+++ b/app/shared/inputs/Checkbox.stories.js
@@ -1,0 +1,17 @@
+import Checkbox from './Checkbox';
+
+export default {
+  title: 'Inputs/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  args: {
+    label: 'Checkbox Input',
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Medium',
+    },
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/EmailForm.stories.js
+++ b/app/shared/inputs/EmailForm.stories.js
@@ -1,0 +1,18 @@
+import EmailForm from './EmailForm';
+
+export default {
+  title: 'Inputs/EmailForm',
+  component: EmailForm,
+  tags: ['autodocs'],
+  args: {
+    formId: '123',
+    placeholder: 'Enter your email to subscribe',
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Medium',
+    },
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/EmailFormV2.stories.js
+++ b/app/shared/inputs/EmailFormV2.stories.js
@@ -1,0 +1,23 @@
+import EmailFormV2 from './EmailFormV2';
+
+export default {
+  title: 'Inputs/EmailFormV2',
+  component: EmailFormV2,
+  tags: ['autodocs'],
+  args: {
+    formId: '123',
+    placeholder: 'Enter your email to subscribe',
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Medium',
+    },
+  },
+};
+
+export const Default = {};
+export const PrimaryButton = {
+  args: {
+    primaryButton: true,
+  },
+};

--- a/app/shared/inputs/EmailInput.stories.js
+++ b/app/shared/inputs/EmailInput.stories.js
@@ -1,0 +1,46 @@
+import EmailInput from './EmailInput';
+import { useState } from 'react';
+
+export default {
+  title: 'Inputs/EmailInput',
+  component: EmailInput,
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Enter your email',
+    newCallbackSignature: true,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState();
+
+    return (
+      <div class="flex flex-col gap-3 items-start">
+        <p>Default</p>
+        <EmailInput {...args} value={value} onChangeCallback={setValue} />
+        <p>Shrink Label</p>
+        <EmailInput
+          {...args}
+          shrink
+          value={value}
+          onChangeCallback={setValue}
+        />
+        <p>Required</p>
+        <EmailInput
+          {...args}
+          required
+          value={value}
+          onChangeCallback={setValue}
+        />
+        <p>No Label</p>
+        <EmailInput
+          {...args}
+          useLabel={false}
+          value={value}
+          onChangeCallback={setValue}
+        />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/FileDropZone.stories.js
+++ b/app/shared/inputs/FileDropZone.stories.js
@@ -1,0 +1,31 @@
+import Image from 'next/image';
+import FileDropZone from './FileDropZone';
+import { useState } from 'react';
+
+export default {
+  title: 'Inputs/FileDropZone',
+  component: FileDropZone,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [file, setFile] = useState(null);
+
+    const fileUrl = file && URL.createObjectURL(file);
+
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <FileDropZone {...args} onChange={setFile} />
+
+        {file && (
+          <>
+            <p>Selected image shown here for storybook</p>
+            <Image src={fileUrl} width={200} height={200} alt="img" />
+          </>
+        )}
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/ImageCropPreview.stories.js
+++ b/app/shared/inputs/ImageCropPreview.stories.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import ImageCropPreview from './ImageCropPreview';
+
+export default {
+  title: 'Inputs/ImageCropPreview',
+  component: ImageCropPreview,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [file, setFile] = useState(null);
+
+    return (
+      <div className="max-w-[400px]">
+        <p>Select image to crop</p>
+        <input
+          className="mb-4"
+          type="file"
+          accept="image/png, image/jpg, image/jpeg"
+          onChange={(e) => setFile(e.target.files[0])}
+        />
+        {file && (
+          <ImageCropPreview
+            {...args}
+            file={file}
+            onCrop={setFile}
+            onClear={() => setFile(null)}
+          />
+        )}
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/PasswordInput.stories.js
+++ b/app/shared/inputs/PasswordInput.stories.js
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import PasswordInput from './PasswrodInput';
+
+export default {
+  title: 'Inputs/PasswordInput',
+  component: PasswordInput,
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Enter new password',
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState();
+
+    return (
+      <PasswordInput {...args} value={value} onChangeCallback={setValue} />
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/PhoneInput.stories.js
+++ b/app/shared/inputs/PhoneInput.stories.js
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import PhoneInput from './PhoneInput';
+
+export default {
+  title: 'Inputs/PhoneInput',
+  component: PhoneInput,
+  tags: ['autodocs'],
+  args: {
+    placeholder: 'Enter phone number',
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState();
+
+    return (
+      <div class="flex flex-col gap-3 items-start">
+        <p>Default</p>
+        <PhoneInput {...args} value={value} onChangeCallback={setValue} />
+        <p>Shrink Label</p>
+        <PhoneInput
+          {...args}
+          shrink
+          value={value}
+          onChangeCallback={setValue}
+        />
+        <p>Required</p>
+        <PhoneInput
+          {...args}
+          required
+          value={value}
+          onChangeCallback={setValue}
+        />
+        <p>No Label</p>
+        <PhoneInput
+          {...args}
+          useLabel={false}
+          value={value}
+          onChangeCallback={setValue}
+        />
+        <p>No Icon</p>
+        <PhoneInput
+          {...args}
+          hideIcon
+          value={value}
+          onChangeCallback={setValue}
+        />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/RadioList.stories.js
+++ b/app/shared/inputs/RadioList.stories.js
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import RadioList from './RadioList';
+
+export default {
+  title: 'Inputs/RadioList',
+  component: RadioList,
+  tags: ['autodocs'],
+  args: {
+    options: [
+      { key: '1', label: 'Option One' },
+      { key: '2', label: 'Option Two' },
+      { key: '3', label: 'Option Three' },
+    ],
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState();
+
+    return <RadioList {...args} selected={value} selectCallback={setValue} />;
+  },
+};
+
+export const Default = {};

--- a/app/shared/inputs/RenderInputField.stories.js
+++ b/app/shared/inputs/RenderInputField.stories.js
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import RenderInputField from './RenderInputField';
+
+const textField = {
+  type: 'text',
+  label: 'Text Field',
+  placeholder: 'Put some text here',
+  helperText: 'Some helper text',
+};
+
+export default {
+  title: 'Inputs/RenderInputField',
+  component: RenderInputField,
+  tags: ['autodocs'],
+  args: {
+    field: textField,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState();
+
+    const handleChange = (_k, v) => setValue(v);
+
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <p>Default</p>
+        <RenderInputField
+          value={value}
+          onChangeCallback={handleChange}
+          {...args}
+        />
+        <p>Required</p>
+        <RenderInputField
+          value={value}
+          onChangeCallback={handleChange}
+          {...{ ...args, field: { ...args?.field, required: true } }}
+        />
+        <p>Error</p>
+        <RenderInputField
+          value={value}
+          onChangeCallback={handleChange}
+          {...args}
+          error
+        />
+        <p>Disabled</p>
+        <RenderInputField
+          value={value}
+          onChangeCallback={handleChange}
+          {...{ ...args, field: { ...args?.field, disabled: true } }}
+        />
+      </div>
+    );
+  },
+};
+
+export const Default = {};
+
+export const Multiline = {
+  args: {
+    field: {
+      ...textField,
+      rows: 3,
+    },
+  },
+};
+
+export const Date = {
+  args: {
+    field: {
+      type: 'date',
+      label: 'Date Field',
+      helperText: 'Some helper text',
+    },
+  },
+};
+
+export const Number = {
+  args: {
+    field: {
+      type: 'number',
+      label: 'Number Field',
+      helperText: 'Some helper text',
+      placeholder: 'Put number here',
+    },
+  },
+};
+
+export const Email = {
+  args: {
+    field: {
+      type: 'email',
+      label: 'Email Field',
+      placeholder: 'Enter your email',
+    },
+  },
+};
+
+export const Phone = {
+  args: {
+    field: {
+      type: 'phone',
+      label: 'Phone Field',
+      placeholder: 'Enter phone number',
+    },
+  },
+};
+
+export const Radio = {
+  args: {
+    field: {
+      type: 'radio',
+      label: 'Radio Field',
+    },
+  },
+};
+
+export const Checkbox = {
+  args: {
+    field: {
+      type: 'checkbox',
+      label: 'Checkbox Field',
+    },
+  },
+};
+
+export const Select = {
+  args: {
+    field: {
+      type: 'select',
+      label: 'Select Field',
+      options: ['Option One', 'Option Two', 'Option Three'],
+    },
+  },
+};

--- a/app/shared/inputs/TextField.stories.js
+++ b/app/shared/inputs/TextField.stories.js
@@ -1,0 +1,34 @@
+import TextField from './TextField';
+import { MdOutlineMailOutline } from 'react-icons/md';
+
+export default {
+  title: 'Inputs/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  args: {
+    label: 'Text Field',
+    placeholder: 'Input some text here',
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-3 items-start">
+      <p>Default label</p>
+      <TextField {...args} />
+      <p>Shrink label</p>
+      <TextField {...args} InputLabelProps={{ shrink: true }} />
+    </div>
+  ),
+};
+
+export const Default = {};
+export const Error = {
+  args: {
+    error: true,
+    endAdornments: ['error'],
+    helperText: 'Something is wrong',
+  },
+};
+export const CustomIcon = {
+  args: {
+    endAdornments: [<MdOutlineMailOutline key="1234" />],
+  },
+};

--- a/app/shared/layouts/CookiesSnackbar.stories.js
+++ b/app/shared/layouts/CookiesSnackbar.stories.js
@@ -1,0 +1,17 @@
+import CookiesSnackbar from './CookiesSnackbar';
+
+export default {
+  title: 'Layouts/CookiesSnackbar',
+  component: CookiesSnackbar,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <>
+      (Clear your <strong>cookiesAccepted</strong> cookie if you cannot see the
+      component)
+      <CookiesSnackbar />
+    </>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/layouts/PortalPanel.stories.js
+++ b/app/shared/layouts/PortalPanel.stories.js
@@ -1,0 +1,32 @@
+import H1 from '@shared/typography/H1';
+import PortalPanel from './PortalPanel';
+import Body1 from '@shared/typography/Body1';
+
+export default {
+  title: 'Layouts/PortalPanel',
+  component: PortalPanel,
+  tags: ['autodocs'],
+  args: {
+    color: '#2CCDB0',
+  },
+  parameters: {
+    backgrounds: {
+      default: 'Medium',
+    },
+  },
+  render: (args) => (
+    <PortalPanel {...args}>
+      <H1>Content Header</H1>
+      <Body1>
+        Ut elit laboris anim occaecat esse exercitation ea magna enim
+        consectetur excepteur enim proident Lorem. Aliqua minim sunt id
+        reprehenderit dolor. Exercitation veniam do laboris labore anim dolor
+        Lorem quis irure. Officia nisi eiusmod ad aute Lorem do adipisicing
+        aliquip qui. Veniam Lorem enim aliquip dolore ut nulla. Magna aliqua qui
+        nostrud officia qui culpa aliqua do est.
+      </Body1>
+    </PortalPanel>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/unshared/AlertBanner.stories.js
+++ b/app/shared/unshared/AlertBanner.stories.js
@@ -1,0 +1,25 @@
+import { AlertBanner } from 'app/(candidate)/dashboard/components/AlertBanner';
+
+export default {
+  title: 'Unshared/AlertBanner',
+  component: AlertBanner,
+  tags: ['autodocs'],
+  args: {
+    title: 'You have an alert',
+    message: 'Some content for you to pay attention to please now',
+    actionText: 'Click Here',
+  },
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3">
+        <strong>(Used in dashboard)</strong>
+        <AlertBanner {...args} severity="info" />
+        <AlertBanner {...args} severity="success" />
+        <AlertBanner {...args} severity="warning" />
+        <AlertBanner {...args} severity="error" />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/AnimatedBar.stories.js
+++ b/app/shared/unshared/AnimatedBar.stories.js
@@ -1,0 +1,25 @@
+import { AnimatedBar } from 'app/(candidate)/dashboard/components/p2v/AnimatedBar';
+
+export default {
+  title: 'Unshared/AnimatedBar',
+  component: AnimatedBar,
+  tags: ['autodocs'],
+  args: {
+    contacted: 60,
+    needed: 100,
+    bgColor: 'bg-purple-500',
+  },
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3">
+        <strong>(Used in dashboard / campaign tracker)</strong>
+        <AnimatedBar {...args} />
+        <AnimatedBar {...args} contacted={80} bgColor="bg-green-500" />
+        <AnimatedBar {...args} contacted={20} bgColor="bg-red-500" />
+        <AnimatedBar {...args} contacted={40} bgColor="bg-orange-500" />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/AsyncValidationIcon.stories.js
+++ b/app/shared/unshared/AsyncValidationIcon.stories.js
@@ -1,0 +1,24 @@
+import { AsyncValidationIcon } from 'app/(candidate)/dashboard/shared/AsyncValidationIcon';
+
+export default {
+  title: 'Unshared/AsyncValidationIcon',
+  component: AsyncValidationIcon,
+  tags: ['autodocs'],
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <strong>(Used in upgrade to pro pages)</strong>
+        <p>Default</p>
+        <AsyncValidationIcon {...args} />
+        <p>Loading</p>
+        <AsyncValidationIcon {...args} loading />
+        <p>Validated</p>
+        <AsyncValidationIcon {...args} validated={true} />
+        <p>Validate Failed</p>
+        <AsyncValidationIcon {...args} validated={false} />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/FocusedExperienceWrapper.stories.js
+++ b/app/shared/unshared/FocusedExperienceWrapper.stories.js
@@ -1,0 +1,42 @@
+import Body1 from '@shared/typography/Body1';
+import H1 from '@shared/typography/H1';
+import { FocusedExperienceWrapper } from 'app/(candidate)/dashboard/shared/FocusedExperienceWrapper';
+
+export default {
+  title: 'Unshared/FocusedExperienceWrapper',
+  component: FocusedExperienceWrapper,
+  tags: ['autodocs'],
+  args: {
+    message: 'Some helpful text here',
+  },
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <strong>(Used in upgrade to pro flow)</strong>
+        <FocusedExperienceWrapper {...args}>
+          <H1 className="mb-4">Focused Experience Content</H1>
+          <Body1>
+            Magna esse commodo ea tempor velit aliqua est labore elit
+            consectetur cupidatat adipisicing. Aute laborum commodo ex ad
+            tempor. Elit pariatur enim tempor excepteur sint aute nisi. Et qui
+            cupidatat eiusmod commodo eiusmod velit. Nulla nulla nulla aliqua
+            cupidatat id proident non culpa cupidatat. Qui voluptate mollit
+            cupidatat duis ea Lorem id elit velit aute proident est. Aute ut
+            commodo elit magna.
+          </Body1>
+          <Body1>
+            Magna esse commodo ea tempor velit aliqua est labore elit
+            consectetur cupidatat adipisicing. Aute laborum commodo ex ad
+            tempor. Elit pariatur enim tempor excepteur sint aute nisi. Et qui
+            cupidatat eiusmod commodo eiusmod velit. Nulla nulla nulla aliqua
+            cupidatat id proident non culpa cupidatat. Qui voluptate mollit
+            cupidatat duis ea Lorem id elit velit aute proident est. Aute ut
+            commodo elit magna.
+          </Body1>
+        </FocusedExperienceWrapper>
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/InputHelpIcon.stories.js
+++ b/app/shared/unshared/InputHelpIcon.stories.js
@@ -1,0 +1,20 @@
+import { InputHelpIcon } from 'app/(candidate)/dashboard/shared/InputHelpIcon';
+
+export default {
+  title: 'Unshared/InputHelpIcon',
+  component: InputHelpIcon,
+  tags: ['autodocs'],
+  args: {
+    message: 'Some helpful text here',
+  },
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <strong>(Used in upgrade to pro pages)</strong>
+        <InputHelpIcon {...args} />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/LoadMoreWrapper.stories.js
+++ b/app/shared/unshared/LoadMoreWrapper.stories.js
@@ -1,0 +1,41 @@
+import LoadMoreWrapper from 'app/blog/shared/LoadMoreWrapper';
+
+export default {
+  title: 'Unshared/LoadMoreWrapper',
+  component: LoadMoreWrapper,
+  tags: ['autodocs'],
+  render: (args) => {
+    return (
+      <>
+        <strong>(Used in blog list pages)</strong>
+        <p>
+          Ullamco deserunt et ea velit fugiat commodo aute cupidatat culpa duis
+          dolor in. Magna reprehenderit ipsum deserunt ipsum ex nostrud deserunt
+          Lorem mollit sunt aliqua in. Ipsum fugiat officia do dolor non
+          deserunt ullamco do non non aliqua cillum. Nostrud cupidatat anim ad
+          veniam cillum. Adipisicing elit non irure fugiat Lorem eiusmod esse
+          Lorem magna exercitation. Aliquip magna magna do ipsum. Consequat
+          aliqua aute magna consequat Lorem id mollit amet. Sunt adipisicing
+          adipisicing eiusmod elit proident id aute officia in consequat ad.
+        </p>
+        <LoadMoreWrapper {...args}>
+          <p>
+            Occaecat ex nisi mollit qui consequat esse aliqua non minim.
+            Exercitation culpa aliquip duis mollit consequat. Aute sunt laborum
+            do excepteur mollit ex proident id fugiat elit ut. Ea adipisicing
+            officia exercitation qui officia sit culpa commodo nostrud Lorem
+            aliqua ex fugiat aliqua. Et dolore quis nostrud do excepteur et
+            cupidatat commodo officia. Duis laboris consequat voluptate non anim
+            exercitation aute quis fugiat. Anim nulla officia anim magna id
+            velit tempor laboris amet tempor consequat sint veniam ad. Enim
+            exercitation veniam nostrud consectetur qui dolore quis irure ad
+            aliquip irure velit. Sunt laborum ullamco aliquip eiusmod. Qui
+            mollit ipsum non magna proident ut ullamco quis et.
+          </p>
+        </LoadMoreWrapper>
+      </>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/RichEditor.stories.js
+++ b/app/shared/unshared/RichEditor.stories.js
@@ -1,0 +1,20 @@
+import RichEditor from 'app/(candidate)/dashboard/plan/components/RichEditor';
+
+export default {
+  title: 'Unshared/RichEditor',
+  component: RichEditor,
+  tags: ['autodocs'],
+  args: {
+    initialText: 'Some initial text to edit here',
+  },
+  render: (args) => {
+    return (
+      <div className="flex flex-col gap-3 items-start">
+        <strong>(Used in dashboard / campaign plan )</strong>
+        <RichEditor {...args} />
+      </div>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/TealButton.stories.js
+++ b/app/shared/unshared/TealButton.stories.js
@@ -1,0 +1,17 @@
+import TealButton from 'app/candidate/[name]/[office]/components/TealButton';
+
+export default {
+  title: 'Unshared/TealButton',
+  component: TealButton,
+  tags: ['autodocs'],
+  render: (args) => {
+    return (
+      <>
+        <strong>(Used in candidate pages)</strong>
+        <TealButton {...args}>Teal Button</TealButton>
+      </>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/unshared/WhiteButton.stories.js
+++ b/app/shared/unshared/WhiteButton.stories.js
@@ -1,0 +1,21 @@
+import WhiteButton from 'app/(landing)/run-for-office/components/WhiteButton';
+
+export default {
+  title: 'Unshared/WhiteButton',
+  component: WhiteButton,
+  tags: ['autodocs'],
+  args: {
+    label: 'White Button',
+  },
+  render: (args) => {
+    return (
+      <>
+        <strong>(Used in run for office page)</strong>
+        <br />
+        <WhiteButton {...args} />
+      </>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/user/UserAvatar.stories.js
+++ b/app/shared/user/UserAvatar.stories.js
@@ -1,0 +1,41 @@
+import UserAvatar from './UserAvatar';
+
+export default {
+  title: 'User/UserAvatar',
+  component: UserAvatar,
+  tags: ['autodocs'],
+  args: {
+    user: {
+      firstName: null,
+      lastName: null,
+      avatar: null,
+    },
+  },
+  render: (args) => (
+    <div className="flex gap-3 text-dark">
+      <UserAvatar {...args} size="large" />
+      <UserAvatar {...args} size="small" />
+      <UserAvatar {...args} size="smaller" />
+    </div>
+  ),
+};
+
+export const Default = {};
+export const WithImage = {
+  args: {
+    user: {
+      firstName: 'John',
+      lastName: 'Doe',
+      avatar: 'https://i.pravatar.cc/100?u=goodparty123',
+    },
+  },
+};
+export const WithInitials = {
+  args: {
+    user: {
+      firstName: 'John',
+      lastName: 'Doe',
+      avatar: null,
+    },
+  },
+};

--- a/app/shared/utils/AlertDialog.stories.js
+++ b/app/shared/utils/AlertDialog.stories.js
@@ -1,0 +1,14 @@
+import AlertDialog from './AlertDialog';
+
+export default {
+  title: 'Utils/AlertDialog',
+  component: AlertDialog,
+  tags: ['autodocs'],
+  args: {
+    open: true,
+    title: 'Alert Dialog',
+    description: 'This is an example alert dialog component.',
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/AnimatedEllipsis.stories.js
+++ b/app/shared/utils/AnimatedEllipsis.stories.js
@@ -1,0 +1,10 @@
+import { AnimatedEllipsis } from './AnimatedEllipsis';
+
+export default {
+  title: 'Utils/AnimatedEllipsis',
+  component: AnimatedEllipsis,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/utils/Breadcrumbs.stories.js
+++ b/app/shared/utils/Breadcrumbs.stories.js
@@ -1,0 +1,18 @@
+import Breadcrumbs from './Breadcrumbs';
+
+export default {
+  title: 'Utils/Breadcrumbs',
+  component: Breadcrumbs,
+  tags: ['autodocs'],
+  args: {
+    links: [
+      { label: 'Blog', href: 'https://goodparty.org' },
+      { label: 'Politics', href: 'https://goodparty.org' },
+      { label: 'Activism', href: 'https://goodparty.org' },
+      { label: 'How to Get Involved With Political Activism.' },
+    ],
+  },
+};
+
+export const Default = {};
+export const ChevronDelimiter = { args: { delimiter: 'chevron' } };

--- a/app/shared/utils/Callout.stories.js
+++ b/app/shared/utils/Callout.stories.js
@@ -1,0 +1,10 @@
+import Callout from './Callout';
+
+export default {
+  title: 'Utils/Callout',
+  component: Callout,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/utils/CopyToClipboard.stories.js
+++ b/app/shared/utils/CopyToClipboard.stories.js
@@ -1,0 +1,20 @@
+import CopyToClipboard from './CopyToClipboard';
+import Snackbar from './Snackbar';
+
+export default {
+  title: 'Utils/CopyToClipboard',
+  component: CopyToClipboard,
+  tags: ['autodocs'],
+  args: {
+    children: <button>Click to copy text</button>,
+    text: 'Copy this text',
+  },
+  render: (args) => (
+    <>
+      <Snackbar></Snackbar>
+      <CopyToClipboard {...args} />
+    </>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/utils/DemoAccountDeleteDialog.stories.js
+++ b/app/shared/utils/DemoAccountDeleteDialog.stories.js
@@ -1,0 +1,10 @@
+import { DemoAccountDeleteDialog } from './DemoAccountDeleteDialog';
+
+export default {
+  title: 'Utils/DemoAccountDeleteDialog',
+  component: DemoAccountDeleteDialog,
+  tags: ['autodocs'],
+  args: { open: true },
+};
+
+export const Default = {};

--- a/app/shared/utils/Hamburger.stories.js
+++ b/app/shared/utils/Hamburger.stories.js
@@ -1,0 +1,10 @@
+import Hamburger from './Hamburger';
+
+export default {
+  title: 'Utils/Hamburger',
+  component: Hamburger,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/utils/ImageUpload.stories.js
+++ b/app/shared/utils/ImageUpload.stories.js
@@ -1,0 +1,21 @@
+import ImageUpload from './ImageUpload';
+
+export default {
+  title: 'Utils/ImageUpload',
+  component: ImageUpload,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};
+export const CustomElement = {
+  args: {
+    customElement: (
+      <div
+        className={`text-lg py-3 px-6 rounded-lg font-medium bg-primary-dark text-slate-50 inline-block bg-primary-dark`}
+      >
+        {'Upload Image'}
+      </div>
+    ),
+  },
+};

--- a/app/shared/utils/LoadingAnimation.stories.js
+++ b/app/shared/utils/LoadingAnimation.stories.js
@@ -1,0 +1,16 @@
+import LoadingAnimation from './LoadingAnimation';
+
+export default {
+  title: 'Utils/LoadingAnimation',
+  component: LoadingAnimation,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};
+export const CustomText = {
+  args: {
+    label: 'Custom text underneath here',
+    title: 'Custom Title',
+  },
+};

--- a/app/shared/utils/LoadingList.stories.js
+++ b/app/shared/utils/LoadingList.stories.js
@@ -1,0 +1,10 @@
+import LoadingList from './LoadingList';
+
+export default {
+  title: 'Utils/LoadingList',
+  component: LoadingList,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/utils/Modal.stories.js
+++ b/app/shared/utils/Modal.stories.js
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import Modal from './Modal';
+import H1 from '@shared/typography/H1';
+import Body1 from '@shared/typography/Body1';
+import Button from '@shared/buttons/Button';
+
+export default {
+  title: 'Utils/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>(open modal)</Button>
+        <Modal open={open} closeCallback={() => setOpen(false)}>
+          <H1>Modal Content</H1>
+          <Body1>
+            Non qui ad voluptate enim Lorem. Proident commodo quis cillum
+            excepteur est enim sunt. Id est Lorem aute ipsum. Aute in duis
+            occaecat est consequat eu esse quis adipisicing eiusmod. Irure
+            aliquip fugiat non excepteur ea enim irure culpa incididunt.
+            Deserunt ullamco exercitation eu proident occaecat nisi est veniam
+            et dolore. Est ullamco est non sunt ad qui anim.
+          </Body1>
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/MoreMenu.stories.js
+++ b/app/shared/utils/MoreMenu.stories.js
@@ -1,0 +1,16 @@
+import { MoreMenu } from './MoreMenu';
+
+export default {
+  title: 'Utils/MoreMenu',
+  component: MoreMenu,
+  tags: ['autodocs'],
+  args: {
+    menuItems: [
+      { label: 'Item One' },
+      { label: 'Item Two' },
+      { label: 'Item Three' },
+    ],
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/NotificationDot.stories.js
+++ b/app/shared/utils/NotificationDot.stories.js
@@ -1,0 +1,20 @@
+import IconButton from '@shared/buttons/IconButton';
+import { NotificationDot } from './NotificationDot';
+import { MdNotifications } from 'react-icons/md';
+
+export default {
+  title: 'Utils/NotificationDot',
+  component: NotificationDot,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => (
+    <>
+      <IconButton className="relative">
+        <MdNotifications />
+        <NotificationDot />
+      </IconButton>
+    </>
+  ),
+};
+
+export const Default = {};

--- a/app/shared/utils/Paper.stories.js
+++ b/app/shared/utils/Paper.stories.js
@@ -1,0 +1,28 @@
+import H1 from '@shared/typography/H1';
+import Paper from './Paper';
+import Body1 from '@shared/typography/Body1';
+
+export default {
+  title: 'Utils/Paper',
+  component: Paper,
+  tags: ['autodocs'],
+  args: {
+    children: (
+      <>
+        <H1>Content Title</H1>
+        <Body1>
+          Minim quis aute ut consequat non do laborum proident occaecat eu ut.
+          Dolore labore quis aliqua proident Lorem nulla proident velit anim. Et
+          sint id eu sunt sit ut aliqua cupidatat laborum in Lorem dolor aute.
+          Exercitation eiusmod culpa enim esse proident aliquip nisi velit
+          eiusmod fugiat. Quis proident id labore nisi excepteur aute velit sunt
+          ipsum duis ex magna fugiat mollit. Ex reprehenderit Lorem ea esse
+          fugiat duis sint Lorem exercitation. Fugiat reprehenderit nulla
+          consectetur aliqua sit qui elit consectetur sint aliqua.
+        </Body1>
+      </>
+    ),
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/RichEditor.stories.js
+++ b/app/shared/utils/RichEditor.stories.js
@@ -1,0 +1,12 @@
+import RichEditor from './RichEditor';
+
+export default {
+  title: 'Utils/RichEditor',
+  component: RichEditor,
+  tags: ['autodocs'],
+  args: {
+    initialText: 'Some initial text to edit',
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/Snackbar.stories.js
+++ b/app/shared/utils/Snackbar.stories.js
@@ -1,0 +1,38 @@
+import { useSnackbar } from 'helpers/useSnackbar';
+import Button from '@shared/buttons/Button';
+import Snackbar from './Snackbar';
+
+export default {
+  title: 'Utils/Snackbar',
+  component: Snackbar,
+  tags: ['autodocs'],
+  args: {},
+  render: (args) => {
+    const { successSnackbar, errorSnackbar } = useSnackbar();
+
+    const show = (type) => {
+      if (type === 'success') {
+        successSnackbar('You have done something successfully.');
+      } else if (type === 'error') {
+        errorSnackbar('An error has occured.');
+      } else {
+      }
+    };
+
+    return (
+      <>
+        <Snackbar />
+        <div className="flex gap-3">
+          <Button color="success" onClick={() => show('success')}>
+            Show Success Snackbar
+          </Button>
+          <Button color="error" onClick={() => show('error')}>
+            Show Error Snackbar
+          </Button>
+        </div>
+      </>
+    );
+  },
+};
+
+export const Default = {};

--- a/app/shared/utils/Snackbar.stories.js
+++ b/app/shared/utils/Snackbar.stories.js
@@ -8,6 +8,7 @@ export default {
   tags: ['autodocs'],
   args: {},
   render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { successSnackbar, errorSnackbar } = useSnackbar();
 
     const show = (type) => {

--- a/app/shared/utils/StickersCallout.stories.js
+++ b/app/shared/utils/StickersCallout.stories.js
@@ -1,0 +1,10 @@
+import StickersCallout from './StickersCallout';
+
+export default {
+  title: 'Utils/StickersCallout',
+  component: StickersCallout,
+  tags: ['autodocs'],
+  args: {},
+};
+
+export const Default = {};

--- a/app/shared/utils/Table.stories.js
+++ b/app/shared/utils/Table.stories.js
@@ -1,0 +1,144 @@
+import Table from './Table';
+
+const mockData = {
+  columns: [
+    {
+      Header: 'Name',
+      accessor: 'name',
+    },
+    {
+      Header: 'Age',
+      accessor: 'age',
+    },
+    {
+      Header: 'Job',
+      accessor: 'job',
+    },
+    {
+      Header: 'Location',
+      accessor: 'location',
+    },
+    {
+      Header: 'Years of Experience',
+      accessor: 'experience',
+    },
+  ],
+  data: [
+    {
+      name: 'Pete Peterson',
+      age: 34,
+      job: 'Window Washer',
+      location: 'Chicago',
+      experience: 5,
+    },
+    {
+      name: 'Andy Anderson',
+      age: 25,
+      job: 'Doctor',
+      location: 'New York',
+      experience: 2,
+    },
+    {
+      name: 'Rob Robson',
+      age: 33,
+      job: 'Author',
+      location: 'San Francisco',
+      experience: 10,
+    },
+    {
+      name: 'Bob Bobson',
+      age: 47,
+      job: 'Football Star',
+      location: 'Miami',
+      experience: 20,
+    },
+    {
+      name: 'Jane Johnson',
+      age: 29,
+      job: 'Engineer',
+      location: 'Seattle',
+      experience: 7,
+    },
+    {
+      name: 'Sara Sanders',
+      age: 40,
+      job: 'Teacher',
+      location: 'Dallas',
+      experience: 15,
+    },
+    {
+      name: 'Tommy Thompson',
+      age: 52,
+      job: 'Chef',
+      location: 'Las Vegas',
+      experience: 25,
+    },
+    {
+      name: 'Emily Evans',
+      age: 22,
+      job: 'Graphic Designer',
+      location: 'Austin',
+      experience: 1,
+    },
+    {
+      name: 'Michael Miller',
+      age: 45,
+      job: 'Architect',
+      location: 'Los Angeles',
+      experience: 18,
+    },
+    {
+      name: 'Rachel Roberts',
+      age: 38,
+      job: 'Nurse',
+      location: 'Boston',
+      experience: 12,
+    },
+    {
+      name: 'Lucy Liu',
+      age: 30,
+      job: 'Software Developer',
+      location: 'San Diego',
+      experience: 6,
+    },
+    {
+      name: 'David Davidson',
+      age: 28,
+      job: 'Marketing Specialist',
+      location: 'Denver',
+      experience: 3,
+    },
+    {
+      name: 'Linda Lopez',
+      age: 42,
+      job: 'Accountant',
+      location: 'Phoenix',
+      experience: 15,
+    },
+    {
+      name: 'Gary Grant',
+      age: 55,
+      job: 'Pilot',
+      location: 'Orlando',
+      experience: 30,
+    },
+    {
+      name: 'Mona Martinez',
+      age: 36,
+      job: 'Sales Manager',
+      location: 'Houston',
+      experience: 14,
+    },
+  ],
+};
+
+export default {
+  title: 'Utils/Table',
+  component: Table,
+  tags: ['autodocs'],
+  args: {
+    ...mockData,
+  },
+};
+
+export const Default = {};


### PR DESCRIPTION
- Added stories to remaining components inside the `app/shared` folder, unless I did not see them being used anywhere.
- Also added an `app/shared/unshared` folder with stories to surface components that are shareable but are in other routes/folders

**No app functionality should be affected at all, only storybook files have been added / changed**