### PR TITLE
Updated workflow file to run tests against QA for QA pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,10 @@ on:
   pull_request:
     branches:
       - develop
-      - qa
-      - master
+
   push:
     branches:
-      - develop
       - qa
-      - master
 
 jobs:
   test:
@@ -33,13 +30,18 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy
+        if: ${{ github.ref_name != 'qa' }}
         run: |
           vercel --token ${{ secrets.VERCEL_TOKEN }}
 
-      - name: Capture Vercel Deployment URL
+      - name: Capture Deployment URL
         run: |
-          DEPLOYMENT_URL=$(vercel --token ${{ secrets.VERCEL_TOKEN }} --yes)
-          echo "BASE_URL=$DEPLOYMENT_URL" >> $GITHUB_ENV
+          if [ "${{ github.ref_name }}" = "qa" ]; then
+            echo "BASE_URL=https://qa.goodparty.org" >> $GITHUB_ENV
+          else
+            DEPLOYMENT_URL=$(vercel --token ${{ secrets.VERCEL_TOKEN }} --yes)
+            echo "BASE_URL=$DEPLOYMENT_URL" >> $GITHUB_ENV
+          fi
 
       - name: Checkout test-automation Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the `deploy.yml` file to set Playwright automation to run under these conditions:

* When creating a pull request to `develop`, it will test against a Vercel instance.
* When pushing to the `qa` branch, it will test against `https://qa.goodparty.org`