### PR TITLE
[GP-Bot] ENG-7309 Fix Next button overlap with HubSpot chat icon

### DIFF
--- a/app/dashboard/website/editor/components/WebsiteEditorPageStepper.test.tsx
+++ b/app/dashboard/website/editor/components/WebsiteEditorPageStepper.test.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import WebsiteEditorPageStepper from './WebsiteEditorPageStepper'
+
+const defaultProps = {
+  totalSteps: 6,
+  currentStep: 1,
+  onStepChange: vi.fn(),
+  onComplete: vi.fn(),
+}
+
+describe('WebsiteEditorPageStepper', () => {
+  it('renders the progress indicators for all steps', () => {
+    const { container } = render(<WebsiteEditorPageStepper {...defaultProps} />)
+
+    const progressDots = container.querySelectorAll('.rounded-full')
+    expect(progressDots).toHaveLength(6)
+  })
+
+  it('highlights completed steps with bg-neutral-800', () => {
+    const { container } = render(
+      <WebsiteEditorPageStepper {...defaultProps} currentStep={3} />,
+    )
+
+    const progressDots = container.querySelectorAll('.rounded-full')
+    expect(progressDots[0]).toHaveClass('bg-neutral-800')
+    expect(progressDots[1]).toHaveClass('bg-neutral-800')
+    expect(progressDots[2]).toHaveClass('bg-neutral-800')
+    expect(progressDots[3]).toHaveClass('bg-gray-300')
+  })
+
+  it('renders Back and Next buttons', () => {
+    render(<WebsiteEditorPageStepper {...defaultProps} />)
+
+    expect(screen.getByRole('button', { name: /back/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument()
+  })
+
+  it('disables Back button on first step', () => {
+    render(<WebsiteEditorPageStepper {...defaultProps} currentStep={1} />)
+
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled()
+  })
+
+  it('enables Back button on steps after first', () => {
+    render(<WebsiteEditorPageStepper {...defaultProps} currentStep={2} />)
+
+    expect(screen.getByRole('button', { name: /back/i })).not.toBeDisabled()
+  })
+
+  it('calls onStepChange with next step when Next is clicked', () => {
+    const onStepChange = vi.fn()
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={2}
+        onStepChange={onStepChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(onStepChange).toHaveBeenCalledWith(3)
+  })
+
+  it('calls onStepChange with previous step when Back is clicked', () => {
+    const onStepChange = vi.fn()
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={3}
+        onStepChange={onStepChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    expect(onStepChange).toHaveBeenCalledWith(2)
+  })
+
+  it('renders Complete button on last step', () => {
+    render(
+      <WebsiteEditorPageStepper {...defaultProps} currentStep={6} canPublish />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /complete/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /next/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('calls onComplete when Complete button is clicked', () => {
+    const onComplete = vi.fn()
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={6}
+        canPublish
+        onComplete={onComplete}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /complete/i }))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Complete button when canPublish is false', () => {
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={6}
+        canPublish={false}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /complete/i })).toBeDisabled()
+  })
+
+  it('shows cantSaveReason message on last step when provided', () => {
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={6}
+        cantSaveReason="Invalid email"
+      />,
+    )
+
+    expect(screen.getByText('Invalid email')).toBeInTheDocument()
+  })
+
+  it('does not show cantSaveReason message on non-final steps', () => {
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={3}
+        cantSaveReason="Invalid email"
+      />,
+    )
+
+    expect(screen.queryByText('Invalid email')).not.toBeInTheDocument()
+  })
+
+  it('uses custom button labels when provided', () => {
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        prevLabel="Previous"
+        nextLabel="Continue"
+        completeLabel="Publish website"
+        currentStep={6}
+        canPublish
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /previous/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /publish website/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('disables Next button when nextDisabled is true', () => {
+    render(
+      <WebsiteEditorPageStepper {...defaultProps} currentStep={3} nextDisabled />,
+    )
+
+    expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+  })
+
+  it('calls onBeforeNext and stops if it returns false', () => {
+    const onStepChange = vi.fn()
+    const onBeforeNext = vi.fn().mockReturnValue(false)
+
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={3}
+        onStepChange={onStepChange}
+        onBeforeNext={onBeforeNext}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(onBeforeNext).toHaveBeenCalledTimes(1)
+    expect(onStepChange).not.toHaveBeenCalled()
+  })
+
+  it('calls onBeforeNext and proceeds if it returns true', () => {
+    const onStepChange = vi.fn()
+    const onBeforeNext = vi.fn().mockReturnValue(true)
+
+    render(
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={3}
+        onStepChange={onStepChange}
+        onBeforeNext={onBeforeNext}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(onBeforeNext).toHaveBeenCalledTimes(1)
+    expect(onStepChange).toHaveBeenCalledWith(4)
+  })
+
+  it('has right padding on mobile/tablet to avoid chat widget overlap', () => {
+    const { container } = render(<WebsiteEditorPageStepper {...defaultProps} />)
+
+    // The outer container for the buttons/progress should have pr-16 for mobile
+    // and lg:pr-0 for large screens
+    const stepperContainer = container.querySelector('.flex.gap-4')
+    expect(stepperContainer).toHaveClass('pr-16')
+    expect(stepperContainer).toHaveClass('lg:pr-0')
+  })
+})

--- a/app/dashboard/website/editor/components/WebsiteEditorPageStepper.test.tsx
+++ b/app/dashboard/website/editor/components/WebsiteEditorPageStepper.test.tsx
@@ -162,7 +162,11 @@ describe('WebsiteEditorPageStepper', () => {
 
   it('disables Next button when nextDisabled is true', () => {
     render(
-      <WebsiteEditorPageStepper {...defaultProps} currentStep={3} nextDisabled />,
+      <WebsiteEditorPageStepper
+        {...defaultProps}
+        currentStep={3}
+        nextDisabled
+      />,
     )
 
     expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()

--- a/app/dashboard/website/editor/components/WebsiteEditorPageStepper.tsx
+++ b/app/dashboard/website/editor/components/WebsiteEditorPageStepper.tsx
@@ -50,7 +50,7 @@ const WebsiteEditorPageStepper = ({
           {cantSaveReason}
         </div>
       )}
-      <div className="flex gap-4 md:gap-16 flex-wrap md:flex-nowrap w-full pb-6">
+      <div className="flex gap-4 md:gap-16 flex-wrap md:flex-nowrap w-full pb-6 pr-16 lg:pr-0">
         <div className="md:order-2 flex grow items-center justify-between gap-x-2 w-full">
           {Array.from({ length: totalSteps }, (_, idx) => (
             <div


### PR DESCRIPTION
## Summary
- Adds right padding (`pr-16`) on mobile/tablet viewports to the website creation stepper component
- Prevents the Next/Publish button from being covered by the HubSpot support chat widget
- Removes padding on large screens (`lg:pr-0`) where the layout doesn't have this conflict
- Adds comprehensive test coverage for the WebsiteEditorPageStepper component

## Test plan
- [ ] Navigate to Dashboard > Website > Start building on a mobile/tablet viewport
- [ ] Verify the Next button is not covered by the HubSpot chat icon in the bottom right
- [ ] Verify the progress bar and buttons are properly spaced from the chat widget
- [ ] Verify on desktop that the layout remains unchanged (no extra padding)
- [ ] Test all steps of the website creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak plus new component tests; main risk is minor spacing/regression on small breakpoints due to added responsive padding.
> 
> **Overview**
> Adds responsive right padding (`pr-16 lg:pr-0`) to the `WebsiteEditorPageStepper` container so the Next/Complete CTA isn’t overlapped by the HubSpot chat widget on smaller viewports.
> 
> Introduces a new `WebsiteEditorPageStepper` test suite covering step indicator rendering, Back/Next/Complete behavior (including disabled states and `onBeforeNext` gating), optional error messaging, custom labels, and the new padding classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a6ce7fd48608daba517f5da2cbbb308c0031df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->