### PR TITLE
Contact search fixes

### DIFF
--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactSearch.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactSearch.js
@@ -1,23 +1,53 @@
 'use client'
 
 import SearchInput from 'app/(candidate)/dashboard/issues/components/search/SearchInput'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { useShowContactProModal } from '../hooks/ContactProModal'
+import { useCampaign } from '@shared/hooks/useCampaign'
 
 export const ContactSearch = () => {
-  const [searchText, setSearchText] = useState('')
+  const [campaign] = useCampaign()
+  const showProUpgradeModal = useShowContactProModal()
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-  // TODO in follow-up:
-  // - hook up to API
+  const [searchText, setSearchText] = useState(
+    () => searchParams.get('query') ?? '',
+  )
+
+  useEffect(() => {
+    setSearchText(searchParams.get('query') ?? '')
+  }, [searchParams.get('query')])
+
   return (
-    <SearchInput
-      fullWidth
-      variant="standard"
-      className="max-w-md"
-      placeholder="Search contacts by name or phone number"
-      value={searchText}
-      onChange={(e) => {
-        setSearchText(e.target.value)
-      }}
-    />
+    <div className="w-full max-w-md">
+      <SearchInput
+        fullWidth
+        variant="standard"
+        placeholder="Search contacts by name or phone number"
+        value={searchText}
+        onChange={(e) => {
+          setSearchText(e.target.value)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            if (!campaign?.isPro) {
+              showProUpgradeModal(true)
+              return
+            }
+            const params = new URLSearchParams({ query: searchText })
+            router.push(`?${params.toString()}`)
+          }
+        }}
+      />
+      <div
+        className={`text-xs text-gray-500 mt-1 transition-all duration-200 ${
+          searchText ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-1'
+        }`}
+      >
+        Press Enter to search
+      </div>
+    </div>
   )
 }

--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsPage.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsPage.js
@@ -7,6 +7,7 @@ import PersonOverlay from './person/PersonOverlay'
 import Download from './Download'
 import SegmentSection from './segments/SegmentSection'
 import ContactsStatsSection from './ContactsStatsSection'
+import { ContactSearch } from './ContactSearch'
 import { ContactProModalProvider } from '../hooks/ContactProModal'
 import { useState } from 'react'
 import {
@@ -20,7 +21,10 @@ export default function ContactsPage({ peopleStats }) {
     <ContactProModalProvider value={setShowProModal}>
       <DashboardLayout>
         <Paper className="h-full">
-          <TitleSection />
+          <div className="flex flex-row justify-between items-end">
+            <TitleSection />
+            <ContactSearch />
+          </div>
           <ContactsStatsSection peopleStats={peopleStats} />
           <div className="relative">
             <SegmentSection />

--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/segments/SegmentSection.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/segments/SegmentSection.js
@@ -152,6 +152,13 @@ export default function SegmentSection() {
     appendParam(router, searchParams, 'segment', ALL_SEGMENTS)
   }
 
+  const params = useSearchParams()
+  useEffect(() => {
+    if (params.get('query')) {
+      resetSelect()
+    }
+  }, [params.get('query')])
+
   const handleAfterSave = (segmentId) => {
     setSegment(segmentId.toString())
     appendParam(router, searchParams, 'segment', segmentId.toString())

--- a/gpApi/routes.js
+++ b/gpApi/routes.js
@@ -4,6 +4,10 @@ export const apiRoutes = {
       path: '/contacts',
       method: 'GET',
     },
+    search: {
+      path: '/contacts/search',
+      method: 'GET',
+    },
     get: {
       path: '/contacts/:id',
       method: 'GET',


### PR DESCRIPTION
This wires contact searching up to the api.

https://github.com/user-attachments/assets/3e304be2-dd3d-4d33-8974-2287499f0081



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wires contacts search to `/contacts/search` with query-param-driven fetching, adds a gated search input to the Contacts page, and resets segments when searching.
> 
> - **Contacts UI**:
>   - Add `ContactSearch` in `ContactsPage` header; shows hint and triggers search on Enter.
>   - Gate search by `campaign.isPro` via `ContactProModal`; syncs `searchText` with `?query=`.
> - **Data Fetching**:
>   - Add `fetchSearchedContacts` in `page.js` to call `apiRoutes.contacts.search`, sending `phone` for numeric queries or `name` otherwise.
>   - Rename `fetchContacts` → `fetchFilteredContacts`; conditionally fetch by `segment` or `query`.
>   - Extend `gpApi/routes` with `contacts.search` (`GET /contacts/search`).
> - **Segments**:
>   - In `SegmentSection`, reset to `ALL_SEGMENTS` when a `?query=` param is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f72c46816804e5baa78bab48f74e11528b2851e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->