### PR TITLE
Candidate Map Fixes

### DIFF
--- a/app/candidates/components/Hero.js
+++ b/app/candidates/components/Hero.js
@@ -10,8 +10,10 @@ export default memo(function Hero({ count = 0, longState }) {
     <div className="bg-primary-dark py-8 lg:py-24 text-white text-center ">
       <MaxWidth>
         <h1 className="text-center font-medium text-4xl md:text-5xl lg:text-6xl xl:text-7xl">
-          {numberFormatter(count)} Wins by
-          <div className="md:hidden" />
+          {numberFormatter(count)} Wins&nbsp;
+          <div className="sm:hidden" />
+          & Counting
+          <br /> by
           <Image
             src="/images/heart.svg"
             width={80}

--- a/app/candidates/components/Hero.js
+++ b/app/candidates/components/Hero.js
@@ -10,7 +10,7 @@ export default memo(function Hero({ count = 0, longState }) {
     <div className="bg-primary-dark py-8 lg:py-24 text-white text-center ">
       <MaxWidth>
         <h1 className="text-center font-medium text-4xl md:text-5xl lg:text-6xl xl:text-7xl">
-          3,120 Wins by
+          {numberFormatter(count)} Wins by
           <div className="md:hidden" />
           <Image
             src="/images/heart.svg"

--- a/app/candidates/page.js
+++ b/app/candidates/page.js
@@ -11,7 +11,10 @@ const fetchCount = async (onlyWinners = false) => {
 };
 
 export async function generateMetadata({ params, searchParams }) {
-  const title = `3,120 Wins by Independents across the U.S. 🎉`;
+  const { count } = await fetchCount(true);
+  const title = `${numberFormatter(
+    count,
+  )} Wins by Independents across the U.S. 🎉`;
   const meta = pageMetaData({
     title,
     description:
@@ -23,6 +26,7 @@ export async function generateMetadata({ params, searchParams }) {
 }
 
 export default async function Page({ params, searchParams }) {
-  const childProps = { searchParams };
+  const { count } = await fetchCount(true);
+  const childProps = { count, searchParams };
   return <CandidatesPage {...childProps} />;
 }

--- a/app/homepage/Hero.js
+++ b/app/homepage/Hero.js
@@ -13,12 +13,18 @@ const fetchWinnerCount = async () => {
 };
 
 export default async function Hero() {
+  const { count } = await fetchWinnerCount();
+
+  // fallback to hardcoded 1,000 in case of bad api call
+  const winnerCount =
+    typeof count === 'number' && count > 0 ? count.toLocaleString() : '1,000';
+
   return (
     <MaxWidth>
       <div className="grid grid-cols-12 gap-4 lg:gap-8 md:justify-items-center pt-20 bg-indigo-50 items-stretch sm:p-8 md:px-10 lg:p-16 xl:px-0">
         <div className="col-span-12 lg:col-span-6">
           <h1 className="text-4xl leading-tight font-semibold xs:font-bold md:text-5xl md:leading-tight xl:text-6xl xl:leading-snug">
-            We empowered 3,120 Independent wins in 2024 🎉
+            We empowered {winnerCount} Independent wins in 2024 🎉
           </h1>
           <h2 className="text-lg font-sfpro font-normal leading-6 mt-8">
             GoodParty.org is empowering civic heroes to run, win, and serve as


### PR DESCRIPTION
- Reverts the winner counts to the dynamic number
- Adds `& Counting` to map header and tweaks the breakpoints
- Updates map to move to contain all campaign markers on first load