### PR TITLE
feat: awareness tasks

### DIFF
--- a/app/dashboard/components/tasks/AwarenessDetailModal.tsx
+++ b/app/dashboard/components/tasks/AwarenessDetailModal.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
+import { CalendarCheck } from 'lucide-react'
+import { dateUsHelper } from 'helpers/dateHelper'
+import type { Task } from './TaskItem'
+
+interface AwarenessDetailModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  task: Task
+}
+
+export default function AwarenessDetailModal({
+  open,
+  onOpenChange,
+  task,
+}: AwarenessDetailModalProps) {
+  const { title, description, date } = task
+  const formattedDate = date
+    ? dateUsHelper(date.slice(0, 10).replace(/-/g, '/'), 'long')
+    : null
+
+  return (
+    <ModalOrDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      title={title}
+      description={description || 'Awareness milestone'}
+      dialogClassName="max-w-md"
+    >
+      <div className="flex flex-col gap-4 p-4 md:p-1">
+        <div>
+          <h3 className="text-lg font-semibold">{title}</h3>
+          {description && (
+            <p className="mt-1 text-sm text-base-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+
+        {formattedDate && (
+          <div className="flex items-center gap-2 text-sm">
+            <CalendarCheck className="h-4 w-4 text-base-muted-foreground" />
+            <span>{formattedDate}</span>
+          </div>
+        )}
+      </div>
+    </ModalOrDrawer>
+  )
+}

--- a/app/dashboard/components/tasks/AwarenessDetailModal.tsx
+++ b/app/dashboard/components/tasks/AwarenessDetailModal.tsx
@@ -2,24 +2,22 @@
 
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
 import { CalendarCheck } from 'lucide-react'
-import { dateUsHelper } from 'helpers/dateHelper'
 import type { Task } from './TaskItem'
 
 interface AwarenessDetailModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   task: Task
+  formattedDate: string
 }
 
 export default function AwarenessDetailModal({
   open,
   onOpenChange,
   task,
+  formattedDate,
 }: AwarenessDetailModalProps) {
-  const { title, description, date } = task
-  const formattedDate = date
-    ? dateUsHelper(date.slice(0, 10).replace(/-/g, '/'), 'long')
-    : null
+  const { title, description } = task
 
   return (
     <ModalOrDrawer

--- a/app/dashboard/components/tasks/AwarenessTaskItem.tsx
+++ b/app/dashboard/components/tasks/AwarenessTaskItem.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { CalendarCheck, ChevronRight } from 'lucide-react'
+import { cn } from '@styleguide/lib/utils'
+
+interface AwarenessTaskItemProps {
+  title: string
+  description: string
+  date: string
+  onClick: () => void
+  className?: string
+}
+
+export default function AwarenessTaskItem({
+  title,
+  description,
+  date,
+  onClick,
+  className,
+}: AwarenessTaskItemProps) {
+  return (
+    <div
+      data-slot="task-item"
+      className={cn('flex w-full items-center font-opensans', className)}
+    >
+      <div className="flex shrink-0 items-start justify-center self-stretch pb-3 pl-4 pr-3 pt-3.5">
+        <CalendarCheck
+          size={20}
+          strokeWidth={1.5}
+          className="text-base-foreground"
+        />
+      </div>
+      <button
+        type="button"
+        aria-label={title}
+        className="flex min-w-0 flex-1 items-center overflow-hidden py-3 pr-4 group cursor-pointer w-full border-0 bg-transparent pl-0 text-left font-inherit text-inherit no-underline outline-offset-2"
+        onClick={onClick}
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-2">
+            <p className="min-w-0 flex-1 truncate text-base font-medium text-base-foreground group-hover:text-primary">
+              {title}
+            </p>
+            <ChevronRight
+              size={18}
+              className="shrink-0 text-base-foreground md:opacity-0 transition-opacity group-hover:opacity-100 group-hover:text-primary"
+            />
+          </div>
+          {description && (
+            <p className="text-sm text-base-muted-foreground">{description}</p>
+          )}
+          {date && (
+            <div className="flex items-start gap-1 pt-1 text-xs text-base-muted-foreground">
+              <span>{date}</span>
+            </div>
+          )}
+        </div>
+      </button>
+    </div>
+  )
+}

--- a/app/dashboard/components/tasks/TaskItem.tsx
+++ b/app/dashboard/components/tasks/TaskItem.tsx
@@ -3,6 +3,7 @@ import {
   TASK_TYPES,
 } from '../../shared/constants/tasks.const'
 import CampaignPlanTaskItem from 'app/dashboard/campaign-plan/components/CampaignPlanTaskItem'
+import AwarenessTaskItem from './AwarenessTaskItem'
 import { format, subDays } from 'date-fns'
 
 export interface Task {
@@ -50,6 +51,28 @@ export default function TaskItem({
     proRequired,
   } = task
 
+  const formattedDate = date
+    ? format(new Date(date.slice(0, 10).replace(/-/g, '/')), 'MMM d')
+    : electionDate && deadline
+    ? format(
+        subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
+        'MMM d',
+      )
+    : ''
+
+  if (flowType === TASK_TYPES.awareness) {
+    return (
+      <li className="border-t border-black/12">
+        <AwarenessTaskItem
+          title={title}
+          description={description}
+          date={formattedDate}
+          onClick={() => onAction(task)}
+        />
+      </li>
+    )
+  }
+
   const isExpired = deadline ? daysUntilElection < deadline : false
   const noLongerAvailable = isExpired && !completed
   const locked = noLongerAvailable || Boolean(proRequired && !isPro)
@@ -60,7 +83,9 @@ export default function TaskItem({
     lockedReason = 'This task is only available to Pro users'
   }
 
-  const displayTaskType = DISPLAY_TASK_TYPES[flowType] ?? flowType
+  const displayTaskType = flowType
+    ? (DISPLAY_TASK_TYPES[flowType] ?? flowType)
+    : ''
 
   const linkForRow =
     (isLegacyList && completed) ||
@@ -75,16 +100,7 @@ export default function TaskItem({
       <CampaignPlanTaskItem
         title={title}
         description={description}
-        date={
-          date
-            ? format(new Date(date.slice(0, 10).replace(/-/g, '/')), 'MMM d')
-            : electionDate && deadline
-            ? format(
-                subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
-                'MMM d',
-              )
-            : ''
-        }
+        date={formattedDate}
         type={displayTaskType}
         checked={completed}
         locked={locked}

--- a/app/dashboard/components/tasks/TaskItem.tsx
+++ b/app/dashboard/components/tasks/TaskItem.tsx
@@ -1,10 +1,10 @@
 import {
   DISPLAY_TASK_TYPES,
   TASK_TYPES,
+  formatTaskDate,
 } from '../../shared/constants/tasks.const'
 import CampaignPlanTaskItem from 'app/dashboard/campaign-plan/components/CampaignPlanTaskItem'
 import AwarenessTaskItem from './AwarenessTaskItem'
-import { format, subDays } from 'date-fns'
 
 export interface Task {
   id: string
@@ -51,14 +51,7 @@ export default function TaskItem({
     proRequired,
   } = task
 
-  const formattedDate = date
-    ? format(new Date(date.slice(0, 10).replace(/-/g, '/')), 'MMM d')
-    : electionDate && deadline
-    ? format(
-        subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
-        'MMM d',
-      )
-    : ''
+  const formattedDate = formatTaskDate(date, electionDate, deadline)
 
   if (flowType === TASK_TYPES.awareness) {
     return (

--- a/app/dashboard/components/tasks/TaskItem.tsx
+++ b/app/dashboard/components/tasks/TaskItem.tsx
@@ -77,7 +77,7 @@ export default function TaskItem({
   }
 
   const displayTaskType = flowType
-    ? (DISPLAY_TASK_TYPES[flowType] ?? flowType)
+    ? DISPLAY_TASK_TYPES[flowType] ?? flowType
     : ''
 
   const linkForRow =

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -339,6 +339,13 @@ const TasksList = ({
   }
 
   const handleActionClick = (task: Task) => {
+    const { flowType, proRequired, deadline } = task
+
+    if (flowType === TASK_TYPES.awareness) {
+      setAwarenessDetailTask(task)
+      return
+    }
+
     if (task.completed && !isLegacyList) {
       const href = task.link
       if (href?.startsWith('/')) {
@@ -346,8 +353,6 @@ const TasksList = ({
       }
       return
     }
-
-    const { flowType, proRequired, deadline } = task
 
     if (!isLegacyList) {
       const campaignPlanTaskType = getCampaignPlanEventTaskType(flowType)
@@ -363,11 +368,6 @@ const TasksList = ({
 
     if (!isLegacyList && flowType === TASK_TYPES.events) {
       setEventDetailTask(task)
-      return
-    }
-
-    if (flowType === TASK_TYPES.awareness) {
-      setAwarenessDetailTask(task)
       return
     }
 

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -15,6 +15,7 @@ import LogTaskModal, {
 } from './LogTaskModal'
 import CountModal from './CountModal'
 import EventDetailModal from './EventDetailModal'
+import AwarenessDetailModal from './AwarenessDetailModal'
 import DeadlineModal from './flows/DeadlineModal'
 import {
   ProUpgradeModal,
@@ -66,6 +67,7 @@ const NON_OUTREACH_TYPES = [
   TASK_TYPES.education,
   TASK_TYPES.events,
   TASK_TYPES.compliance,
+  TASK_TYPES.awareness,
 ]
 
 type TaskId = Task['id']
@@ -180,6 +182,9 @@ const TasksList = ({
 
   const [completeModalTask, setCompleteModalTask] = useState<Task | null>(null)
   const [eventDetailTask, setEventDetailTask] = useState<Task | null>(null)
+  const [awarenessDetailTask, setAwarenessDetailTask] = useState<Task | null>(
+    null,
+  )
   const taskCountsRef = useRef<
     Partial<Record<TaskId, { field: keyof VoterContactsState; count: number }>>
   >({})
@@ -358,6 +363,11 @@ const TasksList = ({
 
     if (!isLegacyList && flowType === TASK_TYPES.events) {
       setEventDetailTask(task)
+      return
+    }
+
+    if (flowType === TASK_TYPES.awareness) {
+      setAwarenessDetailTask(task)
       return
     }
 
@@ -564,6 +574,15 @@ const TasksList = ({
             if (!open) setEventDetailTask(null)
           }}
           task={eventDetailTask}
+        />
+      )}
+      {awarenessDetailTask && (
+        <AwarenessDetailModal
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setAwarenessDetailTask(null)
+          }}
+          task={awarenessDetailTask}
         />
       )}
       {deadlineModalTask && deadlineModalTask.deadline !== undefined && (

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -42,7 +42,7 @@ import type {
   TrackingSource,
   WeekPosition,
 } from '../../shared/constants/tasks.const'
-import { differenceInDays } from 'date-fns'
+import { differenceInDays, format, subDays } from 'date-fns'
 import { buildTrackingAttrs, EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { identifyUser } from '@shared/utils/analytics'
 import WeeklyTaskNavigator from './WeeklyTaskNavigator'
@@ -182,9 +182,10 @@ const TasksList = ({
 
   const [completeModalTask, setCompleteModalTask] = useState<Task | null>(null)
   const [eventDetailTask, setEventDetailTask] = useState<Task | null>(null)
-  const [awarenessDetailTask, setAwarenessDetailTask] = useState<Task | null>(
-    null,
-  )
+  const [awarenessDetail, setAwarenessDetail] = useState<{
+    task: Task
+    formattedDate: string
+  } | null>(null)
   const taskCountsRef = useRef<
     Partial<Record<TaskId, { field: keyof VoterContactsState; count: number }>>
   >({})
@@ -342,7 +343,15 @@ const TasksList = ({
     const { flowType, proRequired, deadline } = task
 
     if (flowType === TASK_TYPES.awareness) {
-      setAwarenessDetailTask(task)
+      const date = task.date
+        ? format(new Date(task.date.slice(0, 10).replace(/-/g, '/')), 'MMM d')
+        : electionDate && deadline
+          ? format(
+              subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
+              'MMM d',
+            )
+          : ''
+      setAwarenessDetail({ task, formattedDate: date })
       return
     }
 
@@ -576,13 +585,14 @@ const TasksList = ({
           task={eventDetailTask}
         />
       )}
-      {awarenessDetailTask && (
+      {awarenessDetail && (
         <AwarenessDetailModal
           open={true}
           onOpenChange={(open) => {
-            if (!open) setAwarenessDetailTask(null)
+            if (!open) setAwarenessDetail(null)
           }}
-          task={awarenessDetailTask}
+          task={awarenessDetail.task}
+          formattedDate={awarenessDetail.formattedDate}
         />
       )}
       {deadlineModalTask && deadlineModalTask.deadline !== undefined && (

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -30,6 +30,7 @@ import { ComplianceModal } from '../../shared/ComplianceModal'
 import { TCR_COMPLIANCE_STATUS } from 'app/dashboard/profile/texting-compliance/components/ComplianceSteps'
 import TaskFlow from './flows/TaskFlow'
 import {
+  formatTaskDate,
   getCampaignPlanEventTaskType,
   NAV_DIRECTIONS,
   STATUS_CHANGES,
@@ -42,7 +43,7 @@ import type {
   TrackingSource,
   WeekPosition,
 } from '../../shared/constants/tasks.const'
-import { differenceInDays, format, subDays } from 'date-fns'
+import { differenceInDays } from 'date-fns'
 import { buildTrackingAttrs, EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { identifyUser } from '@shared/utils/analytics'
 import WeeklyTaskNavigator from './WeeklyTaskNavigator'
@@ -343,15 +344,10 @@ const TasksList = ({
     const { flowType, proRequired, deadline } = task
 
     if (flowType === TASK_TYPES.awareness) {
-      const date = task.date
-        ? format(new Date(task.date.slice(0, 10).replace(/-/g, '/')), 'MMM d')
-        : electionDate && deadline
-          ? format(
-              subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
-              'MMM d',
-            )
-          : ''
-      setAwarenessDetail({ task, formattedDate: date })
+      setAwarenessDetail({
+        task,
+        formattedDate: formatTaskDate(task.date, electionDate, deadline),
+      })
       return
     }
 

--- a/app/dashboard/shared/constants/tasks.const.ts
+++ b/app/dashboard/shared/constants/tasks.const.ts
@@ -1,3 +1,5 @@
+import { format, subDays } from 'date-fns'
+
 // NOTE: copied from CampaignTaskType enum in gp-api
 export const TASK_TYPES = {
   text: 'text',
@@ -94,6 +96,23 @@ export const getCampaignPlanEventTaskType = (
     default:
       return null
   }
+}
+
+export function formatTaskDate(
+  taskDate: string | null | undefined,
+  electionDate: string | undefined,
+  deadline: number | undefined,
+): string {
+  if (taskDate) {
+    return format(new Date(taskDate.slice(0, 10).replace(/-/g, '/')), 'MMM d')
+  }
+  if (electionDate && deadline) {
+    return format(
+      subDays(new Date(electionDate.replace(/-/g, '/')), deadline),
+      'MMM d',
+    )
+  }
+  return ''
 }
 
 type TaskTypeKey = keyof typeof TASK_TYPES

--- a/app/dashboard/shared/constants/tasks.const.ts
+++ b/app/dashboard/shared/constants/tasks.const.ts
@@ -9,6 +9,7 @@ export const TASK_TYPES = {
   events: 'events',
   education: 'education',
   compliance: 'compliance',
+  awareness: 'awareness',
 }
 
 // Legacy types, these were based on voter file types
@@ -44,6 +45,7 @@ export const DISPLAY_TASK_TYPES: Record<
   events: 'Event',
   education: 'Education',
   compliance: 'Compliance',
+  awareness: 'Awareness',
 }
 
 export const WEEK_POSITIONS = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new task flow branch (`awareness`) in the dashboard task list with new UI components and click handling, which could affect task interaction behavior and completion/navigation for that type. Low security risk, but moderate UX/regression risk in the tasks list rendering and action routing.
> 
> **Overview**
> Adds support for a new **`awareness`** campaign-plan task type in the dashboard tasks UI.
> 
> Awareness tasks now render with a dedicated row component (`AwarenessTaskItem`) and, on click, open a new `AwarenessDetailModal` instead of entering the existing task flows. Date formatting for tasks is centralized via a new `formatTaskDate` helper and reused by both awareness and existing task items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4514870458e5e1c38e162ffe7626f5e3062bf2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->