### PR TITLE
WEB-4422 - Remove district picker, put dev in a releasable state

### DIFF
--- a/app/(candidate)/onboarding/[slug]/[step]/components/OnboardingPage.js
+++ b/app/(candidate)/onboarding/[slug]/[step]/components/OnboardingPage.js
@@ -4,7 +4,7 @@ import OfficeStep from './OfficeStep'
 import PledgeStep from './PledgeStep'
 import UserSnapScript from '@shared/scripts/UserSnapScript'
 import CompleteStep from './CompleteStep'
-import DistrictStep from './districts/DistrictStep'
+
 
 export default function OnboardingPage(props) {
   const { step } = props
@@ -12,10 +12,9 @@ export default function OnboardingPage(props) {
     <OnboardingLayout {...props}>
       <div className="max-w-screen-sm mx-auto px-4 xl:p-0 ">
         {step === 1 && <OfficeStep {...props} />}
-        {step === 2 && <DistrictStep {...props} />}
-        {step === 3 && <PartyStep {...props} />}
-        {step === 4 && <PledgeStep {...props} />}
-        {step === 5 && <CompleteStep {...props} />}
+        {step === 2 && <PartyStep {...props} />}
+        {step === 3 && <PledgeStep {...props} />}
+        {step === 4 && <CompleteStep {...props} />}
       </div>
       <UserSnapScript />
     </OnboardingLayout>

--- a/app/(candidate)/onboarding/[slug]/[step]/page.js
+++ b/app/(candidate)/onboarding/[slug]/[step]/page.js
@@ -17,7 +17,7 @@ export default async function Page({ params }) {
   const { slug, step } = await params
   const campaign = await getCampaign(params)
 
-  const totalSteps = 5
+  const totalSteps = 4
 
   let stepInt = step ? parseInt(step, 10) : 1
   if (Number.isNaN(stepInt) || stepInt < 1 || stepInt > totalSteps) {
@@ -25,7 +25,7 @@ export default async function Page({ params }) {
   }
 
   let pledge
-  if (stepInt === 4) {
+  if (stepInt === 3) {
     pledge = await fetchContentByType('pledge')
   }
 

--- a/app/admin/victory-path/[slug]/components/AdminVictoryPathPage.js
+++ b/app/admin/victory-path/[slug]/components/AdminVictoryPathPage.js
@@ -6,26 +6,21 @@ import BlackButtonClient from '@shared/buttons/BlackButtonClient'
 import { updateCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions'
 import RenderInputField from '@shared/inputs/RenderInputField'
 import TextField from '@shared/inputs/TextField'
+import { Autocomplete } from '@mui/material'
 import { revalidatePage } from 'helpers/cacheHelper'
 import H3 from '@shared/typography/H3'
 import H2 from '@shared/typography/H2'
 import H4 from '@shared/typography/H4'
 import { dateUsHelper } from 'helpers/dateHelper'
 import Checkbox from '@shared/inputs/Checkbox'
+import VoterFileSection from './VoterFileSection'
 import AdditionalFieldsSection from 'app/admin/victory-path/[slug]/components/AdditionalFieldsSection'
 import { useAdminCampaign } from '@shared/hooks/useAdminCampaign'
 import { P2VProSection } from 'app/admin/victory-path/[slug]/components/P2VProSection'
 import { useSnackbar } from 'helpers/useSnackbar'
 import { apiRoutes } from 'gpApi/routes'
 import { clientFetch } from 'gpApi/clientFetch'
-import DistrictPicker from 'app/(candidate)/onboarding/[slug]/[step]/components/districts/DistrictPicker'
-
-const updateDistrict = (slug, L2DistrictType, L2DistrictName) =>
-  clientFetch(apiRoutes.campaign.district, {
-    slug,
-    L2DistrictType,
-    L2DistrictName,
-  })
+import { ELECTION_TYPE_CHOICES } from '../constants/electionTypeChoices.const'
 
 export async function sendVictoryMail(id) {
   try {
@@ -37,6 +32,25 @@ export async function sendVictoryMail(id) {
 }
 
 const sections = [
+  {
+    title: 'Voter File Settings',
+    fields: [
+      {
+        key: 'electionType',
+        label: 'Election Type',
+        type: 'text',
+        options: ELECTION_TYPE_CHOICES,
+        autocomplete: false,
+      },
+      {
+        key: 'electionLocation',
+        label: 'Election Location',
+        type: 'text',
+        options: ELECTION_TYPE_CHOICES,
+        autocomplete: true,
+      },
+    ],
+  },
   {
     title: 'Viability Score',
     fields: [
@@ -79,6 +93,11 @@ const sections = [
     title: 'Vote Goal',
     fields: [
       {
+        key: 'totalRegisteredVoters',
+        label: 'Total Registered Voters',
+        type: 'number',
+      },
+      {
         key: 'projectedTurnout',
         label: 'Projected Turnout number',
         type: 'number',
@@ -90,6 +109,40 @@ const sections = [
         type: 'number',
         formula: true,
       },
+    ],
+  },
+
+  {
+    title: 'Registered Voters',
+    fields: [
+      { key: 'republicans', label: 'Republicans', type: 'number' },
+      { key: 'democrats', label: 'Democrats', type: 'number' },
+      { key: 'indies', label: 'Indies', type: 'number' },
+      {
+        key: 'averageTurnout',
+        label: 'Average turnout number from past 3 races',
+        type: 'number',
+      },
+      {
+        key: 'averageTurnoutPercent',
+        label: 'Average Turnout Percent',
+        type: 'number',
+        formula: true,
+      },
+    ],
+  },
+
+  {
+    title: 'Voter Demographics',
+    fields: [
+      { key: 'allAvailVoters', label: 'All avail voters', type: 'number' },
+      { key: 'availVotersTo35', label: '18-35 avail voters', type: 'number' },
+      { key: 'women', label: 'Women', type: 'number' },
+      { key: 'men', label: 'Men', type: 'number' },
+      { key: 'africanAmerican', label: 'African American', type: 'number' },
+      { key: 'white', label: 'White', type: 'number' },
+      { key: 'asian', label: 'Asian', type: 'number' },
+      { key: 'hispanic', label: 'Hispanic', type: 'number' },
     ],
   },
   {
@@ -153,35 +206,52 @@ export default function AdminVictoryPathPage(props) {
   const [campaign, _, refreshCampaign] = useAdminCampaign()
   const { pathToVictory: p2vObject, details } = campaign
   const pathToVictory = useMemo(() => p2vObject?.data || {}, [p2vObject])
+  const [locations, setLocations] = useState([])
+  const [loadingLocations, setLoadingLocations] = useState(false)
 
   const [state, setState] = useState({
     ...initialState,
     ...pathToVictory,
   })
 
+  async function getVoterLocations(electionType, state) {
+    try {
+      setLoadingLocations(true)
+      const locationResp = await clientFetch(apiRoutes.voters.locations, {
+        electionType,
+        state,
+      })
+      const items = locationResp?.data || []
+      setLocations(items)
+      setLoadingLocations(false)
+    } catch (e) {
+      console.error('error', e)
+      return false
+    }
+  }
+
   function isNumeric(str) {
     return !isNaN(str) && !isNaN(parseFloat(str))
   }
+
+  useEffect(() => {
+    if (
+      state.electionType &&
+      state.electionType !== '' &&
+      state.electionType !== null &&
+      campaign.details?.state &&
+      campaign.details?.state !== '' &&
+      campaign.details?.state !== null
+    ) {
+      console.log(`getting voter locations for ${state.electionType}`)
+      getVoterLocations(state.electionType, campaign.details?.state)
+    }
+  }, [state.electionType, campaign.details?.state])
 
   const [notNeeded, setNotNeeded] = useState(
     pathToVictory?.p2vNotNeeded || false,
   )
   const { successSnackbar, errorSnackbar } = useSnackbar()
-
-  const handleDistrictSave = async (typeObj, nameObj) => {
-    try {
-      await updateDistrict(
-        campaign.slug,
-        typeObj.L2DistrictType,
-        nameObj.L2DistrictName,
-      )
-      successSnackbar('District updated')
-      await refreshCampaign()
-    } catch (e) {
-      console.error(e)
-      errorSnackbar('Error updating district')
-    }
-  }
 
   useEffect(() => {
     if (!state.winNumber || !state.averageTurnoutPercent) {
@@ -292,6 +362,31 @@ export default function AdminVictoryPathPage(props) {
       voterContactGoal,
       'viability.candidatesPerSeat': candidatesPerSeat,
       'viability.score': score,
+    })
+  }
+
+  const onChangeLocation = async (key, value) => {
+    setState({
+      ...state,
+      [key]: value,
+    })
+    let attr = []
+    attr.push({ key: 'pathToVictory.electionLocation', value })
+    attr.push({
+      key: 'pathToVictory.electionType',
+      value: state['electionType'],
+    })
+    await updateCampaign(attr, campaign.slug)
+    successSnackbar('Saved Election Location.')
+  }
+
+  const onChangeElectionType = async (key, value) => {
+    // we only want to update the election type if the location set
+    // now we clear the location options when the election type changes
+    setState({
+      ...state,
+      [key]: value,
+      ['electionLocation']: '',
     })
   }
 
@@ -428,14 +523,6 @@ export default function AdminVictoryPathPage(props) {
           </H3>{' '}
           <AdditionalFieldsSection />
           <P2VProSection />
-          <H2 className="mb-8">District Picker</H2>
-          <DistrictPicker
-            state={details.state}
-            electionYear={new Date(details?.electionDate).getFullYear()}
-            buttonText="Save District"
-            onSubmit={handleDistrictSave}
-            className="max-w-4xl mx-auto grid lg:grid-cols-2 gap-6"
-          />
           <H4 className="my-8">
             Office: <strong>{office || 'N/A'}</strong>. State:{' '}
             <strong>{details?.state || 'N/A'}</strong>. District:{' '}
@@ -465,6 +552,83 @@ export default function AdminVictoryPathPage(props) {
                           disabled
                           value={state[field.key]}
                         />
+                      </div>
+                    ) : field.key === 'electionType' ? (
+                      <div>
+                        <Autocomplete
+                          options={field.options}
+                          getOptionLabel={(option) => option.title}
+                          // value={state[field.key]}
+                          value={
+                            field.options.find(
+                              (option) => option.id === state[field.key],
+                            ) || null
+                          }
+                          onChange={(e, value) => {
+                            onChangeElectionType(
+                              field.key,
+                              value ? value.id : null,
+                            )
+                          }}
+                          renderInput={(params) => (
+                            <TextField
+                              {...params}
+                              label={field.label}
+                              required
+                              variant="outlined"
+                              InputProps={{
+                                ...params.InputProps,
+                                style: { borderRadius: '4px' },
+                              }}
+                            />
+                          )}
+                        />
+                      </div>
+                    ) : field.key === 'electionLocation' &&
+                      locations.length > 0 ? (
+                      <div>
+                        <>
+                          <Autocomplete
+                            options={locations}
+                            value={state[field.key]}
+                            onChange={(e, value) => {
+                              onChangeLocation(field.key, value)
+                            }}
+                            renderInput={(params) => (
+                              <TextField
+                                {...params}
+                                disabled={
+                                  state?.electionType === undefined ||
+                                  state.electionType === ''
+                                }
+                                label={field.label}
+                                required
+                                variant="outlined"
+                                InputProps={{
+                                  ...params.InputProps,
+                                  style: { borderRadius: '4px' },
+                                }}
+                              />
+                            )}
+                          />
+                          {!notNeeded && <VoterFileSection />}
+                        </>
+                      </div>
+                    ) : field.key === 'electionLocation' &&
+                      locations.length === 0 ? (
+                      <div>
+                        {loadingLocations ? (
+                          <div role="status" className="animate-pulse w-full">
+                            <div className="h-10 bg-gray-200 rounded-[4px] dark:bg-gray-700 w-full"></div>
+                            <span className="sr-only">Loading...</span>
+                          </div>
+                        ) : (
+                          <TextField
+                            label={field.label}
+                            disabled
+                            value="No locations available"
+                          />
+                        )}
                       </div>
                     ) : (
                       <RenderInputField

--- a/app/admin/victory-path/[slug]/components/VoterFileSection.js
+++ b/app/admin/victory-path/[slug]/components/VoterFileSection.js
@@ -7,6 +7,13 @@ export default function VoterFileSection() {
   return (
     <div className="bg-indigo-50 rounded border border-slate-300 p-4 my-12">
       <div>
+        {campaign?.details?.raceId === undefined ? (
+          <div className="my-4">
+            This campaign is not eligible for an Automatic Path To Victory
+            because the user manually selected an office.
+          </div>
+        ) : null}
+
         {campaign.pathToVictory?.p2vStatus === 'Waiting' &&
         campaign?.details?.raceId ? (
           <div className="my-4">

--- a/app/shared/CreateCampaignForm.js
+++ b/app/shared/CreateCampaignForm.js
@@ -12,27 +12,48 @@ import { CampaignOfficeSelectionModal } from 'app/(candidate)/dashboard/shared/C
 import { getUserCookie } from 'helpers/cookieHelper'
 import { apiRoutes } from 'gpApi/routes'
 import { clientFetch } from 'gpApi/clientFetch'
-import DistrictPicker from 'app/(candidate)/onboarding/[slug]/[step]/components/districts/DistrictPicker'
+import { useAnalytics } from './hooks/useAnalytics'
 
 const createCampaign = async (payload) => {
-  const user = getUserCookie(true)
-  if (user?.email) payload.adminUserEmail = user.email
-  return clientFetch(apiRoutes.admin.campaign.create, payload)
+  try {
+    const user = getUserCookie(true)
+    if (!user || !user.email) {
+      console.error('User not found or missing email')
+    } else {
+      payload.adminUserEmail = user.email
+    }
+
+    return await clientFetch(apiRoutes.admin.campaign.create, payload)
+  } catch (e) {
+    console.error('error', e)
+    return false
+  }
 }
 
-const updateDistrict = (slug, type, name) =>
-  clientFetch(apiRoutes.campaign.district, {
-    slug,
-    L2DistrictType: type,
-    L2DistrictName: name,
-  })
-
 const fields = [
-  { key: 'firstName', label: 'First Name', type: 'text', cols: 6, required: true },
-  { key: 'lastName', label: 'Last Name', type: 'text', cols: 6, required: true },
+  {
+    key: 'firstName',
+    label: 'First Name',
+    type: 'text',
+    cols: 6,
+    required: true,
+  },
+  {
+    key: 'lastName',
+    label: 'Last Name',
+    type: 'text',
+    cols: 6,
+    required: true,
+  },
   { key: 'email', label: 'Email', type: 'email', cols: 12, required: true },
   { key: 'phone', label: 'Phone', type: 'phone', cols: 6, required: true },
-  { key: 'zip', label: 'Zip Code', type: 'text', cols: 6, required: true },
+  {
+    key: 'zip',
+    label: 'Zip Code',
+    type: 'text',
+    cols: 6,
+    required: true,
+  },
   {
     key: 'party',
     label: 'Party',
@@ -49,156 +70,132 @@ const fields = [
     ],
   },
 ]
+export const initialValues = fields.reduce((acc, field) => {
+  acc[field.key] = ''
+  return acc
+}, {})
 
-const initialValues = fields.reduce((o, f) => ({ ...o, [f.key]: '' }), {})
-
-export const CreateCampaignForm = () => {
+export const CreateCampaignForm = ({}) => {
   const [values, setValues] = useState(initialValues)
-  const [campaign, setCampaign] = useState()
-  const [officeSelected, setOfficeSelected] = useState(false)
-  const [districtSaved, setDistrictSaved] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [showOffice, setShowOffice] = useState(false)
+  const [showOfficeSelectionModal, setShowOfficeSelectionModal] =
+    useState(false)
+  const [newCampaign, setNewCampaign] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
   const { successSnackbar, errorSnackbar } = useSnackbar()
+  const analytics = useAnalytics()
 
-  const step1Done = !!campaign
-  const step2Done = officeSelected
-  const step3Done = districtSaved
-  const step1Disabled = step1Done
-  const step2Disabled = !step1Done || step2Done
-  const step3Disabled = !step2Done || step3Done
-
-  const onChange = (k, v) => setValues({ ...values, [k]: v })
-
-  const handleCreate = async () => {
-    setLoading(true)
-    const resp = await createCampaign(values)
-    setLoading(false)
-    if (!resp.ok) return errorSnackbar(`Creation failed: ${resp.data?.message}`)
-    successSnackbar('Campaign created!')
-    setCampaign(resp.data)
+  const onChangeField = (key, value) => {
+    setValues({
+      ...values,
+      [key]: value,
+    })
   }
 
-  const handleOfficeComplete = async (updatedCampaign) => {
-    setCampaign(updatedCampaign)
-    setOfficeSelected(true)
-    setShowOffice(false)
-    successSnackbar('Office saved!')
-    
+  const openOfficeSelectionModal = () => {
+    setShowOfficeSelectionModal(true)
   }
 
-  const handleDistrictSave = async (type, name) => {
-    try {
-      await updateDistrict(
-        campaign.slug,
-        type.L2DistrictType,
-        name.L2DistrictName,
-      )
-      setDistrictSaved(true)
-      successSnackbar('District saved!')
-    } catch (e) {
-      console.error(e)
-      errorSnackbar('Error saving district')
+  const handleChooseOfficeComplete = async () => {
+    successSnackbar('Office Saved! Sending set password email...')
+    setShowOfficeSelectionModal(false)
+    setValues(initialValues)
+    setNewCampaign(null)
+  }
+
+  const disableCreate =
+    newCampaign ||
+    isLoading ||
+    (values.party === 'Other' && values.otherParty === '') ||
+    !fields.every((field) => values[field.key])
+
+  const handleCreateCampaign = async () => {
+    setIsLoading(true)
+    const campaignResponse = await createCampaign(values)
+    if (campaignResponse.ok) {
+      setNewCampaign(campaignResponse.data)
+      successSnackbar('Created!')
+
+    } else {
+      const errorData = campaignResponse.data
+      console.error('Campaign creation error', errorData)
+      errorSnackbar(`Creation failed: ${errorData?.message}`)
     }
+    setIsLoading(false)
   }
 
   return (
     <PortalPanel color="#2CCDB0">
       <H2 className="mb-12">Add a new Campaign</H2>
 
-      <h4 className="font-bold mb-2">Step 1 – Create Campaign</h4>
-
-      <div
-        className={`grid grid-cols-12 gap-3 ${
-          step1Disabled ? 'opacity-50 pointer-events-none' : ''
-        }`}
-      >
-        {fields.map((f) => (
+      <div className="grid grid-cols-12 gap-3">
+        {fields.map((field) => (
           <RenderInputField
-            key={f.key}
-            field={f}
-            value={values[f.key]}
-            onChangeCallback={onChange}
+            field={field}
+            value={values[field.key]}
+            onChangeCallback={onChangeField}
+            key={field.key}
           />
         ))}
-
         {values.party === 'Other' && (
-          <div className="col-span-12 md:col-span-6 mt-5">
+          <div className=" col-span-12 md:col-span-6 mt-5">
             <TextField
               label="Other Party"
-              fullWidth
+              onChange={(e) => onChangeField('otherParty', e.target.value)}
               value={values.otherParty}
-              onChange={(e) => onChange('otherParty', e.target.value)}
+              fullWidth
             />
           </div>
         )}
       </div>
 
-      <Button
-        color="primary"
-        className="mt-4"
-        loading={loading}
-        disabled={
-          step1Disabled ||
-          (values.party === 'Other' && !values.otherParty) ||
-          !fields.every((f) => values[f.key])
-        }
-        onClick={handleCreate}
-      >
-        Create Campaign
-      </Button>
-
-      {step1Done && (
-        <Body1 className="mt-4 text-success">Campaign created ✔</Body1>
-      )}
-
-      <hr className="my-8" />
-
-      <h4 className="font-bold mb-2">Step 2 – Select Office</h4>
-
-      <Button
-        color="primary"
-        disabled={step2Disabled}
-        onClick={() => setShowOffice(true)}
-      >
-        {step2Done ? 'Office Selected ✔' : 'Open Office Selector'}
-      </Button>
-
-      {campaign && (
-        <CampaignOfficeSelectionModal
-          adminMode
-          campaign={campaign}
-          show={showOffice}
-          onClose={() => setShowOffice(false)}
-          onSelect={handleOfficeComplete}
-        />
-      )}
-
-      <hr className="my-8" />
-
-      <h4 className="font-bold mb-4">Step 3 – Select District</h4>
-
-      <div
-        className={`max-w-4xl mx-auto grid lg:grid-cols-2 gap-6 ${
-          step3Disabled ? 'opacity-50 pointer-events-none' : ''
-        }`}
-      >
-      {step2Done && campaign && (
-        <DistrictPicker
-          state={campaign?.details.state}
-          electionYear={
-            campaign
-              ? new Date(campaign.details.electionDate).getFullYear()
-              : undefined
-          }
-          buttonText="Save District"
-          onSubmit={handleDistrictSave}
-        />
-      )}
+      <div className="my-6">
+        {newCampaign ? (
+          <Body1>
+            <H4 className="text-success">Campaign created!</H4>
+            <div className="mt-2 flex gap-2">
+              <span>
+                <span className="font-bold">UserId ID:</span>
+                {newCampaign?.userId}
+              </span>
+              <span>
+                <span className="font-bold">Campaign ID:</span>
+                {newCampaign?.id}
+              </span>
+              <span>
+                <span className="font-bold">Campaign Slug:</span>
+                {newCampaign?.slug}
+              </span>
+            </div>
+          </Body1>
+        ) : (
+          <Button
+            color="primary"
+            onClick={handleCreateCampaign}
+            disabled={disableCreate}
+            loading={isLoading}
+          >
+            Step 1 - Create Campaign
+          </Button>
+        )}
       </div>
-
-      {step3Done && (
-        <H4 className="text-success mt-4">District saved ✔</H4>
+      <hr />
+      <div className="mt-6">
+        <Button
+          color="primary"
+          onClick={openOfficeSelectionModal}
+          disabled={!newCampaign}
+        >
+          Step 2 - Select Office
+        </Button>
+      </div>
+      {newCampaign && (
+        <CampaignOfficeSelectionModal
+          campaign={newCampaign}
+          show={newCampaign && showOfficeSelectionModal}
+          onClose={() => setShowOfficeSelectionModal(false)}
+          onSelect={handleChooseOfficeComplete}
+          adminMode
+        />
       )}
     </PortalPanel>
   )

--- a/gpApi/routes.js
+++ b/gpApi/routes.js
@@ -79,10 +79,6 @@ export const apiRoutes = {
     },
   },
   campaign: {
-    district: {
-      path: '/campaigns/mine/district',
-      method: 'PUT',
-    },
     pathToVictory: {
       create: {
         path: '/campaigns/mine/path-to-victory',
@@ -404,16 +400,6 @@ export const apiRoutes = {
       path: '/elections/races-by-year',
       method: 'GET',
     },
-    districts: {
-      types: {
-        path: '/elections/districts/types',
-        method: 'GET'
-      },
-      names: {
-        path: '/elections/districts/names',
-        method: 'GET'
-      }
-    }
   },
   payments: {
     createCheckoutSession: {


### PR DESCRIPTION
Mostly just resets to the previous commit, except for in cases where the district picker commit was not the most recent one. I left the actual district picker and supporting components in for re-use in possibly the admin or post pro - still to be decided by stakeholders.
Previous PR for adding the district picker: https://github.com/thegoodparty/gp-webapp/pull/756

All three flows (Onboarding, Add a Campaign, Admin Victory Path) work fine with these gp-api changes: https://github.com/thegoodparty/gp-webapp/pull/756