### PR TITLE
DT-247 - Fix Long Blocking of Advancement - Removed unnecessary await

### DIFF
--- a/app/(candidate)/onboarding/[slug]/[step]/components/OfficeStep.js
+++ b/app/(candidate)/onboarding/[slug]/[step]/components/OfficeStep.js
@@ -49,7 +49,7 @@ async function runPostOfficeStepUpdates(attr, slug = undefined) {
   await updateCampaign(attr, slug)
   const campaign = await updateRaceTargetDetails(slug)
   if (!campaign?.pathToVictory?.data?.projectedTurnout) {
-    await runP2V(slug)
+    runP2V(slug)
   }
 }
 
@@ -185,7 +185,7 @@ export default function OfficeStep({
     }
 
     if (adminMode) {
-      runPostOfficeStepUpdates(attr, campaign.slug)
+      await runPostOfficeStepUpdates(attr, campaign.slug)
     } else {
       const trackingProperties = {
         officeState: position.state,
@@ -198,7 +198,7 @@ export default function OfficeStep({
         ...trackingProperties,
         officeManuallyInput: false,
       })
-      runPostOfficeStepUpdates(attr)
+      await runPostOfficeStepUpdates(attr)
     }
 
     if (step) {

--- a/app/(candidate)/onboarding/[slug]/[step]/components/OfficeStep.js
+++ b/app/(candidate)/onboarding/[slug]/[step]/components/OfficeStep.js
@@ -185,7 +185,7 @@ export default function OfficeStep({
     }
 
     if (adminMode) {
-      await runPostOfficeStepUpdates(attr, campaign.slug)
+      runPostOfficeStepUpdates(attr, campaign.slug)
     } else {
       const trackingProperties = {
         officeState: position.state,
@@ -198,7 +198,7 @@ export default function OfficeStep({
         ...trackingProperties,
         officeManuallyInput: false,
       })
-      await runPostOfficeStepUpdates(attr)
+      runPostOfficeStepUpdates(attr)
     }
 
     if (step) {


### PR DESCRIPTION
Issue: The "Next" button on the office picker, in a minority of races <= 5%, would block the user for long periods of time, 5-10+ seconds. After running a bit of tracing down the call stack, the culprit was an LLM call that's made _before_ P2V is actually enqueued, for some reason

Solution: Remove the unnecessary await(s) on the frontend. This makes that next button advancement feel nearly instantaneous.