### PR TITLE
switching router navigation to window location href

### DIFF
--- a/app/impersonate/ImpersonatePageContent.tsx
+++ b/app/impersonate/ImpersonatePageContent.tsx
@@ -2,14 +2,12 @@
 
 import { useEffect, useState } from 'react'
 import { useClerk } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
 import { useSearchParams } from 'next/navigation'
 
 export default function ImpersonatePageContent() {
   const { client, setActive, signOut, loaded } = useClerk()
   const searchParams = useSearchParams()
   const [error, setError] = useState<string | null>(null)
-  const router = useRouter()
 
   const ticket = searchParams?.get('__clerk_ticket') ?? null
 
@@ -43,8 +41,7 @@ export default function ImpersonatePageContent() {
         }
 
         await setActive({ session: result.createdSessionId })
-        router.refresh()
-        router.push('/dashboard')
+        window.location.href = '/dashboard'
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error('[impersonate] Failed:', err)


### PR DESCRIPTION
### Summary

Fix post-impersonation redirect race condition

After setActive resolves, the previous code called router.refresh() (fire-and-forget, returns void) immediately followed by router.push('/dashboard'). The soft navigation landed on /dashboard before Next.js could invalidate the RSC cache and before Clerk's React context had propagated the actor session client-side, causing the page to render in a broken state until a manual reload.

Replace both calls with window.location.href = '/dashboard', which forces a full HTTP round-trip. The updated Clerk session cookie is included in the fresh request, the server renders with the actor session fully established, and the React tree initializes clean — no race condition possible. This matches the existing pattern in ImpersonationBanner for the stop-impersonating flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the impersonation/session transition path; while the change is small, redirect semantics and session propagation are sensitive and could affect post-impersonation UX if incorrect.
> 
> **Overview**
> Fixes post-impersonation navigation by replacing Next.js `router.refresh()` + `router.push('/dashboard')` with a hard redirect via `window.location.href = '/dashboard'` after `setActive` completes.
> 
> This removes the `useRouter` dependency and ensures the dashboard loads via a fresh request using the newly-established Clerk session, avoiding client-side race conditions during impersonation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0f8c0ef6701a5abd2fe3d553f57475c00d9211. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->