### PR TITLE
fix(ENG-7339): complete recurring tasks directly without outreach flow

### DIFF
--- a/app/dashboard/components/tasks/TasksList.test.tsx
+++ b/app/dashboard/components/tasks/TasksList.test.tsx
@@ -520,7 +520,7 @@ describe('TasksList revert completion flow', () => {
 })
 
 describe('TasksList recurring task completion', () => {
-  it('sends {type, quantity} payload to the API when completing a recurring task via CountModal', async () => {
+  it('completes the task directly without opening a CountModal when checking off a recurring task', async () => {
     const user = userEvent.setup()
     const task = makeTask({
       flowType: TASK_TYPES.recurring,
@@ -539,7 +539,6 @@ describe('TasksList recurring task completion', () => {
     )
 
     await user.click(screen.getByRole('checkbox'))
-    await user.click(screen.getByRole('button', { name: 'Save count' }))
 
     await waitFor(() => {
       expect(mockClientFetch).toHaveBeenCalledWith(
@@ -547,9 +546,13 @@ describe('TasksList recurring task completion', () => {
           path: '/campaigns/tasks/complete/:taskId',
           method: 'PUT',
         }),
-        { taskId: 'task-1', type: 'recurring', quantity: 5 },
+        { taskId: 'task-1' },
       )
     })
+
+    expect(
+      screen.queryByRole('button', { name: 'Save count' }),
+    ).not.toBeInTheDocument()
   })
 
   it('does NOT update local voter contacts when completing a recurring task', async () => {
@@ -571,7 +574,6 @@ describe('TasksList recurring task completion', () => {
     )
 
     await user.click(screen.getByRole('checkbox'))
-    await user.click(screen.getByRole('button', { name: 'Save count' }))
 
     await waitFor(() => {
       expect(mockClientFetch).toHaveBeenCalledWith(

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -71,6 +71,7 @@ const NON_OUTREACH_TYPES = [
   TASK_TYPES.events,
   TASK_TYPES.compliance,
   TASK_TYPES.awareness,
+  TASK_TYPES.recurring,
 ]
 
 const useIsomorphicLayoutEffect =

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -356,14 +356,13 @@ const TasksList = ({
     if (!completeModalTask) return
 
     const task = completeModalTask
-    const isRecurring = task.flowType === TASK_TYPES.recurring
     const resolvedType =
       task.flowType === TASK_TYPES.p2pDisabledText
         ? TASK_TYPES.text
         : task.flowType
 
     let fieldForRollback: keyof VoterContactsState | undefined
-    if (!isLegacyList && !isRecurring) {
+    if (!isLegacyList) {
       const field = getVoterContactField(resolvedType)
       fieldForRollback = field
       updateVoterContactsLocal((prev) => ({


### PR DESCRIPTION
## Problem

When a user checked off a recurring task (e.g. "Social media update", "Plan and Schedule 2 Social Posts for the week") in the Campaign Plan, a **"Failed to complete task"** error snackbar appeared.

**Root cause:** `recurring` was missing from `NON_OUTREACH_TYPES`, so checking off a recurring task fell into the outreach `CountModal` flow. Submitting the count sent `{ type: 'recurring', quantity }` to `PUT /campaigns/tasks/complete/:taskId`, which fails Zod validation because `recurring` is not a valid `CampaignUpdateHistoryType`. The resulting 400 triggered the error snackbar.

## Fix

Added `TASK_TYPES.recurring` to `NON_OUTREACH_TYPES` so recurring tasks complete directly via checkbox (no voter-contact count needed — "Social media update" etc. are not voter-contact activities).

Tasks with an explicit outreach flowType (`doorKnocking`, `phoneBanking`) are unaffected and still open the CountModal correctly.

## Testing

- Updated the `TasksList recurring task completion` test suite to assert the new behavior (direct completion, no CountModal).
- All 54 `TasksList` tests pass.

Fixes ENG-7339

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to task-type routing that only affects `recurring` completion behavior, plus corresponding test updates.
> 
> **Overview**
> Recurring tasks are now treated as **non-outreach** in `TasksList`, so checking them off completes immediately via `PUT /campaigns/tasks/complete/:taskId` without opening the outreach `CountModal` or sending `{type, quantity}` payloads.
> 
> Tests were updated to assert the direct-completion behavior and that the count modal does not appear (and voter contacts are not updated) for recurring tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec3340e6a6f9df46635d65e8b0b146b936e5f24. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->