### PR TITLE
Fix: always include current week in campaign plan navigation

### DIFF
--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -151,10 +151,12 @@ const makeCampaign = (overrides: Partial<Campaign> = {}): Campaign =>
     ...overrides,
   } as unknown as Campaign)
 
+const TEST_SESSION_KEY = 'campaign-plan-selected-week:campaign-1'
+
 beforeEach(() => {
   vi.clearAllMocks()
   sessionStorage.clear()
-  sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '1')
+  sessionStorage.setItem(TEST_SESSION_KEY, '1')
   mockUpdateVoterContactsLocal.mockReset()
   mockUseUser.mockReturnValue([{ id: 'user-1' }, vi.fn()])
   mockClientFetch.mockImplementation(
@@ -194,7 +196,7 @@ describe('TasksList non-legacy event tasks', () => {
         date: '2026-04-13',
       })
 
-      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
 
       render(
         <TasksList
@@ -494,7 +496,7 @@ describe('TasksList tracking events', () => {
 
   describe('Campaign Plan Viewed', () => {
     it('fires Viewed event with the selected week counts', () => {
-      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       const tasks = [
         makeTask({ id: 'task-1', week: 30, completed: false }),
         makeTask({ id: 'task-2', week: 30, completed: true }),
@@ -536,6 +538,7 @@ describe('TasksList tracking events', () => {
     })
 
     it('does NOT re-fire Viewed event when tasks are completed within the same week', async () => {
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       const user = userEvent.setup()
       const task = makeTask({
         week: 30,
@@ -571,6 +574,7 @@ describe('TasksList tracking events', () => {
     })
 
     it('identifies the real user when the user becomes available after initial render', async () => {
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       mockUseUser.mockReturnValueOnce([null, vi.fn()])
 
       const task = makeTask({ week: 30 })
@@ -882,10 +886,7 @@ describe('TasksList tracking events', () => {
       const currentWeek = Math.ceil(
         differenceInDays(new Date('2026/11/03'), new Date()) / 7,
       )
-      sessionStorage.setItem(
-        'campaign-plan-selected-week:campaign-1',
-        String(currentWeek + 1),
-      )
+      sessionStorage.setItem(TEST_SESSION_KEY, String(currentWeek + 1))
       const tasks = [
         makeTask({ id: 'task-1', week: currentWeek + 1 }),
         makeTask({ id: 'task-2', week: currentWeek }),
@@ -918,10 +919,7 @@ describe('TasksList tracking events', () => {
       const currentWeek = Math.ceil(
         differenceInDays(new Date('2026/11/03'), new Date()) / 7,
       )
-      sessionStorage.setItem(
-        'campaign-plan-selected-week:campaign-1',
-        String(currentWeek),
-      )
+      sessionStorage.setItem(TEST_SESSION_KEY, String(currentWeek))
       const tasks = [
         makeTask({ id: 'task-1', week: currentWeek + 1 }),
         makeTask({ id: 'task-2', week: currentWeek }),

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -154,6 +154,7 @@ const makeCampaign = (overrides: Partial<Campaign> = {}): Campaign =>
 beforeEach(() => {
   vi.clearAllMocks()
   sessionStorage.clear()
+  sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '1')
   mockUpdateVoterContactsLocal.mockReset()
   mockUseUser.mockReturnValue([{ id: 'user-1' }, vi.fn()])
   mockClientFetch.mockImplementation(
@@ -192,6 +193,8 @@ describe('TasksList non-legacy event tasks', () => {
         week: 30,
         date: '2026-04-13',
       })
+
+      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
 
       render(
         <TasksList
@@ -301,7 +304,6 @@ describe('TasksList revert completion flow', () => {
     const textTask = makeTask({
       flowType: TASK_TYPES.text,
       completed: false,
-      week: 1,
     })
     const completedTextTask = { ...textTask, completed: true }
 
@@ -875,12 +877,11 @@ describe('TasksList tracking events', () => {
   })
 
   describe('Week Navigated', () => {
-    const getCurrentWeek = () =>
-      Math.ceil(differenceInDays(new Date('2026/11/03'), new Date()) / 7)
-
     it('fires WeekNavigated with direction "next" when navigating forward', async () => {
       const user = userEvent.setup()
-      const currentWeek = getCurrentWeek()
+      const currentWeek = Math.ceil(
+        differenceInDays(new Date('2026/11/03'), new Date()) / 7,
+      )
       sessionStorage.setItem(
         'campaign-plan-selected-week:campaign-1',
         String(currentWeek + 1),
@@ -914,7 +915,9 @@ describe('TasksList tracking events', () => {
 
     it('fires WeekNavigated with direction "previous" when navigating back', async () => {
       const user = userEvent.setup()
-      const currentWeek = getCurrentWeek()
+      const currentWeek = Math.ceil(
+        differenceInDays(new Date('2026/11/03'), new Date()) / 7,
+      )
       sessionStorage.setItem(
         'campaign-plan-selected-week:campaign-1',
         String(currentWeek),

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -154,6 +154,27 @@ describe('useWeekNavigation', () => {
     }
   })
 
+  it('defaults to the most-recent week when electionDateObj is null and multiple weeks exist', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+
+    try {
+      const tasks = [
+        makeTask({ id: 'a', week: 30 }),
+        makeTask({ id: 'b', week: 20 }),
+        makeTask({ id: 'c', week: 10 }),
+      ]
+
+      const { result } = renderHook(() =>
+        useWeekNavigation(tasks, 'campaign-1', null, Infinity),
+      )
+
+      expect(result.current.selectedWeek).toBe(10)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('includes current week even when no tasks exist for it', () => {
     const election = new Date('2026/11/03')
     const daysUntilElection = 49

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -32,12 +32,13 @@ describe('useWeekNavigation', () => {
     const week = 30
     const tasks = [makeTask({ week })]
     const daysUntilElection = 200
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
 
     const { result } = renderHook(() =>
       useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
     )
 
-    const expected = addWeeks(election, -week)
+    const expected = addWeeks(election, -weeksUntilElection)
     expect(result.current.currentWeekStart.getTime()).toBe(expected.getTime())
   })
 
@@ -64,13 +65,15 @@ describe('useWeekNavigation', () => {
 
   it('selects the week closest to current weeksUntilElection', () => {
     const election = new Date('2026/11/03')
+    const daysUntilElection = 77
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
     const tasks = [makeTask({ week: 10 }), makeTask({ week: 20 })]
 
     const { result } = renderHook(() =>
-      useWeekNavigation(tasks, 'campaign-1', election, 77),
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
     )
 
-    expect(result.current.selectedWeek).toBe(10)
+    expect(result.current.selectedWeek).toBe(weeksUntilElection)
   })
 
   it('filters tasks to only the selected week', () => {
@@ -141,11 +144,29 @@ describe('useWeekNavigation', () => {
         useWeekNavigation(tasks, 'campaign-1', null, Infinity),
       )
 
+      expect(result.current.selectedWeek).toBe(5)
+      expect(result.current.filteredTasks).toHaveLength(1)
       expect(result.current.currentWeekStart.getTime()).toBe(
         startOfWeek(new Date(), { weekStartsOn: 0 }).getTime(),
       )
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('includes current week even when no tasks exist for it', () => {
+    const election = new Date('2026/11/03')
+    const daysUntilElection = 49
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
+    const nextWeek = weeksUntilElection - 1
+    const tasks = [makeTask({ week: nextWeek })]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    expect(result.current.selectedWeek).toBe(weeksUntilElection)
+    expect(result.current.filteredTasks).toHaveLength(0)
+    expect(result.current.canGoNext).toBe(true)
   })
 })

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -65,7 +65,7 @@ export function useWeekNavigation(
             if (currDiff === bestDiff && w < bestW) return idx
             return bestIdx
           }, 0)
-        : 0
+        : weekNumbers.length - 1
       : 0
 
   const [savedWeek, setSavedWeek] = useState<number | null>(() =>

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -46,22 +46,26 @@ export function useWeekNavigation(
   daysUntilElection: number,
 ): WeekNavigationResult {
   const weeksUntilElection = Math.ceil(daysUntilElection / 7)
+  const hasCurrentWeek = Number.isFinite(weeksUntilElection)
+  const taskWeeks = tasks.map((task) => task.week)
 
-  const weekNumbers = [...new Set(tasks.map((t) => t.week))].sort(
-    (a, b) => b - a,
-  )
+  const weekNumbers = [
+    ...new Set([...taskWeeks, ...(hasCurrentWeek ? [weeksUntilElection] : [])]),
+  ].sort((a, b) => b - a)
 
   const defaultIndex =
     weekNumbers.length > 0
-      ? weekNumbers.reduce((bestIdx, w, idx) => {
-          const bestW = weekNumbers[bestIdx]
-          if (bestW === undefined) return idx
-          const bestDiff = Math.abs(bestW - weeksUntilElection)
-          const currDiff = Math.abs(w - weeksUntilElection)
-          if (currDiff < bestDiff) return idx
-          if (currDiff === bestDiff && w < bestW) return idx
-          return bestIdx
-        }, 0)
+      ? hasCurrentWeek
+        ? weekNumbers.reduce((bestIdx, w, idx) => {
+            const bestW = weekNumbers[bestIdx]
+            if (bestW === undefined) return idx
+            const bestDiff = Math.abs(bestW - weeksUntilElection)
+            const currDiff = Math.abs(w - weeksUntilElection)
+            if (currDiff < bestDiff) return idx
+            if (currDiff === bestDiff && w < bestW) return idx
+            return bestIdx
+          }, 0)
+        : 0
       : 0
 
   const [savedWeek, setSavedWeek] = useState<number | null>(() =>


### PR DESCRIPTION
## Summary

When no tasks exist for the current week, the week was skipped entirely instead of showing "This Week" with an empty state. Now `weeksUntilElection` is always injected into the `weekNumbers` array so the current week is always navigable.

## Changes

- **useWeekNavigation.ts**: Inject `weeksUntilElection` into `weekNumbers` (guarded by `Number.isFinite` for null election dates). Wrap `defaultIndex` in a `hasCurrentWeek` ternary so the Infinity path falls back to index 0.
- **useWeekNavigation.test.ts**: Updated assertions for election-relative week selection; added test for empty current week scenario.
- **TasksList.test.tsx**: Made test fixtures deterministic with static `week: 1` default and explicit `sessionStorage` pinning.

Resolves ENG-7183

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI state change confined to week selection/navigation logic; main risk is off-by-one/Infinity handling affecting which week is shown by default.
> 
> **Overview**
> Ensures the campaign plan week navigator always includes the *current* `weeksUntilElection` week even when there are no tasks for it, so users can still land on “This Week” and see an empty state.
> 
> Updates `useWeekNavigation` to inject the current week into the computed `weekNumbers` (guarded by `Number.isFinite`) and adjusts default week selection when `weeksUntilElection` is non-finite (e.g., missing election date). Tests are updated/added to validate the new selection behavior and to make `TasksList` week-dependent tests deterministic via explicit `sessionStorage` setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ea8ebfda34b78b1122f518cdc4902dcaa9a365. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->