### PR TITLE
Collin/web 4375 more warnings for personal info in website builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ invalid_urls.csv
 /.ai/
 /.cursor
 *repomix*
+CLAUDE.md

--- a/app/(candidate)/dashboard/website/editor/components/ContactStep.js
+++ b/app/(candidate)/dashboard/website/editor/components/ContactStep.js
@@ -15,7 +15,7 @@ export default function ContactStep({
 }) {
   return (
     <div>
-      {!noHeading && <H2 className="mb-6">How can people find you?</H2>}
+      {!noHeading && <H2 className="mb-6">How can voters contact you?</H2>}
       <Label>Address</Label>
       <AddressAutocomplete
         value={address}


### PR DESCRIPTION
the ticket was changed after product took a look.

as a process change suggestion: could we (product and devs) look at each card at grooming/sprint planning so we're on the same page? it would help shift things to the left and would help us avoid rework/shifting goalposts

reverts (instead of reset) all the changes from the previously merged commits. and adds a copy change