### PR TITLE
fix: show only "This week" label, date ranges for all other weeks

### DIFF
--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { addWeeks, startOfWeek, format, endOfWeek } from 'date-fns'
+import WeeklyTaskNavigator from './WeeklyTaskNavigator'
+
+describe('WeeklyTaskNavigator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const defaultProps = {
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    canGoPrevious: true,
+    canGoNext: true,
+  }
+
+  it('renders the date range for a week within the same month', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+      />,
+    )
+
+    expect(screen.getByText('Jun 1-6')).toBeInTheDocument()
+  })
+
+  it('renders the date range spanning two months', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/04/28')}
+      />,
+    )
+
+    expect(screen.getByText('Apr 28 - May 2')).toBeInTheDocument()
+  })
+
+  it('shows only "This week" with no date range when today falls in the range', () => {
+    const weekStart = startOfWeek(new Date(), { weekStartsOn: 0 })
+
+    render(
+      <WeeklyTaskNavigator {...defaultProps} currentWeekStart={weekStart} />,
+    )
+
+    expect(screen.getByText('This week')).toBeInTheDocument()
+    const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 })
+    const dateRange = `${format(weekStart, 'MMM')} ${format(
+      weekStart,
+      'd',
+    )}-${format(weekEnd, 'd')}`
+    expect(screen.queryByText(dateRange)).not.toBeInTheDocument()
+  })
+
+  it('shows date range instead of "Next week" label for the following week', () => {
+    const nextWeekStart = startOfWeek(addWeeks(new Date(), 1), {
+      weekStartsOn: 0,
+    })
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={nextWeekStart}
+      />,
+    )
+
+    expect(screen.queryByText('Next week')).not.toBeInTheDocument()
+    const weekEnd = endOfWeek(nextWeekStart, { weekStartsOn: 0 })
+    const startMonth = format(nextWeekStart, 'MMM')
+    const endMonth = format(weekEnd, 'MMM')
+    const expectedRange =
+      startMonth === endMonth
+        ? `${startMonth} ${format(nextWeekStart, 'd')}-${format(weekEnd, 'd')}`
+        : `${format(nextWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
+    expect(screen.getByText(expectedRange)).toBeInTheDocument()
+  })
+
+  it('shows date range instead of "Last week" label for the previous week', () => {
+    const lastWeekStart = startOfWeek(addWeeks(new Date(), -1), {
+      weekStartsOn: 0,
+    })
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={lastWeekStart}
+      />,
+    )
+
+    expect(screen.queryByText('Last week')).not.toBeInTheDocument()
+    const weekEnd = endOfWeek(lastWeekStart, { weekStartsOn: 0 })
+    const startMonth = format(lastWeekStart, 'MMM')
+    const endMonth = format(weekEnd, 'MMM')
+    const expectedRange =
+      startMonth === endMonth
+        ? `${startMonth} ${format(lastWeekStart, 'd')}-${format(weekEnd, 'd')}`
+        : `${format(lastWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
+    expect(screen.getByText(expectedRange)).toBeInTheDocument()
+  })
+
+  it('disables previous button when canGoPrevious is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoPrevious={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Previous week')).toBeDisabled()
+  })
+
+  it('disables next button when canGoNext is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoNext={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Next week')).toBeDisabled()
+  })
+
+  it('calls onPrevious and onNext when buttons are clicked', async () => {
+    vi.useRealTimers()
+
+    try {
+      const user = userEvent.setup()
+      const onPrevious = vi.fn()
+      const onNext = vi.fn()
+
+      render(
+        <WeeklyTaskNavigator
+          currentWeekStart={new Date('2026/06/01')}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          canGoPrevious={true}
+          canGoNext={true}
+        />,
+      )
+
+      await user.click(screen.getByLabelText('Previous week'))
+      expect(onPrevious).toHaveBeenCalledOnce()
+
+      await user.click(screen.getByLabelText('Next week'))
+      expect(onNext).toHaveBeenCalledOnce()
+    } finally {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+    }
+  })
+})

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { format, endOfWeek, addWeeks, isSameWeek } from 'date-fns'
+import { format, endOfWeek, isSameWeek } from 'date-fns'
 import { ArrowLeftIcon, ArrowRightIcon, IconButton } from '@styleguide'
 
 interface WeeklyTaskNavigatorProps {
@@ -22,26 +22,8 @@ function formatWeekLabel(weekStart: Date): string {
   return `${format(weekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
 }
 
-function getDisplayLabel(weekStart: Date): string {
-  const today = new Date()
-  if (isSameWeek(today, weekStart, { weekStartsOn: 0 })) {
-    return 'This week'
-  }
-  if (
-    isSameWeek(today, addWeeks(weekStart, 1), {
-      weekStartsOn: 0,
-    })
-  ) {
-    return 'Last week'
-  }
-  if (
-    isSameWeek(today, addWeeks(weekStart, -1), {
-      weekStartsOn: 0,
-    })
-  ) {
-    return 'Next week'
-  }
-  return formatWeekLabel(weekStart)
+function isCurrentWeek(weekStart: Date): boolean {
+  return isSameWeek(new Date(), weekStart, { weekStartsOn: 0 })
 }
 
 export default function WeeklyTaskNavigator({
@@ -51,9 +33,8 @@ export default function WeeklyTaskNavigator({
   canGoPrevious,
   canGoNext,
 }: WeeklyTaskNavigatorProps) {
-  const label = getDisplayLabel(currentWeekStart)
+  const isThisWeek = isCurrentWeek(currentWeekStart)
   const dateRange = formatWeekLabel(currentWeekStart)
-  const showDateRange = label !== dateRange
 
   return (
     <div className="flex items-center gap-3 px-6 py-3">
@@ -76,10 +57,9 @@ export default function WeeklyTaskNavigator({
         <ArrowRightIcon className="size-4" />
       </IconButton>
       <div className="flex flex-col">
-        <span className="text-base font-semibold">{label}</span>
-        {showDateRange && (
-          <span className="text-xs text-muted-foreground">{dateRange}</span>
-        )}
+        <span className="text-base font-semibold">
+          {isThisWeek ? 'This week' : dateRange}
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes the week navigation header in the AI Campaign Plan to correctly display labels and date ranges.

**Before:** "This Week" showed a date range, while "Last Week" and "Next Week" showed labels — all incorrect.

**After:** Only the current week shows "This week" (no date range). All other weeks (including previous/next) show only their date range (e.g. "Apr 12–18").

## Changes

- **WeeklyTaskNavigator.tsx** — Replaced `getDisplayLabel()` (which returned "Last week"/"Next week" labels) with a simple `isCurrentWeek()` boolean. Display now shows "This week" for the current week and just the date range for everything else.
- **WeeklyTaskNavigator.test.tsx** — Updated tests to verify "Last week" and "Next week" labels are no longer shown, and date ranges appear instead. Also fixed 2 pre-existing broken date expectations from a prior `endOfWeek` refactor.

Closes ENG-7238

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts week label rendering and adds/updates unit tests; no data handling or business logic beyond date formatting.
> 
> **Overview**
> Fixes `WeeklyTaskNavigator` week header labeling: the current week now renders only **"This week"**, while *all other weeks* render only their formatted date range (including previously labeled "Last week"/"Next week").
> 
> Adds `WeeklyTaskNavigator.test.tsx` to verify date-range formatting (same-month vs cross-month), ensure the current week hides the date range, confirm "Last week"/"Next week" labels no longer appear, and keep coverage for disabled navigation buttons and click handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b93dac00f08106b745dc184f9deb607983c20d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->