### PR TITLE
Added data-testid tags for cookie snackbar

### DIFF
--- a/app/shared/buttons/ErrorButton.js
+++ b/app/shared/buttons/ErrorButton.js
@@ -14,6 +14,7 @@ export default function ErrorButton({
   loading = false,
   fullWidth = false,
   onClick,
+  dataTestId,
 }) {
   let baseClass = {
     'rounded-lg': true,
@@ -85,6 +86,7 @@ export default function ErrorButton({
       style={style}
       disabled={disabled}
       onClick={buttonOnClickHandler(onClick)}
+      data-testid={dataTestId || undefined}
     >
       {loading ? <ButtonLoading /> : null}
       {children}

--- a/app/shared/layouts/CookiesSnackbar.js
+++ b/app/shared/layouts/CookiesSnackbar.js
@@ -22,12 +22,12 @@ export default function CookiesSnackbar() {
     setShowBanner(false);
   };
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-primary-dark text-white p-4 text-center">
+    <div className="fixed bottom-0 left-0 right-0 bg-primary-dark text-white p-4 text-center" data-testid="cookie-snackbar">
       We use cookies to personalize content, analyze traffic, and provide you
       with a better user experience. By continuing to browse this site, you
       consent to the use of cookies.
       <div className="mt-6" onClick={handleAccept}>
-        <ErrorButton className="ml-4" size="medium">
+        <ErrorButton className="ml-4" size="medium" dataTestId={"cookie-accept-btn"}>
           Accept
         </ErrorButton>
       </div>


### PR DESCRIPTION
This PR adds `data-testid` tags for the cookie snackbar and cookie accept button.

Added for automation tests: https://github.com/thegoodparty/test-automation/pull/5
