### PR TITLE
WEB-3386: Update Candidate map count + add primary election result to preview

### DIFF
--- a/app/candidates/components/Hero.js
+++ b/app/candidates/components/Hero.js
@@ -3,7 +3,7 @@ import { numberFormatter } from 'helpers/numberHelper';
 import Image from 'next/image';
 import { memo } from 'react';
 
-export const WINNER_COUNT = 3435;
+export const WINNER_COUNT = 3441;
 
 export default memo(function Hero({ count = 0, longState }) {
   return (

--- a/app/candidates/components/Hero.js
+++ b/app/candidates/components/Hero.js
@@ -1,16 +1,17 @@
 import MaxWidth from '@shared/layouts/MaxWidth';
-import MarketingH1 from '@shared/typography/MarketingH1';
-import MarketingH4 from '@shared/typography/MarketingH4';
 import { numberFormatter } from 'helpers/numberHelper';
 import Image from 'next/image';
 import { memo } from 'react';
+
+export const WINNER_COUNT = 3435;
 
 export default memo(function Hero({ count = 0, longState }) {
   return (
     <div className="bg-primary-dark py-8 lg:py-24 text-white text-center ">
       <MaxWidth>
         <h1 className="text-center font-medium text-4xl md:text-5xl lg:text-6xl xl:text-7xl">
-          {numberFormatter(count)} Wins&nbsp;
+          {/* {numberFormatter(count)} Wins&nbsp; */}
+          {WINNER_COUNT.toLocaleString()} Wins&nbsp;
           <div className="sm:hidden" />
           & Counting
           <br /> by

--- a/app/candidates/components/map/CampaignPreview.js
+++ b/app/candidates/components/map/CampaignPreview.js
@@ -44,8 +44,6 @@ export default memo(function CampaignPreview({
     ? /won/i.test(hubSpotUpdates?.election_results)
     : didWin;
 
-  console.log(firstName, lastName, electionResults, primaryResults);
-
   return (
     <div className="absolute top-0 p-4 md:p-0 left-4 w-[calc(100vw-32px)]   md:left-[416px] lg:left-[516px] md:w-[320px]   md:shadow md:mt-4  rounded-2xl z-50">
       <div className="h-full bg-white p-4 rounded-2xl shadow-md md:shadow-none">

--- a/app/candidates/components/map/CampaignPreview.js
+++ b/app/candidates/components/map/CampaignPreview.js
@@ -34,7 +34,18 @@ export default memo(function CampaignPreview({
     avatar,
     electionDate,
     didWin,
+    data: { hubSpotUpdates } = {},
   } = selectedCampaign;
+
+  const primaryResults = hubSpotUpdates?.primary_election_result
+    ? /won/i.test(hubSpotUpdates?.primary_election_result)
+    : null;
+  const electionResults = hubSpotUpdates?.election_results
+    ? /won/i.test(hubSpotUpdates?.election_results)
+    : didWin;
+
+  console.log(firstName, lastName, electionResults, primaryResults);
+
   return (
     <div className="absolute top-0 p-4 md:p-0 left-4 w-[calc(100vw-32px)]   md:left-[416px] lg:left-[516px] md:w-[320px]   md:shadow md:mt-4  rounded-2xl z-50">
       <div className="h-full bg-white p-4 rounded-2xl shadow-md md:shadow-none">
@@ -95,10 +106,23 @@ export default memo(function CampaignPreview({
             </Body1>
           </div>
         )}
+        {primaryResults && (
+          <div className="flex mb-3 items-center">
+            <MdBeenhere size={20} className="text-primary-light" />
+            <Body1 className="ml-2 gray-600">
+              Primary Election Result: {primaryResults ? 'Winner' : 'Lost'}
+            </Body1>
+          </div>
+        )}
         <div className="flex mb-3 items-center">
           <MdBeenhere size={20} className="text-primary-light" />
           <Body1 className="ml-2 gray-600">
-            Election Results: {didWin ? 'Winner' : 'Upcoming'}
+            Election Result:&nbsp;
+            {typeof electionResults === 'boolean'
+              ? electionResults
+                ? 'Winner'
+                : 'Lost'
+              : 'Upcoming'}
           </Body1>
         </div>
       </div>

--- a/app/candidates/page.js
+++ b/app/candidates/page.js
@@ -3,6 +3,7 @@ import gpApi from 'gpApi';
 import gpFetch from 'gpApi/gpFetch';
 import CandidatesPage from './components/CandidatesPage';
 import { numberFormatter } from 'helpers/numberHelper';
+import { WINNER_COUNT } from './components/Hero';
 
 const fetchCount = async (onlyWinners = false) => {
   const api = gpApi.campaign.mapCount;
@@ -11,7 +12,8 @@ const fetchCount = async (onlyWinners = false) => {
 };
 
 export async function generateMetadata({ params, searchParams }) {
-  const { count } = await fetchCount(true);
+  // const { count } = await fetchCount(true);
+  const count = WINNER_COUNT;
   const title = `${numberFormatter(
     count,
   )} Wins by Independents across the U.S. 🎉`;

--- a/app/homepage/Hero.js
+++ b/app/homepage/Hero.js
@@ -5,6 +5,7 @@ import Button from '@shared/buttons/Button';
 import gpApi from 'gpApi';
 import gpFetch from 'gpApi/gpFetch';
 import Link from 'next/link';
+import { WINNER_COUNT } from 'app/candidates/components/Hero';
 
 const fetchWinnerCount = async () => {
   const api = gpApi.campaign.mapCount;
@@ -16,8 +17,9 @@ export default async function Hero() {
   const { count } = await fetchWinnerCount();
 
   // fallback to hardcoded 1,000 in case of bad api call
-  const winnerCount =
-    typeof count === 'number' && count > 0 ? count.toLocaleString() : '1,000';
+  // const winnerCount =
+  //   typeof count === 'number' && count > 0 ? count.toLocaleString() : '1,000';
+  const winnerCount = WINNER_COUNT.toLocaleString();
 
   return (
     <MaxWidth>


### PR DESCRIPTION
Requires this tgp-api change: https://github.com/thegoodparty/tgp-api/pull/311
- switches top level winner count number on homepage, candidate map to hardcoded number
- Adds primary result to candidate preview card over map if present