### PR TITLE
ENG-6983-c 

### DIFF
--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -172,8 +172,13 @@ const bootstrapTestUser = async (
     },
   )
 
-  client.defaults.headers.common['x-organization-slug'] =
-    `campaign-${campaign.id}`
+  if (!campaign?.id) {
+    throw new Error('Campaign creation did not return a valid id')
+  }
+
+  client.defaults.headers.common[
+    'x-organization-slug'
+  ] = `campaign-${campaign.id}`
 
   await client.put('/v1/campaigns/mine/race-target-details', {})
   await client.put('/v1/campaigns/mine', {

--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -153,21 +153,28 @@ const bootstrapTestUser = async (
     throw new Error('No race found for the specific office selector')
   }
 
-  await client.post('/v1/campaigns', {
-    ballotReadyPositionId: race.position.id,
-    details: {
-      electionId: race.election.id,
-      raceId: race.id,
-      state: race.election.state,
-      ballotLevel: race.position.level,
-      electionDate: race.election.electionDay,
-      partisanType: race.position.partisanType,
-      hasPrimary: race.position.hasPrimary,
-      filingPeriodsStart: race.filingPeriods[0]?.startOn,
-      filingPeriodsEnd: race.filingPeriods[0]?.endOn,
+  const { data: campaign } = await client.post<{ id: number }>(
+    '/v1/campaigns',
+    {
+      ballotReadyPositionId: race.position.id,
+      details: {
+        electionId: race.election.id,
+        raceId: race.id,
+        state: race.election.state,
+        ballotLevel: race.position.level,
+        electionDate: race.election.electionDay,
+        partisanType: race.position.partisanType,
+        hasPrimary: race.position.hasPrimary,
+        filingPeriodsStart: race.filingPeriods[0]?.startOn,
+        filingPeriodsEnd: race.filingPeriods[0]?.endOn,
+      },
+      data: { currentStep: 'onboarding-1' },
     },
-    data: { currentStep: 'onboarding-1' },
-  })
+  )
+
+  client.defaults.headers.common['x-organization-slug'] =
+    `campaign-${campaign.id}`
+
   await client.put('/v1/campaigns/mine/race-target-details', {})
   await client.put('/v1/campaigns/mine', {
     data: { currentStep: 'onboarding-complete' },


### PR DESCRIPTION
Tests should pass once - https://github.com/thegoodparty/gp-api/pull/1424 is merged

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only the e2e test registration helper, but could affect many tests by altering default API headers during onboarding.
> 
> **Overview**
> During e2e user bootstrap, the `POST /v1/campaigns` call now captures the returned campaign id and sets the Axios default `x-organization-slug` header to `campaign-{id}` before continuing onboarding.
> 
> This ensures subsequent `/v1/campaigns/mine/*` requests are made in the correct organization context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c035a49e0abcc80aaba850666a54534f4202bfd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->