### PR TITLE
feat: add city attribute to ballot office details in OfficeStep compo…

### DIFF
--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -106,12 +106,13 @@ export default function OfficeStep({
       step,
     })
 
-    const { position, election, id, filingPeriods } = state.ballotOffice
+    const { position, election, id, filingPeriods, city } = state.ballotOffice
 
     const attr = [
       { key: 'details.electionId', value: election?.id },
       { key: 'details.raceId', value: id },
       { key: 'details.state', value: election?.state },
+      ...(city ? [{ key: 'details.city', value: city }] : []),
       {
         key: 'details.officeTermLength',
         value: calcTerm(position),

--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -112,7 +112,7 @@ export default function OfficeStep({
       { key: 'details.electionId', value: election?.id },
       { key: 'details.raceId', value: id },
       { key: 'details.state', value: election?.state },
-      ...(city ? [{ key: 'details.city', value: city }] : []),
+      { key: 'details.city', value: city ?? null },
       {
         key: 'details.officeTermLength',
         value: calcTerm(position),
@@ -160,7 +160,7 @@ export default function OfficeStep({
 
     const trackingProperties = {
       officeState: position.state,
-      officeMunicipality: 'Unavailable',
+      officeMunicipality: city ?? 'Unavailable',
       officeName: position.name,
       officeElectionDate: election.electionDay,
     }

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/types.ts
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/types.ts
@@ -35,6 +35,7 @@ export interface Race {
   position: RacePosition
   election: RaceElection
   filingPeriods?: FilingPeriod[]
+  city?: string | null
 }
 
 export interface RaceWithHighlight extends Omit<Race, 'position'> {


### PR DESCRIPTION
…nent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `city` field to the `Race` type and threads it into existing campaign attribute updates and tracking properties.
> 
> **Overview**
> The onboarding `OfficeStep` now reads `city` from the selected ballot office and saves it to campaign/org metadata via a new `details.city` attribute (null when unavailable).
> 
> Analytics/identify tracking for the step is updated to report `officeMunicipality` as the resolved `city` instead of the previous hardcoded "Unavailable", and the `Race` type is extended to include optional `city`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbed34b54472e14f42b0a11e830975bf25792e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->