### PR TITLE
feat: load initial top issues

### DIFF
--- a/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
+++ b/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
@@ -20,7 +20,7 @@ import { updateCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions'
 const COMPLETE_STEP = 'complete'
 const NUM_STEPS = 6
 
-export default function WebsiteCreateFlow() {
+export default function WebsiteCreateFlow({ initialIssues }) {
   const { errorSnackbar, successSnackbar } = useSnackbar()
   const { website, setWebsite } = useWebsite()
   const [previewOpen, setPreviewOpen] = useState(false)
@@ -313,6 +313,7 @@ export default function WebsiteCreateFlow() {
                 issues={website.content.about?.issues}
                 onBioChange={handleBioChange}
                 onIssuesChange={handleIssuesChange}
+                initialIssues={initialIssues}
               />
             )}
 

--- a/app/(candidate)/dashboard/website/create/components/WebsiteCreatePage.js
+++ b/app/(candidate)/dashboard/website/create/components/WebsiteCreatePage.js
@@ -3,7 +3,7 @@ import DashboardLayout from '../../../shared/DashboardLayout'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import WebsiteCreateFlow from './WebsiteCreateFlow'
 
-export default function WebsiteCreatePage({ pathname }) {
+export default function WebsiteCreatePage({ pathname, initialIssues }) {
   const [campaign] = useCampaign()
 
   return (
@@ -13,7 +13,7 @@ export default function WebsiteCreatePage({ pathname }) {
       showAlert={false}
       hideMenu
     >
-      <WebsiteCreateFlow />
+      <WebsiteCreateFlow initialIssues={initialIssues} />
     </DashboardLayout>
   )
 }

--- a/app/(candidate)/dashboard/website/create/page.js
+++ b/app/(candidate)/dashboard/website/create/page.js
@@ -6,6 +6,8 @@ import { redirect } from 'next/navigation'
 import { WebsiteProvider } from '../components/WebsiteProvider'
 import candidateAccess from '../../shared/candidateAccess'
 import { WEBSITE_STATUS } from '../util/website.util'
+import { serverLoadCandidatePosition } from '../../campaign-details/components/issues/serverIssuesUtils'
+import { fetchUserCampaign } from 'app/(candidate)/onboarding/shared/getCampaign'
 
 const meta = pageMetaData({
   title: 'Website Creator | GoodParty.org',
@@ -16,8 +18,26 @@ export const metadata = meta
 
 export const dynamic = 'force-dynamic'
 
+function combineIssues(issues, customIssues) {
+  const mappedIssues = issues.map((issue) => {
+    return {
+      title: issue.position?.name || '',
+      description: issue.description || '',
+    }
+  })
+  const customIssuesWithDescription = customIssues.map((issue) => {
+    return {
+      title: issue.position?.name || '',
+      description: issue.position || '',
+    }
+  })
+  const parsedIssues = [...mappedIssues, ...customIssuesWithDescription]
+  return parsedIssues
+}
+
 export default async function Page() {
   await candidateAccess()
+  const campaign = await fetchUserCampaign()
 
   const resp = await serverFetch(apiRoutes.website.get)
   const website = resp.ok ? resp.data : null
@@ -25,10 +45,16 @@ export default async function Page() {
   if (website && website.status === WEBSITE_STATUS.published) {
     redirect('/dashboard/website/editor')
   }
+  const issues = await serverLoadCandidatePosition(campaign.id)
+
+  const combinedIssues = combineIssues(issues, campaign?.details?.customIssues)
 
   return (
     <WebsiteProvider website={website}>
-      <WebsiteCreatePage pathname="/dashboard/website/create" />
+      <WebsiteCreatePage
+        pathname="/dashboard/website/create"
+        initialIssues={combinedIssues}
+      />
     </WebsiteProvider>
   )
 }

--- a/app/(candidate)/dashboard/website/editor/components/AboutStep.js
+++ b/app/(candidate)/dashboard/website/editor/components/AboutStep.js
@@ -11,7 +11,7 @@ const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
 
 export default function AboutStep({
   initialBio,
-  bio,
+  initialIssues,
   issues,
   onBioChange,
   onIssuesChange,
@@ -29,7 +29,11 @@ export default function AboutStep({
         useOnChange
       />
 
-      <IssuesForm issues={issues} onChange={onIssuesChange} />
+      <IssuesForm
+        issues={issues}
+        onChange={onIssuesChange}
+        initialIssues={initialIssues}
+      />
     </div>
   )
 }

--- a/app/(candidate)/dashboard/website/editor/components/IssuesForm.js
+++ b/app/(candidate)/dashboard/website/editor/components/IssuesForm.js
@@ -1,17 +1,34 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Button from '@shared/buttons/Button'
 import TextField from '@shared/inputs/TextField'
 import Label from './Label'
 import { LuPlus, LuPencil } from 'react-icons/lu'
 import ResponsiveModal from '@shared/utils/ResponsiveModal'
 
-export default function IssuesForm({ issues = [], onChange }) {
+export default function IssuesForm({
+  issues: websiteIssues = [],
+  onChange,
+  initialIssues, // top issues and custom issues from the campaign
+}) {
   const [editingIssue, setEditingIssue] = useState(null)
   const [editingIssueIndex, setEditingIssueIndex] = useState(null)
 
+  const currentIssues =
+    websiteIssues.length > 0 ? websiteIssues : initialIssues || []
+
+  useEffect(() => {
+    if (
+      websiteIssues.length === 0 &&
+      initialIssues &&
+      initialIssues.length > 0
+    ) {
+      onChange(initialIssues)
+    }
+  }, [initialIssues, websiteIssues, onChange])
+
   const handleAddIssue = () => {
     setEditingIssue({ title: '', description: '' })
-    setEditingIssueIndex(issues.length)
+    setEditingIssueIndex(currentIssues.length)
   }
 
   const handleOpenEditDialog = (issue, index) => {
@@ -26,7 +43,7 @@ export default function IssuesForm({ issues = [], onChange }) {
 
   const handleSaveIssue = () => {
     if (editingIssueIndex !== null && editingIssue) {
-      const newIssues = [...issues]
+      const newIssues = [...currentIssues]
       newIssues[editingIssueIndex] = editingIssue
       onChange(newIssues)
       handleCloseEditDialog()
@@ -34,7 +51,9 @@ export default function IssuesForm({ issues = [], onChange }) {
   }
 
   const handleDeleteIssue = () => {
-    const newIssues = issues.filter((_, index) => index !== editingIssueIndex)
+    const newIssues = currentIssues.filter(
+      (_, index) => index !== editingIssueIndex,
+    )
     onChange(newIssues)
     handleCloseEditDialog()
   }
@@ -43,7 +62,7 @@ export default function IssuesForm({ issues = [], onChange }) {
     <div className="mt-4">
       <Label className="mb-2">Key Issues</Label>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        {issues?.map((issue, index) => (
+        {currentIssues?.map((issue, index) => (
           <Button
             key={index}
             variant="outlined"

--- a/app/(candidate)/dashboard/website/util/website.util.js
+++ b/app/(candidate)/dashboard/website/util/website.util.js
@@ -29,8 +29,19 @@ export function createWebsite() {
 
 export function updateWebsite(content) {
   try {
-    const formData = serialize(content, { indices: true })
-    return clientFetch(apiRoutes.website.update, formData)
+    const hasEmptyIssuesArray =
+      Array.isArray(content.about?.issues) && content.about.issues.length === 0
+
+    const formData = serialize(content, {
+      indices: true,
+    })
+
+    if (hasEmptyIssuesArray) {
+      formData.append('about[issues]', [])
+    }
+
+    // return clientFetch(apiRoutes.website.update, formData)
+    return clientFetch(apiRoutes.website.update, content)
   } catch (e) {
     console.error('error', e)
     return false


### PR DESCRIPTION
If the user has top issues or custom issues, they should be the default input for the website issues.

We still keep website issues and top issues as separate entities.

In the future, we will completely delete top issues and only have website issues.

