### PR TITLE
Eng 7346 alignment

### DIFF
--- a/app/dashboard/campaign-plan/components/CampaignPlanTaskItem.tsx
+++ b/app/dashboard/campaign-plan/components/CampaignPlanTaskItem.tsx
@@ -153,7 +153,7 @@ export default function CampaignPlanTaskItem({
               <Lock
                 size={20}
                 strokeWidth={1.5}
-                className="text-base-foreground"
+                className="text-base-foreground ml-3"
               />
             </TooltipTrigger>
             <TooltipContent>{lockedReason}</TooltipContent>

--- a/app/dashboard/components/tasks/AwarenessTaskItem.tsx
+++ b/app/dashboard/components/tasks/AwarenessTaskItem.tsx
@@ -23,7 +23,7 @@ export default function AwarenessTaskItem({
       data-slot="task-item"
       className={cn('flex w-full items-center font-opensans', className)}
     >
-      <div className="flex shrink-0 items-start justify-center self-stretch pb-3 pl-4 pr-3 pt-3.5">
+      <div className="flex shrink-0 items-start justify-center self-stretch pb-3 pl-8 pr-3 pt-3.5">
         <CalendarCheck
           size={20}
           strokeWidth={1.5}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persisted view mode and rendering path for the campaign plan task list, plus new analytics events; regressions could affect task visibility, week navigation UX, and tracking accuracy.
> 
> **Overview**
> Adds a **weekly vs full** view toggle to the non-legacy `TasksList`, persisting the selection per-campaign in `sessionStorage` and emitting a new analytics event `Dashboard - Campaign Plan View Mode Toggled`.
> 
> In *full* mode, tasks are grouped under week headers (including a highlighted “This week” section and date-range labels via exported `formatWeekLabel`), the weekly navigator is hidden, and empty states are adjusted. Tracking for `CampaignPlan.Viewed` now includes `viewMode` and counts reflect either the selected week or the full list depending on mode.
> 
> Includes small task-item alignment tweaks (left padding/margins) and comprehensive tests covering toggle behavior, persistence, and full-view rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ee27758dab28d1ec380e1ad14a19c0e62bc85a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->