### PR TITLE
fix: update city attribute handling in OfficeStep component to remove…

### DIFF
--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -106,8 +106,7 @@ export default function OfficeStep({
       step,
     })
 
-    const { position, election, id, filingPeriods } = state.ballotOffice
-    const city = state.ballotOffice.city as string | null | undefined
+    const { position, election, id, filingPeriods, city } = state.ballotOffice
 
     const attr = [
       { key: 'details.electionId', value: election?.id },

--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -106,13 +106,14 @@ export default function OfficeStep({
       step,
     })
 
-    const { position, election, id, filingPeriods, city } = state.ballotOffice
+    const { position, election, id, filingPeriods } = state.ballotOffice
+    const city = state.ballotOffice.city as string | null | undefined
 
     const attr = [
       { key: 'details.electionId', value: election?.id },
       { key: 'details.raceId', value: id },
       { key: 'details.state', value: election?.state },
-      { key: 'details.city', value: city ?? null },
+      { key: 'details.city', value: city },
       {
         key: 'details.officeTermLength',
         value: calcTerm(position),


### PR DESCRIPTION
… null fallback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to how the `details.city` campaign attribute is populated, affecting only onboarding office-save metadata.
> 
> **Overview**
> Updates `OfficeStep` to pass through `ballotOffice.city` directly when building campaign attributes, removing the explicit `?? null` fallback for `details.city` and tightening the city extraction/casting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed16804171a29bf5a89101450e8be79a8a0a1ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->