### PR TITLE
[ENG-4397] - Fixes RichEditor re-rendering on keystrokes

### DIFF
--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateReviewScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateReviewScreen.js
@@ -24,6 +24,7 @@ export const GenerateReviewScreen = ({
 }) => {
   const { errorSnackbar } = useSnackbar()
   const [aiContent, setAiContent] = useState({})
+  const [scriptContent, setScriptContent] = useState('')
   const [saving, setSaving] = useState(false)
 
   useEffect(() => {
@@ -49,10 +50,10 @@ export const GenerateReviewScreen = ({
       await updateCampaign([
         {
           key: `aiContent.${aiScriptKey}`,
-          value: aiContent,
+          value: { ...aiContent, content: scriptContent },
         },
       ])
-      onNext(aiScriptKey, aiContent.content)
+      onNext(aiScriptKey, scriptContent)
     } catch (e) {
       console.error('Error updating campaign with AI content => ', e)
       errorSnackbar('Error saving AI-generated content')
@@ -71,9 +72,9 @@ export const GenerateReviewScreen = ({
       </header>
       <section>
         <RichEditor
-          initialText={aiContent?.content}
+          initialText={aiContent.content}
           onChangeCallback={(content) => {
-            setAiContent({ ...aiContent, content })
+            setScriptContent(content)
           }}
           useOnChange
         />

--- a/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateReviewScreen.js
+++ b/app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateReviewScreen.js
@@ -36,6 +36,7 @@ export const GenerateReviewScreen = ({
           throw new Error(`No aiScriptKey AI content found => ${aiScriptKey}`)
         }
         setAiContent(aiContent[aiScriptKey])
+        setScriptContent(aiContent[aiScriptKey]?.content || '')
       } catch (e) {
         console.error('error fetching aiContent for review => ', e)
         errorSnackbar('Error fetching AI-generated content')
@@ -82,7 +83,7 @@ export const GenerateReviewScreen = ({
       <ModalFooter
         onBack={onBack}
         onNext={handleOnNext}
-        disabled={!aiContent?.content || saving}
+        disabled={!scriptContent || saving}
         nextText="Save"
         nextButtonProps={{
           loading: saving,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Separates editor input into a new scriptContent state and updates save/next logic to use it, avoiding RichEditor re-renders.
> 
> - **Frontend** (`app/(candidate)/dashboard/components/tasks/flows/AddScriptStep/GenerateReviewScreen.js`):
>   - Introduce `scriptContent` state to track editor input separately from `aiContent`.
>   - `RichEditor`: set `initialText` from `aiContent.content`; `onChange` updates `scriptContent`.
>   - Save flow: persist `{ ...aiContent, content: scriptContent }` and pass `scriptContent` to `onNext`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9164633408a3fda80893457595af69120f73bc46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->