### PR TITLE
Temporary flow for using CSV for serve polls

### DIFF
--- a/app/polls/hooks/useContactsSample.js
+++ b/app/polls/hooks/useContactsSample.js
@@ -1,0 +1,53 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { clientFetch } from 'gpApi/clientFetch'
+import { apiRoutes } from 'gpApi/routes'
+
+export const useContactsSample = () => {
+  const [contactsSample, setContactsSample] = useState(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchContactsSample = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        
+        const response = await clientFetch(apiRoutes.contacts.sample)
+        
+        if (!response.ok) {
+          throw new Error(response.statusText || 'Failed to fetch contacts sample')
+        }
+        
+        if (isMounted) {
+          setContactsSample(response.data)
+          console.log('contactsSample', response.data)
+        }
+      } catch (error) {
+        console.error(error)
+        if (isMounted) {
+          setError('Unable to load sample contacts right now')
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchContactsSample()
+    
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return {
+    contactsSample,
+    isLoadingContactsSample: isLoading,
+    contactsSampleError: error
+  }
+}

--- a/app/polls/hooks/useContactsSample.js
+++ b/app/polls/hooks/useContactsSample.js
@@ -24,7 +24,6 @@ export const useContactsSample = () => {
         
         if (isMounted) {
           setContactsSample(response.data)
-          console.log('contactsSample', response.data)
         }
       } catch (error) {
         console.error(error)

--- a/app/polls/hooks/useCsvUpload.js
+++ b/app/polls/hooks/useCsvUpload.js
@@ -1,0 +1,49 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { uploadSampleCsv } from '../utils/uploadSampleCsv'
+
+export const useCsvUpload = (contactsSample, campaign, csvUrl, setCsvUrl) => {
+  const [isUploading, setIsUploading] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const uploadCsv = async () => {
+      // Early returns for conditions that don't require upload
+      if (!contactsSample || !Array.isArray(contactsSample) || contactsSample.length === 0) return
+      if (!campaign?.id || !campaign?.slug) return
+      if (csvUrl) return // already uploaded
+
+      try {
+        setIsUploading(true)
+        setError(null)
+
+        const publicUrl = await uploadSampleCsv(contactsSample, campaign)
+        if (publicUrl && isMounted) {
+          setCsvUrl(publicUrl)
+        }
+      } catch (error) {
+        console.error(error)
+        if (isMounted) {
+          setError('Failed to upload sample CSV')
+        }
+      } finally {
+        if (isMounted) {
+          setIsUploading(false)
+        }
+      }
+    }
+
+    uploadCsv()
+    
+    return () => {
+      isMounted = false
+    }
+  }, [contactsSample, campaign, csvUrl, setCsvUrl])
+
+  return {
+    isUploadingCsvSample: isUploading,
+    csvSampleError: error
+  }
+}

--- a/app/polls/hooks/useCsvUpload.js
+++ b/app/polls/hooks/useCsvUpload.js
@@ -11,7 +11,11 @@ export const useCsvUpload = (contactsSample, campaign, csvUrl, setCsvUrl) => {
 
     const uploadCsv = async () => {
       // Early returns for conditions that don't require upload
-      if (!contactsSample || !Array.isArray(contactsSample) || contactsSample.length === 0) return
+      if (!contactsSample || !Array.isArray(contactsSample)) return
+      if (contactsSample.length === 0){
+        setError('No contacts sample available')
+        return
+      }
       if (!campaign?.id || !campaign?.slug) return
       if (csvUrl) return // already uploaded
 

--- a/app/polls/hooks/useOnboarding.js
+++ b/app/polls/hooks/useOnboarding.js
@@ -81,9 +81,23 @@ export const useOnboarding = () => {
 
   const submitOnboarding = useCallback(async () => {
     try {
-      if (csvSampleError) {
-        throw new Error(csvSampleError)
+      // Check if contacts sample is still loading
+      if (isLoadingContactsSample) {
+        throw new Error('Contact data is still loading.')
       }
+      if (isUploadingCsvSample) {
+        throw new Error('Contact data is still being prepared.')
+      }
+      if (contactsSampleError) {
+        throw new Error('Failed to load contact data.')
+      }
+      if (csvSampleError) {
+        throw new Error('Failed to prepare contact data.')
+      }
+      if (!formData.csvUrl) {
+        throw new Error('Contact data is not ready.')
+      }
+      
       setIsSubmitting(true)
       setSubmitError(null)
 
@@ -105,7 +119,7 @@ export const useOnboarding = () => {
     } finally {
       setIsSubmitting(false)
     }
-  }, [formData, csvSampleError])
+  }, [formData, csvSampleError, isLoadingContactsSample, isUploadingCsvSample, contactsSampleError])
 
   const resetFormData = useCallback(() => {
     setFormData({ imageUrl: null, csvUrl: null, textMessage: null })

--- a/app/polls/hooks/useOnboarding.js
+++ b/app/polls/hooks/useOnboarding.js
@@ -5,10 +5,13 @@ import { useUser } from '@shared/hooks/useUser'
 import { clientFetch } from 'gpApi/clientFetch'
 import { apiRoutes } from 'gpApi/routes'
 import { DemoMessageText, MessageText } from '../onboarding/components/DemoMessageText'
+import { useContactsSample } from './useContactsSample'
+import { useCsvUpload } from './useCsvUpload'
 
 export const useOnboarding = () => {
   const [campaign] = useCampaign()
   const [user] = useUser()
+  const { contactsSample, isLoadingContactsSample, contactsSampleError } = useContactsSample()
   
   const [formData, setFormData] = useState({
     imageUrl: null,
@@ -62,6 +65,14 @@ export const useOnboarding = () => {
     updateFormData({csvUrl})
   }, [updateFormData])
 
+  // Handle CSV upload when contacts sample is available
+  const { isUploadingCsvSample, csvSampleError } = useCsvUpload(
+    contactsSample, 
+    campaign, 
+    formData.csvUrl, 
+    setCsvUrl
+  )
+
   const setTextMessage = useCallback((textMessage) => {
     updateFormData({
       textMessage
@@ -70,6 +81,9 @@ export const useOnboarding = () => {
 
   const submitOnboarding = useCallback(async () => {
     try {
+      if (csvSampleError) {
+        throw new Error(csvSampleError)
+      }
       setIsSubmitting(true)
       setSubmitError(null)
 
@@ -91,14 +105,10 @@ export const useOnboarding = () => {
     } finally {
       setIsSubmitting(false)
     }
-  }, [formData])
+  }, [formData, csvSampleError])
 
   const resetFormData = useCallback(() => {
-    setFormData({
-      imageUrl: null,
-      csvUrl: null,
-      textMessage: null,
-    })
+    setFormData({ imageUrl: null, csvUrl: null, textMessage: null })
     setSubmitError(null)
   }, [])
 
@@ -113,6 +123,13 @@ export const useOnboarding = () => {
     setTextMessage,
     submitOnboarding,
     resetFormData,
+    
+    // Contacts sample
+    contactsSample,
+    isLoadingContactsSample,
+    contactsSampleError,
+    isUploadingCsvSample,
+    csvSampleError,
     
     // Campaign and user data
     campaign,

--- a/app/polls/onboarding/components/steps/AddImageStep.js
+++ b/app/polls/onboarding/components/steps/AddImageStep.js
@@ -6,52 +6,11 @@ import { CircularProgress } from '@mui/material'
 import { HiddenFileUploadInput } from '@shared/inputs/HiddenFileUploadInput'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useOnboardingContext } from '../../../contexts/OnboardingContext'
-import { apiRoutes } from 'gpApi/routes'
-import { clientFetch } from 'gpApi/clientFetch'
-import { IS_LOCAL, IS_PROD } from 'appEnv'
+import { uploadFileToS3 } from '@shared/utils/s3Upload'
+import { getPollSubFolderName, FOLDER_NAME } from '../../../utils/s3utils'
 
 const FILE_LIMIT_MB = 5
 const ACCEPTED_FORMATS = ['.png', '.jpg', '.jpeg']
-const FOLDER_NAME = 'poll-text-images'
-
-const getBucketName = () => {
-  if (IS_LOCAL) return 'assets-dev.goodparty.org'
-  if (IS_PROD) return 'assets.goodparty.org'
-  return 'assets-qa.goodparty.org' // fallback for preview/development
-}
-
-const getPollImageFolderName = (id, slug) =>
-  `${id}-${slug}`
-
-const uploadImageToS3 = async (file, bucket) => {
-  const { name: fileName, type: fileType } = file
-
-  const resp = await clientFetch(apiRoutes.user.files.generateSignedUploadUrl, {
-    fileType,
-    fileName,
-    bucket
-  })
-
-  if (!resp.ok) {
-    throw new Error(`Failed to get signed URL: ${resp.status} ${resp.statusText}`)
-  }
-
-  const { signedUploadUrl } = resp.data
-  
-  const uploadResult = await fetch(signedUploadUrl, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': fileType,
-    },
-    body: file,
-  })
-
-  if (!uploadResult.ok) {
-    throw new Error(`S3 upload failed: ${uploadResult.status} ${uploadResult.statusText}`)
-  }
-
-  return uploadResult
-}
 
 export default function AddImageStep({}) {
   const [authenticatedCampaign = {}] = useCampaign()
@@ -118,12 +77,9 @@ export default function AddImageStep({}) {
 
       try {
         // THis is a little strange, but it is called bucket on our backend, but it's actually a folder inside of the main assets bucket
-        const campaignFolderName = getPollImageFolderName(campaignId, campaignSlug)
+        const campaignFolderName = getPollSubFolderName(campaignId, campaignSlug)
         const folder = `${FOLDER_NAME}/${campaignFolderName}`
-        await uploadImageToS3(file, folder)
-        
-        const bucketName = getBucketName()
-        const imageUrl = `https://${bucketName}/${folder}/${file.name}`
+        const imageUrl = await uploadFileToS3(file, folder)
         
         // Store in onboarding context
         setImageUrl(imageUrl)

--- a/app/polls/onboarding/components/steps/InsightsStep.js
+++ b/app/polls/onboarding/components/steps/InsightsStep.js
@@ -19,20 +19,8 @@ export default function InsightsStep({ }) {
   const tcrCompliant = true
   const isLoadingTcrCompliance = false
 
-  const insights = [
-    {
-      title: 'Expect education, safety, and youth services to dominate your agenda.',
-      description: '62% of you community is families with school aged children. Most districts are 30-40%.',
-    },
-    {
-      title: 'Expect tension on development, services, and tax priorities.',
-      description: 'Your wealth gap is wider than 87% of districts. Most see only 3-4x difference between top and bottom halves.',
-    },
-    {
-      title: 'Expect complaints about truck traffic, road damage, and noise - especially near new rail hubs.',
-      description: 'Your industrial growth rate is 5x faster than regional average where most see 8% over two years.',
-    },
-  ]
+  // temporary placeholder for insights. Constituent insights are coming soon.
+  const insights = []
 
   return (
     <div className="flex flex-col items-center md:justify-center mb-28 md:mb-4">

--- a/app/polls/onboarding/components/steps/PreviewStep.js
+++ b/app/polls/onboarding/components/steps/PreviewStep.js
@@ -1,5 +1,4 @@
 'use client'
-import { Button } from 'goodparty-styleguide'
 import { MessageCard } from '../MessageCard'
 import TextMessagePreview from '@shared/text-message-previews/TextMessagePreview'
 import Image from 'next/image'

--- a/app/polls/onboarding/components/steps/PreviewStep.js
+++ b/app/polls/onboarding/components/steps/PreviewStep.js
@@ -41,7 +41,8 @@ export default function PreviewStep() {
                   </div>
                 } />
               </div>
-              <Button size="small" variant="ghost" className="text-blue-500 my-2">Send yourself a test</Button>
+              {/* TODO: Add send yourself a test button. We will do that once we have the real text message API */}
+              {/* <Button size="small" variant="ghost" className="text-blue-500 my-2">Send yourself a test</Button> */}
             </div>
           }
           note="You can add more recipients after launch."

--- a/app/polls/utils/s3utils.js
+++ b/app/polls/utils/s3utils.js
@@ -1,0 +1,5 @@
+
+export const getPollSubFolderName = (id, slug) =>
+    `${id}-${slug}`
+  
+export const FOLDER_NAME = 'poll-text-images'

--- a/app/polls/utils/uploadSampleCsv.js
+++ b/app/polls/utils/uploadSampleCsv.js
@@ -1,0 +1,45 @@
+import { uploadBlobToS3 } from '@shared/utils/s3Upload'
+import { FOLDER_NAME, getPollSubFolderName } from './s3utils'
+
+const csvEscape = (value) => {
+  if (value === null || value === undefined) return ''
+  const str = String(value)
+  const mustQuote = /[",\n]/.test(str)
+  const escaped = str.replace(/"/g, '""')
+  return mustQuote ? `"${escaped}"` : escaped
+}
+
+export const buildCsvFromContacts = (contactsArray) => {
+  if (!Array.isArray(contactsArray) || contactsArray.length === 0) return ''
+  const headers = [
+    'id','firstName','lastName','gender','age','politicalParty','registeredVoter','activeVoter','voterStatus','address','cellPhone','landline','maritalStatus','hasChildrenUnder18','veteranStatus','homeowner','businessOwner','levelOfEducation','ethnicityGroup','language','estimatedIncomeRange','lat','lng'
+  ]
+  const lines = [headers.join(',')]
+  for (const person of contactsArray) {
+    const row = headers.map((key) => csvEscape(person?.[key] ?? ''))
+    lines.push(row.join(','))
+  }
+  return lines.join('\n')
+}
+
+export const uploadSampleCsv = async (contactsSample, campaign) => {
+  if (!contactsSample || !Array.isArray(contactsSample) || contactsSample.length === 0) return null
+  if (!campaign?.id || !campaign?.slug) return null
+
+  const csvString = buildCsvFromContacts(contactsSample)
+  if (!csvString) return null
+
+  const fileName = `sample-contacts-${Date.now()}.csv`
+  const fileType = 'text/csv'
+  const folder = `${FOLDER_NAME}/${getPollSubFolderName(campaign.id, campaign.slug)}`
+
+  const publicUrl = await uploadBlobToS3({
+    blobOrFile: new Blob([csvString], { type: fileType }),
+    fileType,
+    fileName,
+    folder,
+  })
+  return publicUrl
+}
+
+

--- a/app/shared/utils/s3Upload.js
+++ b/app/shared/utils/s3Upload.js
@@ -1,0 +1,45 @@
+'use client'
+import { clientFetch } from 'gpApi/clientFetch'
+import { apiRoutes } from 'gpApi/routes'
+import { IS_LOCAL, IS_PROD } from 'appEnv'
+
+export const getBucketName = () => {
+  if (IS_LOCAL) return 'assets-dev.goodparty.org'
+  if (IS_PROD) return 'assets.goodparty.org'
+  return 'assets-qa.goodparty.org'
+}
+
+export const uploadBlobToS3 = async ({ blobOrFile, fileType, fileName, folder }) => {
+  const resp = await clientFetch(apiRoutes.user.files.generateSignedUploadUrl, {
+    fileType,
+    fileName,
+    bucket: folder,
+  })
+
+  if (!resp.ok) {
+    throw new Error(`Failed to get signed URL: ${resp.status} ${resp.statusText}`)
+  }
+
+  const { signedUploadUrl } = resp.data
+
+  const uploadResult = await fetch(signedUploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': fileType,
+    },
+    body: blobOrFile,
+  })
+
+  if (!uploadResult.ok) {
+    throw new Error(`S3 upload failed: ${uploadResult.status} ${uploadResult.statusText}`)
+  }
+
+  const bucketName = getBucketName()
+  const publicUrl = `https://${bucketName}/${folder}/${fileName}`
+  return publicUrl
+}
+
+export const uploadFileToS3 = async (file, folder) => {
+  const { name: fileName, type: fileType } = file
+  return uploadBlobToS3({ blobOrFile: file, fileType, fileName, folder })
+}

--- a/app/shared/utils/s3Upload.js
+++ b/app/shared/utils/s3Upload.js
@@ -10,10 +10,18 @@ export const getBucketName = () => {
 }
 
 export const uploadBlobToS3 = async ({ blobOrFile, fileType, fileName, folder }) => {
+
+  if(!blobOrFile || !fileType || !fileName || !folder) {
+    throw new Error('Missing required parameters')
+  }
+  
+  const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_')
+  const sanitizedFolder = folder.replace(/[^a-zA-Z0-9/_-]/g, '_')
+
   const resp = await clientFetch(apiRoutes.user.files.generateSignedUploadUrl, {
     fileType,
-    fileName,
-    bucket: folder,
+    fileName: sanitizedFileName,
+    bucket: sanitizedFolder,
   })
 
   if (!resp.ok) {
@@ -35,7 +43,7 @@ export const uploadBlobToS3 = async ({ blobOrFile, fileType, fileName, folder })
   }
 
   const bucketName = getBucketName()
-  const publicUrl = `https://${bucketName}/${folder}/${fileName}`
+  const publicUrl = `https://${bucketName}/${sanitizedFolder}/${sanitizedFileName}`
   return publicUrl
 }
 

--- a/gpApi/routes.js
+++ b/gpApi/routes.js
@@ -24,6 +24,10 @@ export const apiRoutes = {
       path: '/contacts/tevyn-api',
       method: 'POST',
     },
+    sample: {
+      path: '/contacts/sample',
+      method: 'GET',
+    },
   },
   homepage: {
     subscribeEmail: {


### PR DESCRIPTION
Temporary flow for using CSV for serve polls for sending Image, CSV file and text message to tevyn in slack for Wizard of Oz flow.

This will be replaced when we do the full flow of serve onboarding.

In the full flow, we will not be doing the S3 logic on the frontend and no longer using a CSV.

<img width="1149" height="673" alt="Screenshot 2025-10-07 at 7 01 42 PM" src="https://github.com/user-attachments/assets/6a1936ea-d4f6-4b8b-aaf2-8deaa24d812b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetches sample contacts and auto-uploads a CSV during onboarding, refactors image upload to shared S3 helpers, and adds `contacts.sample` API route.
> 
> - **Onboarding flow**:
>   - Auto-fetch sample contacts via `useContactsSample` and auto-upload CSV with `useCsvUpload` integrated into `useOnboarding`.
>   - Submission now guards on CSV upload errors and exposes loading/error state for contacts and CSV.
> - **S3 upload refactor**:
>   - Replace inline S3 upload logic in `AddImageStep` with shared helpers `uploadFileToS3` and utilities `getPollSubFolderName`/`FOLDER_NAME`.
>   - New shared utilities in `app/shared/utils/s3Upload.js` and poll utils in `app/polls/utils/s3utils.js` and `app/polls/utils/uploadSampleCsv.js` (includes CSV builder).
> - **API routes**:
>   - Add `apiRoutes.contacts.sample` (`GET /contacts/sample`).
> - **New hooks**:
>   - `app/polls/hooks/useContactsSample.js` and `app/polls/hooks/useCsvUpload.js` for data fetch and CSV upload orchestration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb3142d4b342786eeacbd84450d1cfb4eb730732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->