### PR TITLE
WEB-3316: updated map result count to be fixed above scrolled content

### DIFF
--- a/app/candidates/components/map/Filters.js
+++ b/app/candidates/components/map/Filters.js
@@ -118,7 +118,7 @@ export default memo(function Filters({ filters, onChangeFilters, campaigns }) {
           />
         </div>
       </div>
-      <div className="bg-indigo-100 p-4">
+      <div className="bg-indigo-100 p-4 pb-2">
         <TextField
           label="Search for a candidate"
           fullWidth

--- a/app/candidates/components/map/Results.js
+++ b/app/candidates/components/map/Results.js
@@ -21,15 +21,14 @@ export default memo(function Results({
   const viewingSubset = campaigns.length < totalNumCampaigns;
 
   return (
-    <div className="md:w-[400px] lg:w-[500px] h-80  md:h-[calc(100vh-56px-298px)] border-r border-gray-300 md:overflow-y-auto bg-indigo-100 overflow-auto">
-      <H5 className="p-6 flex gap-2 items-center">
-        Viewing {campaigns.length ? numberFormatter(campaigns.length) : ''}{' '}
-        candidates
+    <div className="md:w-[400px] lg:w-[500px] h-80  md:h-[calc(100vh-56px-298px)] border-r border-gray-300 bg-indigo-100 flex flex-col">
+      <H5 className="pb-2 px-6 flex gap-2 items-center min-h-[50px]">
+        {totalNumCampaigns ? numberFormatter(totalNumCampaigns) : ''} candidates
         {viewingSubset && (
           <>
             <span className="font-normal">
-              ({totalNumCampaigns ? numberFormatter(totalNumCampaigns) : ''}{' '}
-              total)
+              ({campaigns.length ? numberFormatter(campaigns.length) : ''}{' '}
+              within view)
             </span>
             <Button
               onClick={onZoomOut}
@@ -43,31 +42,33 @@ export default memo(function Results({
           </>
         )}
       </H5>
-      {campaigns.map((campaign) => (
-        <CampaignSnippet
-          key={campaign.slug}
-          campaign={campaign}
-          onSelectCampaign={onSelectCampaign}
-          selectedCampaign={selectedCampaign}
-        />
-      ))}
-      {campaigns.length === 0 && (
-        <div className="px-4">
-          <div className="px-6 py-8 lg:py-24 bg-white rounded-2xl border border-slate-300 text-center">
-            <H3>No results found</H3>
-            <Body1 className="mt-2 mb-8">
-              Know a candidate? Share GoodParty.org with them to get them listed
-              on the map.
-            </Body1>
+      <div className="grow overflow-auto">
+        {campaigns.map((campaign) => (
+          <CampaignSnippet
+            key={campaign.slug}
+            campaign={campaign}
+            onSelectCampaign={onSelectCampaign}
+            selectedCampaign={selectedCampaign}
+          />
+        ))}
+        {campaigns.length === 0 && (
+          <div className="px-4">
+            <div className="px-6 py-8 lg:py-24 bg-white rounded-2xl border border-slate-300 text-center">
+              <H3>No results found</H3>
+              <Body1 className="mt-2 mb-8">
+                Know a candidate? Share GoodParty.org with them to get them
+                listed on the map.
+              </Body1>
 
-            <a
-              href={`mailto:?subject=Question about your campaign&body=Hi there,%0A%0AI ran across this site when researching candidates running for office in my area that are running people-powered, non-partisan campaigns.%0A%0AI didn’t notice your name on here, and think your campaign would be a great fit alongside other community powered candidates. If you’d like to be featured on the map, this organization (GoodParty.org) noted that you can get in touch by creating an account at goodparty.org/sign-up.%0A%0AThank you for stepping up to serve our community. I hope to celebrate your victory on election night!%0A%0ABest,${user.firstName} ${user.lastName}`}
-            >
-              <Button variant="primary">Invite a Candidate</Button>
-            </a>
+              <a
+                href={`mailto:?subject=Question about your campaign&body=Hi there,%0A%0AI ran across this site when researching candidates running for office in my area that are running people-powered, non-partisan campaigns.%0A%0AI didn’t notice your name on here, and think your campaign would be a great fit alongside other community powered candidates. If you’d like to be featured on the map, this organization (GoodParty.org) noted that you can get in touch by creating an account at goodparty.org/sign-up.%0A%0AThank you for stepping up to serve our community. I hope to celebrate your victory on election night!%0A%0ABest,${user.firstName} ${user.lastName}`}
+              >
+                <Button variant="primary">Invite a Candidate</Button>
+              </a>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
- Updates the count of candidates on the map view to be fixed and not scroll with the result list
- Also updates the text a little: now shows # candidates with the total number of results. When viewing only a subset of the results in the map viewport, the text will read # candidates (# within view)

<img width="594" alt="Screenshot 2024-11-18 at 10 57 51 AM" src="https://github.com/user-attachments/assets/ed8258c0-2a0f-4a77-9065-ec8b4f1fe766">
