### PR TITLE
Added data-testids for personal information in profile, updates deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - qa
 
   push:
     branches:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         id: deploy
         if: ${{ github.ref_name != 'qa' }}
         run: |
-          vercel --token ${{ secrets.VERCEL_TOKEN }}
+          vercel --token ${{ secrets.VERCEL_TOKEN }} --yes
 
       - name: Capture Deployment URL
         run: |

--- a/app/(user)/profile/components/PersonalSection.js
+++ b/app/(user)/profile/components/PersonalSection.js
@@ -37,6 +37,7 @@ export const USER_SETTING_FIELDS = [
     initialValue: '',
     maxLength: 20,
     required: true,
+    dataTestid: 'personal-first-name',
   },
   {
     key: 'lastName',
@@ -44,6 +45,7 @@ export const USER_SETTING_FIELDS = [
     initialValue: '',
     maxLength: 20,
     required: true,
+    dataTestid: 'personal-last-name',
   },
   {
     key: 'email',
@@ -53,6 +55,7 @@ export const USER_SETTING_FIELDS = [
     type: 'email',
     cols: 12,
     required: true,
+    dataTestid: 'personal-email',
   },
   {
     key: 'phone',
@@ -61,6 +64,7 @@ export const USER_SETTING_FIELDS = [
     maxLength: 12,
     type: 'phone',
     required: true,
+    dataTestid: 'personal-phone',
   },
   {
     key: 'zip',
@@ -68,6 +72,7 @@ export const USER_SETTING_FIELDS = [
     initialValue: '',
     maxLength: 5,
     required: true,
+    dataTestid: 'personal-zip',
   },
 ];
 
@@ -179,6 +184,7 @@ function PersonalSection({ user }) {
                     shrink
                     required
                     label={field.label}
+                    data-testid={field.dataTestId}
                   />
                 </div>
               ) : (
@@ -192,6 +198,7 @@ function PersonalSection({ user }) {
                   required={field.required}
                   style={{ marginBottom: '16px' }}
                   InputLabelProps={{ shrink: true }}
+                  inputProps={{ 'data-testid': field.dataTestid }}
                 />
               )}
             </div>


### PR DESCRIPTION
Added `data-testid` tags for the personal information section of the profile settings page.

Note: Since I could not sign-in locally or in a Vercel environment, I cannot not test these tags until it is pushed up to qa.goodparty.org

This PR also updates `deploy.yml` to run Playwright tests against pull requests to the `qa` branch