### PR TITLE
Added matrix strategy to Playwright tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,7 +39,7 @@ jobs:
         id: global-setup
         run: |
           cd test-automation
-          npx ts-node globalSetup.js
+          NODE_OPTIONS=--experimental-specifier-resolution=node npx ts-node --project tsconfig.json globalSetup.ts
         env:
           CI: "true"
           BASE_URL: ${{ env.BASE_URL }}


### PR DESCRIPTION
Applied Sharding strategy to Playwright tests:

```
jobs:
  run-e2e-tests:
    runs-on: ubuntu-latest
    if: github.event.deployment_status.state == 'success'
    strategy:
      matrix:
        shard: [1/4, 2/4, 3/4, 4/4]
      fail-fast: false
```