### PR TITLE
Updated Test Credential Secrets Names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,16 @@ jobs:
         env:
           BASE_URL: ${{ env.BASE_URL }}
           TEST_RUN_NAME: "Playwright Test Run - Branch: ${{ github.ref_name }} - Commit: ${{ github.sha }}"
+          NODE_PATH: ${{ secrets.NODE_PATH }}
+          TESTRAIL_API_KEY: ${{ secrets.TESTRAIL_API_KEY }}
+          TESTRAIL_API_URL: ${{ secrets.TESTRAIL_API_URL }}
+          TESTRAIL_PROJECT_ID: ${{ secrets.TESTRAIL_PROJECT_ID }}
+          TESTRAIL_URL: ${{ secrets.TESTRAIL_URL }}
+          TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
+          TEST_USER_EMAIL_1: ${{ secrets.TEST_USER_EMAIL_1 }}
+          TEST_USER_EMAIL_2: ${{ secrets.TEST_USER_EMAIL_2 }}
+          TEST_USER_PASSWORD_1: ${{ secrets.TEST_USER_PASSWORD_1 }}
+          TEST_USER_PASSWORD_2: ${{ secrets.TEST_USER_PASSWORD_2 }}
 
       - name: Report Test Results
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,10 +70,12 @@ jobs:
           TESTRAIL_PROJECT_ID: ${{ secrets.TESTRAIL_PROJECT_ID }}
           TESTRAIL_URL: ${{ secrets.TESTRAIL_URL }}
           TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
-          TEST_USER_EMAIL_1: ${{ secrets.TEST_USER_EMAIL_1 }}
-          TEST_USER_EMAIL_2: ${{ secrets.TEST_USER_EMAIL_2 }}
-          TEST_USER_PASSWORD_1: ${{ secrets.TEST_USER_PASSWORD_1 }}
-          TEST_USER_PASSWORD_2: ${{ secrets.TEST_USER_PASSWORD_2 }}
+          TEST_USER_ONBOARDING: ${{ secrets.TEST_USER_ONBOARDING}}
+          TEST_USER_LOCAL: ${{ secrets.TEST_USER_LOCAL }}
+          TEST_USER_STATE: ${{ secrets.TEST_USER_STATE }}
+          TEST_USER_ONBOARDING_PASSWORD: ${{ secrets.TEST_USER_ONBOARDING_PASSWORD }}
+          TEST_USER_LOCAL_PASSWORD: ${{ secrets.TEST_USER_LOCAL_PASSWORD }}
+          TEST_USER_STATE_PASSWORD: ${{ secrets.TEST_USER_STATE_PASSWORD}}
 
       - name: Report Test Results
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,9 +73,15 @@ jobs:
           TEST_USER_ONBOARDING: ${{ secrets.TEST_USER_ONBOARDING}}
           TEST_USER_LOCAL: ${{ secrets.TEST_USER_LOCAL }}
           TEST_USER_STATE: ${{ secrets.TEST_USER_STATE }}
+          TEST_USER_FEDERAL: ${{ secrets.TEST_USER_FEDERAL }}
+          TEST_USER_DEMO_LOCAL: ${{ secrets.TEST_USER_DEMO_LOCAL }}
+          TEST_USER_DEMO_FEDERAL: ${{ secrets.TEST_USER_DEMO_FEDERAL }}
           TEST_USER_ONBOARDING_PASSWORD: ${{ secrets.TEST_USER_ONBOARDING_PASSWORD }}
           TEST_USER_LOCAL_PASSWORD: ${{ secrets.TEST_USER_LOCAL_PASSWORD }}
           TEST_USER_STATE_PASSWORD: ${{ secrets.TEST_USER_STATE_PASSWORD}}
+          TEST_USER_FEDERAL_PASSWORD: ${{ secrets.TEST_USER_FEDERAL_PASSWORD}}
+          TEST_USER_DEMO_LOCAL_PASSWORD: ${{ secrets.TEST_USER_DEMO_LOCAL_PASSWORD }}
+          TEST_USER_DEMO_FEDERAL_PASSWORD: ${{ secrets.TEST_USER_DEMO_FEDERAL_PASSWORD }}
 
       - name: Report Test Results
         if: failure()


### PR DESCRIPTION
Updated the Test Credential Secrets Names' to be more descriptive, as well as added additional test accounts:

- TEST_USER_ONBOARDING - User has not completed onboarding
- TEST_USER_LOCAL - User is running for a local office
- TEST_USER_STATE - User is running for a state office
- TEST_USER_FEDERAL - User is running for a federal office
- TEST_USER_DEMO_STATE - User is on the Demo (State)
- TEST_USER_DEMO_FEDERAL - User is on the Demo (Federal)