### PR TITLE
Fix Phone Formatting on Candidate Website Inbox

### DIFF
--- a/app/(candidate)/dashboard/website/components/WebsiteInbox.js
+++ b/app/(candidate)/dashboard/website/components/WebsiteInbox.js
@@ -8,7 +8,7 @@ import { LuInbox } from 'react-icons/lu'
 import { useWebsite } from './WebsiteProvider'
 import SimpleTable from '@shared/utils/SimpleTable'
 import { dateUsHelper } from 'helpers/dateHelper'
-import { formatPhoneNumber } from 'helpers/numberHelper'
+import { formatDisplayPhoneNumber } from 'helpers/numberHelper'
 import ResponsiveModal from '@shared/utils/ResponsiveModal'
 import H4 from '@shared/typography/H4'
 import PaginationButtons from '../../voter-records/components/PaginationButtons'
@@ -71,7 +71,7 @@ export default function WebsiteInbox({}) {
       {
         header: 'Phone',
         accessorKey: 'phone',
-        cell: ({ row }) => formatPhoneNumber(row.phone),
+        cell: ({ row }) => formatDisplayPhoneNumber(row.phone),
       },
       {
         header: 'Message',

--- a/helpers/numberHelper.js
+++ b/helpers/numberHelper.js
@@ -66,23 +66,39 @@ export const kFormatter = (num) => {
 }
 
 export const formatPhoneNumber = (value) => {
+  if (!value) {
+    return ''
+  }
+  let noCountryCode = value
+  if (value.charAt(0) === '1') {
+    noCountryCode = value.substring(1)
+  }
+  const input = noCountryCode.replace(/\D/g, '').substring(0, 10) // First ten digits of input only
+  const areaCode = input.substring(0, 3)
+  const middle = input.substring(3, 6)
+  const last = input.substring(6, 10)
+
+  if (input.length > 6) {
+    return `(${areaCode}) ${middle}-${last}`
+  }
+  if (input.length > 3) {
+    return `(${areaCode}) ${middle}`
+  }
+  if (input.length > 0) {
+    return `(${areaCode}`
+  }
+}
+
+export const formatDisplayPhoneNumber = (value) => {
+  // For use in static displays, like the website contact inbox
+
   if (!value) return ''
 
-  // Strip all non-digits
-  const cleaned = value.replace(/\D/g, '')
+  // Strip all non-digits, then grab last 10
+  const digits = value.replace(/\D/g, '').slice(-10)
 
-  // If we don't have 10–11 digits (normal US phone numbers), bail out
-  if (cleaned.length < 10 || cleaned.length > 11) return ''
+  // Show nothing if not exactly 10 digits
+  if (digits.length !== 10) return ''
 
-  // Always take last 10 digits (handles +1 or 1 prefix)
-  const digits = cleaned.slice(-10)
-
-  const areaCode = digits.substring(0, 3)
-  const middle = digits.substring(3, 6)
-  const last = digits.substring(6, 10)
-
-  if (digits.length > 6) return `(${areaCode}) ${middle}-${last}`
-  if (digits.length > 3) return `(${areaCode}) ${middle}`
-  if (digits.length > 0) return `(${areaCode}`
-  return ''
+  return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`
 }


### PR DESCRIPTION
# Issue

Candidate website contact forms allow both `+1 [phone number]` and `1 [phone number]` but the website dashboard inbox only renders the latter correctly.

# Fix Description

This PR adds a new phone number formatter specifically for static renders (not dynamic forms) since the old formatter appears to be pulling double duty, applied for both cases. The new formatter:
 - Strips all non-digit characters.
 - Handles both +1 and 1 country code prefixes by taking the last 10 digits.
 - Returns an empty string for invalid input lengths (<10 or >11 digits). Note: invalid lengths are currently rejected by the back end API, so in theory this isn't necessary, but... felt like a nice contingency to plan for.

This ensures that US phone numbers are always formatted correctly, and avoids displaying incorrect partial numbers when input is malformed.

## I'm Sorry

These screenshot are enormous and hard to see without magnification, but felt like it was important to show that this was from a local build. Getting there without valid creds to the many connected systems required many a disgusting hack.

### Before Screenshot
<img width="1901" height="941" alt="before" src="https://github.com/user-attachments/assets/35be7a6d-ba39-4694-a0fd-facbd63eb2fb" />

### After Screenshot
<img width="1901" height="941" alt="after" src="https://github.com/user-attachments/assets/d2393108-17b1-45fc-941b-97350f6c0cdb" />

## Testing notes:
- If you use a phone number that is recognized as being in the fictional testing range (some area code 555 numbers), the back end will reject the submission with a +1 in front. Numbers out of that range are accepted with +1 prefixes.