### PR TITLE
WEB-3870: Fix for users not able to upgrade

### DIFF
--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.js
@@ -95,7 +95,7 @@ export const CommitteeSupportingFilesUpload = ({
       );
       onUploadSuccess(file.name);
     } catch (e) {
-      console.error('Error uploading file', e);
+      onUploadError(e);
     } finally {
       setLoadingFileUpload(false);
     }

--- a/app/(candidate)/dashboard/pro-sign-up/committee-check/components/EinCheckInput.js
+++ b/app/(candidate)/dashboard/pro-sign-up/committee-check/components/EinCheckInput.js
@@ -18,7 +18,6 @@ const EIN_HELP_MESSAGE = (
 );
 
 export const EinCheckInput = ({
-  loading = false,
   value = '',
   validated,
   setValidated,
@@ -45,14 +44,12 @@ export const EinCheckInput = ({
       className="mb-3"
       label="EIN Number"
       maxLength={10}
-      disabled={loading}
       value={value}
       onChange={handleOnChange}
       InputProps={{
         endAdornment: (
           <AsyncValidationIcon
             message={EIN_HELP_MESSAGE}
-            loading={loading}
             validated={validated}
             onTooltipOpen={() => {
               trackEvent(EVENTS.ProUpgrade.CommitteeCheck.HoverEinHelp);

--- a/gpApi/index.js
+++ b/gpApi/index.js
@@ -10,13 +10,6 @@ const gpApi = {
       method: 'DELETE',
       withAuth: true,
     },
-
-    einCheck: {
-      url: `${base}campaign/ein-check`,
-      method: 'GET',
-      withAuth: true,
-      returnFullResponse: true,
-    },
   },
 
   //


### PR DESCRIPTION
- removed failing ein-check call for local client side validation 
- this was preventing users from continuing past the committee files upload step of the pro upgrade flow