### PR TITLE
feat: recurring tasks

### DIFF
--- a/app/dashboard/components/tasks/AwarenessDetailModal.tsx
+++ b/app/dashboard/components/tasks/AwarenessDetailModal.tsx
@@ -24,7 +24,7 @@ export default function AwarenessDetailModal({
       open={open}
       onOpenChange={onOpenChange}
       title={title}
-      description={description || 'Awareness milestone'}
+      description={description || 'Task details'}
       dialogClassName="max-w-md"
     >
       <div className="flex flex-col gap-4 p-4 md:p-1">

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -486,6 +486,98 @@ describe('TasksList revert completion flow', () => {
   })
 })
 
+describe('TasksList recurring task completion', () => {
+  it('sends {type, quantity} payload to the API when completing a recurring task via CountModal', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      completed: false,
+    })
+    const completedTask = { ...task, completed: true }
+
+    mockClientFetch.mockResolvedValueOnce({ ok: true, data: completedTask })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Save count' }))
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/campaigns/tasks/complete/:taskId',
+          method: 'PUT',
+        }),
+        { taskId: 'task-1', type: 'recurring', quantity: 5 },
+      )
+    })
+  })
+
+  it('does NOT update local voter contacts when completing a recurring task', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      completed: false,
+    })
+    const completedTask = { ...task, completed: true }
+
+    mockClientFetch.mockResolvedValueOnce({ ok: true, data: completedTask })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Save count' }))
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'PUT' }),
+        expect.anything(),
+      )
+    })
+
+    expect(mockUpdateVoterContactsLocal).not.toHaveBeenCalled()
+  })
+
+  it('opens the detail modal (not the outreach flow) when clicking the row action for a recurring task', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      title: 'Weekly canvass',
+      description: 'Go knock doors',
+      completed: false,
+    })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Weekly canvass/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(
+      screen.getAllByRole('heading', { name: 'Weekly canvass' }),
+    ).not.toHaveLength(0)
+  })
+})
+
 describe('TasksList tracking events', () => {
   const mockTrackEvent = vi.mocked(trackEvent)
   const mockIdentifyUser = vi.mocked(identifyUser)

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -298,13 +298,14 @@ const TasksList = ({
     if (!completeModalTask) return
 
     const task = completeModalTask
+    const isRecurring = task.flowType === TASK_TYPES.recurring
     const resolvedType =
       task.flowType === TASK_TYPES.p2pDisabledText
         ? TASK_TYPES.text
         : task.flowType
 
     let fieldForRollback: keyof VoterContactsState | undefined
-    if (!isLegacyList) {
+    if (!isLegacyList && !isRecurring) {
       const field = getVoterContactField(resolvedType)
       fieldForRollback = field
       updateVoterContactsLocal((prev) => ({
@@ -314,10 +315,10 @@ const TasksList = ({
       taskCountsRef.current[task.id] = { field, count }
     }
 
-    const ok = await completeTask(task.id, {
-      type: resolvedType,
-      quantity: count,
-    })
+    const ok = await completeTask(
+      task.id,
+      isRecurring ? undefined : { type: resolvedType, quantity: count },
+    )
 
     if (ok) {
       trackTaskStatusUpdate(
@@ -343,7 +344,7 @@ const TasksList = ({
   const handleActionClick = (task: Task) => {
     const { flowType, proRequired, deadline } = task
 
-    if (flowType === TASK_TYPES.awareness) {
+    if (flowType === TASK_TYPES.awareness || flowType === TASK_TYPES.recurring) {
       setAwarenessDetail({
         task,
         formattedDate: formatTaskDate(task.date, electionDate, deadline),

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -344,7 +344,10 @@ const TasksList = ({
   const handleActionClick = (task: Task) => {
     const { flowType, proRequired, deadline } = task
 
-    if (flowType === TASK_TYPES.awareness || flowType === TASK_TYPES.recurring) {
+    if (
+      flowType === TASK_TYPES.awareness ||
+      flowType === TASK_TYPES.recurring
+    ) {
       setAwarenessDetail({
         task,
         formattedDate: formatTaskDate(task.date, electionDate, deadline),

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -315,10 +315,10 @@ const TasksList = ({
       taskCountsRef.current[task.id] = { field, count }
     }
 
-    const ok = await completeTask(
-      task.id,
-      isRecurring ? undefined : { type: resolvedType, quantity: count },
-    )
+    const ok = await completeTask(task.id, {
+      type: resolvedType,
+      quantity: count,
+    })
 
     if (ok) {
       trackTaskStatusUpdate(

--- a/app/dashboard/shared/constants/tasks.const.ts
+++ b/app/dashboard/shared/constants/tasks.const.ts
@@ -12,6 +12,7 @@ export const TASK_TYPES = {
   education: 'education',
   compliance: 'compliance',
   awareness: 'awareness',
+  recurring: 'recurring',
 }
 
 // Legacy types, these were based on voter file types
@@ -48,6 +49,7 @@ export const DISPLAY_TASK_TYPES: Record<
   education: 'Education',
   compliance: 'Compliance',
   awareness: 'Awareness',
+  recurring: '',
 }
 
 export const WEEK_POSITIONS = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes task completion behavior by conditionally omitting voter-contact payloads and local count updates for the new `recurring` type, which could affect task tracking and completion flows. UI impact is small but touches core task mutation paths.
> 
> **Overview**
> Adds a new `TASK_TYPES.recurring` and routes recurring tasks through the same detail UX as awareness tasks (opens the detail modal on row action).
> 
> Updates task completion so recurring tasks **do not** update local voter-contact counters and call `completeTask` without the `{type, quantity}` payload. Also tweaks the detail modal fallback copy from “Awareness milestone” to “Task details”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4d83d2b29318343e9c8b05583ef2df920d43ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->