### PR TITLE
[GP-Bot] ENG-7337 Fix broken contact link in Account Settings

### DIFF
--- a/app/dashboard/profile/components/AccountSettingsSection.test.tsx
+++ b/app/dashboard/profile/components/AccountSettingsSection.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { AccountSettingsSection } from './AccountSettingsSection'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+
+const mockUseCampaign = vi.fn()
+const mockUseUser = vi.fn()
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => mockUseCampaign(),
+}))
+
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: () => mockUseUser(),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  trackEvent: vi.fn(),
+  EVENTS: {
+    Account: { ProSubscriptionCanceled: 'Account - Pro Subscription Canceled' },
+    Settings: { Account: { ClickSendEmail: 'Settings - Account Click Send Email' } },
+  },
+}))
+
+vi.mock('@shared/utils/analytics', () => ({
+  identifyUser: vi.fn(),
+}))
+
+vi.mock('helpers/linkhelper', () => ({
+  getMarketingUrl: (path: string) => `https://goodparty.org${path}`,
+}))
+
+vi.mock('app/dashboard/profile/components/AccountSettingsButton', () => ({
+  AccountSettingsButton: ({ isPro }: { isPro: boolean }) => (
+    <button data-testid="account-settings-button">
+      {isPro ? 'Manage Subscription' : 'Upgrade'}
+    </button>
+  ),
+}))
+
+vi.mock('app/dashboard/profile/components/SubscriptionPendingCancellationAlert', () => ({
+  SubscriptionPendingCancellationAlert: () => (
+    <div data-testid="cancellation-alert">Subscription pending cancellation</div>
+  ),
+}))
+
+const mockTrackEvent = vi.mocked(trackEvent)
+
+describe('AccountSettingsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseUser.mockReturnValue([{ id: 'user-1' }, vi.fn()])
+  })
+
+  describe('when user is on FREE plan', () => {
+    beforeEach(() => {
+      mockUseCampaign.mockReturnValue([
+        {
+          isPro: false,
+          details: { subscriptionCancelAt: null, subscriptionId: null },
+        },
+      ])
+    })
+
+    it('renders the FREE plan name', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.getByText(/GoodParty\.org - Candidate FREE/)).toBeInTheDocument()
+    })
+
+    it('renders the Account Settings button', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.getByTestId('account-settings-button')).toBeInTheDocument()
+    })
+
+    it('does not render the cancellation alert', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.queryByTestId('cancellation-alert')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when user is on PRO plan', () => {
+    beforeEach(() => {
+      mockUseCampaign.mockReturnValue([
+        {
+          isPro: true,
+          details: { subscriptionCancelAt: null, subscriptionId: 'sub-123' },
+        },
+      ])
+    })
+
+    it('renders the PRO plan name', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.getByText(/GoodParty\.org - Candidate PRO/)).toBeInTheDocument()
+    })
+
+    it('renders the Account Settings button for PRO users with subscription', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.getByTestId('account-settings-button')).toBeInTheDocument()
+    })
+  })
+
+  describe('when PRO user has pending cancellation', () => {
+    beforeEach(() => {
+      mockUseCampaign.mockReturnValue([
+        {
+          isPro: true,
+          details: { subscriptionCancelAt: 1735689600000, subscriptionId: 'sub-123' },
+        },
+      ])
+    })
+
+    it('renders the cancellation alert', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.getByTestId('cancellation-alert')).toBeInTheDocument()
+    })
+
+    it('tracks ProSubscriptionCanceled event', () => {
+      render(<AccountSettingsSection />)
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.Account.ProSubscriptionCanceled,
+        { cancellationDate: 1735689600000 },
+      )
+    })
+  })
+
+  describe('when PRO user is in limbo state (no subscriptionId)', () => {
+    beforeEach(() => {
+      mockUseCampaign.mockReturnValue([
+        {
+          isPro: true,
+          details: { subscriptionCancelAt: null, subscriptionId: null },
+        },
+      ])
+    })
+
+    it('hides the Account Settings button for limbo PRO users', () => {
+      render(<AccountSettingsSection />)
+      expect(screen.queryByTestId('account-settings-button')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('contact link', () => {
+    beforeEach(() => {
+      mockUseCampaign.mockReturnValue([
+        {
+          isPro: false,
+          details: { subscriptionCancelAt: null, subscriptionId: null },
+        },
+      ])
+    })
+
+    it('renders the "Send us an email" link with the correct external URL', () => {
+      render(<AccountSettingsSection />)
+      const link = screen.getByRole('link', { name: /Send us an email/i })
+      expect(link).toHaveAttribute('href', 'https://goodparty.org/contact')
+    })
+
+    it('opens the contact link in a new tab', () => {
+      render(<AccountSettingsSection />)
+      const link = screen.getByRole('link', { name: /Send us an email/i })
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+
+    it('has proper security attributes for external link', () => {
+      render(<AccountSettingsSection />)
+      const link = screen.getByRole('link', { name: /Send us an email/i })
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('tracks ClickSendEmail event when link is clicked', async () => {
+      const user = userEvent.setup()
+      render(<AccountSettingsSection />)
+      const link = screen.getByRole('link', { name: /Send us an email/i })
+
+      await user.click(link)
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(EVENTS.Settings.Account.ClickSendEmail)
+    })
+  })
+})

--- a/app/dashboard/profile/components/AccountSettingsSection.tsx
+++ b/app/dashboard/profile/components/AccountSettingsSection.tsx
@@ -1,7 +1,6 @@
 'use client'
 import H4 from '@shared/typography/H4'
 import Body2 from '@shared/typography/Body2'
-import Link from 'next/link'
 import { SubscriptionPendingCancellationAlert } from 'app/dashboard/profile/components/SubscriptionPendingCancellationAlert'
 import Paper from '@shared/utils/Paper'
 import H2 from '@shared/typography/H2'
@@ -12,6 +11,7 @@ import { AccountSettingsButton } from 'app/dashboard/profile/components/AccountS
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { useEffect } from 'react'
 import { identifyUser } from '@shared/utils/analytics'
+import { getMarketingUrl } from 'helpers/linkhelper'
 
 export const AccountSettingsSection = (): React.JSX.Element => {
   const [user] = useUser()
@@ -55,15 +55,17 @@ export const AccountSettingsSection = (): React.JSX.Element => {
             <H5> GoodParty.org - {plan} </H5>
             <Body2 className="mt-2 text-gray-600">
               Need help?
-              <Link
+              <a
                 className="ml-1 underline text-info-main"
-                href="/contact"
+                href={getMarketingUrl('/contact')}
+                target="_blank"
+                rel="noopener noreferrer"
                 onClick={() =>
                   trackEvent(EVENTS.Settings.Account.ClickSendEmail)
                 }
               >
                 Send us an email.
-              </Link>
+              </a>
             </Body2>
           </div>
           {hideButtonForLimboProUsers ? null : (


### PR DESCRIPTION
## Summary
- Fixed the "Send us an email" link in Account Settings that was returning a 404 error
- The link was pointing to `/contact` (relative), which resolved to `app.goodparty.org/contact`
- Changed to use `getMarketingUrl('/contact')` to correctly link to `goodparty.org/contact`
- Added `target="_blank"` and `rel="noopener noreferrer"` for proper external link behavior and security

## Test plan
- [ ] Navigate to Account Settings (as any user with a campaign)
- [ ] Click "Send us an email" link
- [ ] Verify it opens `https://goodparty.org/contact` in a new tab (not 404)
- [ ] Verify the contact form page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI/link change plus new component tests; main risk is only around external URL generation or analytics click tracking.
> 
> **Overview**
> Fixes the Account Settings *“Send us an email”* link by switching from a relative `/contact` route to `getMarketingUrl('/contact')`, and opens it as a secure external link (`target="_blank"` + `rel="noopener noreferrer"`).
> 
> Adds a new `AccountSettingsSection` test suite covering plan rendering, subscription-cancellation alert behavior and analytics, limbo PRO button hiding, and the contact-link URL/attributes plus click tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d90af2fa786d5dc8a5038656a14506ad924f4be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->