### PR TITLE
Add EC2 runner for Playwright Tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -143,7 +143,7 @@ jobs:
           repository: thegoodparty/test-automation
           token: ${{ secrets.GH_PAT_TEST }}
           path: test-automation
-          ref: enable_all_tests
+          ref: develop
 
       - name: Install Playwright Dependencies in test-automation Repo
         run: |


### PR DESCRIPTION
This PR adds an EC2 runner for GitHub Actions, to be used for Playwright tests. The .yml file starts the runner, installs all necessary dependencies, then executes the tests. Afterwards, the instance is terminated