### PR TITLE
User account self deletion

### DIFF
--- a/app/dashboard/account/components/AccountProfilePage.tsx
+++ b/app/dashboard/account/components/AccountProfilePage.tsx
@@ -2,26 +2,34 @@
 
 import { UserProfile } from '@clerk/nextjs'
 import DashboardLayout from 'app/dashboard/shared/DashboardLayout'
+import DeleteAccountPage from './DeleteAccountPage'
+import { MdDeleteForever } from 'react-icons/md'
 
 const AccountProfilePage = (): React.JSX.Element => (
   <DashboardLayout pathname="/dashboard/account">
     <div className="-m-2 md:-m-4 h-full">
       <UserProfile
-        {...{
-          routing: 'hash',
-          appearance: {
-            variables: {
-              borderRadius: 'none',
-              colorBackground: '#f5f5f5',
-            },
-            elements: {
-              rootBox: 'w-full! h-full! border-none! max-w-full!',
-              cardBox: 'w-full! h-full! border-none! shadow-none! max-w-full!',
-              navbar: 'hidden',
-            },
+        routing="hash"
+        appearance={{
+          variables: {
+            borderRadius: 'none',
+            colorBackground: '#f5f5f5',
+          },
+          elements: {
+            rootBox: 'w-full! h-full! border-none! max-w-full!',
+            cardBox: 'w-full! h-full! border-none! shadow-none! max-w-full!',
+            navbar: 'hidden',
           },
         }}
-      />
+      >
+        <UserProfile.Page
+          label="Delete Account"
+          url="delete-account"
+          labelIcon={<MdDeleteForever />}
+        >
+          <DeleteAccountPage />
+        </UserProfile.Page>
+      </UserProfile>
     </div>
   </DashboardLayout>
 )

--- a/app/dashboard/account/components/DeleteAccountPage.test.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import DeleteAccountPage from './DeleteAccountPage'
+
+vi.mock('gpApi/clientFetch', () => ({
+  clientFetch: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useClerk: vi.fn(() => ({ signOut: vi.fn() })),
+}))
+
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: vi.fn(() => [{ id: 42 }, vi.fn(), false]),
+}))
+
+import { clientFetch } from 'gpApi/clientFetch'
+import { useClerk } from '@clerk/nextjs'
+
+const mockClientFetch = vi.mocked(clientFetch)
+const mockUseClerk = vi.mocked(useClerk)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseClerk.mockReturnValue({ signOut: vi.fn() } as ReturnType<typeof useClerk>)
+})
+
+describe('DeleteAccountPage', () => {
+  it('renders the Delete Account button and no modal on initial load', () => {
+    render(<DeleteAccountPage />)
+    expect(
+      screen.getByRole('button', { name: /delete account/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens the confirmation modal when Delete Account is clicked', () => {
+    render(<DeleteAccountPage />)
+    fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    expect(screen.getByText(/this cannot be undone/i)).toBeInTheDocument()
+  })
+
+  it('closes the modal when Cancel is clicked', () => {
+    render(<DeleteAccountPage />)
+    fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByText(/this cannot be undone/i)).not.toBeInTheDocument()
+  })
+
+  it('calls clientFetch then signOut on 204 success', async () => {
+    const mockSignOut = vi.fn()
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', data: null })
+
+    render(<DeleteAccountPage />)
+    fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'DELETE' }),
+        { id: 42 },
+      )
+      expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: '/' })
+    })
+  })
+
+  it('treats 404 as success and calls signOut', async () => {
+    const mockSignOut = vi.fn()
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', data: null })
+
+    render(<DeleteAccountPage />)
+    fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledWith({ redirectUrl: '/' })
+    })
+  })
+
+  it('shows error message and does not call signOut on API failure', async () => {
+    const mockSignOut = vi.fn()
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error', data: null })
+
+    render(<DeleteAccountPage />)
+    fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
+    fireEvent.click(screen.getByRole('button', { name: /delete my account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    expect(mockSignOut).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/account/components/DeleteAccountPage.test.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.test.tsx
@@ -24,7 +24,7 @@ const mockUseClerk = vi.mocked(useClerk)
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockUseClerk.mockReturnValue({ signOut: vi.fn() } as ReturnType<typeof useClerk>)
+  mockUseClerk.mockReturnValue({ signOut: vi.fn() } as unknown as ReturnType<typeof useClerk>)
 })
 
 describe('DeleteAccountPage', () => {

--- a/app/dashboard/account/components/DeleteAccountPage.test.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.test.tsx
@@ -24,7 +24,9 @@ const mockUseClerk = vi.mocked(useClerk)
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockUseClerk.mockReturnValue({ signOut: vi.fn() } as unknown as ReturnType<typeof useClerk>)
+  mockUseClerk.mockReturnValue({ signOut: vi.fn() } as unknown as ReturnType<
+    typeof useClerk
+  >)
 })
 
 describe('DeleteAccountPage', () => {
@@ -51,8 +53,15 @@ describe('DeleteAccountPage', () => {
 
   it('calls clientFetch then signOut on 204 success', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
-    mockClientFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', data: null })
+    mockUseClerk.mockReturnValue({
+      signOut: mockSignOut,
+    } as unknown as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+      data: null,
+    })
 
     render(<DeleteAccountPage />)
     fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
@@ -69,8 +78,15 @@ describe('DeleteAccountPage', () => {
 
   it('treats 404 as success and calls signOut', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
-    mockClientFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', data: null })
+    mockUseClerk.mockReturnValue({
+      signOut: mockSignOut,
+    } as unknown as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      data: null,
+    })
 
     render(<DeleteAccountPage />)
     fireEvent.click(screen.getByRole('button', { name: /delete account/i }))
@@ -83,8 +99,15 @@ describe('DeleteAccountPage', () => {
 
   it('shows error message and does not call signOut on API failure', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
-    mockClientFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error', data: null })
+    mockUseClerk.mockReturnValue({
+      signOut: mockSignOut,
+    } as unknown as ReturnType<typeof useClerk>)
+    mockClientFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      data: null,
+    })
 
     render(<DeleteAccountPage />)
     fireEvent.click(screen.getByRole('button', { name: /delete account/i }))

--- a/app/dashboard/account/components/DeleteAccountPage.test.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.test.tsx
@@ -51,7 +51,7 @@ describe('DeleteAccountPage', () => {
 
   it('calls clientFetch then signOut on 204 success', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
     mockClientFetch.mockResolvedValue({ ok: true, status: 204, statusText: 'No Content', data: null })
 
     render(<DeleteAccountPage />)
@@ -69,7 +69,7 @@ describe('DeleteAccountPage', () => {
 
   it('treats 404 as success and calls signOut', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
     mockClientFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found', data: null })
 
     render(<DeleteAccountPage />)
@@ -83,7 +83,7 @@ describe('DeleteAccountPage', () => {
 
   it('shows error message and does not call signOut on API failure', async () => {
     const mockSignOut = vi.fn()
-    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as ReturnType<typeof useClerk>)
+    mockUseClerk.mockReturnValue({ signOut: mockSignOut } as unknown as ReturnType<typeof useClerk>)
     mockClientFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error', data: null })
 
     render(<DeleteAccountPage />)

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -78,10 +78,7 @@ export default function DeleteAccountPage(): React.JSX.Element {
           </p>
         )}
         <div className="flex gap-3 justify-end">
-          <Button
-            onClick={() => setModalOpen(false)}
-            disabled={loading}
-          >
+          <Button onClick={() => setModalOpen(false)} disabled={loading}>
             Cancel
           </Button>
           <Button

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { useClerk } from '@clerk/nextjs'
+import { useUser } from '@shared/hooks/useUser'
+import { clientFetch } from 'gpApi/clientFetch'
+import { apiRoutes } from 'gpApi/routes'
+import Modal from '@shared/utils/Modal'
+
+export default function DeleteAccountPage(): React.JSX.Element {
+  const [user] = useUser()
+  const { signOut } = useClerk()
+  const [modalOpen, setModalOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleDeleteConfirm = async () => {
+    if (!user?.id) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const resp = await clientFetch(apiRoutes.user.deleteAccount, { id: user.id })
+
+      if (resp.ok || resp.status === 404) {
+        await signOut({ redirectUrl: '/' })
+        return
+      }
+
+      setError(
+        'Failed to delete your account. Please try again or contact support.',
+      )
+    } catch {
+      setError(
+        'An unexpected error occurred. Please try again or contact support.',
+      )
+    }
+
+    setLoading(false)
+  }
+
+  return (
+    <div className="p-6 max-w-lg">
+      <h2 className="text-xl font-semibold mb-2">Delete Account</h2>
+      <p className="text-gray-600 mb-6">
+        Permanently delete your account and all associated campaign data.
+      </p>
+      <button
+        className="bg-red-600 hover:bg-red-700 text-white font-medium px-4 py-2 rounded"
+        onClick={() => setModalOpen(true)}
+      >
+        Delete Account
+      </button>
+
+      <Modal
+        open={modalOpen}
+        closeCallback={() => {
+          if (!loading) setModalOpen(false)
+        }}
+        preventBackdropClose={loading}
+        preventEscClose={loading}
+      >
+        <h3 className="text-lg font-semibold mb-2">Are you sure?</h3>
+        <p className="text-gray-600 mb-4">
+          This cannot be undone. All your campaign data will be permanently
+          deleted.
+        </p>
+        {error && (
+          <p role="alert" className="text-red-600 text-sm mb-4">
+            {error}
+          </p>
+        )}
+        <div className="flex gap-3 justify-end">
+          <button
+            className="px-4 py-2 border rounded font-medium"
+            onClick={() => setModalOpen(false)}
+            disabled={loading}
+          >
+            Cancel
+          </button>
+          <button
+            className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white font-medium px-4 py-2 rounded"
+            onClick={handleDeleteConfirm}
+            disabled={loading}
+          >
+            {loading ? 'Deleting...' : 'Delete My Account'}
+          </button>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -71,6 +71,12 @@ export default function DeleteAccountPage(): React.JSX.Element {
         Delete Account
       </Button>
 
+      {error && (
+        <Alert variant="destructive" className="mt-4">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
       <AlertDialog
         open={modalOpen}
         onOpenChange={(open) => {
@@ -85,11 +91,6 @@ export default function DeleteAccountPage(): React.JSX.Element {
               deleted.
             </AlertDialogDescription>
           </AlertDialogHeader>
-          {error && (
-            <Alert variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
           <AlertDialogFooter>
             <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
             <AlertDialogAction

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -20,7 +20,9 @@ export default function DeleteAccountPage(): React.JSX.Element {
     setError(null)
 
     try {
-      const resp = await clientFetch(apiRoutes.user.deleteAccount, { id: user.id })
+      const resp = await clientFetch(apiRoutes.user.deleteAccount, {
+        id: user.id,
+      })
 
       if (resp.ok || resp.status === 404) {
         await signOut({ redirectUrl: '/' })

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -5,8 +5,20 @@ import { useClerk } from '@clerk/nextjs'
 import { useUser } from '@shared/hooks/useUser'
 import { clientFetch } from 'gpApi/clientFetch'
 import { apiRoutes } from 'gpApi/routes'
-import { Button } from 'styleguide/components/ui/button'
-import Modal from '@shared/utils/Modal'
+import { buttonVariants } from 'styleguide/components/ui/button'
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+  Button,
+} from 'styleguide/components/ui'
 
 export default function DeleteAccountPage(): React.JSX.Element {
   const [user] = useUser()
@@ -59,37 +71,37 @@ export default function DeleteAccountPage(): React.JSX.Element {
         Delete Account
       </Button>
 
-      <Modal
+      <AlertDialog
         open={modalOpen}
-        closeCallback={() => {
-          if (!loading) setModalOpen(false)
+        onOpenChange={(open) => {
+          if (!loading) setModalOpen(open)
         }}
-        preventBackdropClose={loading}
-        preventEscClose={loading}
       >
-        <h3 className="text-lg font-semibold mb-2">Are you sure?</h3>
-        <p className="text-gray-600 mb-4">
-          This cannot be undone. All your campaign data will be permanently
-          deleted.
-        </p>
-        {error && (
-          <p role="alert" className="text-red-600 text-sm mb-4">
-            {error}
-          </p>
-        )}
-        <div className="flex gap-3 justify-end">
-          <Button onClick={() => setModalOpen(false)} disabled={loading}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleDeleteConfirm}
-            disabled={loading}
-          >
-            {loading ? 'Deleting...' : 'Delete My Account'}
-          </Button>
-        </div>
-      </Modal>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This cannot be undone. All your campaign data will be permanently
+              deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: 'destructive' })}
+              onClick={handleDeleteConfirm}
+              disabled={loading}
+            >
+              {loading ? 'Deleting...' : 'Delete My Account'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/app/dashboard/account/components/DeleteAccountPage.tsx
+++ b/app/dashboard/account/components/DeleteAccountPage.tsx
@@ -34,9 +34,9 @@ export default function DeleteAccountPage(): React.JSX.Element {
       setError(
         'An unexpected error occurred. Please try again or contact support.',
       )
+    } finally {
+      setLoading(false)
     }
-
-    setLoading(false)
   }
 
   return (
@@ -47,7 +47,10 @@ export default function DeleteAccountPage(): React.JSX.Element {
       </p>
       <button
         className="bg-red-600 hover:bg-red-700 text-white font-medium px-4 py-2 rounded"
-        onClick={() => setModalOpen(true)}
+        onClick={() => {
+          setError(null)
+          setModalOpen(true)
+        }}
       >
         Delete Account
       </button>


### PR DESCRIPTION
### Summary
Adds self-service account deletion for users via a new "Delete Account" page surfaced inside the Clerk UserProfile component
DeleteAccountPage presents a confirmation modal, calls the DELETE /user API endpoint, then signs the user out and redirects to / on success (treats 404 as success to handle already-deleted accounts)
Errors surface inline in the modal without closing it; loading state prevents double-submission
### Test Plan
 Navigate to /dashboard/account and confirm "Delete Account" appears in the Clerk profile sidebar
 Click "Delete Account", confirm modal opens with warning copy
 Click "Cancel", confirm modal closes without any action taken
 Click "Delete My Account", confirm loading state during request, signout and redirect to / on success
 Simulate API failure, confirm error message appears in modal and user remains signed in
Note: the RightSide.tsx fix (removing the erroneous signOut from "Finish Later" during onboarding) is not yet committed — we still need to resolve where to redirect when electedOfficeId isn't set. That should likely be a separate PR or added to this one before pushing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new destructive user flow that calls the account deletion API and signs users out, so mistakes in routing/permissions or error handling could lead to accidental deletion or inconsistent session state.
> 
> **Overview**
> Adds a self-service **Delete Account** page inside the Clerk `UserProfile` on `/dashboard/account`, including a sidebar entry with a delete icon.
> 
> Implements `DeleteAccountPage` with a confirmation modal and loading/error states; it calls `DELETE /users/:id` via `clientFetch` and then `signOut({ redirectUrl: '/' })` on success (treating `404` as success), with new Vitest coverage for the modal behavior and success/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15da8640bf29748a3749db75c117de17ceebb90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->