### PR TITLE
[WEB-4459] update voter contacts p2p

### DIFF
--- a/app/(candidate)/dashboard/components/tasks/flows/TaskFlow.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/TaskFlow.js
@@ -73,6 +73,7 @@ export default function TaskFlow({
   const purchaseMetaData = {
     contactCount: state.voterCount,
     pricePerContact: dollarsToCents(outreachOption?.cost || 0) || 0,
+    outreachType: type,
   }
 
   const trackingAttrs = useMemo(
@@ -282,7 +283,7 @@ export default function TaskFlow({
         {stepName === STEPS.purchase && (
           <PurchaseIntentProvider
             {...{
-              type: type.toUpperCase(),
+              type: (type === 'p2p' ? 'text' : type).toUpperCase(),
               purchaseMetaData,
             }}
           >

--- a/app/(candidate)/dashboard/outreach/components/OutreachCreateCards.js
+++ b/app/(candidate)/dashboard/outreach/components/OutreachCreateCards.js
@@ -22,6 +22,13 @@ export const OUTREACH_OPTIONS = [
     requiresPro: true,
   },
   {
+    title: 'P2P Text',
+    impact: IMPACTS_LEVELS.medium,
+    cost: 0.035,
+    type: OUTREACH_TYPES.p2p,
+    requiresPro: true,
+  },
+  {
     title: 'Robocall',
     impact: IMPACTS_LEVELS.medium,
     cost: 0.045,

--- a/app/(candidate)/dashboard/outreach/constants.js
+++ b/app/(candidate)/dashboard/outreach/constants.js
@@ -48,6 +48,7 @@ export const AUDIENCE_LABELS_MAPPING = {
 // Based off the OutreachType in gp-api
 export const OUTREACH_TYPES = {
   text: 'text',
+  p2p: 'p2p',
   doorKnocking: 'doorKnocking',
   phoneBanking: 'phoneBanking',
   socialMedia: 'socialMedia',


### PR DESCRIPTION
### Add P2P Text Outreach Option with Payment Integration

#### Summary
Adds P2P (peer-to-peer) text outreach as a purchasable option in the dashboard, integrating with existing payment infrastructure. P2P purchases automatically update voter contact counts on the backend.

#### Changes Made
- **Added P2P outreach option**: New "P2P Text" card in outreach creation interface with same cost structure as regular text
- **Integrated payment mapping**: P2P purchases are processed as TEXT purchase type while preserving original outreach type in metadata
- **Enhanced purchase metadata**: Includes `outreachType` field to distinguish between text and P2P for backend processing

#### User Experience
- P2P Text appears alongside other outreach options for Pro users
- Same payment flow and user interface as existing outreach types
- Voter contact counts automatically update after successful P2P purchases
- No additional user interaction required

#### Technical Implementation
- Maps P2P to TEXT at payment layer: `type: (type === 'p2p' ? 'text' : type).toUpperCase()`
- Preserves original type in metadata: `outreachType: type`
- Uses existing purchase infrastructure with no new payment flows
- Maintains UI consistency with other outreach types

#### Testing
- ✅ Frontend build completes successfully
- ✅ P2P option appears in outreach creation interface
- ✅ Payment metadata includes correct outreach type mapping