### PR TITLE
Fix for running app locally with api-dev

### DIFF
--- a/helpers/handleApiRequestRewrite.js
+++ b/helpers/handleApiRequestRewrite.js
@@ -7,9 +7,11 @@ const apiRootUrl = new URL(API_ROOT)
 const apiRewriteUrl = (ReqNextUrl) => {
   const newUrl = ReqNextUrl.clone()
   newUrl.protocol = apiRootUrl.protocol
-  newUrl.host = apiRootUrl.host
+  newUrl.hostname = apiRootUrl.hostname
   newUrl.pathname = ReqNextUrl.pathname.replace('/api', '')
   newUrl.search = ReqNextUrl.search
+  newUrl.port = ''
+
   return newUrl.toString()
 }
 


### PR DESCRIPTION
- localhost's :4000 port number was getting passed over to the rewritten URL
- Was never an when running also api locally where we overwrite the port with the local api's port number