### PR TITLE
chore: validate builder

### DIFF
--- a/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
+++ b/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
@@ -265,6 +265,13 @@ export default function WebsiteCreateFlow({ initialIssues }) {
     setIsValid(value)
   }
 
+  const canPublish =
+    isValidEmail(website.content.contact?.email) &&
+    isValidPhone(website.content.contact?.phone) &&
+    website.content.main?.title != '' &&
+    website.vanityPath != '' &&
+    website.content?.contact?.address != ''
+
   return (
     <>
       <div className="flex flex-col gap-4 h-full min-h-full">
@@ -371,6 +378,7 @@ export default function WebsiteCreateFlow({ initialIssues }) {
             completeLabel="Publish website"
             completeLoading={saveLoading}
             nextDisabled={!isValid}
+            canPublish={canPublish}
           />
         )}
       </div>

--- a/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
+++ b/app/(candidate)/dashboard/website/create/components/WebsiteCreateFlow.js
@@ -16,6 +16,8 @@ import { updateWebsite, WEBSITE_STATUS } from '../../util/website.util'
 import { useWebsite } from '../../components/WebsiteProvider'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { updateCampaign } from 'app/(candidate)/onboarding/shared/ajaxActions'
+import { isValidEmail } from 'helpers/validations'
+import { isValidPhone } from '@shared/inputs/PhoneInput'
 
 const COMPLETE_STEP = 'complete'
 const NUM_STEPS = 6
@@ -136,6 +138,11 @@ export default function WebsiteCreateFlow({ initialIssues }) {
         main: { ...current.content.main, title: value },
       },
     }))
+    if (value.length > 0) {
+      setIsValid(true)
+    } else {
+      setIsValid(false)
+    }
   }
 
   function handleTaglineChange(value) {
@@ -203,6 +210,9 @@ export default function WebsiteCreateFlow({ initialIssues }) {
 
     if (place.formatted_address && place.place_id) {
       setUpdatedPlace(place)
+      setIsValid(true)
+    } else {
+      setIsValid(false)
     }
   }
 
@@ -214,6 +224,11 @@ export default function WebsiteCreateFlow({ initialIssues }) {
         contact: { ...current.content.contact, email: value },
       },
     }))
+    if (isValidEmail(value)) {
+      setIsValid(true)
+    } else {
+      setIsValid(false)
+    }
   }
 
   function handlePhoneChange(value) {
@@ -224,6 +239,11 @@ export default function WebsiteCreateFlow({ initialIssues }) {
         contact: { ...current.content.contact, phone: value },
       },
     }))
+    if (isValidPhone(value)) {
+      setIsValid(true)
+    } else {
+      setIsValid(false)
+    }
   }
 
   function handleCommitteeChange(value) {

--- a/app/(candidate)/dashboard/website/editor/components/WebsiteEditorPageStepper.js
+++ b/app/(candidate)/dashboard/website/editor/components/WebsiteEditorPageStepper.js
@@ -53,7 +53,7 @@ export default function WebsiteEditorPageStepper({
           size="large"
           onClick={onComplete}
           loading={completeLoading}
-          disabled={completeLoading}
+          disabled={completeLoading || nextDisabled}
         >
           {completeLabel}
         </Button>

--- a/app/(candidate)/dashboard/website/editor/components/WebsiteEditorPageStepper.js
+++ b/app/(candidate)/dashboard/website/editor/components/WebsiteEditorPageStepper.js
@@ -12,6 +12,7 @@ export default function WebsiteEditorPageStepper({
   completeLabel = 'Complete',
   completeLoading = false,
   nextDisabled = false,
+  canPublish = false,
 }) {
   const hasNext = currentStep < totalSteps
   const hasPrev = currentStep > 1
@@ -53,7 +54,7 @@ export default function WebsiteEditorPageStepper({
           size="large"
           onClick={onComplete}
           loading={completeLoading}
-          disabled={completeLoading || nextDisabled}
+          disabled={completeLoading || !canPublish}
         >
           {completeLabel}
         </Button>


### PR DESCRIPTION
**PR #875: chore: validate builder** - 
This pull request adds form validation to the website creation flow by implementing validation checks for title, email, phone, and address fields, importing validation helpers (`isValidEmail` and `isValidPhone`) and adding validation logic to handler functions that set the form's validity state based on user input, while also ensuring the "Publish website" button is properly disabled when validation fails by adding the `nextDisabled` condition to prevent users from proceeding with invalid data.