### PR TITLE
Clean Vercel URL if it contains Style Guide

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Capture Deployment URL
         run: |
           DEPLOYMENT_URL=${{ github.event.deployment_status.environment_url }}
-          echo "DEPLOYMENT_URL = $DEPLOYMENT_URL"
-          echo "BASE_URL=$DEPLOYMENT_URL" >> $GITHUB_ENV
+          # Remove '-styleguide' from the URL if present
+          CLEANED_URL=$(echo "$DEPLOYMENT_URL" | sed 's/-styleguide//')
+          echo "DEPLOYMENT_URL = $CLEANED_URL"
+          echo "BASE_URL=$CLEANED_URL" >> $GITHUB_ENV
 
       - name: Checkout test-automation Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adjust the Vercel deploy URL if it has `-styleguide` in it, and removes it from being used in automated tests