### PR TITLE
Added specific naming for Test Runs, Slack Integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,14 +71,17 @@ jobs:
         env:
           SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
         run: |
-          STATUS=$([[ ${{ job.status }} == "success" ]] && echo "Pass" || echo "Fail")
-          COLOR=$([[ ${{ job.status }} == "success" ]] && echo "good" || echo "danger")
+          # Set STATUS and COLOR based on job status
+          STATUS=$(if [[ "${{ job.status }}" == "success" ]]; then echo "Pass"; else echo "Fail"; fi)
+          COLOR=$(if [[ "${{ job.status }}" == "success" ]]; then echo "good"; else echo "danger"; fi)
+          
+          # Send the Slack notification
           curl -X POST -H "Content-type: application/json" \
           --data '{
-            "text": "Playwright Test Results ("$STATUS")",
+            "text": "Playwright Test Results ('"${STATUS}"')",
             "attachments": [
               {
-                "color": "'"$COLOR"'",
+                "color": "'"${COLOR}"'",
                 "fields": [
                   { "title": "Branch", "value": "'"${{ github.ref_name }}"'", "short": true },
                   { "title": "Commit", "value": "'"${{ github.sha }}"'", "short": true },
@@ -95,3 +98,4 @@ jobs:
               }
             ]
           }' $SLACK_WORKFLOW_WEBHOOK
+      

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,52 +75,54 @@ jobs:
           echo "Playwright tests failed. Review the test results."
 
           - name: Notify Slack Workflow with Test Results
-          if: always()
-          env:
-            SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
-            TESTRAIL_API_URL: ${{ secrets.TESTRAIL_API_URL }}
-            TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
-            TEST_RUN_ID: ${{ env.TEST_RUN_ID }}
-            TEST_RUN_NAME: ${{ env.TEST_RUN_NAME }}
-          run: |
-            # Retrieve tests in the run and filter out failed tests
-            TESTRAIL_RESPONSE=$(curl -s -u "your_username:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
-            FAILED_TESTS=$(echo "$TESTRAIL_RESPONSE" | jq '[.[] | select(.status_id == 5)]')
-            FAILED_COUNT=$(echo "$FAILED_TESTS" | jq 'length')
-            
-            # Create a list of failed tests, with each test on a separate line
-            FAILED_SUMMARY=$(echo "$FAILED_TESTS" | jq -r '.[] | "- \(.title)\n"' | tr -d '\n' | sed 's/\n/,/g')
-  
-            # Set overall status based on failed tests
-            if [ "$FAILED_COUNT" -gt 0 ]; then
-              RUN_STATUS="failed"
-            else
-              RUN_STATUS="passed"
-            fi
-  
-            # Generate the TestRail URL for the test run
-            TESTRAIL_URL="${{ secrets.TESTRAIL_API_URL }}/test-runs/${{ env.TEST_RUN_ID }}"
-  
-            # Send data to Slack Workflow Webhook with placeholders, including the commit SHA
-            curl -X POST -H "Content-type: application/json" \
-              --data '{
-                "branch": "'"${{ github.ref_name }}"'",
-                "commit_sha": "'"${{ github.sha }}"'",
-                "failed_count": "'"$FAILED_COUNT"'",
-                "failed_summary": "'"$FAILED_SUMMARY"'",
-                "run_status": "'"$RUN_STATUS"'",
-                "attachments": [
-                  {
-                    "text": "Click below to view the full TestRun details.",
-                    "fallback": "View TestRun Details",
-                    "actions": [
-                      {
-                        "type": "button",
-                        "text": "View TestRun",
-                        "url": "'"$TESTRAIL_URL"'"
-                      }
-                    ]
-                  }
-                ]
-              }' \
-              $SLACK_WORKFLOW_WEBHOOK
+          
+      - name: Notify Slack Workflow with Test Results
+        if: always()
+        env:
+          SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
+          TESTRAIL_API_URL: ${{ secrets.TESTRAIL_API_URL }}
+          TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+          TEST_RUN_ID: ${{ env.TEST_RUN_ID }}
+          TEST_RUN_NAME: ${{ env.TEST_RUN_NAME }}
+        run: |
+          # Retrieve tests in the run and filter out failed tests
+          TESTRAIL_RESPONSE=$(curl -s -u "your_username:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
+          FAILED_TESTS=$(echo "$TESTRAIL_RESPONSE" | jq '[.[] | select(.status_id == 5)]')
+          FAILED_COUNT=$(echo "$FAILED_TESTS" | jq 'length')
+          
+          # Create a list of failed tests, with each test on a separate line
+          FAILED_SUMMARY=$(echo "$FAILED_TESTS" | jq -r '.[] | "- \(.title)\n"' | tr -d '\n' | sed 's/\n/,/g')
+
+          # Set overall status based on failed tests
+          if [ "$FAILED_COUNT" -gt 0 ]; then
+            RUN_STATUS="failed"
+          else
+            RUN_STATUS="passed"
+          fi
+
+          # Generate the TestRail URL for the test run
+          TESTRAIL_URL="${{ secrets.TESTRAIL_API_URL }}/test-runs/${{ env.TEST_RUN_ID }}"
+
+          # Send data to Slack Workflow Webhook with placeholders, including the commit SHA
+          curl -X POST -H "Content-type: application/json" \
+            --data '{
+              "branch": "'"${{ github.ref_name }}"'",
+              "commit_sha": "'"${{ github.sha }}"'",
+              "failed_count": "'"$FAILED_COUNT"'",
+              "failed_summary": "'"$FAILED_SUMMARY"'",
+              "run_status": "'"$RUN_STATUS"'",
+              "attachments": [
+                {
+                  "text": "Click below to view the full TestRun details.",
+                  "fallback": "View TestRun Details",
+                  "actions": [
+                    {
+                      "type": "button",
+                      "text": "View TestRun",
+                      "url": "'"$TESTRAIL_URL"'"
+                    }
+                  ]
+                }
+              ]
+            }' \
+            $SLACK_WORKFLOW_WEBHOOK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,13 +61,6 @@ jobs:
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
-
-      - name: Extract TestRun ID from Playwright results
-        id: extract_testrun_id
-        run: |
-          # Extract the TestRail TestRun ID from Playwright test run result file
-          TEST_RUN_ID=$(cat test-automation/test-results/playwright-results.json | jq -r '.testRunId')
-          echo "TEST_RUN_ID=$TEST_RUN_ID" >> $GITHUB_ENV
           
       - name: Report Test Results
         if: failure()
@@ -76,53 +69,47 @@ jobs:
 
           - name: Notify Slack Workflow with Test Results
           
-      - name: Notify Slack Workflow with Test Results
-        if: always()
-        env:
-          SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
-          TESTRAIL_API_URL: ${{ secrets.TESTRAIL_API_URL }}
-          TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
-          TEST_RUN_ID: ${{ env.TEST_RUN_ID }}
-          TEST_RUN_NAME: ${{ env.TEST_RUN_NAME }}
-        run: |
-          # Retrieve tests in the run and filter out failed tests
-          TESTRAIL_RESPONSE=$(curl -s -u "dustin+playwright@goodparty.org:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
-          FAILED_TESTS=$(echo "$TESTRAIL_RESPONSE" | jq '[.[] | select(.status_id == 5)]')
-          FAILED_COUNT=$(echo "$FAILED_TESTS" | jq 'length')
-          
-          # Create a list of failed tests, with each test on a separate line
-          FAILED_SUMMARY=$(echo "$FAILED_TESTS" | jq -r '.[] | "- \(.title)\n"' | tr -d '\n' | sed 's/\n/,/g')
-
-          # Set overall status based on failed tests
-          if [ "$FAILED_COUNT" -gt 0 ]; then
-            RUN_STATUS="failed"
-          else
-            RUN_STATUS="passed"
-          fi
-
-          # Generate the TestRail URL for the test run
-          TESTRAIL_URL="${{ secrets.TESTRAIL_API_URL }}/test-runs/${{ env.TEST_RUN_ID }}"
-
-          # Send data to Slack Workflow Webhook with placeholders, including the commit SHA
-          curl -X POST -H "Content-type: application/json" \
+          - name: Notify Slack Workflow with Test Results
+          if: always()
+          env:
+            SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
+          run: |
+            # Parse Playwright results
+            RESULTS_FILE=test-results/playwright-results.json
+            TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
+            FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
+            RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)
+            FAILED_SUMMARY=$(jq -r '.suites[].specs[].tests[] | select(.results[].status == "unexpected") | "- \(.title)"' $RESULTS_FILE | tr '\n' ',' | sed 's/,$//')
+  
+            # Convert duration to seconds
+            RUN_DURATION_SECS=$(awk "BEGIN {print $RUN_DURATION / 1000}")
+  
+            # Determine overall run status
+            if [ "$FAILED_COUNT" -gt 0 ]; then
+              RUN_STATUS="failed"
+            else
+              RUN_STATUS="passed"
+            fi
+  
+            # Generate the Slack notification
+            curl -X POST -H "Content-type: application/json" \
             --data '{
-              "branch": "'"${{ github.ref_name }}"'",
-              "commit_sha": "'"${{ github.sha }}"'",
-              "failed_count": "'"$FAILED_COUNT"'",
-              "failed_summary": "'"$FAILED_SUMMARY"'",
-              "run_status": "'"$RUN_STATUS"'",
+              "text": "Playwright Test Results",
               "attachments": [
                 {
-                  "text": "Click below to view the full TestRun details.",
-                  "fallback": "View TestRun Details",
-                  "actions": [
-                    {
-                      "type": "button",
-                      "text": "View TestRun",
-                      "url": "'"$TESTRAIL_URL"'"
-                    }
+                  "color": "'"$(if [ "$FAILED_COUNT" -gt 0 ]; then echo "danger"; else echo "good"; fi)"'",
+                  "fields": [
+                    { "title": "Branch", "value": "'"${{ github.ref_name }}"'", "short": true },
+                    { "title": "Commit", "value": "'"${{ github.sha }}"'", "short": true },
+                    { "title": "Total Tests", "value": "'"$TOTAL_TESTS"'", "short": true },
+                    { "title": "Failed Tests", "value": "'"$FAILED_COUNT"'", "short": true },
+                    { "title": "Duration", "value": "'"${RUN_DURATION_SECS}s"'", "short": true }
                   ]
+                },
+                {
+                  "title": "Failed Tests",
+                  "text": "'"$FAILED_SUMMARY"'",
+                  "color": "danger"
                 }
               ]
-            }' \
-            $SLACK_WORKFLOW_WEBHOOK
+            }' $SLACK_WORKFLOW_WEBHOOK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,8 +61,66 @@ jobs:
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
+
+      - name: Extract TestRun ID from Playwright results
+        id: extract_testrun_id
+        run: |
+          # Extract the TestRail TestRun ID from Playwright test run result file
+          TEST_RUN_ID=$(cat test-automation/test-results/playwright-results.json | jq -r '.testRunId')
+          echo "TEST_RUN_ID=$TEST_RUN_ID" >> $GITHUB_ENV
           
       - name: Report Test Results
         if: failure()
         run: |
           echo "Playwright tests failed. Review the test results."
+
+          - name: Notify Slack Workflow with Test Results
+          if: always()
+          env:
+            SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
+            TESTRAIL_API_URL: ${{ secrets.TESTRAIL_API_URL }}
+            TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+            TEST_RUN_ID: ${{ env.TEST_RUN_ID }}
+            TEST_RUN_NAME: ${{ env.TEST_RUN_NAME }}
+          run: |
+            # Retrieve tests in the run and filter out failed tests
+            TESTRAIL_RESPONSE=$(curl -s -u "your_username:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
+            FAILED_TESTS=$(echo "$TESTRAIL_RESPONSE" | jq '[.[] | select(.status_id == 5)]')
+            FAILED_COUNT=$(echo "$FAILED_TESTS" | jq 'length')
+            
+            # Create a list of failed tests, with each test on a separate line
+            FAILED_SUMMARY=$(echo "$FAILED_TESTS" | jq -r '.[] | "- \(.title)\n"' | tr -d '\n' | sed 's/\n/,/g')
+  
+            # Set overall status based on failed tests
+            if [ "$FAILED_COUNT" -gt 0 ]; then
+              RUN_STATUS="failed"
+            else
+              RUN_STATUS="passed"
+            fi
+  
+            # Generate the TestRail URL for the test run
+            TESTRAIL_URL="${{ secrets.TESTRAIL_API_URL }}/test-runs/${{ env.TEST_RUN_ID }}"
+  
+            # Send data to Slack Workflow Webhook with placeholders, including the commit SHA
+            curl -X POST -H "Content-type: application/json" \
+              --data '{
+                "branch": "'"${{ github.ref_name }}"'",
+                "commit_sha": "'"${{ github.sha }}"'",
+                "failed_count": "'"$FAILED_COUNT"'",
+                "failed_summary": "'"$FAILED_SUMMARY"'",
+                "run_status": "'"$RUN_STATUS"'",
+                "attachments": [
+                  {
+                    "text": "Click below to view the full TestRun details.",
+                    "fallback": "View TestRun Details",
+                    "actions": [
+                      {
+                        "type": "button",
+                        "text": "View TestRun",
+                        "url": "'"$TESTRAIL_URL"'"
+                      }
+                    ]
+                  }
+                ]
+              }' \
+              $SLACK_WORKFLOW_WEBHOOK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,65 +57,41 @@ jobs:
       - name: Run Playwright Tests
         run: |
           cd test-automation
-          mkdir -p test-results
-          chmod -R u+w test-results
-          npx playwright test --reporter=json > test-results/playwright-results.json
+          npx playwright test
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
-          
+
       - name: Report Test Results
         if: failure()
         run: |
           echo "Playwright tests failed. Review the test results."
           
-      - name: Notify Slack Workflow with Test Results
-        if: always()
+      - name: Notify Slack Workflow
         env:
           SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
         run: |
-          # Locate results file
-          RESULTS_FILE=test-results/playwright-results.json
-          if [ ! -f "$RESULTS_FILE" ]; then
-            echo "{}" > "$RESULTS_FILE"
-            echo "Results file not found. Created an empty file."
-          fi
-
-          # Parse Playwright results
-          TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
-          FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
-          RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)
-          FAILED_SUMMARY=$(jq -r '.suites[].specs[].tests[] | select(.results[].status == "unexpected") | "- \(.title)"' $RESULTS_FILE | tr '\n' ',' | sed 's/,$//')
-
-          # Convert duration to seconds
-          RUN_DURATION_SECS=$(awk "BEGIN {print $RUN_DURATION / 1000}")
-
-          # Determine overall run status
-          if [ "$FAILED_COUNT" -gt 0 ]; then
-            RUN_STATUS="failed"
-          else
-            RUN_STATUS="passed"
-          fi
-
-          # Generate the Slack notification
+          STATUS=$([[ ${{ job.status }} == "success" ]] && echo "Pass" || echo "Fail")
+          COLOR=$([[ ${{ job.status }} == "success" ]] && echo "good" || echo "danger")
           curl -X POST -H "Content-type: application/json" \
           --data '{
-            "text": "Playwright Test Results",
+            "text": "Playwright Test Results ("$STATUS")",
             "attachments": [
               {
-                "color": "'"$(if [ "$FAILED_COUNT" -gt 0 ]; then echo "danger"; else echo "good"; fi)"'",
+                "color": "'"$COLOR"'",
                 "fields": [
                   { "title": "Branch", "value": "'"${{ github.ref_name }}"'", "short": true },
                   { "title": "Commit", "value": "'"${{ github.sha }}"'", "short": true },
-                  { "title": "Total Tests", "value": "'"$TOTAL_TESTS"'", "short": true },
-                  { "title": "Failed Tests", "value": "'"$FAILED_COUNT"'", "short": true },
-                  { "title": "Duration", "value": "'"${RUN_DURATION_SECS}s"'", "short": true }
+                  { "title": "Vercel URL", "value": "'"${{ env.BASE_URL }}"'", "short": true }
+                ],
+                "actions": [
+                  {
+                    "type": "button",
+                    "text": "View Test Runs",
+                    "url": "https://goodparty.testrail.io/index.php?/runs/overview/1",
+                    "style": "primary"
+                  }
                 ]
-              },
-              {
-                "title": "Failed Tests",
-                "text": "'"$FAILED_SUMMARY"'",
-                "color": "danger"
               }
             ]
           }' $SLACK_WORKFLOW_WEBHOOK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
         run: |
           # Parse Playwright results
-          RESULTS_FILE=test-results/playwright-results.json
+          RESULTS_FILE=playwright-results.json
           TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
           FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
           RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
           npx playwright test
         env:
           BASE_URL: ${{ env.BASE_URL }}
+          TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
           
       - name: Report Test Results
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
           TEST_RUN_NAME: ${{ env.TEST_RUN_NAME }}
         run: |
           # Retrieve tests in the run and filter out failed tests
-          TESTRAIL_RESPONSE=$(curl -s -u "your_username:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
+          TESTRAIL_RESPONSE=$(curl -s -u "dustin+playwright@goodparty.org:${{ secrets.TESTRAIL_API_KEY }}" "${{ secrets.TESTRAIL_API_URL }}/get_tests/${{ env.TEST_RUN_ID }}")
           FAILED_TESTS=$(echo "$TESTRAIL_RESPONSE" | jq '[.[] | select(.status_id == 5)]')
           FAILED_COUNT=$(echo "$FAILED_TESTS" | jq 'length')
           

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Run Playwright Tests
         run: |
           cd test-automation
-          npx playwright test --reporter=json > playwright-results.json
+          mkdir -p test-results
+          chmod -R u+w test-results
+          npx playwright test --reporter=json > test-results/playwright-results.json
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
@@ -72,8 +74,14 @@ jobs:
         env:
           SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
         run: |
+          # Locate results file
+          RESULTS_FILE=test-results/playwright-results.json
+          if [ ! -f "$RESULTS_FILE" ]; then
+            echo "{}" > "$RESULTS_FILE"
+            echo "Results file not found. Created an empty file."
+          fi
+
           # Parse Playwright results
-          RESULTS_FILE=playwright-results.json
           TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
           FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
           RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run Playwright Tests
         run: |
           cd test-automation
-          npx playwright test
+          npx playwright test --reporter=json > playwright-results.json
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,50 +66,48 @@ jobs:
         if: failure()
         run: |
           echo "Playwright tests failed. Review the test results."
-
-          - name: Notify Slack Workflow with Test Results
           
-          - name: Notify Slack Workflow with Test Results
-          if: always()
-          env:
-            SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
-          run: |
-            # Parse Playwright results
-            RESULTS_FILE=test-results/playwright-results.json
-            TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
-            FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
-            RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)
-            FAILED_SUMMARY=$(jq -r '.suites[].specs[].tests[] | select(.results[].status == "unexpected") | "- \(.title)"' $RESULTS_FILE | tr '\n' ',' | sed 's/,$//')
-  
-            # Convert duration to seconds
-            RUN_DURATION_SECS=$(awk "BEGIN {print $RUN_DURATION / 1000}")
-  
-            # Determine overall run status
-            if [ "$FAILED_COUNT" -gt 0 ]; then
-              RUN_STATUS="failed"
-            else
-              RUN_STATUS="passed"
-            fi
-  
-            # Generate the Slack notification
-            curl -X POST -H "Content-type: application/json" \
-            --data '{
-              "text": "Playwright Test Results",
-              "attachments": [
-                {
-                  "color": "'"$(if [ "$FAILED_COUNT" -gt 0 ]; then echo "danger"; else echo "good"; fi)"'",
-                  "fields": [
-                    { "title": "Branch", "value": "'"${{ github.ref_name }}"'", "short": true },
-                    { "title": "Commit", "value": "'"${{ github.sha }}"'", "short": true },
-                    { "title": "Total Tests", "value": "'"$TOTAL_TESTS"'", "short": true },
-                    { "title": "Failed Tests", "value": "'"$FAILED_COUNT"'", "short": true },
-                    { "title": "Duration", "value": "'"${RUN_DURATION_SECS}s"'", "short": true }
-                  ]
-                },
-                {
-                  "title": "Failed Tests",
-                  "text": "'"$FAILED_SUMMARY"'",
-                  "color": "danger"
-                }
-              ]
-            }' $SLACK_WORKFLOW_WEBHOOK
+      - name: Notify Slack Workflow with Test Results
+        if: always()
+        env:
+          SLACK_WORKFLOW_WEBHOOK: ${{ secrets.SLACK_WORKFLOW_WEBHOOK }}
+        run: |
+          # Parse Playwright results
+          RESULTS_FILE=test-results/playwright-results.json
+          TOTAL_TESTS=$(jq '.stats.expected' $RESULTS_FILE)
+          FAILED_COUNT=$(jq '.stats.unexpected' $RESULTS_FILE)
+          RUN_DURATION=$(jq '.stats.duration' $RESULTS_FILE)
+          FAILED_SUMMARY=$(jq -r '.suites[].specs[].tests[] | select(.results[].status == "unexpected") | "- \(.title)"' $RESULTS_FILE | tr '\n' ',' | sed 's/,$//')
+
+          # Convert duration to seconds
+          RUN_DURATION_SECS=$(awk "BEGIN {print $RUN_DURATION / 1000}")
+
+          # Determine overall run status
+          if [ "$FAILED_COUNT" -gt 0 ]; then
+            RUN_STATUS="failed"
+          else
+            RUN_STATUS="passed"
+          fi
+
+          # Generate the Slack notification
+          curl -X POST -H "Content-type: application/json" \
+          --data '{
+            "text": "Playwright Test Results",
+            "attachments": [
+              {
+                "color": "'"$(if [ "$FAILED_COUNT" -gt 0 ]; then echo "danger"; else echo "good"; fi)"'",
+                "fields": [
+                  { "title": "Branch", "value": "'"${{ github.ref_name }}"'", "short": true },
+                  { "title": "Commit", "value": "'"${{ github.sha }}"'", "short": true },
+                  { "title": "Total Tests", "value": "'"$TOTAL_TESTS"'", "short": true },
+                  { "title": "Failed Tests", "value": "'"$FAILED_COUNT"'", "short": true },
+                  { "title": "Duration", "value": "'"${RUN_DURATION_SECS}s"'", "short": true }
+                ]
+              },
+              {
+                "title": "Failed Tests",
+                "text": "'"$FAILED_SUMMARY"'",
+                "color": "danger"
+              }
+            ]
+          }' $SLACK_WORKFLOW_WEBHOOK


### PR DESCRIPTION
Previously, test runs in TestRail were generating with the generic name "Playwright Test Run". 
With these changes in `deploy.yml` it will now generate with: 

"Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}". 

This will make it easier to determine which branch/commit each test run is covering.

This also adds integrations with Slack to post test run results to #bot-test-automation