### PR TITLE
[WEB-4351] Add status column to outreach table for texting outreaches

### DIFF
--- a/app/(candidate)/dashboard/outreach/components/OutreachTable.js
+++ b/app/(candidate)/dashboard/outreach/components/OutreachTable.js
@@ -85,6 +85,29 @@ export const OutreachTable = ({ mockOutreaches }) => {
           <NotApplicableLabel />
         ),
     },
+    {
+      header: 'Status',
+      cell: ({ row }) => {
+        if (row.outreachType !== 'text') {
+          return <NotApplicableLabel />
+        }
+        
+        const statusLabels = {
+          pending: 'Draft',
+          approved: 'In review',
+          denied: 'In review',
+          paid: 'Scheduled',
+          in_progress: 'Scheduled',
+          completed: 'Sent'
+        }
+        
+        if (!row.status || !statusLabels[row.status]) {
+          return <NotApplicableLabel />
+        }
+        
+        return <span>{statusLabels[row.status]}</span>
+      },
+    },
   ]
 
   const convertedFilters = useMemo(

--- a/app/(candidate)/dashboard/outreach/components/OutreachTable.js
+++ b/app/(candidate)/dashboard/outreach/components/OutreachTable.js
@@ -6,6 +6,7 @@ import { useMemo, useState } from 'react'
 import H4 from '@shared/typography/H4'
 import { GradientOverlay } from '@shared/GradientOverlay'
 import { StackedChips } from '@shared/utils/StackedChips'
+import { OUTREACH_TYPES } from 'app/(candidate)/dashboard/outreach/constants'
 import { formatAudienceLabels } from 'app/(candidate)/dashboard/outreach/util/formatAudienceLabels.util'
 import { ActualViewAudienceFiltersModal } from 'app/(candidate)/dashboard/voter-records/components/ViewAudienceFiltersModal'
 import { convertAudienceFiltersForModal } from 'app/(candidate)/dashboard/outreach/util/convertAudienceFiltersForModal.util'
@@ -88,7 +89,7 @@ export const OutreachTable = ({ mockOutreaches }) => {
     {
       header: 'Status',
       cell: ({ row }) => {
-        if (row.outreachType !== 'text') {
+        if (row.outreachType !== OUTREACH_TYPES.p2p) {
           return <NotApplicableLabel />
         }
         


### PR DESCRIPTION
Adds a Status column to the outreach table that displays status labels for text messaging campaigns.

### Changes

  - Frontend only: Added Status column to OutreachTable component
  - Selective display: Status column only appears for outreachType === 'text'
  - Graceful fallback: Shows "n/a" for non-text campaigns or invalid status
  values

### Custom Status Labels

 Maps backend status values to user-friendly labels per Figma:
 
    - pending → "Draft"
    - approved/denied → "In review"
    - paid/in_progress → "Scheduled"
    - completed → "Sent"

 ### Why No Backend Changes

  - Status field already exists in Outreach model
  - API already returns status in responses
  - No new data fields required - only presentation layer changes
