### PR TITLE
[GP-Bot] ENG-7336 Fix text campaign showing 'Sent' before being sent

### DIFF
--- a/app/dashboard/outreach/components/OutreachTable.test.tsx
+++ b/app/dashboard/outreach/components/OutreachTable.test.tsx
@@ -1,0 +1,228 @@
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { OutreachTable } from './OutreachTable'
+
+vi.mock('app/dashboard/outreach/hooks/OutreachContext', () => ({
+  useOutreach: () => [[], vi.fn()],
+  OutreachProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('app/dashboard/components/tasks/flows/hooks/P2pUxEnabledProvider', () => ({
+  useP2pUxEnabled: () => ({ p2pUxEnabled: true }),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  trackEvent: vi.fn(),
+  EVENTS: { Outreach: { ActionClicked: 'Outreach - Action Clicked' } },
+}))
+
+vi.mock('@mui/material/Popover', () => ({
+  default: () => null,
+}))
+
+vi.mock('app/dashboard/voter-records/components/ViewAudienceFiltersModal', () => ({
+  ActualViewAudienceFiltersModal: () => null,
+}))
+
+vi.mock('app/dashboard/outreach/components/OutreachActions', () => ({
+  OutreachActions: () => null,
+}))
+
+const createOutreachRow = (overrides = {}) => ({
+  id: 1,
+  date: '2025-04-15T17:00:00Z',
+  outreachType: 'text' as const,
+  phoneListId: 123,
+  status: 'paid' as const,
+  p2pJob: { status: 'active' },
+  voterFileFilter: { voterCount: 100 },
+  ...overrides,
+})
+
+describe('OutreachTable P2P status display', () => {
+  const originalDateNow = Date.now
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
+  describe('isScheduledDatePassed logic', () => {
+    it('shows "Sent" when p2pJob is active AND scheduled date has passed', () => {
+      // Set current time to after the scheduled date
+      Date.now = vi.fn(() => new Date('2025-04-15T18:00:00Z').getTime())
+
+      const outreach = createOutreachRow({
+        date: '2025-04-15T17:00:00Z', // 5 PM - in the past
+        p2pJob: { status: 'active' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Sent')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Scheduled" when p2pJob is active but scheduled date is in the future', () => {
+      // Set current time to before the scheduled date
+      Date.now = vi.fn(() => new Date('2025-04-15T13:00:00Z').getTime())
+
+      const outreach = createOutreachRow({
+        date: '2025-04-15T17:00:00Z', // 5 PM - in the future
+        p2pJob: { status: 'active' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Scheduled')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Sent" when scheduled date is exactly now', () => {
+      const now = new Date('2025-04-15T17:00:00Z')
+      Date.now = vi.fn(() => now.getTime())
+
+      const outreach = createOutreachRow({
+        date: '2025-04-15T17:00:00Z', // exactly now
+        p2pJob: { status: 'active' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Sent')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Scheduled" when p2pJob is active but date is null', () => {
+      Date.now = vi.fn(() => new Date('2025-04-15T13:00:00Z').getTime())
+
+      const outreach = createOutreachRow({
+        date: null,
+        p2pJob: { status: 'active' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      // When date is null, isScheduledDatePassed returns false, so shows Scheduled
+      const statusCell = screen.getByText('Scheduled')
+      expect(statusCell).toBeInTheDocument()
+    })
+  })
+
+  describe('non-active p2pJob status', () => {
+    beforeEach(() => {
+      Date.now = vi.fn(() => new Date('2025-04-15T13:00:00Z').getTime())
+    })
+
+    it('shows "Draft" when outreach status is pending', () => {
+      const outreach = createOutreachRow({
+        status: 'pending',
+        p2pJob: { status: 'pending' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Draft')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "In review" when outreach status is approved', () => {
+      const outreach = createOutreachRow({
+        status: 'approved',
+        p2pJob: { status: 'pending' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('In review')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Scheduled" when outreach status is paid', () => {
+      const outreach = createOutreachRow({
+        status: 'paid',
+        p2pJob: { status: 'pending' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Scheduled')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Scheduled" when outreach status is in_progress', () => {
+      const outreach = createOutreachRow({
+        status: 'in_progress',
+        p2pJob: { status: 'pending' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Scheduled')
+      expect(statusCell).toBeInTheDocument()
+    })
+
+    it('shows "Sent" when outreach status is completed', () => {
+      const outreach = createOutreachRow({
+        status: 'completed',
+        p2pJob: { status: 'pending' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      const statusCell = screen.getByText('Sent')
+      expect(statusCell).toBeInTheDocument()
+    })
+  })
+
+  describe('non-P2P outreach (no phoneListId)', () => {
+    it('shows "n/a" for status when phoneListId is null', () => {
+      const outreach = createOutreachRow({
+        phoneListId: null,
+        p2pJob: { status: 'active' },
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      // The status column (5th column) should show n/a
+      // Since phoneListId is null, getP2pStatusLabel returns null
+      const allNaCells = screen.getAllByText('n/a')
+      expect(allNaCells.length).toBeGreaterThan(0)
+      // Verify no status labels are shown
+      expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+      expect(screen.queryByText('Scheduled')).not.toBeInTheDocument()
+      expect(screen.queryByText('Draft')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('shows "n/a" for status when p2pJob status is missing', () => {
+      const outreach = createOutreachRow({
+        p2pJob: {},
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      // Verify no status labels are shown (status should be n/a)
+      expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+      expect(screen.queryByText('Scheduled')).not.toBeInTheDocument()
+      expect(screen.queryByText('Draft')).not.toBeInTheDocument()
+      expect(screen.queryByText('In review')).not.toBeInTheDocument()
+    })
+
+    it('shows "n/a" for status when outreach status is missing', () => {
+      const outreach = createOutreachRow({
+        status: null,
+      })
+
+      render(<OutreachTable mockOutreaches={[outreach]} />)
+
+      // Verify no status labels are shown
+      expect(screen.queryByText('Sent')).not.toBeInTheDocument()
+      expect(screen.queryByText('Scheduled')).not.toBeInTheDocument()
+      expect(screen.queryByText('Draft')).not.toBeInTheDocument()
+      expect(screen.queryByText('In review')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/dashboard/outreach/components/OutreachTable.tsx
+++ b/app/dashboard/outreach/components/OutreachTable.tsx
@@ -56,6 +56,12 @@ const isStatusKey = (key: string | null | undefined): key is StatusKey => {
   return key !== null && key !== undefined && key in statusLabels
 }
 
+const isScheduledDatePassed = (date: Date | string | null | undefined): boolean => {
+  if (!date) return false
+  const scheduledDate = new Date(date)
+  return scheduledDate.getTime() <= Date.now()
+}
+
 const getP2pStatusLabel = (row: OutreachRow): string | null => {
   // Check if this is a P2P outreach by checking for phoneListId
   // (phoneListId indicates it was created via P2P flow, even if type is normalized to 'text')
@@ -63,17 +69,21 @@ const getP2pStatusLabel = (row: OutreachRow): string | null => {
     return null
   }
 
-  const { p2pJob, status } = row
+  const { p2pJob, status, date } = row
 
   // Need both p2pJob status and outreach status to display
   if (!p2pJob?.status || !status || !isStatusKey(status)) {
     return null
   }
 
-  // If P2P job is active, show as completed; otherwise use the outreach status
-  const displayStatus: StatusKey =
-    p2pJob.status === 'active' ? 'completed' : status
-  return statusLabels[displayStatus]
+  // If P2P job is active, only show as completed if the scheduled date has passed
+  // Otherwise show as scheduled (the job is active but hasn't started sending yet)
+  if (p2pJob.status === 'active') {
+    const displayStatus: StatusKey = isScheduledDatePassed(date) ? 'completed' : 'in_progress'
+    return statusLabels[displayStatus]
+  }
+
+  return statusLabels[status]
 }
 
 const STATUS_COLUMN = {


### PR DESCRIPTION
## Summary
- Fixes a bug where text campaigns displayed "Sent" status even when scheduled for a future time
- The issue occurred because the `p2pJob.status === 'active'` condition was incorrectly interpreted as "sent"
- Now compares the scheduled date/time with the current time before showing "Sent"

## Root Cause
In `OutreachTable.tsx`, the status display logic showed "Sent" (mapped from `completed`) whenever the P2P job status was `active`. However, `active` means the job is ready to run or currently running - not that messages have been delivered. A job can be `active` but scheduled for a future time.

## Fix
Added a `isScheduledDatePassed()` helper function that compares the scheduled date with the current time:
- If the P2P job is active AND the scheduled date has passed → show "Sent"
- If the P2P job is active AND the scheduled date is in the future → show "Scheduled"
- For non-active job statuses, use the outreach status as before

## Test plan
- [x] Added comprehensive unit tests for the status display logic
- [x] Tests cover: active job with past date (Sent), active job with future date (Scheduled), various outreach statuses
- [x] All 234 tests in the codebase pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to status-label rendering logic with comprehensive unit tests; no auth, persistence, or backend behavior changes.
> 
> **Overview**
> Fixes a UI bug in `OutreachTable` where P2P campaigns with `p2pJob.status === "active"` were always shown as **Sent**, even if scheduled in the future.
> 
> Adds `isScheduledDatePassed()` and updates `getP2pStatusLabel()` to show **Scheduled** until the outreach `date` is reached (then **Sent**), while preserving the existing status mapping for non-active jobs. Adds a new `OutreachTable.test.tsx` suite covering past/future/exact/nullable dates, non-active statuses, and `n/a` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa73afd67618f9b0e5017d0e6533f7eb1ee6b42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->