### PR TITLE
[WEB-4502] BUG: Text message estimate cost inconsistency

### DIFF
--- a/app/(candidate)/dashboard/components/tasks/flows/AudienceStep.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AudienceStep.js
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/constants/tasks.const'
 import { buildTrackingAttrs } from 'helpers/analyticsHelper'
 
-const TEXT_PRICE = 0.03
+const TEXT_PRICE = 0.035
 const CALL_PRICE = 0.04
 const CALL_W_VOICEMAIL_PRICE = 0.055
 


### PR DESCRIPTION
## Issue

The text messaging cost calculation in the **"Select target audience"** modal is showing **\$0.03 per voter** instead of the correct **\$0.035**.

---

## Root Cause

In `app/(candidate)/dashboard/components/tasks/flows/AudienceStep.js`, line 19:

```js
const TEXT_PRICE = 0.03  // INCORRECT
```

---

## Pricing Inconsistency Analysis

The codebase has inconsistent pricing:

* **AudienceStep.js**: `TEXT_PRICE = 0.03` (**WRONG** – causes the bug)
* **BudgetStep.js**: `price = 0.035` (**CORRECT**)
* **OutreachCreateCards.js**: `cost: 0.035` (**CORRECT**)

---

## Fix

Update line 19 in `AudienceStep.js`:

```js
const TEXT_PRICE = 0.035  // Updated to correct price
```

This single line change fixes the estimated cost calculation to show the correct amount:

```
numberOfVoters * $0.035
```

in the target audience selection modal.