### PR TITLE
ENG-7239: Fix campaign plan task dates displaying one week ahead of week header

### DIFF
--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -181,6 +181,33 @@ beforeEach(() => {
 })
 
 describe('TasksList non-legacy event tasks', () => {
+  it('renders a week range that contains the rendered task date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/01/01 12:00:00'))
+
+    try {
+      const task = makeTask({
+        id: 'task-week-30',
+        title: 'Week aligned task',
+        week: 30,
+        date: '2026-04-13',
+      })
+
+      render(
+        <TasksList
+          campaign={makeCampaign()}
+          tasks={[task]}
+          isLegacyList={false}
+        />,
+      )
+
+      expect(screen.getByText('Apr 7-13')).toBeInTheDocument()
+      expect(screen.getByText('Apr 13')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('uses the row only to open event details; external link stays in the modal', async () => {
     const user = userEvent.setup()
     mockClientFetch.mockResolvedValue({ ok: true, data: [] })

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { addDays, addWeeks } from 'date-fns'
+import WeeklyTaskNavigator from './WeeklyTaskNavigator'
+
+describe('WeeklyTaskNavigator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const defaultProps = {
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    canGoPrevious: true,
+    canGoNext: true,
+  }
+
+  it('renders the date range for a week within the same month', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+      />,
+    )
+
+    expect(screen.getByText('Jun 1-7')).toBeInTheDocument()
+  })
+
+  it('renders the date range spanning two months', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/04/28')}
+      />,
+    )
+
+    expect(screen.getByText('Apr 28 - May 4')).toBeInTheDocument()
+  })
+
+  it('shows "This week" when today falls in the range', () => {
+    const today = new Date()
+    const weekStart = addDays(today, -2)
+
+    render(
+      <WeeklyTaskNavigator {...defaultProps} currentWeekStart={weekStart} />,
+    )
+
+    expect(screen.getByText('This week')).toBeInTheDocument()
+  })
+
+  it('shows "Next week" for the following week range', () => {
+    const today = new Date()
+    const nextWeekStart = addWeeks(today, 1)
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={nextWeekStart}
+      />,
+    )
+
+    expect(screen.getByText('Next week')).toBeInTheDocument()
+  })
+
+  it('shows "Last week" for the previous week range', () => {
+    const today = new Date()
+    const lastWeekStart = addWeeks(today, -1)
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={lastWeekStart}
+      />,
+    )
+
+    expect(screen.getByText('Last week')).toBeInTheDocument()
+  })
+
+  it('disables previous button when canGoPrevious is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoPrevious={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Previous week')).toBeDisabled()
+  })
+
+  it('disables next button when canGoNext is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoNext={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Next week')).toBeDisabled()
+  })
+
+  it('calls onPrevious and onNext when buttons are clicked', async () => {
+    vi.useRealTimers()
+
+    try {
+      const user = userEvent.setup()
+      const onPrevious = vi.fn()
+      const onNext = vi.fn()
+
+      render(
+        <WeeklyTaskNavigator
+          currentWeekStart={new Date('2026/06/01')}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          canGoPrevious={true}
+          canGoNext={true}
+        />,
+      )
+
+      await user.click(screen.getByLabelText('Previous week'))
+      expect(onPrevious).toHaveBeenCalledOnce()
+
+      await user.click(screen.getByLabelText('Next week'))
+      expect(onNext).toHaveBeenCalledOnce()
+    } finally {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+    }
+  })
+})

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { format, endOfWeek, addWeeks, isSameWeek } from 'date-fns'
+import { format, addDays, addWeeks, startOfDay } from 'date-fns'
 import { ArrowLeftIcon, ArrowRightIcon, IconButton } from '@styleguide'
 
 interface WeeklyTaskNavigatorProps {
@@ -12,7 +12,7 @@ interface WeeklyTaskNavigatorProps {
 }
 
 function formatWeekLabel(weekStart: Date): string {
-  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 })
+  const weekEnd = addDays(weekStart, 6)
   const startMonth = format(weekStart, 'MMM')
   const endMonth = format(weekEnd, 'MMM')
 
@@ -22,23 +22,22 @@ function formatWeekLabel(weekStart: Date): string {
   return `${format(weekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
 }
 
+function isInWeekRange(date: Date, rangeStart: Date): boolean {
+  const d = startOfDay(date).getTime()
+  const s = startOfDay(rangeStart).getTime()
+  const e = startOfDay(addDays(rangeStart, 6)).getTime()
+  return d >= s && d <= e
+}
+
 function getDisplayLabel(weekStart: Date): string {
   const today = new Date()
-  if (isSameWeek(today, weekStart, { weekStartsOn: 0 })) {
+  if (isInWeekRange(today, weekStart)) {
     return 'This week'
   }
-  if (
-    isSameWeek(today, addWeeks(weekStart, 1), {
-      weekStartsOn: 0,
-    })
-  ) {
+  if (isInWeekRange(today, addWeeks(weekStart, 1))) {
     return 'Last week'
   }
-  if (
-    isSameWeek(today, addWeeks(weekStart, -1), {
-      weekStartsOn: 0,
-    })
-  ) {
+  if (isInWeekRange(today, addWeeks(weekStart, -1))) {
     return 'Next week'
   }
   return formatWeekLabel(weekStart)

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  addWeeks,
+  addDays,
+  differenceInWeeks,
+  format,
+  startOfWeek,
+} from 'date-fns'
+import { useWeekNavigation } from './useWeekNavigation'
+import type { Task } from './TaskItem'
+import { TASK_TYPES } from '../../shared/constants/tasks.const'
+
+function makeTask(overrides: Partial<Task> & { week: number }): Task {
+  return {
+    id: `task-${overrides.week}`,
+    title: `Task week ${overrides.week}`,
+    description: '',
+    flowType: TASK_TYPES.education,
+    completed: false,
+    ...overrides,
+  }
+}
+
+describe('useWeekNavigation', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('computes currentWeekStart as election-relative, not calendar-snapped', () => {
+    const election = new Date('2026/11/03')
+    const week = 30
+    const tasks = [makeTask({ week })]
+    const daysUntilElection = 200
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    const expected = addWeeks(election, -week)
+    expect(result.current.currentWeekStart.getTime()).toBe(expected.getTime())
+  })
+
+  it('task dates assigned via ceil fall within the week header range', () => {
+    const election = new Date('2026/11/03')
+    const taskDate = new Date('2026/04/14')
+    const weekNumber = differenceInWeeks(election, taskDate, {
+      roundingMethod: 'ceil',
+    })
+    const tasks = [
+      makeTask({ week: weekNumber, date: format(taskDate, 'yyyy-MM-dd') }),
+    ]
+    const daysUntilElection = 200
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    const weekStart = result.current.currentWeekStart
+    const weekEnd = addDays(weekStart, 6)
+    expect(taskDate.getTime()).toBeGreaterThanOrEqual(weekStart.getTime())
+    expect(taskDate.getTime()).toBeLessThanOrEqual(weekEnd.getTime())
+  })
+
+  it('selects the week closest to current weeksUntilElection', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [makeTask({ week: 10 }), makeTask({ week: 20 })]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 77),
+    )
+
+    expect(result.current.selectedWeek).toBe(10)
+  })
+
+  it('filters tasks to only the selected week', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [
+      makeTask({ id: 'a', week: 10 }),
+      makeTask({ id: 'b', week: 10 }),
+      makeTask({ id: 'c', week: 20 }),
+    ]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 70),
+    )
+
+    expect(result.current.filteredTasks).toHaveLength(2)
+    expect(result.current.filteredTasks.map((t) => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('navigates between weeks', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [
+      makeTask({ week: 30 }),
+      makeTask({ week: 20 }),
+      makeTask({ week: 10 }),
+    ]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 140),
+    )
+
+    expect(result.current.selectedWeek).toBe(20)
+    expect(result.current.canGoPrevious).toBe(true)
+    expect(result.current.canGoNext).toBe(true)
+
+    act(() => result.current.goToNext())
+    expect(result.current.selectedWeek).toBe(10)
+
+    act(() => result.current.goToPrevious())
+    expect(result.current.selectedWeek).toBe(20)
+  })
+
+  it('persists selected week in sessionStorage', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [makeTask({ week: 30 }), makeTask({ week: 20 })]
+
+    const { result, unmount } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 196),
+    )
+
+    act(() => result.current.goToNext())
+    expect(result.current.selectedWeek).toBe(20)
+    unmount()
+
+    const { result: result2 } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 175),
+    )
+    expect(result2.current.selectedWeek).toBe(20)
+  })
+
+  it('returns fallback date when electionDateObj is null', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+
+    try {
+      const tasks = [makeTask({ week: 5 })]
+
+      const { result } = renderHook(() =>
+        useWeekNavigation(tasks, 'campaign-1', null, Infinity),
+      )
+
+      expect(result.current.currentWeekStart.getTime()).toBe(
+        startOfWeek(new Date(), { weekStartsOn: 0 }).getTime(),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { startOfWeek, addWeeks } from 'date-fns'
+import { addWeeks, startOfWeek } from 'date-fns'
 import type { Task } from './TaskItem'
 
 const SESSION_KEY_PREFIX = 'campaign-plan-selected-week'
@@ -92,9 +92,7 @@ export function useWeekNavigation(
   }
 
   const currentWeekStart = electionDateObj
-    ? startOfWeek(addWeeks(electionDateObj, -selectedWeek), {
-        weekStartsOn: 0,
-      })
+    ? addWeeks(electionDateObj, -selectedWeek)
     : startOfWeek(new Date(), { weekStartsOn: 0 })
 
   const filteredTasks = tasks.filter((t) => t.week === selectedWeek)


### PR DESCRIPTION
## Problem

Campaign plan task dates were displaying one week ahead of their assigned week container header. For example, the header would show "Apr 5–11" but tasks within that container displayed dates like "Apr 14" and "Apr 17".

## Root Cause

The API assigns tasks to weeks using `ceil(differenceInWeeks(electionDate, taskDate))`, so a task ~29.3 weeks before election rounds up to `week = 30`. The frontend was computing the week header via `startOfWeek(addWeeks(electionDate, -30))`, which snapped to a calendar Sunday boundary — landing ~1 week earlier than the actual task dates.

## Fix

**`useWeekNavigation.ts`**: Remove `startOfWeek()` snap from the election-date path. `currentWeekStart` is now `addWeeks(electionDateObj, -selectedWeek)` — a pure election-relative offset matching the API's ceil-based week semantics. The null-election fallback is preserved.

**`WeeklyTaskNavigator.tsx`**: Use `addDays(weekStart, 6)` instead of `endOfWeek()` for the range end (since weeks are no longer calendar-aligned). Replace `isSameWeek()` with a custom `isInWeekRange()` helper for "This week" / "Next week" / "Last week" labels.

## Tests Added

- **`useWeekNavigation.test.ts`** (7 tests): Validates election-relative week start, ceil-assigned task dates falling within the header range, closest-week selection, task filtering, navigation, sessionStorage persistence, and null-election fallback.
- **`WeeklyTaskNavigator.test.tsx`** (8 tests): Date range formatting (same-month / cross-month), relative labels, button disabled states, click handlers. All time-dependent tests use `vi.useFakeTimers()`.
- **`TasksList.test.tsx`** (+1 regression test): Renders a full `TasksList` with `week: 30, date: '2026-04-13'` and asserts the header shows `Apr 7-13` and the task shows `Apr 13` — proving the rendered week range contains the rendered task date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core campaign plan week/date calculations and “This/Next/Last week” labeling, which could shift displayed ranges if assumptions are wrong, but the surface area is small and covered by new unit/regression tests.
> 
> **Overview**
> Fixes campaign plan week headers being **one week out of sync** with task dates by making week ranges *election-relative* instead of snapping to calendar week boundaries (`useWeekNavigation` now uses `addWeeks(electionDate, -selectedWeek)` directly).
> 
> Updates `WeeklyTaskNavigator` to compute week end as `weekStart + 6 days` and replaces `isSameWeek` with an explicit `isInWeekRange` check for “This week”/“Next week”/“Last week” labels.
> 
> Adds targeted tests for the navigator and week-navigation hook, plus a `TasksList` regression test asserting the rendered week range contains the task’s rendered date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a06f4138356c85f773b5531cb5c3a0582816def. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->