### PR TITLE
WEB-3847: add feedaback to sales/admin add campaign page

### DIFF
--- a/app/sales/add-campaign/page.js
+++ b/app/sales/add-campaign/page.js
@@ -12,10 +12,5 @@ export const metadata = meta;
 export default async function Page({ searchParams }) {
   await canCreateCampaigns();
 
-  const childProps = {
-    pathname: '/sales/add-campaign',
-    title: 'Add a new Campaign',
-  };
-
   return <CreateCampaignForm />;
 }


### PR DESCRIPTION
- Fixes an issue with the sales/admin campaign creation always giving the user a success message even if the call failed. 
- Adds more feedback to let user know that the call failed, and the error message to say why
- outputs some basic info of the created campaign for more feedback/validation
- Sends a success/error message to let the user know if the set password email sent or not

<img width="986" alt="Screenshot 2025-03-12 at 9 50 32 AM" src="https://github.com/user-attachments/assets/2d194732-428d-4853-b567-fa1be55b1e4f" />
<img width="974" alt="Screenshot 2025-03-12 at 9 50 39 AM" src="https://github.com/user-attachments/assets/7aa72e8c-986e-4b3f-a8cc-32a3d3beb2b7" />
<img width="978" alt="Screenshot 2025-03-12 at 9 50 49 AM" src="https://github.com/user-attachments/assets/bd947429-8789-4d50-bc65-e84df5f9f096" />
