### PR TITLE
fix: route pro sign up continue button through full sign-up flow

### DIFF
--- a/app/dashboard/components/CompleteProSignUpAlert.tsx
+++ b/app/dashboard/components/CompleteProSignUpAlert.tsx
@@ -4,7 +4,7 @@ export const CompleteProSignUpAlert = (): React.JSX.Element => (
   <AlertBanner
     title="Please complete your pro sign up!"
     message="Please remember to complete your Pro Plan sign up to access all the features and tools available to you!"
-    actionHref="/dashboard/pro-sign-up/purchase-redirect"
+    actionHref="/dashboard/pro-sign-up"
     actionText="Continue"
   />
 )


### PR DESCRIPTION
## Summary

The "Continue" button in the **"Please complete your pro sign up!"** dashboard alert was linking directly to `/dashboard/pro-sign-up/purchase-redirect`, bypassing the office details confirmation steps.

This changes the `actionHref` to `/dashboard/pro-sign-up` so the flow matches what "Upgrade Plan" (settings) and "Start today for just $10/month" (upgrade-to-pro page) do:

`pro-sign-up` → `committee-check` → `service-agreement` → `purchase-redirect`

## Changes

- `app/dashboard/components/CompleteProSignUpAlert.tsx`: Updated `actionHref` from `/dashboard/pro-sign-up/purchase-redirect` → `/dashboard/pro-sign-up`

Fixes ENG-7231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single link target change in a dashboard alert; main impact is user navigation through the intended sign-up steps.
> 
> **Overview**
> Updates the **“Complete pro sign up”** dashboard alert so its “Continue” button links to `/dashboard/pro-sign-up` instead of jumping straight to `/dashboard/pro-sign-up/purchase-redirect`, ensuring users go through the full pro sign-up flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe3599b202b8690e655fec180f6156ddf1d99f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->