### PR TITLE
changing a to the to make more sense

### DIFF
--- a/app/(candidate)/dashboard/campaign-details/components/CampaignSection.js
+++ b/app/(candidate)/dashboard/campaign-details/components/CampaignSection.js
@@ -43,7 +43,7 @@ const fields = [
     label: 'Campaign website',
     type: 'text',
     validateFn: isValidUrl,
-    helperText: 'Please provide a full url starting with http:// or https://',
+    helperText: 'Please provide the full url starting with http:// or https://',
   },
 ]
 


### PR DESCRIPTION
First PR walkthrough with Sanjeev. Changing "a" to "the" in url helper text on the profile page.