### PR TITLE
fix typo in add campaign page title

### DIFF
--- a/app/admin/add-campaign/page.js
+++ b/app/admin/add-campaign/page.js
@@ -4,7 +4,7 @@ import AdminWrapper from 'app/admin/shared/AdminWrapper'
 import { CreateCampaignForm } from '@shared/CreateCampaignForm'
 
 const meta = pageMetaData({
-  title: 'Add Campaign| GOOD PARTY',
+  title: 'Add Campaign | GOOD PARTY',
   description: 'Admin Add a new Campaign',
   slug: '/admin/add-campaign',
 })

--- a/app/sales/add-campaign/page.js
+++ b/app/sales/add-campaign/page.js
@@ -3,7 +3,7 @@ import pageMetaData from 'helpers/metadataHelper'
 import { CreateCampaignForm } from '@shared/CreateCampaignForm'
 
 const meta = pageMetaData({
-  title: 'Add Campaign| GOOD PARTY',
+  title: 'Add Campaign | GOOD PARTY',
   description: 'Admin Add a new Campaign',
   slug: '/sales/add-campaign',
 })


### PR DESCRIPTION
Just something small I noticed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects page metadata title spacing to 'Add Campaign | GOOD PARTY' in admin and sales add-campaign pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78d0ec500fe1a54e98e052de6aad86cc2d635aad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->