### PR TITLE
E2E helper alignment and hardening

### DIFF
--- a/app/dashboard/campaign-details/components/OfficeSection.tsx
+++ b/app/dashboard/campaign-details/components/OfficeSection.tsx
@@ -48,7 +48,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
         primaryElectionDate: details.primaryElectionDate || '',
         officeTermLength: details.officeTermLength || '',
       })
-    } else if (organization) {
+    } else {
       setState({
         office: positionName,
         state: organization.position?.state || '',
@@ -80,7 +80,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
   return (
     <section
       className={
-        organization?.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
+        organization.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
       }
     >
       <H3 className="pb-6">Office Details</H3>
@@ -89,7 +89,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
         <CampaignOfficeInputFields
           values={state}
           hiddenFields={
-            organization?.electedOfficeId
+            organization.electedOfficeId
               ? ['electionDate', 'primaryElectionDate', 'officeTermLength']
               : []
           }
@@ -103,7 +103,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
         show={showModal}
         onClose={() => setShowModal(false)}
         onSelect={handleUpdate}
-        organizationSlug={organization?.slug}
+        organizationSlug={organization.slug}
       />
     </section>
   )

--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -3,21 +3,19 @@
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
 import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
-import type { Campaign, TcrCompliance } from 'helpers/types'
+import type { TcrCompliance } from 'helpers/types'
 import CampaignManager from './campaignManager/CampaignManager'
 
 const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
 
 interface DashboardContentProps {
   pathname: string
-  campaign: Campaign | null
   tasks: Task[]
   tcrCompliance: TcrCompliance | null
 }
 
 export default function DashboardContent({
   pathname,
-  campaign,
   tasks,
   tcrCompliance,
 }: DashboardContentProps): React.JSX.Element {
@@ -32,7 +30,6 @@ export default function DashboardContent({
   return (
     <DashboardPage
       pathname={pathname}
-      campaign={campaign}
       tasks={tasks}
       tcrCompliance={tcrCompliance}
     />

--- a/app/dashboard/components/DashboardPage.tsx
+++ b/app/dashboard/components/DashboardPage.tsx
@@ -14,24 +14,24 @@ import { CampaignUpdateHistoryProvider } from '@shared/hooks/CampaignUpdateHisto
 import TasksList from './tasks/TasksList'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import type { Task } from './tasks/TaskItem'
-import type { Campaign, TcrCompliance } from 'helpers/types'
+import type { TcrCompliance } from 'helpers/types'
 import { usePositionName } from '@shared/hooks/usePositionName'
+import { useCampaign } from '@shared/hooks/useCampaign'
 
 interface DashboardPageProps {
   pathname: string
   tasks: Task[]
-  campaign: Campaign | null
   tcrCompliance: TcrCompliance | null
 }
 
 const DashboardPage = ({
   pathname,
   tasks,
-  campaign: campaignProp,
   tcrCompliance,
 }: DashboardPageProps): React.JSX.Element => {
   const [_, setUser] = useUser()
-  const [campaign, setCampaign] = useState<Campaign | null>(campaignProp)
+  const [campaign] = useCampaign()
+
   const { pathToVictory: p2vObject, goals, details } = campaign || {}
   const pathToVictory = p2vObject?.data || {}
   const { primaryElectionDate } = details || {}
@@ -45,7 +45,7 @@ const DashboardPage = ({
     useState<PrimaryResultState>({
       modalOpen: false,
       modalDismissed: false,
-      primaryResult: campaignProp?.details?.primaryResult,
+      primaryResult: campaign?.details?.primaryResult,
     })
 
   const positionName = usePositionName()
@@ -98,19 +98,6 @@ const DashboardPage = ({
           modalOpen: false,
           primaryResult: selectedResult,
         }))
-
-        //update local campaign object
-        setCampaign((campaign) =>
-          campaign
-            ? {
-                ...campaign,
-                details: {
-                  ...campaign.details,
-                  primaryResult: selectedResult,
-                },
-              }
-            : campaign,
-        )
       } else {
         // user pressed Cancel to dismiss modal for now
         setPrimaryResultState({

--- a/app/dashboard/components/PrimaryResultModal.tsx
+++ b/app/dashboard/components/PrimaryResultModal.tsx
@@ -9,6 +9,8 @@ import Button from '@shared/buttons/Button'
 import PartyAnimation from '@shared/animations/PartyAnimation'
 import { useSnackbar } from 'helpers/useSnackbar'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { useQueryClient } from '@tanstack/react-query'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 
 interface WonMessageProps {
   electionDate: string
@@ -77,6 +79,8 @@ export default function PrimaryResultModal({
     setPrimaryResult(key === 'won' || key === 'lost' ? key : null)
   }
 
+  const queryClient = useQueryClient()
+
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
 
@@ -86,9 +90,12 @@ export default function PrimaryResultModal({
     })
 
     try {
-      await updateCampaign([
+      const updatedCampaign = await updateCampaign([
         { key: 'details.primaryResult', value: primaryResult },
       ])
+      if (updatedCampaign) {
+        queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updatedCampaign)
+      }
 
       trackEvent(EVENTS.Candidacy.CampaignCompleted, {
         winner: primaryResult === 'won',

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import pageMetaData from 'helpers/metadataHelper'
 import DashboardContent from './components/DashboardContent'
 import candidateAccess from './shared/candidateAccess'
-import { fetchUserCampaign } from '../onboarding/shared/getCampaign'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
 import HubSpotChatWidgetScript from '@shared/scripts/HubSpotChatWidgetScript'
@@ -34,8 +33,7 @@ export default async function Page(): Promise<React.JSX.Element> {
     return redirect('/dashboard/polls')
   }
 
-  const [campaign, tasks, tcrComplianceResponse] = await Promise.all([
-    fetchUserCampaign(),
+  const [tasks, tcrComplianceResponse] = await Promise.all([
     fetchTasks(),
     serverFetch<TcrCompliance>(apiRoutes.campaign.tcrCompliance.fetch),
   ])
@@ -49,7 +47,6 @@ export default async function Page(): Promise<React.JSX.Element> {
       <HubSpotChatWidgetScript />
       <DashboardContent
         pathname="/dashboard"
-        campaign={campaign}
         tasks={tasks}
         tcrCompliance={tcrCompliance}
       />

--- a/app/dashboard/shared/DashboardLayout.tsx
+++ b/app/dashboard/shared/DashboardLayout.tsx
@@ -116,7 +116,7 @@ const DashboardLayout = ({
               campaign={activeCampaign}
               user={user}
               pathname={currentPath || undefined}
-              isElectedOffice={!!organization?.electedOfficeId}
+              isElectedOffice={!!organization.electedOfficeId}
             />
             {children}
           </div>

--- a/e2e-tests/src/helpers/organizations.ts
+++ b/e2e-tests/src/helpers/organizations.ts
@@ -5,7 +5,7 @@ import {
   type AuthenticatedUser,
   type TestUserOptions,
 } from 'tests/utils/api-registration'
-import { wait } from 'tests/utils/eventually'
+import { eventually, wait } from 'tests/utils/eventually'
 
 type SetupResult = {
   user: AuthenticatedUser
@@ -32,6 +32,26 @@ export const setupElectedOfficeUser = async (
     .getByRole('button', { name: 'I won my race' })
     .click({ timeout: 10000 })
   await page.waitForURL('**/polls/welcome', { timeout: 15000 })
+
+  const electedOfficeOrgSlug = await eventually(
+    { that: 'an elected office organization is created' },
+    async () => {
+      const { data } = await client.get<{ organizations: { slug: string }[] }>(
+        '/v1/organizations',
+      )
+
+      const electedOfficeOrg = data.organizations.find((org) =>
+        org.slug.startsWith('eo-'),
+      )
+
+      if (!electedOfficeOrg) {
+        throw new Error('No elected office organization found')
+      }
+
+      return electedOfficeOrg.slug
+    },
+  )
+  client.defaults.headers['x-organization-slug'] = electedOfficeOrgSlug
 
   return { user, client }
 }

--- a/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts-filters.spec.ts
@@ -4,11 +4,10 @@ import {
   blockSlowScripts,
   NavigationHelper,
 } from 'src/helpers/navigation.helper'
-import { authenticateTestUser } from 'tests/utils/api-registration'
 import { visualSnapshot } from 'src/helpers/visual.helper'
 import { filtersSheet, personContactPanel } from 'src/helpers/contacts-e2e'
 import { WaitHelper } from 'src/helpers/wait.helper'
-import { wait } from 'tests/utils/eventually'
+import { setupElectedOfficeUser } from 'src/helpers/organizations'
 
 const selectCheckbox = async (sheet: Locator, label: string, value: string) => {
   const sectionHeading = sheet.locator('h4', { hasText: label })
@@ -138,20 +137,10 @@ test.beforeEach(async ({ page }) => {
 test('validate contacts filters', async ({ page }) => {
   test.setTimeout(5 * 60 * 1000)
 
-  await authenticateTestUser(page, {
-    isolated: true,
-    race: {
-      zip: '82001',
-      office: 'Cheyenne City Council - Ward 2',
-    },
+  await setupElectedOfficeUser(page, {
+    zip: '82001',
+    office: 'Cheyenne City Council - Ward 2',
   })
-
-  await page.goto('/dashboard/election-result', {
-    waitUntil: 'domcontentloaded',
-  })
-  await wait(500)
-  await page.getByRole('button', { name: 'I won my race' }).click()
-  await page.waitForURL('**/polls/welcome', { timeout: 15000 })
 
   await page.goto('/dashboard/contacts')
   await NavigationHelper.dismissOverlays(page)

--- a/e2e-tests/tests/app/contacts/contacts.spec.ts
+++ b/e2e-tests/tests/app/contacts/contacts.spec.ts
@@ -3,10 +3,10 @@ import {
   blockSlowScripts,
   NavigationHelper,
 } from 'src/helpers/navigation.helper'
-import { authenticateTestUser } from 'tests/utils/api-registration'
 import { visualSnapshot } from 'src/helpers/visual.helper'
 import { filtersSheet, personContactPanel } from 'src/helpers/contacts-e2e'
-import { wait } from 'tests/utils/eventually'
+import { setupElectedOfficeUser } from 'src/helpers/organizations'
+import { eventually } from 'tests/utils/eventually'
 
 test.describe('Contacts Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -15,16 +15,7 @@ test.describe('Contacts Page', () => {
 
   test('contacts page functionality', async ({ page }) => {
     test.setTimeout(120 * 1000)
-    await authenticateTestUser(page, { isolated: true })
-    await page.goto('/dashboard/election-result', {
-      waitUntil: 'domcontentloaded',
-    })
-    await wait(500)
-    await page
-      .getByRole('button', { name: 'I won my race' })
-      .click({ timeout: 10000 })
-
-    await page.waitForURL('**/polls/welcome', { timeout: 15000 })
+    await setupElectedOfficeUser(page)
 
     await page.goto('/dashboard/contacts', { waitUntil: 'domcontentloaded' })
     await NavigationHelper.dismissOverlays(page)
@@ -120,8 +111,18 @@ test.describe('Contacts Page', () => {
     await searchInput.fill(searchTerm)
     await searchInput.press('Enter')
 
-    const searchResults = table.locator('tbody tr')
-    await expect(searchResults).toHaveCount(1, { timeout: 20000 })
+    await eventually({ that: 'the search results are narrowed' }, async () => {
+      const numSearchResults = await table.locator('tbody tr').count()
+      // Sometimes a common name like "Joey" will match multiple contacts. We're targeting a
+      // small district, so we expect 1-5 results, and verify that each one matches.
+      expect(numSearchResults).toBeGreaterThanOrEqual(1)
+      expect(numSearchResults).toBeLessThanOrEqual(5)
+      for (const row of await table.locator('tbody tr').all()) {
+        await expect(row).toContainText(searchTerm, {
+          ignoreCase: true,
+        })
+      }
+    })
 
     await expect(
       pagination.getByRole('link', { name: '1' }).first(),

--- a/e2e-tests/tests/app/polls/polls-onboarding.spec.ts
+++ b/e2e-tests/tests/app/polls/polls-onboarding.spec.ts
@@ -8,12 +8,12 @@ import {
   blockSlowScripts,
   NavigationHelper,
 } from 'src/helpers/navigation.helper'
-import { switchOrganization } from 'src/helpers/organizations'
 import {
-  authenticateTestUser,
-  type AuthenticatedUser,
-} from 'tests/utils/api-registration'
-import { eventually, wait } from 'tests/utils/eventually'
+  setupElectedOfficeUser,
+  switchOrganization,
+} from 'src/helpers/organizations'
+import { type AuthenticatedUser } from 'tests/utils/api-registration'
+import { eventually } from 'tests/utils/eventually'
 import { downloadSlackFile, waitForSlackMessage } from 'tests/utils/slack'
 
 type CsvRow = {
@@ -318,23 +318,16 @@ test.describe.serial('poll onboarding', () => {
   test('poll onboarding and expansion', async ({ page }) => {
     // Set this test's timeout to 10 minutes
     test.setTimeout(10 * 60 * 1000)
-    const { user, client } = await authenticateTestUser(page, {
-      isolated: true,
-      race: { zip: district.zip, office: district.office },
+    const { user, client } = await setupElectedOfficeUser(page, {
+      zip: district.zip,
+      office: district.office,
     })
-
-    // Become a Serve user
-    await page.goto('/dashboard/election-result')
-    await wait(500)
-    await page.getByRole('button', { name: 'I won my race' }).click()
-    await page.waitForTimeout(3000)
 
     // Store for reuse in subsequent tests
     sharedUser = user
     sharedToken = (
       client.defaults.headers.common.Authorization as string
     ).replace('Bearer ', '')
-    await page.goto('/polls/welcome')
     await NavigationHelper.dismissOverlays(page)
 
     await page.getByRole('button', { name: "Let's get started" }).click()

--- a/e2e-tests/tests/core/auth/custom-office.spec.ts
+++ b/e2e-tests/tests/core/auth/custom-office.spec.ts
@@ -105,7 +105,11 @@ test.describe('Custom office flow', () => {
         electionId: string | null
         zip: string | null
       }
-    }>('/v1/campaigns/mine')
+    }>('/v1/campaigns/mine', {
+      headers: {
+        'x-organization-slug': data.organizations[0]!.slug,
+      },
+    })
     expect(campaign).toMatchObject({
       id: expect.any(Number),
       details: {

--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -3,6 +3,7 @@ import { BrowserContext, type Page, test } from '@playwright/test'
 import axios, { type AxiosInstance } from 'axios'
 import { uniqBy } from 'es-toolkit'
 import { TestDataHelper } from 'src/helpers/data.helper'
+import { eventually } from './eventually'
 
 const baseURL = process.env.BASE_URL
 
@@ -185,7 +186,9 @@ const bootstrapTestUser = async (
     'x-organization-slug'
   ] = `campaign-${campaign.id}`
 
-  await client.put('/v1/campaigns/mine/race-target-details', {})
+  await eventually({ that: 'race-target-details are updated' }, async () => {
+    await client.put('/v1/campaigns/mine/race-target-details', {})
+  })
   await client.put('/v1/campaigns/mine', {
     data: { currentStep: 'onboarding-complete' },
     details: { otherParty: 'Independent', pledged: true },
@@ -216,19 +219,24 @@ export const authenticateTestUser = async (
 
   const { title } = test.info()
 
-  createdUsers.push({
-    user,
-    cleanup: async () => {
-      try {
-        await client.delete(`/v1/users/${user.id}`)
-        if (process.env.DEBUG) {
-          console.log(`[${title}] Deleted user ${user.email} (id: ${user.id})`)
+  // If the user is cached, we can't clean it up -- it may still be in use by other tests.
+  if (options?.isolated) {
+    createdUsers.push({
+      user,
+      cleanup: async () => {
+        try {
+          await client.delete(`/v1/users/${user.id}`)
+          if (process.env.DEBUG) {
+            console.log(
+              `[${title}] Deleted user ${user.email} (id: ${user.id})`,
+            )
+          }
+        } catch {
+          // Token may be invalid after long runs or user already removed.
         }
-      } catch {
-        // Token may be invalid after long runs or user already removed.
-      }
-    },
-  })
+      },
+    })
+  }
 
   const userCreated = Date.now()
   if (process.env.DEBUG) {

--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -124,11 +124,6 @@ const bootstrapTestUser = async (
     token: registerResponse.data.token,
   }
 
-  // Cache the user if not isolated
-  if (!options?.isolated) {
-    cachedUser = result
-  }
-
   if (options?.skipCampaignCreation) {
     return result
   }
@@ -179,6 +174,13 @@ const bootstrapTestUser = async (
     throw new Error('Campaign creation did not return a valid id')
   }
 
+  result.campaignId = campaign.id
+
+  // Cache the user if not isolated
+  if (!options?.isolated) {
+    cachedUser = result
+  }
+
   client.defaults.headers.common[
     'x-organization-slug'
   ] = `campaign-${campaign.id}`
@@ -189,7 +191,7 @@ const bootstrapTestUser = async (
     details: { otherParty: 'Independent', pledged: true },
   })
   await client.post('/v1/campaigns/launch', {})
-  return { ...result, campaignId: campaign.id }
+  return result
 }
 
 const createdUsers: {

--- a/e2e-tests/tests/utils/api-registration.ts
+++ b/e2e-tests/tests/utils/api-registration.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { type Page, test } from '@playwright/test'
+import { BrowserContext, type Page, test } from '@playwright/test'
 import axios, { type AxiosInstance } from 'axios'
 import { uniqBy } from 'es-toolkit'
 import { TestDataHelper } from 'src/helpers/data.helper'
@@ -12,7 +12,7 @@ if (!baseURL) {
 
 const apiURL = process.env.API_BASE_URL || `${baseURL}/api`
 
-const cookieDomain = (): string =>
+const COOKIE_DOMAIN =
   baseURL.replace('http://', '').replace('https://', '').split('/')[0] ?? ''
 
 type BaseTestUserOptions = {
@@ -78,7 +78,10 @@ type BootstrappedUser = {
   user: AuthenticatedUser
   token: string
   client: AxiosInstance
+  campaignId?: number
 }
+
+type PlaywrightCookie = Parameters<BrowserContext['addCookies']>[0][0]
 
 // Global cache for shared users per worker
 let cachedUser: BootstrappedUser | null = null
@@ -186,7 +189,7 @@ const bootstrapTestUser = async (
     details: { otherParty: 'Independent', pledged: true },
   })
   await client.post('/v1/campaigns/launch', {})
-  return result
+  return { ...result, campaignId: campaign.id }
 }
 
 const createdUsers: {
@@ -207,7 +210,7 @@ export const authenticateTestUser = async (
   options?: TestUserOptions,
 ) => {
   const start = Date.now()
-  const { user, token, client } = await bootstrapTestUser(options)
+  const { user, token, client, campaignId } = await bootstrapTestUser(options)
 
   const { title } = test.info()
 
@@ -238,13 +241,11 @@ export const authenticateTestUser = async (
     }
   }
 
-  const domain = cookieDomain()
-
-  await page.context().addCookies([
+  const cookies: PlaywrightCookie[] = [
     {
       name: 'token',
       value: token,
-      domain,
+      domain: COOKIE_DOMAIN,
       path: '/',
       httpOnly: true,
       secure: true,
@@ -253,26 +254,22 @@ export const authenticateTestUser = async (
     {
       name: 'user',
       value: JSON.stringify(user),
-      domain,
+      domain: COOKIE_DOMAIN,
       path: '/',
       sameSite: 'Lax',
     },
-  ])
+  ]
 
-  if (!options?.skipCampaignCreation) {
-    const { data: campaign } = await client.get<{ id: number }>(
-      '/v1/campaigns/mine',
-    )
-    await page.context().addCookies([
-      {
-        name: 'organization-slug',
-        value: `campaign-${campaign.id}`,
-        domain,
-        path: '/',
-        sameSite: 'Lax',
-      },
-    ])
+  if (campaignId) {
+    cookies.push({
+      name: 'organization-slug',
+      value: `campaign-${campaignId}`,
+      domain: COOKIE_DOMAIN,
+      path: '/',
+      sameSite: 'Lax',
+    })
   }
+  await page.context().addCookies(cookies)
 
   const loginTime = Date.now()
   if (process.env.DEBUG) {


### PR DESCRIPTION
A few fixes to improve the speed + reliability of E2E tests:
- Align all serve tests to use the `setupElectedOfficeUser` helper. This also ensures the Axios client returned for those tests is hooked up to the EO org slug.
- Update the DashboardPage component to use the campaign from `CampaignProvider`, and flow updates through that provider. This resolves some race conditions that sometimes cause that component to not get the right campaign, and removes one more local campaign state.


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moves dashboard campaign sourcing to the shared `useCampaign`/React Query cache and removes server-passed `campaign` props, which could affect dashboard rendering or state freshness if cache wiring is wrong. E2E changes are mostly refactors but may impact test stability around org selection and cookie setup.
> 
> **Overview**
> **Dashboard campaign data flow is simplified** by removing server-side `fetchUserCampaign()` and the `campaign` prop threading through `DashboardContent`/`DashboardPage`, and instead reading campaign state via `useCampaign()`.
> 
> **Primary result updates now refresh shared state**: `PrimaryResultModal` writes the updated campaign into the React Query cache (`CAMPAIGN_QUERY_KEY`) after `updateCampaign`, and `DashboardPage` no longer manually patches a local campaign copy.
> 
> **E2E setup is consolidated and made more robust** by adding `setupElectedOfficeUser()` (handles election-result flow and waits for the `eo-` org, then sets `x-organization-slug`), updating contacts/polls specs to use it, loosening the contacts search assertion with `eventually`, and simplifying cookie/org slug handling in `api-registration` (constant cookie domain + returning `campaignId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd29cf9b00ad6feb4913eb80c539ddd5461f04f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->