### PR TITLE
fix: Scheduling Voter Outreach Through the Product Flow Does Not Upda…

### DIFF
--- a/app/dashboard/components/tasks/flows/TaskFlow.tsx
+++ b/app/dashboard/components/tasks/flows/TaskFlow.tsx
@@ -168,6 +168,14 @@ const TaskFlow = ({
 
   const handleNext = async () => {
     if (isLastStep) {
+      if (stepName !== STEPS.purchase) {
+        const contactField = getVoterContactField(type)
+        await updateVoterContacts((currentContacts) => ({
+          ...currentContacts,
+          [contactField]:
+            (currentContacts[contactField] || 0) + (state.voterCount || 0),
+        }))
+      }
       await onComplete?.()
       handleCloseConfirm()
       return
@@ -243,12 +251,12 @@ const TaskFlow = ({
     [
       type,
       state,
-      campaign,
       outreaches,
       setOutreaches,
       errorSnackbar,
       refreshCampaign,
       p2pUxEnabled,
+      campaignId,
     ],
   )
 


### PR DESCRIPTION
…te "Voters Contacted" Progress

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts when `updateVoterContacts` is applied at flow completion, which can change user-facing “voters contacted” progress counts if `state.voterCount` is wrong or steps are misidentified.
> 
> **Overview**
> Ensures the task scheduling flow increments the campaign’s “voters contacted” progress when the user completes the flow on non-purchase paths by updating voter contact counts in `handleNext` (skipping the `purchase` step to avoid double counting, since purchase completion already updates it).
> 
> Fixes a stale memoization dependency by removing `campaign` from the `onCreateOutreach` `useMemo` deps and explicitly depending on `campaignId` instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ca9b7b76c39362639acfac0eb14f71141968a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->