### PR TITLE
Removing min-width from a couple of isolated modals in the outreach flows

### DIFF
--- a/app/(candidate)/dashboard/components/tasks/flows/DownloadStep.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/DownloadStep.js
@@ -58,7 +58,7 @@ export default function DownloadStep({
   }
 
   return (
-    <div className="p-4 min-w-[500px]">
+    <div className="p-4">
       <H1 className="text-center mb-8">Download your materials</H1>
       <div className="flex flex-col gap-4 items-center">
         <CopyScriptButton

--- a/app/(candidate)/dashboard/components/tasks/flows/ImageStep.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/ImageStep.js
@@ -41,7 +41,7 @@ export default function ImageStep({
   }
 
   return (
-    <div className="p-4 min-w-[500px]">
+    <div className="p-4">
       <H1 className="mb-4 text-center">Attach image</H1>
       <Body1 className="text-center my-8">
         Attach your image below.

--- a/app/admin/ecanvasser/components/AddEcanvasser.js
+++ b/app/admin/ecanvasser/components/AddEcanvasser.js
@@ -38,7 +38,7 @@ export default function AddEcanvasser({ open, onClose, createCallback }) {
   const isDisabled = !email || !apiKey || !isValidEmail(email)
   return (
     <Modal open={open} closeCallback={onClose}>
-      <div className="min-w-[500px]">
+      <div className="p-4">
         <H2 className="mb-4">Add a new Ecanvasser</H2>
         <form onSubmit={handleSubmit}>
           <EmailInput


### PR DESCRIPTION
Got rid of min-wdith for a couple of isolated modals in the outreach flows and admin. It looks like the social post copy and share modal is using modal.js so I didn't touch that.
DownloadStep.js
ImageStep.js
AddEcanvasser.js (modal is only used in 1 instance in admin)