### PR TITLE
refactor: reorder UserProvider and FeatureFlagsProvider in PageWrappe…

### DIFF
--- a/app/shared/layouts/PageWrapper.tsx
+++ b/app/shared/layouts/PageWrapper.tsx
@@ -49,8 +49,8 @@ const PageWrapper = async ({
   return (
     <ClerkProvider>
       <ReactQueryProvider>
-        <FeatureFlagsProvider>
-          <UserProvider>
+        <UserProvider>
+          <FeatureFlagsProvider>
             <AmplitudeInit />
             <ImpersonatingTracker />
             <OrganizationProvider initialOrganizations={organizations}>
@@ -83,8 +83,8 @@ const PageWrapper = async ({
                 </CampaignStatusProvider>
               </CampaignProvider>
             </OrganizationProvider>
-          </UserProvider>
-        </FeatureFlagsProvider>
+          </FeatureFlagsProvider>
+        </UserProvider>
       </ReactQueryProvider>
     </ClerkProvider>
   )


### PR DESCRIPTION
Fixing: feature flag not working after clerk integration

Root cause: In PageWrapper.tsx, FeatureFlagsProvider was wrapping UserProvider (parent-child). Since React context only flows downward, useUser() inside FeatureFlagsProvider was reading from the default context ([null, noop, true]) — never the actual user. The user was always null.

Fix: Swapped the order so UserProvider is now the outer wrapper and FeatureFlagsProvider is inside it. Now useUser() inside FeatureFlagsProvider will correctly read the Clerk-loaded user.

With the console logs still in place, you should now see the user's email and ID being sent to Amplitude on the next refresh. Once you've confirmed it's working, you can remove the debug logs from FeatureFlagsProvider.tsx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only reorders React context providers; main impact is initialization timing/availability of user-derived feature flag data.
> 
> **Overview**
> Reorders `PageWrapper` providers so `UserProvider` wraps `FeatureFlagsProvider` (instead of the reverse).
> 
> This ensures feature flag initialization can reliably consume user context (via `useUser`) when fetching/refreshing variants, without changing page behavior beyond provider scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b59c81a836a7fe87d3c3f9a9a70bf53351890d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->