### PR TITLE
ENG-4401: blur contacts for non-pro

### DIFF
--- a/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsTable.js
+++ b/app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsTable.js
@@ -8,6 +8,19 @@ import { useSearchParams } from 'next/navigation'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useShowContactProModal } from '../hooks/ContactProModal'
 
+const MaybeBlurredContent = ({ children }) => {
+  const [campaign] = useCampaign()
+  if (campaign?.isPro) {
+    return children
+  }
+  return <span className="blur-[6px]">{children}</span>
+}
+
+const blurredCell = ({ row, column }) => {
+  const value = row.getValue(column.id)
+  return <MaybeBlurredContent>{value}</MaybeBlurredContent>
+}
+
 const columns = [
   {
     accessorKey: 'firstName',
@@ -26,12 +39,14 @@ const columns = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Cell Phone" />
     ),
+    cell: blurredCell,
   },
   {
     accessorKey: 'landline',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Landline" />
     ),
+    cell: blurredCell,
   },
   {
     accessorKey: 'age',
@@ -50,6 +65,7 @@ const columns = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Address" />
     ),
+    cell: blurredCell,
   },
   {
     accessorKey: 'politicalParty',


### PR DESCRIPTION
<img width="1822" height="1180" alt="Screenshot 2025-10-03 at 5 39 30 PM" src="https://github.com/user-attachments/assets/76a12ef3-817f-479d-a26f-8922083c2e78" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally blurs phone numbers and addresses in `ContactsTable` for non‑pro campaigns using a new cell renderer.
> 
> - **Frontend**
>   - **Contacts Table (`app/(candidate)/dashboard/contacts/[[...attr]]/components/ContactsTable.js`)**
>     - Add `MaybeBlurredContent` wrapper gated by `campaign.isPro`.
>     - Introduce `blurredCell` renderer and apply to `cellPhone`, `landline`, and `address` columns to obscure values for non‑pro users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5710f4e5f6265665ebf09a2163876c0765b81cc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->