### PR TITLE
WEB-4225: info session links

### DIFF
--- a/app/(company)/volunteer/components/CTA.js
+++ b/app/(company)/volunteer/components/CTA.js
@@ -2,7 +2,12 @@ import Button from '@shared/buttons/Button'
 
 export default function CTA({ id }) {
   return (
-    <Button href="/info-session" id={id} size="large" color="secondary">
+    <Button
+      href="https://goodpartyorg.circle.so/join?invitation_token=972b834345e05305e97fcc639c51ac54e3a04d8b-1c106100-4719-4b8a-81e1-73e513bbcd5f"
+      id={id}
+      size="large"
+      color="secondary"
+    >
       Get Involved
     </Button>
   )

--- a/app/(company)/volunteer/components/HelpWin.js
+++ b/app/(company)/volunteer/components/HelpWin.js
@@ -23,12 +23,12 @@ export default function HelpWin() {
               </div>
 
               <Button
-                href="/info-session"
+                href="https://goodpartyorg.circle.so/join?invitation_token=972b834345e05305e97fcc639c51ac54e3a04d8b-1c106100-4719-4b8a-81e1-73e513bbcd5f"
                 id="schedule-info-session"
                 size="large"
                 className="w-full md:w-auto"
               >
-                Schedule info session
+                Join the Community
               </Button>
             </div>
             <div className=" col-span-12 md:col-span-6 hidden md:block">

--- a/app/shared/layouts/constants.js
+++ b/app/shared/layouts/constants.js
@@ -57,11 +57,6 @@ export const FOOTER_COLUMNS = [
         link: '/academy',
         id: 'footer-campaign-academy',
       },
-      {
-        label: 'Book an Info Session',
-        link: '/info-session',
-        id: 'footer-campaign-info',
-      },
       { label: 'Book a Demo', link: '/get-a-demo', id: 'footer-campaign-demo' },
       {
         label: 'Political Definitions',

--- a/app/shared/layouts/navigation/NavigationProvider.js
+++ b/app/shared/layouts/navigation/NavigationProvider.js
@@ -10,7 +10,6 @@ import {
   SlideshowRounded,
   SearchRounded,
   VolunteerActivismRounded,
-  EventAvailableRounded,
   MailRounded,
   NewspaperRounded,
   ListRounded,
@@ -90,13 +89,6 @@ export const COMMUNITY_LINKS = [
     icon: <MapIcon />,
     id: 'nav-find-candidates',
     dataTestId: 'nav-find-candidates',
-  },
-  {
-    label: 'Info Session',
-    href: '/info-session',
-    icon: <EventAvailableRounded />,
-    id: 'nav-info-session',
-    dataTestId: 'nav-info-session',
   },
   {
     label: 'Get Stickers',


### PR DESCRIPTION
- removes info session links from main navs
- updates links in /volunteer page to point to circle sign up

<img width="1497" alt="Screenshot 2025-06-17 at 10 18 37 AM" src="https://github.com/user-attachments/assets/50c8c4bc-e6c1-4908-bf88-b01df41295c0" />
<img width="1070" alt="Screenshot 2025-06-17 at 10 18 49 AM" src="https://github.com/user-attachments/assets/43d13fe3-9017-4b59-ba76-06cf090497bc" />
