### PR TITLE
ENG-3695: finish contacts free behavior

### DIFF
--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsPage.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsPage.js
@@ -7,7 +7,6 @@ import PersonOverlay from './person/PersonOverlay'
 import Download from './Download'
 import SegmentSection from './segments/SegmentSection'
 import ContactsStatsSection from './ContactsStatsSection'
-import { ContactSearch } from './ContactSearch'
 import { ContactProModalProvider } from '../hooks/ContactProModal'
 import { useState } from 'react'
 import {
@@ -21,10 +20,7 @@ export default function ContactsPage({ peopleStats }) {
     <ContactProModalProvider value={setShowProModal}>
       <DashboardLayout>
         <Paper className="h-full">
-          <div className="flex flex-row justify-between items-end">
-            <TitleSection />
-            <ContactSearch />
-          </div>
+          <TitleSection />
           <ContactsStatsSection peopleStats={peopleStats} />
           <div className="relative">
             <SegmentSection />
@@ -39,6 +35,7 @@ export default function ContactsPage({ peopleStats }) {
         open={showProModal}
         onClose={() => setShowProModal(false)}
         onUpgradeLinkClick={() => setShowProModal(false)}
+        defaultTrackingEnabled
       />
     </ContactProModalProvider>
   )

--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/Download.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/Download.js
@@ -7,6 +7,7 @@ import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { isCustomSegment, findCustomSegment } from './shared/segments.util'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useShowContactProModal } from '../hooks/ContactProModal'
+import { Lock } from '@mui/icons-material'
 
 export default function Download() {
   const [campaign] = useCampaign()
@@ -67,6 +68,7 @@ export default function Download() {
   return (
     <div className="absolute md:right-36 top-14 md:top-4 flex items-center gap-4">
       <Button variant="outline" onClick={handleDownload}>
+        {!campaign?.isPro && <Lock />}
         Download
       </Button>
     </div>

--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/segments/SegmentSection.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/segments/SegmentSection.js
@@ -26,6 +26,7 @@ import {
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useShowContactProModal } from '../../hooks/ContactProModal'
+import { Lock } from '@mui/icons-material'
 
 export default function SegmentSection() {
   const [customSegments, , , querySegment] = useCustomSegments()
@@ -196,6 +197,7 @@ export default function SegmentSection() {
         onClick={handleCreateSegment}
         className="ml-4"
       >
+        {!campaign?.isPro && <Lock />}
         Create a Segment
       </Button>
       <FiltersSheet

--- a/app/(candidate)/dashboard/shared/ProUpgradePrompt.js
+++ b/app/(candidate)/dashboard/shared/ProUpgradePrompt.js
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { VARIANTS, ProUpgradeModal } from './ProUpgradeModal'
 import { VIABILITY_SCORE_THRESHOLD } from './ProUpgradeModal'
 
@@ -58,11 +57,6 @@ export function ProUpgradePrompt({ campaign, user }) {
     }
 
     function handleOpen(variant) {
-      trackEvent(EVENTS.ProUpgrade.Modal.Shown, {
-        sessionCount,
-        viablityScore,
-        variant,
-      })
       setModalState({
         isOpen: true,
         variant: variant,
@@ -73,24 +67,6 @@ export function ProUpgradePrompt({ campaign, user }) {
   // Don't want to show modal if campaign is already pro
   if (isPro) return null
 
-  function handleClose() {
-    trackEvent(EVENTS.ProUpgrade.Modal.Exit, {
-      sessionCount,
-      viablityScore,
-      variant: modalState.variant,
-    })
-    closeModal()
-  }
-
-  function handleUpgradeLinkClick() {
-    trackEvent(EVENTS.ProUpgrade.Modal.ClickButton, {
-      sessionCount,
-      viablityScore,
-      variant: modalState.variant,
-    })
-    closeModal()
-  }
-
   function closeModal() {
     localStorage.setItem(LOCAL_STORAGE_KEY, sessionCount)
     setModalState((current) => ({ ...current, isOpen: false }))
@@ -100,8 +76,9 @@ export function ProUpgradePrompt({ campaign, user }) {
     <ProUpgradeModal
       open={modalState.isOpen}
       variant={modalState.variant}
-      onClose={handleClose}
-      onUpgradeLinkClick={handleUpgradeLinkClick}
+      onClose={closeModal}
+      onUpgradeLinkClick={closeModal}
+      defaultTrackingEnabled
     />
   )
 }


### PR DESCRIPTION
**Note**: please pay special attention to the pro modal changes. I'm implementing the changes requested here: https://goodpartyorg.slack.com/archives/C08TQH5G98Q/p1759505028728129?thread_ts=1759434997.357169&cid=C08TQH5G98Q

<img width="1822" height="1180" alt="Screenshot 2025-10-03 at 11 43 47 AM" src="https://github.com/user-attachments/assets/9c43cf92-e47c-44f9-87d4-3e31d554029c" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes ProUpgrade modal analytics and adds lock icons to gated actions, while simplifying the Contacts header.
> 
> - **Pro Upgrade Modal (`shared/ProUpgradeModal.js`)**:
>   - Add built-in analytics tracking (shown/exit/click) with `sessionCount`, `viablityScore`, `variant`, and `path`.
>   - Introduce `defaultTrackingEnabled` prop; route `close` and CTA click through new handlers.
>   - Wire `closeCallback` and button `onClick` to new tracked handlers.
> - **Pro Upgrade Prompt (`shared/ProUpgradePrompt.js`)**:
>   - Remove local tracking; delegate to modal and pass `defaultTrackingEnabled`.
>   - Simplify handlers to only close modal and persist dismissal.
> - **Contacts Page (`contacts/.../ContactsPage.js`)**:
>   - Simplify header by removing `ContactSearch` wrapper; show `TitleSection` alone.
>   - Enable modal tracking via `defaultTrackingEnabled`.
> - **UI: Gated Actions**:
>   - `Download.js`: show `Lock` icon on download button when not Pro.
>   - `segments/SegmentSection.js`: show `Lock` icon on "Create a Segment" when not Pro.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b48dacc1500e09802c8865792bd04fb2a104af5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->