### PR TITLE
WEB-3480: t will not let me generate two of the same type of script back-to-back

### DIFF
--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
@@ -12,12 +12,13 @@ import { generateAIContent } from 'helpers/generateAIContent'
 import { getCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions'
 import { debounce } from 'helpers/debounceHelper'
 import { useSnackbar } from 'helpers/useSnackbar'
+import { useCampaign } from '@shared/hooks/useCampaign'
 
 export const GenerateLoadingScreen = ({
-  campaign = {},
   aiTemplateKey = '',
   onNext = (aiScriptKey = '') => {},
 }) => {
+  const [campaign, setCampaign] = useCampaign()
   const [aiContentSections] = buildAiContentSections(
     campaign,
     AI_CONTENT_SUB_SECTION_KEY,
@@ -47,6 +48,7 @@ export const GenerateLoadingScreen = ({
       campaign,
       AI_CONTENT_SUB_SECTION_KEY,
     )
+    setCampaign(campaign)
     if (jobsProcessing) {
       return debounce(() => generateContentPolling(aiScriptKey), 1000 * 3)
     } else {

--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
@@ -30,7 +30,7 @@ export const GenerateLoadingScreen = ({
   const fireError = () => {
     setGenerateTimeoutId(null)
     errorSnackbar(
-      'We are experiencing an issue creating your content. Please report an issue using the Feedback bar on the right',
+      'We are experiencing an issue creating your content. Please report an issue using the Feedback bar on the right.',
     )
   }
 

--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
@@ -48,6 +48,7 @@ export const GenerateLoadingScreen = ({
       campaign,
       AI_CONTENT_SUB_SECTION_KEY,
     )
+
     setCampaign(campaign)
     if (jobsProcessing) {
       return debounce(() => generateContentPolling(aiScriptKey), 1000 * 3)

--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateLoadingScreen.js
@@ -30,7 +30,7 @@ export const GenerateLoadingScreen = ({
   const fireError = () => {
     setGenerateTimeoutId(null)
     errorSnackbar(
-      'We are experiencing an issue creating your content. Please report an issue using the Feedback bar on the right.',
+      'We are experiencing an issue creating your content. Please report an issue using the Feedback bar on the right',
     )
   }
 

--- a/app/shared/hooks/CampaignProvider.js
+++ b/app/shared/hooks/CampaignProvider.js
@@ -1,28 +1,24 @@
 'use client'
-import { createContext, useEffect, useState } from 'react'
+import { createContext, useEffect, useState, useCallback } from 'react'
 import { fetchUserClientCampaign } from 'helpers/fetchUserClientCampaign'
 import { useUser } from '@shared/hooks/useUser'
 
 export const CampaignContext = createContext([null, () => {}])
 
-export const CampaignProvider = ({ children }) => {
-  const [campaign, setCampaign] = useState(null)
+export const CampaignProvider = ({ children, campaign: initCampaign }) => {
+  const [campaign, setCampaign] = useState(initCampaign)
   const [user] = useUser()
 
-  const refreshCampaign = async () => {
-    const campaign = await fetchUserClientCampaign()
-    setCampaign(campaign?.ok && campaign.ok === false ? null : campaign)
-  }
+  const refreshCampaign = useCallback(async () => {
+    const resp = await fetchUserClientCampaign()
+    setCampaign(!resp.ok ? null : resp.data)
+  }, [])
 
   useEffect(() => {
-    const getCampaign = async () => {
-      const campaign = await fetchUserClientCampaign()
-      setCampaign(campaign?.ok && campaign.ok === false ? null : campaign)
-    }
     if (user) {
-      getCampaign()
+      refreshCampaign()
     }
-  }, [user])
+  }, [user, refreshCampaign])
 
   return (
     <CampaignContext.Provider value={[campaign, setCampaign, refreshCampaign]}>

--- a/app/shared/layouts/PageWrapper.js
+++ b/app/shared/layouts/PageWrapper.js
@@ -11,13 +11,17 @@ import { CampaignProvider } from '@shared/hooks/CampaignProvider'
 import { ImpersonateUserProvider } from '@shared/user/ImpersonateUserProvider'
 import PromoBanner from '@shared/utils/PromoBanner'
 import { getReqPathname } from '@shared/utils/getReqPathname'
+import { fetchUserCampaign } from 'app/(candidate)/onboarding/shared/getCampaign'
 
 const PageWrapper = async ({ children }) => {
   const pathname = await getReqPathname()
+
+  const campaign = await fetchUserCampaign()
+
   return (
     <UserProvider>
       <ImpersonateUserProvider>
-        <CampaignProvider>
+        <CampaignProvider initCampaign={campaign}>
           <CampaignStatusProvider>
             <NavigationProvider>
               <div className="overflow-x-hidden">

--- a/helpers/fetchUserClientCampaign.js
+++ b/helpers/fetchUserClientCampaign.js
@@ -1,12 +1,11 @@
-import { apiRoutes } from 'gpApi/routes';
-import { clientFetch } from 'gpApi/clientFetch';
+import { apiRoutes } from 'gpApi/routes'
+import { clientFetch } from 'gpApi/clientFetch'
 
 export async function fetchUserClientCampaign() {
   try {
-    const resp = await clientFetch(apiRoutes.campaign.get);
-    return resp.data;
+    return await clientFetch(apiRoutes.campaign.get)
   } catch (e) {
-    console.error('error', e);
-    return false;
+    console.error('error', e)
+    return false
   }
 }


### PR DESCRIPTION
- This is an issue with an out of sync campaign after firing off a content generation, the front end chooses the same number to append on the template name, so it is trying to generate a script with the same name.
- We are already polling the campaign to check the generation status, so the fix is to just use the campaign context hooks, to update the loaded campaign when polling