### PR TITLE
fix: remove tel link

### DIFF
--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.js
@@ -49,33 +49,13 @@ const sections = [
       {
         key: 'cellPhone',
         label: 'Cell Phone Number',
-        transform: (value) =>
-          value && value !== 'Unknown' ? (
-            <a
-              href={`tel:${value.replace(/\D/g, '')}`}
-              className="text-blue-600 hover:underline"
-            >
-              {value}
-            </a>
-          ) : (
-            'Unknown'
-          ),
+        transform: (value) => value || 'Unknown',
         allowCopy: true,
       },
       {
         key: 'landline',
         label: 'Landline',
-        transform: (value) =>
-          value && value !== 'Unknown' ? (
-            <a
-              href={`tel:${value.replace(/\D/g, '')}`}
-              className="text-blue-600 hover:underline"
-            >
-              {value}
-            </a>
-          ) : (
-            'Unknown'
-          ),
+        transform: (value) => value || 'Unknown',
         allowCopy: true,
       },
     ],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces clickable tel links for `cellPhone` and `landline` with plain text values defaulting to "Unknown".
> 
> - **UI**:
>   - `app/(candidate)/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.js`
>     - Replace `cellPhone` and `landline` transform outputs from tel links to plain text.
>     - Default both fields to `"Unknown"` when missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2b6ecfa6cea0783e9590878eb7ab987cf19a130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->