### PR TITLE
WEB-4244

### DIFF
--- a/helpers/stringHelper.js
+++ b/helpers/stringHelper.js
@@ -38,7 +38,7 @@ export function camelToKebab(camelCase) {
   if (!camelCase || camelCase == '') {
     return '';
   }
-  return camelCase.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+  return camelCase.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }
 
 export function toTitleCase(str) {


### PR DESCRIPTION
update regex so we capture digits as well as the letters in a camel case. before: one4You would return one4you but now it will return one4-you on the return trip to go back to camel case the original would turn into one4you, the second case would reform the original one4You
