### PR TITLE
fix: put https:// back in app base string

### DIFF
--- a/appEnv.js
+++ b/appEnv.js
@@ -23,7 +23,7 @@ export const API_VERSION_PREFIX = '/v1';
 
 export const APP_BASE = IS_LOCAL
   ? 'http://localhost:4000'
-  : `${
+  : `https://${
       IS_PROD
         ? process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
         : process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL


### PR DESCRIPTION
`NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL` is usually set by vercel automatically, we are setting it manually on production to `https://goodparty.org`. We just need to remove the `https://` from the env var, and keep it here, so this still works the same on all envs