### PR TITLE
EFDWAPI-3915 add logging if we show electionOver in case we see this …

### DIFF
--- a/app/(candidate)/dashboard/components/DashboardPage.js
+++ b/app/(candidate)/dashboard/components/DashboardPage.js
@@ -114,7 +114,7 @@ export default function DashboardPage({
   const primaryLost = primaryResultState.primaryResult === 'lost'
 
   if (electionInPast || primaryLost) {
-    //for usersnap to pick up if this issue persists
+    //for usersnap to pick up if this issue persists. https://goodparty.atlassian.net/browse/WEB-3915
     console.log(
       `displaying election over - electionInPast: ${electionInPast}, primaryLost: ${primaryLost}, resolvedDate: ${resolvedDate}, weeksUntil: ${JSON.stringify(
         weeksUntil,


### PR DESCRIPTION
…issue again and the user reports it on usersnap again

going back to the original card, there was nothing that stood out immediately as could cause this as a bug, instead it may have happened as a db data inaccuracy? but there is no way to replay that. so i've added logs for the condition that we display ElectionOver, so if this happens again and if the user reports it, we can at least have the log to help debug better.