### PR TITLE
QA <- Dev

### DIFF
--- a/app/dashboard/components/CompleteProSignUpAlert.tsx
+++ b/app/dashboard/components/CompleteProSignUpAlert.tsx
@@ -4,7 +4,7 @@ export const CompleteProSignUpAlert = (): React.JSX.Element => (
   <AlertBanner
     title="Please complete your pro sign up!"
     message="Please remember to complete your Pro Plan sign up to access all the features and tools available to you!"
-    actionHref="/dashboard/pro-sign-up/purchase-redirect"
+    actionHref="/dashboard/pro-sign-up"
     actionText="Continue"
   />
 )

--- a/app/dashboard/components/tasks/AwarenessDetailModal.tsx
+++ b/app/dashboard/components/tasks/AwarenessDetailModal.tsx
@@ -24,7 +24,7 @@ export default function AwarenessDetailModal({
       open={open}
       onOpenChange={onOpenChange}
       title={title}
-      description={description || 'Awareness milestone'}
+      description={description || 'Task details'}
       dialogClassName="max-w-md"
     >
       <div className="flex flex-col gap-4 p-4 md:p-1">

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -181,6 +181,33 @@ beforeEach(() => {
 })
 
 describe('TasksList non-legacy event tasks', () => {
+  it('renders a week range that contains the rendered task date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/01/01 12:00:00'))
+
+    try {
+      const task = makeTask({
+        id: 'task-week-30',
+        title: 'Week aligned task',
+        week: 30,
+        date: '2026-04-13',
+      })
+
+      render(
+        <TasksList
+          campaign={makeCampaign()}
+          tasks={[task]}
+          isLegacyList={false}
+        />,
+      )
+
+      expect(screen.getByText('Apr 7-13')).toBeInTheDocument()
+      expect(screen.getByText('Apr 13')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('uses the row only to open event details; external link stays in the modal', async () => {
     const user = userEvent.setup()
     mockClientFetch.mockResolvedValue({ ok: true, data: [] })

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -151,10 +151,12 @@ const makeCampaign = (overrides: Partial<Campaign> = {}): Campaign =>
     ...overrides,
   } as unknown as Campaign)
 
+const TEST_SESSION_KEY = 'campaign-plan-selected-week:campaign-1'
+
 beforeEach(() => {
   vi.clearAllMocks()
   sessionStorage.clear()
-  sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '1')
+  sessionStorage.setItem(TEST_SESSION_KEY, '1')
   mockUpdateVoterContactsLocal.mockReset()
   mockUseUser.mockReturnValue([{ id: 'user-1' }, vi.fn()])
   mockClientFetch.mockImplementation(
@@ -194,7 +196,7 @@ describe('TasksList non-legacy event tasks', () => {
         date: '2026-04-13',
       })
 
-      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
 
       render(
         <TasksList
@@ -494,7 +496,7 @@ describe('TasksList tracking events', () => {
 
   describe('Campaign Plan Viewed', () => {
     it('fires Viewed event with the selected week counts', () => {
-      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       const tasks = [
         makeTask({ id: 'task-1', week: 30, completed: false }),
         makeTask({ id: 'task-2', week: 30, completed: true }),
@@ -536,6 +538,7 @@ describe('TasksList tracking events', () => {
     })
 
     it('does NOT re-fire Viewed event when tasks are completed within the same week', async () => {
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       const user = userEvent.setup()
       const task = makeTask({
         week: 30,
@@ -571,6 +574,7 @@ describe('TasksList tracking events', () => {
     })
 
     it('identifies the real user when the user becomes available after initial render', async () => {
+      sessionStorage.setItem(TEST_SESSION_KEY, '30')
       mockUseUser.mockReturnValueOnce([null, vi.fn()])
 
       const task = makeTask({ week: 30 })
@@ -882,10 +886,7 @@ describe('TasksList tracking events', () => {
       const currentWeek = Math.ceil(
         differenceInDays(new Date('2026/11/03'), new Date()) / 7,
       )
-      sessionStorage.setItem(
-        'campaign-plan-selected-week:campaign-1',
-        String(currentWeek + 1),
-      )
+      sessionStorage.setItem(TEST_SESSION_KEY, String(currentWeek + 1))
       const tasks = [
         makeTask({ id: 'task-1', week: currentWeek + 1 }),
         makeTask({ id: 'task-2', week: currentWeek }),
@@ -918,10 +919,7 @@ describe('TasksList tracking events', () => {
       const currentWeek = Math.ceil(
         differenceInDays(new Date('2026/11/03'), new Date()) / 7,
       )
-      sessionStorage.setItem(
-        'campaign-plan-selected-week:campaign-1',
-        String(currentWeek),
-      )
+      sessionStorage.setItem(TEST_SESSION_KEY, String(currentWeek))
       const tasks = [
         makeTask({ id: 'task-1', week: currentWeek + 1 }),
         makeTask({ id: 'task-2', week: currentWeek }),

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -486,6 +486,98 @@ describe('TasksList revert completion flow', () => {
   })
 })
 
+describe('TasksList recurring task completion', () => {
+  it('sends {type, quantity} payload to the API when completing a recurring task via CountModal', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      completed: false,
+    })
+    const completedTask = { ...task, completed: true }
+
+    mockClientFetch.mockResolvedValueOnce({ ok: true, data: completedTask })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Save count' }))
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/campaigns/tasks/complete/:taskId',
+          method: 'PUT',
+        }),
+        { taskId: 'task-1', type: 'recurring', quantity: 5 },
+      )
+    })
+  })
+
+  it('does NOT update local voter contacts when completing a recurring task', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      completed: false,
+    })
+    const completedTask = { ...task, completed: true }
+
+    mockClientFetch.mockResolvedValueOnce({ ok: true, data: completedTask })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'Save count' }))
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'PUT' }),
+        expect.anything(),
+      )
+    })
+
+    expect(mockUpdateVoterContactsLocal).not.toHaveBeenCalled()
+  })
+
+  it('opens the detail modal (not the outreach flow) when clicking the row action for a recurring task', async () => {
+    const user = userEvent.setup()
+    const task = makeTask({
+      flowType: TASK_TYPES.recurring,
+      title: 'Weekly canvass',
+      description: 'Go knock doors',
+      completed: false,
+    })
+
+    render(
+      <TasksList
+        campaign={makeCampaign()}
+        tasks={[task]}
+        isLegacyList={false}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Weekly canvass/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+    expect(
+      screen.getAllByRole('heading', { name: 'Weekly canvass' }),
+    ).not.toHaveLength(0)
+  })
+})
+
 describe('TasksList tracking events', () => {
   const mockTrackEvent = vi.mocked(trackEvent)
   const mockIdentifyUser = vi.mocked(identifyUser)

--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -154,6 +154,7 @@ const makeCampaign = (overrides: Partial<Campaign> = {}): Campaign =>
 beforeEach(() => {
   vi.clearAllMocks()
   sessionStorage.clear()
+  sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '1')
   mockUpdateVoterContactsLocal.mockReset()
   mockUseUser.mockReturnValue([{ id: 'user-1' }, vi.fn()])
   mockClientFetch.mockImplementation(
@@ -192,6 +193,8 @@ describe('TasksList non-legacy event tasks', () => {
         week: 30,
         date: '2026-04-13',
       })
+
+      sessionStorage.setItem('campaign-plan-selected-week:campaign-1', '30')
 
       render(
         <TasksList
@@ -301,7 +304,6 @@ describe('TasksList revert completion flow', () => {
     const textTask = makeTask({
       flowType: TASK_TYPES.text,
       completed: false,
-      week: 1,
     })
     const completedTextTask = { ...textTask, completed: true }
 
@@ -875,12 +877,11 @@ describe('TasksList tracking events', () => {
   })
 
   describe('Week Navigated', () => {
-    const getCurrentWeek = () =>
-      Math.ceil(differenceInDays(new Date('2026/11/03'), new Date()) / 7)
-
     it('fires WeekNavigated with direction "next" when navigating forward', async () => {
       const user = userEvent.setup()
-      const currentWeek = getCurrentWeek()
+      const currentWeek = Math.ceil(
+        differenceInDays(new Date('2026/11/03'), new Date()) / 7,
+      )
       sessionStorage.setItem(
         'campaign-plan-selected-week:campaign-1',
         String(currentWeek + 1),
@@ -914,7 +915,9 @@ describe('TasksList tracking events', () => {
 
     it('fires WeekNavigated with direction "previous" when navigating back', async () => {
       const user = userEvent.setup()
-      const currentWeek = getCurrentWeek()
+      const currentWeek = Math.ceil(
+        differenceInDays(new Date('2026/11/03'), new Date()) / 7,
+      )
       sessionStorage.setItem(
         'campaign-plan-selected-week:campaign-1',
         String(currentWeek),

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -298,13 +298,14 @@ const TasksList = ({
     if (!completeModalTask) return
 
     const task = completeModalTask
+    const isRecurring = task.flowType === TASK_TYPES.recurring
     const resolvedType =
       task.flowType === TASK_TYPES.p2pDisabledText
         ? TASK_TYPES.text
         : task.flowType
 
     let fieldForRollback: keyof VoterContactsState | undefined
-    if (!isLegacyList) {
+    if (!isLegacyList && !isRecurring) {
       const field = getVoterContactField(resolvedType)
       fieldForRollback = field
       updateVoterContactsLocal((prev) => ({
@@ -314,10 +315,10 @@ const TasksList = ({
       taskCountsRef.current[task.id] = { field, count }
     }
 
-    const ok = await completeTask(task.id, {
-      type: resolvedType,
-      quantity: count,
-    })
+    const ok = await completeTask(
+      task.id,
+      isRecurring ? undefined : { type: resolvedType, quantity: count },
+    )
 
     if (ok) {
       trackTaskStatusUpdate(
@@ -343,7 +344,7 @@ const TasksList = ({
   const handleActionClick = (task: Task) => {
     const { flowType, proRequired, deadline } = task
 
-    if (flowType === TASK_TYPES.awareness) {
+    if (flowType === TASK_TYPES.awareness || flowType === TASK_TYPES.recurring) {
       setAwarenessDetail({
         task,
         formattedDate: formatTaskDate(task.date, electionDate, deadline),

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -344,7 +344,10 @@ const TasksList = ({
   const handleActionClick = (task: Task) => {
     const { flowType, proRequired, deadline } = task
 
-    if (flowType === TASK_TYPES.awareness || flowType === TASK_TYPES.recurring) {
+    if (
+      flowType === TASK_TYPES.awareness ||
+      flowType === TASK_TYPES.recurring
+    ) {
       setAwarenessDetail({
         task,
         formattedDate: formatTaskDate(task.date, electionDate, deadline),

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -315,10 +315,10 @@ const TasksList = ({
       taskCountsRef.current[task.id] = { field, count }
     }
 
-    const ok = await completeTask(
-      task.id,
-      isRecurring ? undefined : { type: resolvedType, quantity: count },
-    )
+    const ok = await completeTask(task.id, {
+      type: resolvedType,
+      quantity: count,
+    })
 
     if (ok) {
       trackTaskStatusUpdate(

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { addDays, addWeeks } from 'date-fns'
+import WeeklyTaskNavigator from './WeeklyTaskNavigator'
+
+describe('WeeklyTaskNavigator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const defaultProps = {
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    canGoPrevious: true,
+    canGoNext: true,
+  }
+
+  it('renders the date range for a week within the same month', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+      />,
+    )
+
+    expect(screen.getByText('Jun 1-7')).toBeInTheDocument()
+  })
+
+  it('renders the date range spanning two months', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/04/28')}
+      />,
+    )
+
+    expect(screen.getByText('Apr 28 - May 4')).toBeInTheDocument()
+  })
+
+  it('shows "This week" when today falls in the range', () => {
+    const today = new Date()
+    const weekStart = addDays(today, -2)
+
+    render(
+      <WeeklyTaskNavigator {...defaultProps} currentWeekStart={weekStart} />,
+    )
+
+    expect(screen.getByText('This week')).toBeInTheDocument()
+  })
+
+  it('shows "Next week" for the following week range', () => {
+    const today = new Date()
+    const nextWeekStart = addWeeks(today, 1)
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={nextWeekStart}
+      />,
+    )
+
+    expect(screen.getByText('Next week')).toBeInTheDocument()
+  })
+
+  it('shows "Last week" for the previous week range', () => {
+    const today = new Date()
+    const lastWeekStart = addWeeks(today, -1)
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={lastWeekStart}
+      />,
+    )
+
+    expect(screen.getByText('Last week')).toBeInTheDocument()
+  })
+
+  it('disables previous button when canGoPrevious is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoPrevious={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Previous week')).toBeDisabled()
+  })
+
+  it('disables next button when canGoNext is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoNext={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Next week')).toBeDisabled()
+  })
+
+  it('calls onPrevious and onNext when buttons are clicked', async () => {
+    vi.useRealTimers()
+
+    try {
+      const user = userEvent.setup()
+      const onPrevious = vi.fn()
+      const onNext = vi.fn()
+
+      render(
+        <WeeklyTaskNavigator
+          currentWeekStart={new Date('2026/06/01')}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          canGoPrevious={true}
+          canGoNext={true}
+        />,
+      )
+
+      await user.click(screen.getByLabelText('Previous week'))
+      expect(onPrevious).toHaveBeenCalledOnce()
+
+      await user.click(screen.getByLabelText('Next week'))
+      expect(onNext).toHaveBeenCalledOnce()
+    } finally {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+    }
+  })
+})

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { addWeeks, startOfWeek, format, endOfWeek } from 'date-fns'
+import WeeklyTaskNavigator from './WeeklyTaskNavigator'
+
+describe('WeeklyTaskNavigator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const defaultProps = {
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    canGoPrevious: true,
+    canGoNext: true,
+  }
+
+  it('renders the date range for a week within the same month', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+      />,
+    )
+
+    expect(screen.getByText('Jun 1-6')).toBeInTheDocument()
+  })
+
+  it('renders the date range spanning two months', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/04/28')}
+      />,
+    )
+
+    expect(screen.getByText('Apr 28 - May 2')).toBeInTheDocument()
+  })
+
+  it('shows only "This week" with no date range when today falls in the range', () => {
+    const weekStart = startOfWeek(new Date(), { weekStartsOn: 0 })
+
+    render(
+      <WeeklyTaskNavigator {...defaultProps} currentWeekStart={weekStart} />,
+    )
+
+    expect(screen.getByText('This week')).toBeInTheDocument()
+    const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 })
+    const dateRange = `${format(weekStart, 'MMM')} ${format(
+      weekStart,
+      'd',
+    )}-${format(weekEnd, 'd')}`
+    expect(screen.queryByText(dateRange)).not.toBeInTheDocument()
+  })
+
+  it('shows date range instead of "Next week" label for the following week', () => {
+    const nextWeekStart = startOfWeek(addWeeks(new Date(), 1), {
+      weekStartsOn: 0,
+    })
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={nextWeekStart}
+      />,
+    )
+
+    expect(screen.queryByText('Next week')).not.toBeInTheDocument()
+    const weekEnd = endOfWeek(nextWeekStart, { weekStartsOn: 0 })
+    const startMonth = format(nextWeekStart, 'MMM')
+    const endMonth = format(weekEnd, 'MMM')
+    const expectedRange =
+      startMonth === endMonth
+        ? `${startMonth} ${format(nextWeekStart, 'd')}-${format(weekEnd, 'd')}`
+        : `${format(nextWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
+    expect(screen.getByText(expectedRange)).toBeInTheDocument()
+  })
+
+  it('shows date range instead of "Last week" label for the previous week', () => {
+    const lastWeekStart = startOfWeek(addWeeks(new Date(), -1), {
+      weekStartsOn: 0,
+    })
+
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={lastWeekStart}
+      />,
+    )
+
+    expect(screen.queryByText('Last week')).not.toBeInTheDocument()
+    const weekEnd = endOfWeek(lastWeekStart, { weekStartsOn: 0 })
+    const startMonth = format(lastWeekStart, 'MMM')
+    const endMonth = format(weekEnd, 'MMM')
+    const expectedRange =
+      startMonth === endMonth
+        ? `${startMonth} ${format(lastWeekStart, 'd')}-${format(weekEnd, 'd')}`
+        : `${format(lastWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
+    expect(screen.getByText(expectedRange)).toBeInTheDocument()
+  })
+
+  it('disables previous button when canGoPrevious is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoPrevious={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Previous week')).toBeDisabled()
+  })
+
+  it('disables next button when canGoNext is false', () => {
+    render(
+      <WeeklyTaskNavigator
+        {...defaultProps}
+        currentWeekStart={new Date('2026/06/01')}
+        canGoNext={false}
+      />,
+    )
+
+    expect(screen.getByLabelText('Next week')).toBeDisabled()
+  })
+
+  it('calls onPrevious and onNext when buttons are clicked', async () => {
+    vi.useRealTimers()
+
+    try {
+      const user = userEvent.setup()
+      const onPrevious = vi.fn()
+      const onNext = vi.fn()
+
+      render(
+        <WeeklyTaskNavigator
+          currentWeekStart={new Date('2026/06/01')}
+          onPrevious={onPrevious}
+          onNext={onNext}
+          canGoPrevious={true}
+          canGoNext={true}
+        />,
+      )
+
+      await user.click(screen.getByLabelText('Previous week'))
+      expect(onPrevious).toHaveBeenCalledOnce()
+
+      await user.click(screen.getByLabelText('Next week'))
+      expect(onNext).toHaveBeenCalledOnce()
+    } finally {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+    }
+  })
+})

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { format, endOfWeek, addWeeks, isSameWeek } from 'date-fns'
+import { format, endOfWeek, isSameWeek } from 'date-fns'
 import { ArrowLeftIcon, ArrowRightIcon, IconButton } from '@styleguide'
 
 interface WeeklyTaskNavigatorProps {
@@ -22,26 +22,8 @@ function formatWeekLabel(weekStart: Date): string {
   return `${format(weekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
 }
 
-function getDisplayLabel(weekStart: Date): string {
-  const today = new Date()
-  if (isSameWeek(today, weekStart, { weekStartsOn: 0 })) {
-    return 'This week'
-  }
-  if (
-    isSameWeek(today, addWeeks(weekStart, 1), {
-      weekStartsOn: 0,
-    })
-  ) {
-    return 'Last week'
-  }
-  if (
-    isSameWeek(today, addWeeks(weekStart, -1), {
-      weekStartsOn: 0,
-    })
-  ) {
-    return 'Next week'
-  }
-  return formatWeekLabel(weekStart)
+function isCurrentWeek(weekStart: Date): boolean {
+  return isSameWeek(new Date(), weekStart, { weekStartsOn: 0 })
 }
 
 export default function WeeklyTaskNavigator({
@@ -51,9 +33,8 @@ export default function WeeklyTaskNavigator({
   canGoPrevious,
   canGoNext,
 }: WeeklyTaskNavigatorProps) {
-  const label = getDisplayLabel(currentWeekStart)
+  const isThisWeek = isCurrentWeek(currentWeekStart)
   const dateRange = formatWeekLabel(currentWeekStart)
-  const showDateRange = label !== dateRange
 
   return (
     <div className="flex items-center gap-3 px-6 py-3">
@@ -76,10 +57,9 @@ export default function WeeklyTaskNavigator({
         <ArrowRightIcon className="size-4" />
       </IconButton>
       <div className="flex flex-col">
-        <span className="text-base font-semibold">{label}</span>
-        {showDateRange && (
-          <span className="text-xs text-muted-foreground">{dateRange}</span>
-        )}
+        <span className="text-base font-semibold">
+          {isThisWeek ? 'This week' : dateRange}
+        </span>
       </div>
     </div>
   )

--- a/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
+++ b/app/dashboard/components/tasks/WeeklyTaskNavigator.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { format, endOfWeek, addWeeks, isSameWeek } from 'date-fns'
+import { format, addDays, addWeeks, startOfDay } from 'date-fns'
 import { ArrowLeftIcon, ArrowRightIcon, IconButton } from '@styleguide'
 
 interface WeeklyTaskNavigatorProps {
@@ -12,7 +12,7 @@ interface WeeklyTaskNavigatorProps {
 }
 
 function formatWeekLabel(weekStart: Date): string {
-  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 })
+  const weekEnd = addDays(weekStart, 6)
   const startMonth = format(weekStart, 'MMM')
   const endMonth = format(weekEnd, 'MMM')
 
@@ -22,23 +22,22 @@ function formatWeekLabel(weekStart: Date): string {
   return `${format(weekStart, 'MMM d')} - ${format(weekEnd, 'MMM d')}`
 }
 
+function isInWeekRange(date: Date, rangeStart: Date): boolean {
+  const d = startOfDay(date).getTime()
+  const s = startOfDay(rangeStart).getTime()
+  const e = startOfDay(addDays(rangeStart, 6)).getTime()
+  return d >= s && d <= e
+}
+
 function getDisplayLabel(weekStart: Date): string {
   const today = new Date()
-  if (isSameWeek(today, weekStart, { weekStartsOn: 0 })) {
+  if (isInWeekRange(today, weekStart)) {
     return 'This week'
   }
-  if (
-    isSameWeek(today, addWeeks(weekStart, 1), {
-      weekStartsOn: 0,
-    })
-  ) {
+  if (isInWeekRange(today, addWeeks(weekStart, 1))) {
     return 'Last week'
   }
-  if (
-    isSameWeek(today, addWeeks(weekStart, -1), {
-      weekStartsOn: 0,
-    })
-  ) {
+  if (isInWeekRange(today, addWeeks(weekStart, -1))) {
     return 'Next week'
   }
   return formatWeekLabel(weekStart)

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -154,6 +154,27 @@ describe('useWeekNavigation', () => {
     }
   })
 
+  it('defaults to the most-recent week when electionDateObj is null and multiple weeks exist', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+
+    try {
+      const tasks = [
+        makeTask({ id: 'a', week: 30 }),
+        makeTask({ id: 'b', week: 20 }),
+        makeTask({ id: 'c', week: 10 }),
+      ]
+
+      const { result } = renderHook(() =>
+        useWeekNavigation(tasks, 'campaign-1', null, Infinity),
+      )
+
+      expect(result.current.selectedWeek).toBe(10)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('includes current week even when no tasks exist for it', () => {
     const election = new Date('2026/11/03')
     const daysUntilElection = 49

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -32,12 +32,13 @@ describe('useWeekNavigation', () => {
     const week = 30
     const tasks = [makeTask({ week })]
     const daysUntilElection = 200
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
 
     const { result } = renderHook(() =>
       useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
     )
 
-    const expected = addWeeks(election, -week)
+    const expected = addWeeks(election, -weeksUntilElection)
     expect(result.current.currentWeekStart.getTime()).toBe(expected.getTime())
   })
 
@@ -64,13 +65,15 @@ describe('useWeekNavigation', () => {
 
   it('selects the week closest to current weeksUntilElection', () => {
     const election = new Date('2026/11/03')
+    const daysUntilElection = 77
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
     const tasks = [makeTask({ week: 10 }), makeTask({ week: 20 })]
 
     const { result } = renderHook(() =>
-      useWeekNavigation(tasks, 'campaign-1', election, 77),
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
     )
 
-    expect(result.current.selectedWeek).toBe(10)
+    expect(result.current.selectedWeek).toBe(weeksUntilElection)
   })
 
   it('filters tasks to only the selected week', () => {
@@ -141,11 +144,29 @@ describe('useWeekNavigation', () => {
         useWeekNavigation(tasks, 'campaign-1', null, Infinity),
       )
 
+      expect(result.current.selectedWeek).toBe(5)
+      expect(result.current.filteredTasks).toHaveLength(1)
       expect(result.current.currentWeekStart.getTime()).toBe(
         startOfWeek(new Date(), { weekStartsOn: 0 }).getTime(),
       )
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('includes current week even when no tasks exist for it', () => {
+    const election = new Date('2026/11/03')
+    const daysUntilElection = 49
+    const weeksUntilElection = Math.ceil(daysUntilElection / 7)
+    const nextWeek = weeksUntilElection - 1
+    const tasks = [makeTask({ week: nextWeek })]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    expect(result.current.selectedWeek).toBe(weeksUntilElection)
+    expect(result.current.filteredTasks).toHaveLength(0)
+    expect(result.current.canGoNext).toBe(true)
   })
 })

--- a/app/dashboard/components/tasks/useWeekNavigation.test.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  addWeeks,
+  addDays,
+  differenceInWeeks,
+  format,
+  startOfWeek,
+} from 'date-fns'
+import { useWeekNavigation } from './useWeekNavigation'
+import type { Task } from './TaskItem'
+import { TASK_TYPES } from '../../shared/constants/tasks.const'
+
+function makeTask(overrides: Partial<Task> & { week: number }): Task {
+  return {
+    id: `task-${overrides.week}`,
+    title: `Task week ${overrides.week}`,
+    description: '',
+    flowType: TASK_TYPES.education,
+    completed: false,
+    ...overrides,
+  }
+}
+
+describe('useWeekNavigation', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('computes currentWeekStart as election-relative, not calendar-snapped', () => {
+    const election = new Date('2026/11/03')
+    const week = 30
+    const tasks = [makeTask({ week })]
+    const daysUntilElection = 200
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    const expected = addWeeks(election, -week)
+    expect(result.current.currentWeekStart.getTime()).toBe(expected.getTime())
+  })
+
+  it('task dates assigned via ceil fall within the week header range', () => {
+    const election = new Date('2026/11/03')
+    const taskDate = new Date('2026/04/14')
+    const weekNumber = differenceInWeeks(election, taskDate, {
+      roundingMethod: 'ceil',
+    })
+    const tasks = [
+      makeTask({ week: weekNumber, date: format(taskDate, 'yyyy-MM-dd') }),
+    ]
+    const daysUntilElection = 200
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, daysUntilElection),
+    )
+
+    const weekStart = result.current.currentWeekStart
+    const weekEnd = addDays(weekStart, 6)
+    expect(taskDate.getTime()).toBeGreaterThanOrEqual(weekStart.getTime())
+    expect(taskDate.getTime()).toBeLessThanOrEqual(weekEnd.getTime())
+  })
+
+  it('selects the week closest to current weeksUntilElection', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [makeTask({ week: 10 }), makeTask({ week: 20 })]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 77),
+    )
+
+    expect(result.current.selectedWeek).toBe(10)
+  })
+
+  it('filters tasks to only the selected week', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [
+      makeTask({ id: 'a', week: 10 }),
+      makeTask({ id: 'b', week: 10 }),
+      makeTask({ id: 'c', week: 20 }),
+    ]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 70),
+    )
+
+    expect(result.current.filteredTasks).toHaveLength(2)
+    expect(result.current.filteredTasks.map((t) => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('navigates between weeks', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [
+      makeTask({ week: 30 }),
+      makeTask({ week: 20 }),
+      makeTask({ week: 10 }),
+    ]
+
+    const { result } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 140),
+    )
+
+    expect(result.current.selectedWeek).toBe(20)
+    expect(result.current.canGoPrevious).toBe(true)
+    expect(result.current.canGoNext).toBe(true)
+
+    act(() => result.current.goToNext())
+    expect(result.current.selectedWeek).toBe(10)
+
+    act(() => result.current.goToPrevious())
+    expect(result.current.selectedWeek).toBe(20)
+  })
+
+  it('persists selected week in sessionStorage', () => {
+    const election = new Date('2026/11/03')
+    const tasks = [makeTask({ week: 30 }), makeTask({ week: 20 })]
+
+    const { result, unmount } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 196),
+    )
+
+    act(() => result.current.goToNext())
+    expect(result.current.selectedWeek).toBe(20)
+    unmount()
+
+    const { result: result2 } = renderHook(() =>
+      useWeekNavigation(tasks, 'campaign-1', election, 175),
+    )
+    expect(result2.current.selectedWeek).toBe(20)
+  })
+
+  it('returns fallback date when electionDateObj is null', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026/06/10 12:00:00'))
+
+    try {
+      const tasks = [makeTask({ week: 5 })]
+
+      const { result } = renderHook(() =>
+        useWeekNavigation(tasks, 'campaign-1', null, Infinity),
+      )
+
+      expect(result.current.currentWeekStart.getTime()).toBe(
+        startOfWeek(new Date(), { weekStartsOn: 0 }).getTime(),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { startOfWeek, addWeeks } from 'date-fns'
+import { addWeeks, startOfWeek } from 'date-fns'
 import type { Task } from './TaskItem'
 
 const SESSION_KEY_PREFIX = 'campaign-plan-selected-week'
@@ -92,9 +92,7 @@ export function useWeekNavigation(
   }
 
   const currentWeekStart = electionDateObj
-    ? startOfWeek(addWeeks(electionDateObj, -selectedWeek), {
-        weekStartsOn: 0,
-      })
+    ? addWeeks(electionDateObj, -selectedWeek)
     : startOfWeek(new Date(), { weekStartsOn: 0 })
 
   const filteredTasks = tasks.filter((t) => t.week === selectedWeek)

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -65,7 +65,7 @@ export function useWeekNavigation(
             if (currDiff === bestDiff && w < bestW) return idx
             return bestIdx
           }, 0)
-        : 0
+        : weekNumbers.length - 1
       : 0
 
   const [savedWeek, setSavedWeek] = useState<number | null>(() =>

--- a/app/dashboard/components/tasks/useWeekNavigation.ts
+++ b/app/dashboard/components/tasks/useWeekNavigation.ts
@@ -46,22 +46,26 @@ export function useWeekNavigation(
   daysUntilElection: number,
 ): WeekNavigationResult {
   const weeksUntilElection = Math.ceil(daysUntilElection / 7)
+  const hasCurrentWeek = Number.isFinite(weeksUntilElection)
+  const taskWeeks = tasks.map((task) => task.week)
 
-  const weekNumbers = [...new Set(tasks.map((t) => t.week))].sort(
-    (a, b) => b - a,
-  )
+  const weekNumbers = [
+    ...new Set([...taskWeeks, ...(hasCurrentWeek ? [weeksUntilElection] : [])]),
+  ].sort((a, b) => b - a)
 
   const defaultIndex =
     weekNumbers.length > 0
-      ? weekNumbers.reduce((bestIdx, w, idx) => {
-          const bestW = weekNumbers[bestIdx]
-          if (bestW === undefined) return idx
-          const bestDiff = Math.abs(bestW - weeksUntilElection)
-          const currDiff = Math.abs(w - weeksUntilElection)
-          if (currDiff < bestDiff) return idx
-          if (currDiff === bestDiff && w < bestW) return idx
-          return bestIdx
-        }, 0)
+      ? hasCurrentWeek
+        ? weekNumbers.reduce((bestIdx, w, idx) => {
+            const bestW = weekNumbers[bestIdx]
+            if (bestW === undefined) return idx
+            const bestDiff = Math.abs(bestW - weeksUntilElection)
+            const currDiff = Math.abs(w - weeksUntilElection)
+            if (currDiff < bestDiff) return idx
+            if (currDiff === bestDiff && w < bestW) return idx
+            return bestIdx
+          }, 0)
+        : 0
       : 0
 
   const [savedWeek, setSavedWeek] = useState<number | null>(() =>

--- a/app/dashboard/shared/constants/tasks.const.ts
+++ b/app/dashboard/shared/constants/tasks.const.ts
@@ -12,6 +12,7 @@ export const TASK_TYPES = {
   education: 'education',
   compliance: 'compliance',
   awareness: 'awareness',
+  recurring: 'recurring',
 }
 
 // Legacy types, these were based on voter file types
@@ -48,6 +49,7 @@ export const DISPLAY_TASK_TYPES: Record<
   education: 'Education',
   compliance: 'Compliance',
   awareness: 'Awareness',
+  recurring: '',
 }
 
 export const WEEK_POSITIONS = {

--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -153,21 +153,33 @@ const bootstrapTestUser = async (
     throw new Error('No race found for the specific office selector')
   }
 
-  await client.post('/v1/campaigns', {
-    ballotReadyPositionId: race.position.id,
-    details: {
-      electionId: race.election.id,
-      raceId: race.id,
-      state: race.election.state,
-      ballotLevel: race.position.level,
-      electionDate: race.election.electionDay,
-      partisanType: race.position.partisanType,
-      hasPrimary: race.position.hasPrimary,
-      filingPeriodsStart: race.filingPeriods[0]?.startOn,
-      filingPeriodsEnd: race.filingPeriods[0]?.endOn,
+  const { data: campaign } = await client.post<{ id: number }>(
+    '/v1/campaigns',
+    {
+      ballotReadyPositionId: race.position.id,
+      details: {
+        electionId: race.election.id,
+        raceId: race.id,
+        state: race.election.state,
+        ballotLevel: race.position.level,
+        electionDate: race.election.electionDay,
+        partisanType: race.position.partisanType,
+        hasPrimary: race.position.hasPrimary,
+        filingPeriodsStart: race.filingPeriods[0]?.startOn,
+        filingPeriodsEnd: race.filingPeriods[0]?.endOn,
+      },
+      data: { currentStep: 'onboarding-1' },
     },
-    data: { currentStep: 'onboarding-1' },
-  })
+  )
+
+  if (!campaign?.id) {
+    throw new Error('Campaign creation did not return a valid id')
+  }
+
+  client.defaults.headers.common[
+    'x-organization-slug'
+  ] = `campaign-${campaign.id}`
+
   await client.put('/v1/campaigns/mine/race-target-details', {})
   await client.put('/v1/campaigns/mine', {
     data: { currentStep: 'onboarding-complete' },


### PR DESCRIPTION
This PR releases gp-webapp to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates task completion behavior and week selection/date calculations in the dashboard campaign plan, which could affect task tracking and voter contact counts. Changes are mostly scoped and covered by new unit tests, but touch user-facing workflow logic.
> 
> **Overview**
> Adjusts dashboard campaign plan navigation to use **election-relative week ranges** (no calendar snapping) and simplifies the `WeeklyTaskNavigator` label to show only *“This week”* or the computed date range; expands `useWeekNavigation` to always include the current week and to pick a sensible default when the election date is missing.
> 
> Adds support for a new `TASK_TYPES.recurring`: completing recurring tasks sends the `{type, quantity}` payload but **does not** update local voter-contact counters, and row clicks open the detail modal instead of an outreach flow. Also tweaks minor UX copy (`AwarenessDetailModal` fallback description) and updates the pro signup alert link.
> 
> E2E registration now validates campaign creation returns an id and sets `x-organization-slug` from that id before continuing onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311da0af0cb0183ab2a83a7a50b476d4b4994ef8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->