### PR TITLE
chore: use styleguide 1.3.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "date-fns": "^4.1.0",
         "es-toolkit": "^1.32.0",
         "fuse.js": "^7.1.0",
-        "goodparty-styleguide": "^1.3.19",
+        "goodparty-styleguide": "1.3.20",
         "hamburger-react": "^2.5.2",
         "intro.js": "^8.3.2",
         "intro.js-react": "^1.0.0",
@@ -15154,9 +15154,9 @@
       }
     },
     "node_modules/goodparty-styleguide": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/goodparty-styleguide/-/goodparty-styleguide-1.3.19.tgz",
-      "integrity": "sha512-u1fqcLY8bu4tGmVl+xdwpjF3pu96CxhAbWx8ELrlcSVJtIFX9sVdzLb4xYxRMwfIrEx0Sg6HKpP/LwFwCgvd3g==",
+      "version": "1.3.20",
+      "resolved": "https://registry.npmjs.org/goodparty-styleguide/-/goodparty-styleguide-1.3.20.tgz",
+      "integrity": "sha512-CckKLwkCDgujCE8dMR2sWFw9345K8sjtuYf09myDhj4nw/48677YxBptJhcZb0j/5BzsrVhUFEWcn/a2oSDbzQ==",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "date-fns": "^4.1.0",
     "es-toolkit": "^1.32.0",
     "fuse.js": "^7.1.0",
-    "goodparty-styleguide": "1.3.19",
+    "goodparty-styleguide": "1.3.20",
     "hamburger-react": "^2.5.2",
     "intro.js": "^8.3.2",
     "intro.js-react": "^1.0.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `goodparty-styleguide` from `1.3.19` to `1.3.20`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac3e69ec727df3beac856f89543bc12574b468f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->