### PR TITLE
fix(ENG-7327): show actionable error when L2 district data is missing

### DIFF
--- a/app/dashboard/components/tasks/flows/AudienceStep.tsx
+++ b/app/dashboard/components/tasks/flows/AudienceStep.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import H1 from '@shared/typography/H1'
+import Body2 from '@shared/typography/Body2'
 import Button from '@shared/buttons/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import CustomVoterAudienceFilters, {
@@ -9,7 +10,10 @@ import CustomVoterAudienceFilters, {
   AudienceFilterKey,
 } from 'app/dashboard/voter-records/components/CustomVoterAudienceFilters'
 import { useEffect, useMemo, useState } from 'react'
-import { countVoterFile } from 'app/dashboard/voter-records/[type]/components/RecordCount'
+import {
+  countVoterFile,
+  CountVoterFileError,
+} from 'app/dashboard/voter-records/[type]/components/RecordCount'
 import { numberFormatter } from 'helpers/numberHelper'
 import { debounce } from 'helpers/debounceHelper'
 import {
@@ -25,6 +29,12 @@ import { PhoneListInput } from 'helpers/createP2pPhoneList'
 const TEXT_PRICE = 0.035
 const CALL_PRICE = 0.04
 const CALL_W_VOICEMAIL_PRICE = 0.055
+
+const MISSING_L2_DISTRICT_DATA_ERROR_CODE = 'MISSING_L2_DISTRICT_DATA'
+const MISSING_L2_DISTRICT_DATA_DEFAULT_MESSAGE =
+  'Voter data is not available for your selected office. Please contact support at help@goodparty.org so we can update your district information.'
+const GENERIC_COUNT_ERROR_MESSAGE =
+  'We were unable to count voters for this audience. Please try again, or contact support if the problem persists.'
 
 const isAudienceFilterKey = (
   key: string,
@@ -72,6 +82,7 @@ export default function AudienceStep({
   const { p2pUxEnabled } = useP2pUxEnabled()
   const [count, setCount] = useState(0)
   const [loading, setLoading] = useState(false)
+  const [countError, setCountError] = useState<CountVoterFileError | null>(null)
   const hasValues = useMemo(
     () => Object.values(audience).some((value) => value === true),
     [audience],
@@ -94,10 +105,21 @@ export default function AudienceStep({
       type === LEGACY_TASK_TYPES.sms || type === TASK_TYPES.text
 
     const voterFileFilter = await onCreateVoterFileFilter()
-    const phoneListToken =
-      p2pUxEnabled && isTextType
-        ? await onCreatePhoneList(voterFileFilter)
-        : null
+    if (!voterFileFilter) {
+      setLoading(false)
+      return
+    }
+
+    const needsPhoneList = p2pUxEnabled && isTextType
+    const phoneListToken = needsPhoneList
+      ? await onCreatePhoneList(voterFileFilter)
+      : null
+
+    if (needsPhoneList && !phoneListToken) {
+      setLoading(false)
+      return
+    }
+
     setLoading(false)
     onChangeCallback({
       voterFileFilter,
@@ -118,9 +140,14 @@ export default function AudienceStep({
         filters: selectedAudience,
       })
 
-      if (res !== false) {
+      if (typeof res === 'number') {
+        setCountError(null)
         setCount(res)
         onChangeCallback('voterCount', res)
+      } else {
+        setCountError(res)
+        setCount(0)
+        onChangeCallback('voterCount', 0)
       }
       setLoading(false)
     }, 300)
@@ -151,6 +178,17 @@ export default function AudienceStep({
     }
     return textCount * (price ?? 0)
   }
+
+  const isMissingDistrictData =
+    countError?.errorCode === MISSING_L2_DISTRICT_DATA_ERROR_CODE
+  const inlineCountErrorMessage = countError
+    ? isMissingDistrictData
+      ? countError.message || MISSING_L2_DISTRICT_DATA_DEFAULT_MESSAGE
+      : countError.message || GENERIC_COUNT_ERROR_MESSAGE
+    : null
+  const hasCountError = !!countError
+  const isNextDisabled =
+    !hasValues || loading || hasCountError || (hasValues && count === 0)
 
   return (
     <div className="p-4 w-[80vw] max-w-4xl">
@@ -192,6 +230,14 @@ export default function AudienceStep({
             </>
           )}
         </div>
+        {inlineCountErrorMessage ? (
+          <div
+            className="mx-auto mb-4 max-w-2xl rounded-lg border border-red-200 bg-red-50 p-3 text-left"
+            role="alert"
+          >
+            <Body2 className="text-red-800">{inlineCountErrorMessage}</Body2>
+          </div>
+        ) : null}
         <div className="text-left">
           <CustomVoterAudienceFilters
             trackingKey={TRACKING_KEYS.scheduleCampaign}
@@ -216,7 +262,7 @@ export default function AudienceStep({
               size="large"
               color="secondary"
               onClick={handleOnNext}
-              disabled={!hasValues || loading}
+              disabled={isNextDisabled}
               loading={loading}
               {...nextTrackingAttrs}
             >

--- a/app/dashboard/components/tasks/flows/AudienceStep.tsx
+++ b/app/dashboard/components/tasks/flows/AudienceStep.tsx
@@ -100,6 +100,10 @@ export default function AudienceStep({
   )
 
   const handleOnNext = async () => {
+    if (countError) {
+      return
+    }
+
     setLoading(true)
 
     const isTextType =
@@ -130,7 +134,12 @@ export default function AudienceStep({
   }
 
   useEffect(() => {
-    if (!hasValues) return
+    if (!hasValues) {
+      setCountError(null)
+      setCount(0)
+      onChangeCallback('voterCount', 0)
+      return
+    }
 
     debounce(async () => {
       setLoading(true)

--- a/app/dashboard/components/tasks/flows/AudienceStep.tsx
+++ b/app/dashboard/components/tasks/flows/AudienceStep.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import H1 from '@shared/typography/H1'
-import Body2 from '@shared/typography/Body2'
 import Button from '@shared/buttons/Button'
 import CircularProgress from '@mui/material/CircularProgress'
+import { Alert, AlertDescription, AlertTitle } from '@styleguide'
+import { MdError } from 'react-icons/md'
 import CustomVoterAudienceFilters, {
   TRACKING_KEYS,
   AudienceFiltersState,
@@ -231,12 +232,11 @@ export default function AudienceStep({
           )}
         </div>
         {inlineCountErrorMessage ? (
-          <div
-            className="mx-auto mb-4 max-w-2xl rounded-lg border border-red-200 bg-red-50 p-3 text-left"
-            role="alert"
-          >
-            <Body2 className="text-red-800">{inlineCountErrorMessage}</Body2>
-          </div>
+          <Alert variant="destructive" className="mb-4 text-left">
+            <MdError />
+            <AlertTitle>Voter data unavailable</AlertTitle>
+            <AlertDescription>{inlineCountErrorMessage}</AlertDescription>
+          </Alert>
         ) : null}
         <div className="text-left">
           <CustomVoterAudienceFilters

--- a/app/dashboard/components/tasks/flows/util/flowHandlers.util.ts
+++ b/app/dashboard/components/tasks/flows/util/flowHandlers.util.ts
@@ -249,15 +249,14 @@ export const handleCreatePhoneList =
     voterFileFilter: PhoneListInput | undefined,
   ): Promise<string | undefined> => {
     const result = await createP2pPhoneList(voterFileFilter)
-    const phoneListToken = result ? result.token : undefined
 
-    if (!phoneListToken) {
-      errorSnackbar(
-        'There was an error generating a phone list. Please try again.',
-      )
+    if (!result.ok) {
+      const fallback =
+        'There was an error generating a phone list. Please try again.'
+      errorSnackbar(result.message || fallback)
       return
     }
-    return phoneListToken
+    return result.token
   }
 
 export const handleCreateVoterFileFilter =

--- a/app/dashboard/voter-records/[type]/components/RecordCount.tsx
+++ b/app/dashboard/voter-records/[type]/components/RecordCount.tsx
@@ -4,12 +4,14 @@ import MarketingH2 from '@shared/typography/MarketingH2'
 import { CircularProgress } from '@mui/material'
 import { numberFormatter } from 'helpers/numberHelper'
 import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
 import { apiRoutes } from 'gpApi/routes'
 import { clientFetch } from 'gpApi/clientFetch'
 import { Campaign } from 'helpers/types'
 
 let attempts = 0
 const MAX_ATTEMPTS = 3
+const MISSING_L2_DISTRICT_DATA_ERROR_CODE = 'MISSING_L2_DISTRICT_DATA'
 
 interface VoterFileFilters {
   filters: string[]
@@ -21,10 +23,36 @@ interface VoterFilePayload {
   customFilters?: string
 }
 
+export interface CountVoterFileError {
+  ok: false
+  status?: number
+  errorCode?: string
+  message?: string
+}
+
+export type CountVoterFileResult = number | CountVoterFileError
+
+const extractErrorInfo = (
+  data: unknown,
+): { message?: string; errorCode?: string } => {
+  if (!data || typeof data !== 'object') return {}
+  const record = data as Record<string, unknown>
+  const rawMessage = record.message
+  const message =
+    typeof rawMessage === 'string'
+      ? rawMessage
+      : Array.isArray(rawMessage)
+      ? rawMessage.filter((m) => typeof m === 'string').join(', ')
+      : undefined
+  const errorCode =
+    typeof record.errorCode === 'string' ? record.errorCode : undefined
+  return { message, errorCode }
+}
+
 export const countVoterFile = async (
   type: string,
   customFilters?: VoterFileFilters | string[],
-): Promise<number | false> => {
+): Promise<CountVoterFileResult> => {
   try {
     const payload: VoterFilePayload = {
       type,
@@ -43,14 +71,18 @@ export const countVoterFile = async (
       payload,
     )
 
+    if (!resp.ok) {
+      return { ok: false, status: resp.status, ...extractErrorInfo(resp.data) }
+    }
+
     const count = resp.data
     if (typeof count === 'number') {
       return count
     }
-    return false
+    return { ok: false }
   } catch (e) {
     console.error('error', e)
-    return false
+    return { ok: false }
   }
 }
 
@@ -67,27 +99,35 @@ export default function RecordCount(
   const { type, isCustom, campaign, index } = props
   const [loading, setLoading] = useState(true)
   const [count, setCount] = useState(0)
-  const [error, setError] = useState(false)
+  const [error, setError] = useState<CountVoterFileError | null>(null)
   useEffect(() => {
     handleCount()
   }, [type, isCustom])
 
   const handleCount = async (): Promise<void> => {
-    let response: number | false
+    let response: CountVoterFileResult
     if (isCustom) {
       const customVoterFile = campaign.data?.customVoterFiles?.[index]
       response = await countVoterFile('custom', customVoterFile?.filters)
     } else {
       response = await countVoterFile(type)
     }
-    if (response === false) {
-      attempts++
-      if (attempts < MAX_ATTEMPTS) {
-        handleCount()
-      } else {
-        setError(true)
-        setLoading(false)
+    if (typeof response !== 'number') {
+      const isMissingDistrictData =
+        response.errorCode === MISSING_L2_DISTRICT_DATA_ERROR_CODE
+      const isClientError =
+        typeof response.status === 'number' &&
+        response.status >= 400 &&
+        response.status < 500
+      if (!isMissingDistrictData && !isClientError) {
+        attempts++
+        if (attempts < MAX_ATTEMPTS) {
+          handleCount()
+          return
+        }
       }
+      setError(response)
+      setLoading(false)
     } else {
       setCount(response)
       setLoading(false)
@@ -101,9 +141,21 @@ export default function RecordCount(
     )
   }
   if (error) {
+    const isMissingDistrictData =
+      error.errorCode === MISSING_L2_DISTRICT_DATA_ERROR_CODE
     return (
       <div className="mt-4">
-        <H2>Error counting records</H2>
+        <H2>
+          {isMissingDistrictData
+            ? 'Voter data not available for your district'
+            : 'Error counting records'}
+        </H2>
+        {isMissingDistrictData ? (
+          <Body2 className="mt-2">
+            {error.message ||
+              'Voter data is missing for the selected office. Please contact support at help@goodparty.org so we can update your district information.'}
+          </Body2>
+        ) : null}
       </div>
     )
   }

--- a/app/dashboard/voter-records/[type]/components/RecordCount.tsx
+++ b/app/dashboard/voter-records/[type]/components/RecordCount.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import MarketingH2 from '@shared/typography/MarketingH2'
 import { CircularProgress } from '@mui/material'
 import { numberFormatter } from 'helpers/numberHelper'
@@ -8,8 +8,8 @@ import Body2 from '@shared/typography/Body2'
 import { apiRoutes } from 'gpApi/routes'
 import { clientFetch } from 'gpApi/clientFetch'
 import { Campaign } from 'helpers/types'
+import { extractApiErrorInfo } from 'helpers/extractApiErrorInfo'
 
-let attempts = 0
 const MAX_ATTEMPTS = 3
 const MISSING_L2_DISTRICT_DATA_ERROR_CODE = 'MISSING_L2_DISTRICT_DATA'
 
@@ -31,23 +31,6 @@ export interface CountVoterFileError {
 }
 
 export type CountVoterFileResult = number | CountVoterFileError
-
-const extractErrorInfo = (
-  data: unknown,
-): { message?: string; errorCode?: string } => {
-  if (!data || typeof data !== 'object') return {}
-  const record = data as Record<string, unknown>
-  const rawMessage = record.message
-  const message =
-    typeof rawMessage === 'string'
-      ? rawMessage
-      : Array.isArray(rawMessage)
-      ? rawMessage.filter((m) => typeof m === 'string').join(', ')
-      : undefined
-  const errorCode =
-    typeof record.errorCode === 'string' ? record.errorCode : undefined
-  return { message, errorCode }
-}
 
 export const countVoterFile = async (
   type: string,
@@ -72,7 +55,11 @@ export const countVoterFile = async (
     )
 
     if (!resp.ok) {
-      return { ok: false, status: resp.status, ...extractErrorInfo(resp.data) }
+      return {
+        ok: false,
+        status: resp.status,
+        ...extractApiErrorInfo(resp.data),
+      }
     }
 
     const count = resp.data
@@ -100,7 +87,9 @@ export default function RecordCount(
   const [loading, setLoading] = useState(true)
   const [count, setCount] = useState(0)
   const [error, setError] = useState<CountVoterFileError | null>(null)
+  const attemptsRef = useRef(0)
   useEffect(() => {
+    attemptsRef.current = 0
     handleCount()
   }, [type, isCustom])
 
@@ -120,8 +109,8 @@ export default function RecordCount(
         response.status >= 400 &&
         response.status < 500
       if (!isMissingDistrictData && !isClientError) {
-        attempts++
-        if (attempts < MAX_ATTEMPTS) {
+        attemptsRef.current++
+        if (attemptsRef.current < MAX_ATTEMPTS) {
           handleCount()
           return
         }
@@ -129,6 +118,7 @@ export default function RecordCount(
       setError(response)
       setLoading(false)
     } else {
+      setError(null)
       setCount(response)
       setLoading(false)
     }

--- a/helpers/createP2pPhoneList.ts
+++ b/helpers/createP2pPhoneList.ts
@@ -1,6 +1,7 @@
 import { clientFetch } from 'gpApi/clientFetch'
 import { apiRoutes } from 'gpApi/routes'
 import { VoterFileFilters } from 'helpers/types'
+import { extractApiErrorInfo } from 'helpers/extractApiErrorInfo'
 
 export type PhoneListInput = VoterFileFilters & { name?: string }
 
@@ -21,23 +22,6 @@ export type PhoneListResult =
 export interface PhoneListStatusResponse {
   phoneListId: number
   leadsLoaded: number
-}
-
-const extractErrorInfo = (
-  data: unknown,
-): { message?: string; errorCode?: string } => {
-  if (!data || typeof data !== 'object') return {}
-  const record = data as Record<string, unknown>
-  const rawMessage = record.message
-  const message =
-    typeof rawMessage === 'string'
-      ? rawMessage
-      : Array.isArray(rawMessage)
-      ? rawMessage.filter((m) => typeof m === 'string').join(', ')
-      : undefined
-  const errorCode =
-    typeof record.errorCode === 'string' ? record.errorCode : undefined
-  return { message, errorCode }
 }
 
 export const createP2pPhoneList = async (
@@ -62,7 +46,7 @@ export const createP2pPhoneList = async (
       return {
         ok: false,
         status: resp.status,
-        ...extractErrorInfo(resp.data),
+        ...extractApiErrorInfo(resp.data),
       }
     }
     return { ok: true, ...resp.data }

--- a/helpers/createP2pPhoneList.ts
+++ b/helpers/createP2pPhoneList.ts
@@ -8,18 +8,45 @@ export interface PhoneListResponse {
   token: string
 }
 
+export interface PhoneListError {
+  message?: string
+  errorCode?: string
+  status?: number
+}
+
+export type PhoneListResult =
+  | ({ ok: true } & PhoneListResponse)
+  | ({ ok: false } & PhoneListError)
+
 export interface PhoneListStatusResponse {
   phoneListId: number
   leadsLoaded: number
 }
 
+const extractErrorInfo = (
+  data: unknown,
+): { message?: string; errorCode?: string } => {
+  if (!data || typeof data !== 'object') return {}
+  const record = data as Record<string, unknown>
+  const rawMessage = record.message
+  const message =
+    typeof rawMessage === 'string'
+      ? rawMessage
+      : Array.isArray(rawMessage)
+      ? rawMessage.filter((m) => typeof m === 'string').join(', ')
+      : undefined
+  const errorCode =
+    typeof record.errorCode === 'string' ? record.errorCode : undefined
+  return { message, errorCode }
+}
+
 export const createP2pPhoneList = async (
   voterFileFilter: PhoneListInput | undefined,
-): Promise<PhoneListResponse | false> => {
+): Promise<PhoneListResult> => {
   try {
     if (!voterFileFilter) {
       console.error('Error creating phone list: voterFileFilter is undefined')
-      return false
+      return { ok: false }
     }
 
     const listName = voterFileFilter.name || `P2P Campaign ${Date.now()}`
@@ -32,12 +59,16 @@ export const createP2pPhoneList = async (
     )
     if (!resp.ok) {
       console.error('Error creating phone list:', resp.statusText)
-      return false
+      return {
+        ok: false,
+        status: resp.status,
+        ...extractErrorInfo(resp.data),
+      }
     }
-    return resp.data
+    return { ok: true, ...resp.data }
   } catch (e) {
     console.error('error', e)
-    return false
+    return { ok: false }
   }
 }
 

--- a/helpers/extractApiErrorInfo.ts
+++ b/helpers/extractApiErrorInfo.ts
@@ -1,0 +1,19 @@
+export interface ApiErrorInfo {
+  message?: string
+  errorCode?: string
+}
+
+export const extractApiErrorInfo = (data: unknown): ApiErrorInfo => {
+  if (!data || typeof data !== 'object') return {}
+  const record = data as Record<string, unknown>
+  const rawMessage = record.message
+  const message =
+    typeof rawMessage === 'string'
+      ? rawMessage
+      : Array.isArray(rawMessage)
+      ? rawMessage.filter((m) => typeof m === 'string').join(', ')
+      : undefined
+  const errorCode =
+    typeof record.errorCode === 'string' ? record.errorCode : undefined
+  return { message, errorCode }
+}


### PR DESCRIPTION
## ENG-7327 — Error counting records in voter data

### Problem
When the API returns the new `MISSING_L2_DISTRICT_DATA` error (see companion gp-api PR), the webapp previously collapsed every failure into a generic `false`, retried 4xx pointlessly, and let users continue through the text-message flow toward scheduling/sending despite no valid voter data.

### Acceptance criteria addressed
- ✅ **Provide an error message that prevents sending a text message when this data isn't there**
- ✅ **Prevent users from going through the flow if their data is invalid**

### Changes
- **`helpers/createP2pPhoneList.ts`** — Returns a discriminated `PhoneListResult` (`{ ok: true, token } | { ok: false, status?, message?, errorCode? }`) instead of `string | false`, preserving the backend's error code and message.
- **`app/dashboard/voter-records/[type]/components/RecordCount.tsx`** — `countVoterFile` now returns `number | CountVoterFileError`. Skips React Query retries on 4xx. Renders dedicated copy + support CTA when `errorCode === 'MISSING_L2_DISTRICT_DATA'`.
- **`app/dashboard/components/tasks/flows/AudienceStep.tsx`**:
  - Tracks `countError` from the live audience-count effect.
  - Shows an inline red banner with the support-email message above the filters.
  - Disables the **Next** button on count failure or zero count.
  - `handleOnNext` early-returns before `nextCallback()` if the voter file filter or P2P phone list creation fails — the wizard cannot advance to Script / Image / Schedule / Purchase steps without valid data, so the actual text send (in `ScheduleStep.onScheduleOutreach`) is never reachable.
- **`app/dashboard/components/tasks/flows/util/flowHandlers.util.ts`** — `handleCreatePhoneList` forwards the backend's specific `result.message` to the error snackbar (with generic fallback) instead of always showing "Please try again."

### Defense-in-depth
1. Inline banner appears on AudienceStep before the user clicks Next (debounced count call catches it first).
2. Next button disabled when there's an error or zero-count.
3. `handleOnNext` early-returns even if the button somehow fires.
4. Backend `BadRequestException` is the final backstop.

### Companion PR
gp-api: https://github.com/thegoodparty/gp-api/pull/new/fix/ENG-7327-l2-district-missing

### Tests
- `npx tsc --noEmit` — clean.
- Existing unit tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core campaign/audience selection gating and retry behavior; while mostly additive error handling, mistakes could block users from proceeding or mask recoverable errors.
> 
> **Overview**
> Improves error propagation and UX around audience voter counting and P2P phone list creation by returning structured error objects (with `status`/`errorCode`/`message`) instead of collapsing failures to `false`.
> 
> Updates the audience selection flow to show an inline, actionable error (including a dedicated message for `MISSING_L2_DISTRICT_DATA`), reset counts on failure, and **prevent advancing** by disabling **Next** and early-returning when voter filter or phone list creation fails. Record count displays a specific “district data not available” state and avoids pointless retries for 4xx/missing-district errors while retaining limited retries for other failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e6e804336b844b7e10b209abe24773ba61a674. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->