### PR TITLE
Add Hubspot sales chat widget to top-level pages in the webapp

### DIFF
--- a/app/(candidate)/dashboard/campaign-assistant/page.js
+++ b/app/(candidate)/dashboard/campaign-assistant/page.js
@@ -3,6 +3,7 @@ import pageMetaData from 'helpers/metadataHelper'
 import CampaignAssistantPage from './components/CampaignAssistantPage'
 import { getServerUser } from 'helpers/userServerHelper'
 import candidateAccess from '../shared/candidateAccess'
+import Script from 'next/script'
 
 const meta = pageMetaData({
   title: 'AI Assistant | GoodParty.org',
@@ -24,5 +25,15 @@ export default async function Page({ params, searchParams }) {
     user,
     campaign,
   }
-  return <CampaignAssistantPage {...childProps} />
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <CampaignAssistantPage {...childProps} />
+    </>
+  )
 }

--- a/app/(candidate)/dashboard/campaign-details/page.js
+++ b/app/(candidate)/dashboard/campaign-details/page.js
@@ -7,6 +7,7 @@ import {
   serverFetchIssues,
   serverLoadCandidatePosition,
 } from 'app/(candidate)/dashboard/campaign-details/components/issues/serverIssuesUtils'
+import Script from 'next/script'
 
 const meta = pageMetaData({
   title: 'campaign Details | GoodParty.org',
@@ -37,5 +38,15 @@ export default async function Page({ params, searchParams }) {
     user,
   }
 
-  return <DetailsPage {...childProps} />
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <DetailsPage {...childProps} />
+    </>
+  )
 }

--- a/app/(candidate)/dashboard/content/page.js
+++ b/app/(candidate)/dashboard/content/page.js
@@ -6,6 +6,7 @@ import ContentPage from './components/ContentPage'
 import { fetchUserCampaign } from 'app/(candidate)/onboarding/shared/getCampaign'
 import { getServerUser } from 'helpers/userServerHelper'
 import { serverLoadCandidatePosition } from 'app/(candidate)/dashboard/campaign-details/components/issues/serverIssuesUtils'
+import Script from 'next/script'
 
 export const dynamic = 'force-dynamic'
 
@@ -44,7 +45,17 @@ export default async function Page({ params, searchParams }) {
     user,
   }
 
-  return <ContentPage {...childProps} />
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <ContentPage {...childProps} />
+    </>
+  )
 }
 
 function parsePrompts(promptsRaw) {

--- a/app/(candidate)/dashboard/page.js
+++ b/app/(candidate)/dashboard/page.js
@@ -4,6 +4,7 @@ import candidateAccess from './shared/candidateAccess'
 import { fetchUserCampaign } from '../onboarding/shared/getCampaign'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
+import Script from 'next/script'
 
 const fetchTasks = async () => {
   const currentDate = new Date().toISOString().split('T')[0]
@@ -29,6 +30,14 @@ export default async function Page() {
   const tasks = await fetchTasks()
 
   return (
-    <DashboardPage pathname="/dashboard" campaign={campaign} tasks={tasks} />
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <DashboardPage pathname="/dashboard" campaign={campaign} tasks={tasks} />
+    </>
   )
 }

--- a/app/(candidate)/dashboard/upgrade-to-pro/page.js
+++ b/app/(candidate)/dashboard/upgrade-to-pro/page.js
@@ -4,6 +4,7 @@ import candidateAccess from '../shared/candidateAccess'
 import { getServerUser } from 'helpers/userServerHelper'
 import UpgradeToProPage from './components/UpdateToProPage'
 import { serverLoadCandidatePosition } from 'app/(candidate)/dashboard/campaign-details/components/issues/serverIssuesUtils'
+import Script from 'next/script'
 const meta = pageMetaData({
   title: 'Upgrade To Pro! | GoodParty.org',
   description: 'Upgrade To Pro!',
@@ -27,5 +28,15 @@ export default async function Page({ params, searchParams }) {
     candidatePositions,
     user,
   }
-  return <UpgradeToProPage {...childProps} />
+  return (
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <UpgradeToProPage {...childProps} />
+    </>
+  )
 }

--- a/app/(candidate)/dashboard/website/page.js
+++ b/app/(candidate)/dashboard/website/page.js
@@ -4,6 +4,7 @@ import { serverFetch } from 'gpApi/serverFetch'
 import { apiRoutes } from 'gpApi/routes'
 import { WebsiteProvider } from './components/WebsiteProvider'
 import candidateAccess from '../shared/candidateAccess'
+import Script from 'next/script'
 
 const meta = pageMetaData({
   title: 'Website | GoodParty.org',
@@ -26,8 +27,16 @@ export default async function Page() {
   const contacts = contactsResp.ok ? contactsResp.data : null
 
   return (
-    <WebsiteProvider website={website} contacts={contacts}>
-      <WebsitePage pathname="/dashboard/website" />
-    </WebsiteProvider>
+    <>
+      <Script
+        type="text/javascript"
+        id="hs-script-loader"
+        strategy="afterInteractive"
+        src="//js.hs-scripts.com/21589597.js"
+      />
+      <WebsiteProvider website={website} contacts={contacts}>
+        <WebsitePage pathname="/dashboard/website" />
+      </WebsiteProvider>
+    </>
   )
 }


### PR DESCRIPTION
Adding the Hubspot widget in for Sales team to be able to intercept candidates on the dashboard and up-sell them to pro. 