### PR TITLE
[GP-Bot] ENG-7355 Fix impersonation to properly exchange actor token for Clerk session

### DIFF
--- a/app/admin/shared/ImpersonateAction.test.tsx
+++ b/app/admin/shared/ImpersonateAction.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import ImpersonateAction from './ImpersonateAction'
+
+const mockImpersonate = vi.fn()
+const mockSuccessSnackbar = vi.fn()
+const mockErrorSnackbar = vi.fn()
+
+vi.mock('@shared/hooks/useImpersonateUser', () => ({
+  useImpersonateUser: () => ({
+    impersonate: mockImpersonate,
+  }),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({
+    successSnackbar: mockSuccessSnackbar,
+    errorSnackbar: mockErrorSnackbar,
+  }),
+}))
+
+// Mock window.location
+const originalLocation = window.location
+beforeEach(() => {
+  mockImpersonate.mockReset()
+  mockSuccessSnackbar.mockReset()
+  mockErrorSnackbar.mockReset()
+
+  // Reset location mock
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { href: '' },
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: originalLocation,
+  })
+})
+
+describe('ImpersonateAction', () => {
+  it('renders the Impersonate button', () => {
+    render(
+      <ImpersonateAction
+        email="test@example.com"
+        isCandidate={false}
+        launched={undefined}
+      />,
+    )
+
+    expect(screen.getByText('Impersonate')).toBeInTheDocument()
+  })
+
+  it('shows success snackbar when impersonate is clicked', async () => {
+    mockImpersonate.mockResolvedValue('actor_token_123')
+
+    render(
+      <ImpersonateAction
+        email="test@example.com"
+        isCandidate={false}
+        launched={undefined}
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(mockSuccessSnackbar).toHaveBeenCalledWith('Impersonating user')
+    })
+  })
+
+  it('navigates to /impersonate with token for non-candidate users', async () => {
+    const testToken = 'actor_token_123'
+    mockImpersonate.mockResolvedValue(testToken)
+
+    render(
+      <ImpersonateAction
+        email="test@example.com"
+        isCandidate={false}
+        launched={undefined}
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        `/impersonate?__clerk_ticket=${encodeURIComponent(testToken)}&redirect=${encodeURIComponent('/')}`,
+      )
+    })
+  })
+
+  it('navigates to /impersonate with dashboard redirect for live candidate', async () => {
+    const testToken = 'actor_token_456'
+    mockImpersonate.mockResolvedValue(testToken)
+
+    render(
+      <ImpersonateAction
+        email="candidate@example.com"
+        isCandidate={true}
+        launched="Live"
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        `/impersonate?__clerk_ticket=${encodeURIComponent(testToken)}&redirect=${encodeURIComponent('/dashboard')}`,
+      )
+    })
+  })
+
+  it('navigates to / for candidate without Live status', async () => {
+    const testToken = 'actor_token_789'
+    mockImpersonate.mockResolvedValue(testToken)
+
+    render(
+      <ImpersonateAction
+        email="candidate@example.com"
+        isCandidate={true}
+        launched="Pending"
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        `/impersonate?__clerk_ticket=${encodeURIComponent(testToken)}&redirect=${encodeURIComponent('/')}`,
+      )
+    })
+  })
+
+  it('shows error snackbar when impersonate fails', async () => {
+    mockImpersonate.mockResolvedValue(null)
+
+    render(
+      <ImpersonateAction
+        email="test@example.com"
+        isCandidate={false}
+        launched={undefined}
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(mockErrorSnackbar).toHaveBeenCalledWith('Impersonate failed')
+    })
+  })
+
+  it('does not navigate when impersonate fails', async () => {
+    mockImpersonate.mockResolvedValue(null)
+
+    render(
+      <ImpersonateAction
+        email="test@example.com"
+        isCandidate={false}
+        launched={undefined}
+      />,
+    )
+
+    const button = screen.getByText('Impersonate')
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(mockErrorSnackbar).toHaveBeenCalled()
+    })
+
+    expect(window.location.href).toBe('')
+  })
+})

--- a/app/admin/shared/ImpersonateAction.tsx
+++ b/app/admin/shared/ImpersonateAction.tsx
@@ -20,13 +20,12 @@ export default function ImpersonateAction({
   const handleImpersonateUser = async () => {
     successSnackbar('Impersonating user')
 
-    const impersonateResp = await impersonate(email)
-    if (impersonateResp) {
-      if (isCandidate && launchStatus === 'Live') {
-        window.location.href = `/dashboard`
-      } else {
-        window.location.href = '/'
-      }
+    const token = await impersonate(email)
+    if (token) {
+      // Navigate to /impersonate to exchange the actor token for a Clerk session
+      const redirectPath =
+        isCandidate && launchStatus === 'Live' ? '/dashboard' : '/'
+      window.location.href = `/impersonate?__clerk_ticket=${encodeURIComponent(token)}&redirect=${encodeURIComponent(redirectPath)}`
     } else {
       errorSnackbar('Impersonate failed')
     }

--- a/app/impersonate/ImpersonatePageContent.test.tsx
+++ b/app/impersonate/ImpersonatePageContent.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import ImpersonatePageContent from './ImpersonatePageContent'
+
+// Mock the Clerk hooks
+const mockSignOut = vi.fn()
+const mockSetActive = vi.fn()
+const mockSignInCreate = vi.fn()
+const mockRouterPush = vi.fn()
+const mockRouterRefresh = vi.fn()
+const mockGet = vi.fn()
+
+vi.mock('@clerk/nextjs', () => ({
+  useClerk: () => ({
+    client: {
+      signIn: {
+        create: mockSignInCreate,
+      },
+    },
+    setActive: mockSetActive,
+    signOut: mockSignOut,
+    loaded: true,
+  }),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    refresh: mockRouterRefresh,
+  }),
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}))
+
+beforeEach(() => {
+  mockSignOut.mockReset()
+  mockSetActive.mockReset()
+  mockSignInCreate.mockReset()
+  mockRouterPush.mockReset()
+  mockRouterRefresh.mockReset()
+  mockGet.mockReset()
+
+  // Default mock implementations
+  mockSignOut.mockResolvedValue(undefined)
+  mockSetActive.mockResolvedValue(undefined)
+})
+
+describe('ImpersonatePageContent', () => {
+  it('shows error when no ticket is provided', async () => {
+    mockGet.mockReturnValue(null)
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Impersonation failed')).toBeInTheDocument()
+      expect(screen.getByText('No ticket provided in URL')).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading message when processing', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket'
+      if (key === 'redirect') return '/dashboard'
+      return null
+    })
+
+    // Make signInCreate pending
+    mockSignInCreate.mockReturnValue(new Promise(() => {}))
+
+    render(<ImpersonatePageContent />)
+
+    expect(
+      screen.getByText('Setting up impersonation session…'),
+    ).toBeInTheDocument()
+  })
+
+  it('creates Clerk session with ticket and redirects to dashboard by default', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket_123'
+      if (key === 'redirect') return null // No redirect param, should default to /dashboard
+      return null
+    })
+
+    mockSignInCreate.mockResolvedValue({
+      status: 'complete',
+      createdSessionId: 'session_123',
+    })
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(mockSignInCreate).toHaveBeenCalledWith({
+        strategy: 'ticket',
+        ticket: 'test_ticket_123',
+      })
+    })
+
+    await waitFor(() => {
+      expect(mockSetActive).toHaveBeenCalledWith({ session: 'session_123' })
+    })
+
+    await waitFor(() => {
+      expect(mockRouterRefresh).toHaveBeenCalled()
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard')
+    })
+  })
+
+  it('redirects to custom path when redirect param is provided', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket_456'
+      if (key === 'redirect') return '/'
+      return null
+    })
+
+    mockSignInCreate.mockResolvedValue({
+      status: 'complete',
+      createdSessionId: 'session_456',
+    })
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/')
+    })
+  })
+
+  it('shows error when sign-in status is not complete', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket'
+      return null
+    })
+
+    mockSignInCreate.mockResolvedValue({
+      status: 'needs_verification',
+      createdSessionId: null,
+    })
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Impersonation failed')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'Impersonation sign-in not complete (status: needs_verification)',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when no session is created', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket'
+      return null
+    })
+
+    mockSignInCreate.mockResolvedValue({
+      status: 'complete',
+      createdSessionId: null,
+    })
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Impersonation failed')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'Impersonation did not create a session (status: complete)',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('shows error when sign-in throws', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'invalid_ticket'
+      return null
+    })
+
+    mockSignInCreate.mockRejectedValue(new Error('Invalid ticket'))
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Impersonation failed')).toBeInTheDocument()
+      expect(screen.getByText('Invalid ticket')).toBeInTheDocument()
+    })
+  })
+
+  it('signs out existing session before creating impersonation session', async () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === '__clerk_ticket') return 'test_ticket'
+      return null
+    })
+
+    mockSignInCreate.mockResolvedValue({
+      status: 'complete',
+      createdSessionId: 'session_new',
+    })
+
+    render(<ImpersonatePageContent />)
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled()
+    })
+
+    // Verify signInCreate is called after signOut
+    expect(mockSignOut.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSignInCreate.mock.invocationCallOrder[0],
+    )
+  })
+})

--- a/app/impersonate/ImpersonatePageContent.tsx
+++ b/app/impersonate/ImpersonatePageContent.tsx
@@ -12,6 +12,7 @@ export default function ImpersonatePageContent() {
   const router = useRouter()
 
   const ticket = searchParams?.get('__clerk_ticket') ?? null
+  const redirectPath = searchParams?.get('redirect') ?? '/dashboard'
 
   useEffect(() => {
     if (!loaded) return
@@ -44,7 +45,7 @@ export default function ImpersonatePageContent() {
 
         await setActive({ session: result.createdSessionId })
         router.refresh()
-        router.push('/dashboard')
+        router.push(redirectPath)
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error('[impersonate] Failed:', err)
@@ -53,7 +54,7 @@ export default function ImpersonatePageContent() {
     }
 
     run()
-  }, [loaded, ticket])
+  }, [loaded, ticket, redirectPath, signOut, client.signIn, setActive, router])
 
   if (error) {
     return (

--- a/app/shared/user/ImpersonateUserProvider.test.tsx
+++ b/app/shared/user/ImpersonateUserProvider.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import {
+  ImpersonateUserProvider,
+  ImpersonateUserContext,
+} from './ImpersonateUserProvider'
+import { useContext } from 'react'
+
+// Mock dependencies
+const mockClientFetch = vi.fn()
+const mockGetCookie = vi.fn()
+const mockSetCookie = vi.fn()
+const mockDeleteCookie = vi.fn()
+
+vi.mock('gpApi/clientFetch', () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}))
+
+vi.mock('helpers/cookieHelper', () => ({
+  getCookie: (name: string) => mockGetCookie(name),
+  setCookie: (name: string, value: string) => mockSetCookie(name, value),
+  deleteCookie: (name: string) => mockDeleteCookie(name),
+}))
+
+vi.mock('gpApi/routes', () => ({
+  apiRoutes: {
+    admin: {
+      user: {
+        impersonate: {
+          path: '/admin/users/impersonate',
+          method: 'POST',
+        },
+      },
+    },
+  },
+}))
+
+const useImpersonateUser = () => useContext(ImpersonateUserContext)
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ImpersonateUserProvider>{children}</ImpersonateUserProvider>
+)
+
+beforeEach(() => {
+  mockClientFetch.mockReset()
+  mockGetCookie.mockReset()
+  mockSetCookie.mockReset()
+  mockDeleteCookie.mockReset()
+
+  // Default: no existing cookies
+  mockGetCookie.mockReturnValue(null)
+})
+
+describe('ImpersonateUserProvider', () => {
+  describe('initial state', () => {
+    it('initializes with null user and token when no cookies exist', () => {
+      mockGetCookie.mockReturnValue(null)
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      expect(result.current.user).toBeNull()
+      expect(result.current.token).toBeNull()
+    })
+
+    it('loads user and token from cookies on mount', async () => {
+      mockGetCookie.mockImplementation((name: string) => {
+        if (name === 'impersonateToken') return 'stored_token'
+        if (name === 'impersonateUser')
+          return JSON.stringify({ id: '123', email: 'user@test.com' })
+        return null
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.token).toBe('stored_token')
+        expect(result.current.user).toEqual({ id: '123', email: 'user@test.com' })
+      })
+    })
+  })
+
+  describe('impersonate function', () => {
+    it('returns the actor token on success', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: {
+          token: 'actor_token_123',
+          user: { id: '456', email: 'impersonated@test.com' },
+        },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      let token: string | null = null
+      await act(async () => {
+        token = await result.current.impersonate('impersonated@test.com')
+      })
+
+      expect(token).toBe('actor_token_123')
+    })
+
+    it('stores token and user in cookies on success', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: {
+          token: 'actor_token_123',
+          user: { id: '456', email: 'impersonated@test.com' },
+        },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      await act(async () => {
+        await result.current.impersonate('impersonated@test.com')
+      })
+
+      expect(mockSetCookie).toHaveBeenCalledWith(
+        'impersonateToken',
+        'actor_token_123',
+      )
+      expect(mockSetCookie).toHaveBeenCalledWith(
+        'impersonateUser',
+        JSON.stringify({ id: '456', email: 'impersonated@test.com' }),
+      )
+    })
+
+    it('updates state on success', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: {
+          token: 'actor_token_123',
+          user: { id: '456', email: 'impersonated@test.com' },
+        },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      await act(async () => {
+        await result.current.impersonate('impersonated@test.com')
+      })
+
+      expect(result.current.token).toBe('actor_token_123')
+      expect(result.current.user).toEqual({
+        id: '456',
+        email: 'impersonated@test.com',
+      })
+    })
+
+    it('returns null when API returns no token', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: { user: { id: '456', email: 'test@test.com' } },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      let token: string | null = 'initial'
+      await act(async () => {
+        token = await result.current.impersonate('test@test.com')
+      })
+
+      expect(token).toBeNull()
+    })
+
+    it('returns null when API returns no user', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: { token: 'some_token' },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      let token: string | null = 'initial'
+      await act(async () => {
+        token = await result.current.impersonate('test@test.com')
+      })
+
+      expect(token).toBeNull()
+    })
+
+    it('returns null when API call fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockClientFetch.mockRejectedValue(new Error('Network error'))
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      let token: string | null = 'initial'
+      await act(async () => {
+        token = await result.current.impersonate('test@test.com')
+      })
+
+      expect(token).toBeNull()
+      expect(consoleSpy).toHaveBeenCalledWith('error', expect.any(Error))
+      consoleSpy.mockRestore()
+    })
+
+    it('calls the correct API endpoint with email', async () => {
+      mockClientFetch.mockResolvedValue({
+        data: {
+          token: 'token',
+          user: { id: '1', email: 'test@test.com' },
+        },
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      await act(async () => {
+        await result.current.impersonate('target@example.com')
+      })
+
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/admin/users/impersonate',
+          method: 'POST',
+        }),
+        { email: 'target@example.com' },
+      )
+    })
+  })
+
+  describe('clear function', () => {
+    it('clears user and token state', async () => {
+      mockGetCookie.mockImplementation((name: string) => {
+        if (name === 'impersonateToken') return 'stored_token'
+        if (name === 'impersonateUser')
+          return JSON.stringify({ id: '123', email: 'user@test.com' })
+        return null
+      })
+
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(result.current.token).toBe('stored_token')
+      })
+
+      act(() => {
+        result.current.clear()
+      })
+
+      expect(result.current.user).toBeNull()
+      expect(result.current.token).toBeNull()
+    })
+
+    it('deletes cookies when clearing', async () => {
+      const { result } = renderHook(() => useImpersonateUser(), { wrapper })
+
+      act(() => {
+        result.current.clear()
+      })
+
+      expect(mockDeleteCookie).toHaveBeenCalledWith('impersonateToken')
+      expect(mockDeleteCookie).toHaveBeenCalledWith('impersonateUser')
+    })
+  })
+})

--- a/app/shared/user/ImpersonateUserProvider.tsx
+++ b/app/shared/user/ImpersonateUserProvider.tsx
@@ -13,7 +13,7 @@ interface ImpersonateUser {
 interface ImpersonateUserContextValue {
   user: ImpersonateUser | null
   token: string | null
-  impersonate: (email: string) => Promise<boolean>
+  impersonate: (email: string) => Promise<string | null>
   clear: () => void
 }
 
@@ -21,7 +21,7 @@ export const ImpersonateUserContext =
   createContext<ImpersonateUserContextValue>({
     user: null,
     token: null,
-    impersonate: () => Promise.resolve(false),
+    impersonate: () => Promise.resolve(null),
     clear: noop,
   })
 
@@ -65,7 +65,7 @@ export const ImpersonateUserProvider = ({
     setCookie('impersonateUser', JSON.stringify(user))
   }
 
-  const impersonate = async (email: string) => {
+  const impersonate = async (email: string): Promise<string | null> => {
     try {
       const resp = await clientFetch(apiRoutes.admin.user.impersonate, {
         email,
@@ -76,12 +76,12 @@ export const ImpersonateUserProvider = ({
       const { token, user } = data || {}
       if (token && user) {
         set(token, user)
-        return true
+        return token
       }
     } catch (e) {
       console.error('error', e)
     }
-    return false
+    return null
   }
 
   return (


### PR DESCRIPTION
## Summary
- Fixed the admin impersonation flow which was causing 404 errors when updating organizations
- The impersonation flow now properly exchanges the Clerk actor token for a session before redirecting
- Added `redirect` query parameter support to `/impersonate` page for flexible post-login navigation

## Root Cause
The impersonation flow was broken because:
1. Admin clicked "Impersonate" which called the API to get a Clerk actor token
2. The token was stored in cookies but never used for authentication
3. After redirect, requests used the admin's Clerk session (not the impersonated user's)
4. API calls like PATCH `/api/v1/organizations/:slug` failed with 404 because the organization was owned by the impersonated user, not the admin

## Fix
- `ImpersonateUserProvider.impersonate()` now returns the actor token instead of just `true/false`
- `ImpersonateAction` now navigates to `/impersonate?__clerk_ticket={token}&redirect={path}` 
- `ImpersonatePageContent` uses Clerk's `signIn.create({ strategy: 'ticket', ticket })` to exchange the token for an actual session

## Test plan
- [x] Unit tests added for all modified components (26 new tests)
- [x] All existing tests pass (256 total)
- [ ] Manual testing: Admin impersonates a user and updates their organization district - should succeed
- [ ] Verify impersonation redirects to correct path (`/dashboard` for live candidates, `/` for others)

## Related
- Fixes ENG-7355
- ClickUp: https://app.clickup.com/t/86agyj434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session switching logic and navigation during impersonation; mistakes could break admin impersonation or redirect users incorrectly, but scope is localized and covered by new unit tests.
> 
> **Overview**
> **Admin impersonation now completes a real Clerk session swap instead of only storing an actor token.** `ImpersonateUserProvider.impersonate()` returns the actor ticket (`string | null`) and `ImpersonateAction` redirects to `/impersonate?__clerk_ticket=...&redirect=...` (defaulting to `/dashboard` only for *Live* candidates, otherwise `/`).
> 
> **`/impersonate` now honors a `redirect` query param** and pushes to that path after calling `client.signIn.create({ strategy: 'ticket' })`, `setActive`, and `router.refresh`, with expanded effect dependencies and error handling. Adds new unit tests for `ImpersonateAction`, `ImpersonatePageContent`, and `ImpersonateUserProvider` covering success, redirects, and failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 944fb4bffde02cbf58cfbf46a2f76d54bebebac2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->