### PR TITLE
Fix flaky contacts-filters e2e test

### DIFF
--- a/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
@@ -28,7 +28,7 @@ const waitForContactsResponse = (page: Page) =>
     { timeout: 30000 },
   )
 
-const openPersonPanel = async (page: Page, row: Locator, panel: Locator) => {
+const openPersonPanel = async (row: Locator, panel: Locator) => {
   const addressField = panel.locator('p', { hasText: 'Address' }).first()
   await pRetry(
     async () => {
@@ -126,7 +126,7 @@ const testFilterField = async (
   const firstRow = table.locator('tbody tr').first()
   const panel = personContactPanel(page)
 
-  await openPersonPanel(page, firstRow, panel)
+  await openPersonPanel(firstRow, panel)
 
   for (const expectation of config.expectSheetValues) {
     if (typeof expectation === 'function') {

--- a/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page, test } from '@playwright/test'
+import pRetry from 'p-retry'
 import {
   blockSlowScripts,
   NavigationHelper,
@@ -43,17 +44,13 @@ const openPersonPanel = async (page: Page, row: Locator, panel: Locator) => {
 }
 
 const closePanel = async (page: Page, panel: Locator) => {
-  for (let attempt = 0; attempt < 3; attempt++) {
-    await page.keyboard.press('Escape')
-    try {
+  await pRetry(
+    async () => {
+      await page.keyboard.press('Escape')
       await expect(panel).toBeHidden({ timeout: 5000 })
-      return
-    } catch {
-      if (attempt === 2) {
-        await expect(panel).toBeHidden({ timeout: 5000 })
-      }
-    }
-  }
+    },
+    { retries: 3 },
+  )
 }
 
 const testFilterField = async (

--- a/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
@@ -1,5 +1,4 @@
 import { expect, type Locator, type Page, test } from '@playwright/test'
-import pRetry from 'p-retry'
 import {
   blockSlowScripts,
   NavigationHelper,
@@ -19,26 +18,42 @@ const selectCheckbox = async (sheet: Locator, label: string, value: string) => {
 
 let filterCallCount = 0
 
-const openPersonPanel = async (row: Locator, panel: Locator) => {
+const waitForContactsResponse = (page: Page) =>
+  page.waitForResponse(
+    (res) =>
+      res.url().includes('/v1/contacts') &&
+      !res.url().includes('/v1/contacts/') &&
+      res.status() === 200,
+    { timeout: 30000 },
+  )
+
+const openPersonPanel = async (page: Page, row: Locator, panel: Locator) => {
+  const addressField = panel.locator('p', { hasText: 'Address' }).first()
   for (let attempt = 0; attempt < 3; attempt++) {
     await row.locator('td').first().click({ force: true })
     try {
-      await expect(panel).toBeVisible({ timeout: 10000 })
+      await expect(addressField).toBeVisible({ timeout: 20000 })
       return
     } catch {
-      if (attempt === 2) await expect(panel).toBeVisible()
+      if (attempt === 2) {
+        await expect(addressField).toBeVisible({ timeout: 20000 })
+      }
     }
   }
 }
 
 const closePanel = async (page: Page, panel: Locator) => {
-  await pRetry(
-    async () => {
-      await page.keyboard.press('Escape')
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.keyboard.press('Escape')
+    try {
       await expect(panel).toBeHidden({ timeout: 5000 })
-    },
-    { retries: 3 },
-  )
+      return
+    } catch {
+      if (attempt === 2) {
+        await expect(panel).toBeHidden({ timeout: 5000 })
+      }
+    }
+  }
 }
 
 const testFilterField = async (
@@ -89,6 +104,7 @@ const testFilterField = async (
   const updateBtn = sheet.getByRole('button', { name: /update segment/i })
   await updateBtn.scrollIntoViewIfNeeded()
   await expect(updateBtn).toBeEnabled({ timeout: 5000 })
+  const contactsResponsePromise = waitForContactsResponse(page)
   await updateBtn.click()
   try {
     await expect(sheet).toBeHidden({ timeout: 15000 })
@@ -96,6 +112,8 @@ const testFilterField = async (
     await page.keyboard.press('Escape')
     await expect(sheet).toBeHidden({ timeout: 5000 })
   }
+
+  await contactsResponsePromise
 
   const table = page.locator('table').first()
   const firstCell = table.locator('tbody tr').first().locator('td').first()
@@ -115,7 +133,7 @@ const testFilterField = async (
   const firstRow = table.locator('tbody tr').first()
   const panel = personContactPanel(page)
 
-  await openPersonPanel(firstRow, panel)
+  await openPersonPanel(page, firstRow, panel)
 
   for (const expectation of config.expectSheetValues) {
     if (typeof expectation === 'function') {

--- a/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
@@ -30,17 +30,13 @@ const waitForContactsResponse = (page: Page) =>
 
 const openPersonPanel = async (page: Page, row: Locator, panel: Locator) => {
   const addressField = panel.locator('p', { hasText: 'Address' }).first()
-  for (let attempt = 0; attempt < 3; attempt++) {
-    await row.locator('td').first().click({ force: true })
-    try {
+  await pRetry(
+    async () => {
+      await row.locator('td').first().click({ force: true })
       await expect(addressField).toBeVisible({ timeout: 20000 })
-      return
-    } catch {
-      if (attempt === 2) {
-        await expect(addressField).toBeVisible({ timeout: 20000 })
-      }
-    }
-  }
+    },
+    { retries: 3 },
+  )
 }
 
 const closePanel = async (page: Page, panel: Locator) => {


### PR DESCRIPTION
## Summary

- **Wait for contacts API response after filter update** — after clicking "Update Segment", the test now awaits the `GET /v1/contacts` response before interacting with the table. Previously, row clicks were silently ignored because `isLoading` was still true during the refetch.
- **Wait for person data to load before checking panel content** — `openPersonPanel` now waits for the "Address" field (which only renders after the person API call completes) instead of just the panel container visibility. The old check matched the dialog's sr-only `SheetTitle` before content rendered.
- **Replace `pRetry` in `closePanel` with native retry loop** — removes the `p-retry` dependency for this file.

Verified by passing 5 consecutive runs with `--retries=0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to E2E test synchronization/retry behavior and do not affect production code; main risk is potential over-waiting or missing the intended `/v1/contacts` response in CI.
> 
> **Overview**
> Stabilizes `contacts-filters.spec.ts` by explicitly waiting for the `GET /v1/contacts` refresh after clicking **Update Segment** before asserting on/interacting with the table.
> 
> Updates `openPersonPanel` to wait for a concrete field (`Address`) to render (instead of just panel visibility), and replaces `p-retry` usage in `closePanel` with an inline 3-attempt retry loop for closing the panel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22da82497ea698d1083d05e2838657dfcf9babf9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->