### PR TITLE
fix(ENG-7343): use TanStack Query optimistic updates for voter contacts

### DIFF
--- a/app/shared/hooks/VoterContactsProvider.tsx
+++ b/app/shared/hooks/VoterContactsProvider.tsx
@@ -1,7 +1,10 @@
 import { noop, noopAsync } from '@shared/utils/noop'
 import { useCampaign } from '@shared/hooks/useCampaign'
-import { createContext, useCallback, useEffect, useState } from 'react'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { createContext, useCallback, useMemo } from 'react'
 import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Campaign } from 'helpers/types'
 
 export const getVoterContactField = (
   outreachType: string,
@@ -110,42 +113,72 @@ interface VoterContactsProviderProps {
 export const VoterContactsProvider = ({
   children,
 }: VoterContactsProviderProps): React.JSX.Element => {
+  const queryClient = useQueryClient()
   const [campaign] = useCampaign()
-  const { data: campaignData } = campaign || {}
-  const { reportedVoterGoals } = campaignData || {}
-  const [state, setState] = useState(INITIAL_VOTER_CONTACTS_STATE)
+  const reportedVoterGoals = campaign?.data?.reportedVoterGoals
 
-  useEffect(() => {
-    if (reportedVoterGoals) {
-      setState(getFilteredListOfReportedVoterContacts(reportedVoterGoals))
-    }
-  }, [reportedVoterGoals])
+  const state = useMemo(
+    () => getFilteredListOfReportedVoterContacts(reportedVoterGoals),
+    [reportedVoterGoals],
+  )
 
-  const updateState = useCallback(
-    async (
-      next:
-        | VoterContactsState
-        | ((prev: VoterContactsState) => VoterContactsState),
-    ) => {
-      const newValues = typeof next === 'function' ? next(state) : next
+  const writeToCache = useCallback(
+    (next: VoterContactsState) => {
+      queryClient.setQueryData<Campaign | null>(CAMPAIGN_QUERY_KEY, (prev) =>
+        prev
+          ? {
+              ...prev,
+              data: { ...(prev.data ?? {}), reportedVoterGoals: next },
+            }
+          : prev,
+      )
+    },
+    [queryClient],
+  )
+
+  const mutation = useMutation<
+    VoterContactsState,
+    Error,
+    VoterContactsState,
+    { previous: Campaign | null | undefined }
+  >({
+    mutationFn: async (newValues) => {
       await updateCampaign([
         { key: 'data.reportedVoterGoals', value: newValues },
       ])
-
-      setState(newValues)
+      return newValues
     },
-    [state],
+    onMutate: async (newValues) => {
+      await queryClient.cancelQueries({ queryKey: CAMPAIGN_QUERY_KEY })
+      const previous = queryClient.getQueryData<Campaign | null>(
+        CAMPAIGN_QUERY_KEY,
+      )
+      writeToCache(newValues)
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context) {
+        queryClient.setQueryData(CAMPAIGN_QUERY_KEY, context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
+    },
+  })
+
+  const updateState = useCallback<VoterContactsUpdater>(
+    async (next) => {
+      const newValues = typeof next === 'function' ? next(state) : next
+      await mutation.mutateAsync(newValues)
+    },
+    [mutation, state],
   )
 
-  const updateLocalState = useCallback(
-    (
-      next:
-        | VoterContactsState
-        | ((prev: VoterContactsState) => VoterContactsState),
-    ) => {
-      setState((prev) => (typeof next === 'function' ? next(prev) : next))
+  const updateLocalState = useCallback<VoterContactsLocalUpdater>(
+    (next) => {
+      writeToCache(typeof next === 'function' ? next(state) : next)
     },
-    [],
+    [state, writeToCache],
   )
 
   return (

--- a/app/shared/hooks/VoterContactsProvider.tsx
+++ b/app/shared/hooks/VoterContactsProvider.tsx
@@ -123,15 +123,25 @@ export const VoterContactsProvider = ({
   )
 
   const writeToCache = useCallback(
-    (next: VoterContactsState) => {
-      queryClient.setQueryData<Campaign | null>(CAMPAIGN_QUERY_KEY, (prev) =>
-        prev
+    (
+      next:
+        | VoterContactsState
+        | ((prev: VoterContactsState) => VoterContactsState),
+    ): VoterContactsState => {
+      let nextValues: VoterContactsState = INITIAL_VOTER_CONTACTS_STATE
+      queryClient.setQueryData<Campaign | null>(CAMPAIGN_QUERY_KEY, (prev) => {
+        const prevValues = getFilteredListOfReportedVoterContacts(
+          prev?.data?.reportedVoterGoals,
+        )
+        nextValues = typeof next === 'function' ? next(prevValues) : next
+        return prev
           ? {
               ...prev,
-              data: { ...(prev.data ?? {}), reportedVoterGoals: next },
+              data: { ...(prev.data ?? {}), reportedVoterGoals: nextValues },
             }
-          : prev,
-      )
+          : prev
+      })
+      return nextValues
     },
     [queryClient],
   )
@@ -143,9 +153,12 @@ export const VoterContactsProvider = ({
     { previous: Campaign | null | undefined }
   >({
     mutationFn: async (newValues) => {
-      await updateCampaign([
+      const result = await updateCampaign([
         { key: 'data.reportedVoterGoals', value: newValues },
       ])
+      if (result === false) {
+        throw new Error('Failed to update reportedVoterGoals')
+      }
       return newValues
     },
     onMutate: async (newValues) => {
@@ -166,19 +179,25 @@ export const VoterContactsProvider = ({
     },
   })
 
+  const { mutateAsync } = mutation
+
   const updateState = useCallback<VoterContactsUpdater>(
     async (next) => {
-      const newValues = typeof next === 'function' ? next(state) : next
-      await mutation.mutateAsync(newValues)
+      const current = getFilteredListOfReportedVoterContacts(
+        queryClient.getQueryData<Campaign | null>(CAMPAIGN_QUERY_KEY)?.data
+          ?.reportedVoterGoals,
+      )
+      const newValues = typeof next === 'function' ? next(current) : next
+      await mutateAsync(newValues)
     },
-    [mutation, state],
+    [mutateAsync, queryClient],
   )
 
   const updateLocalState = useCallback<VoterContactsLocalUpdater>(
     (next) => {
-      writeToCache(typeof next === 'function' ? next(state) : next)
+      writeToCache(next)
     },
-    [state, writeToCache],
+    [writeToCache],
   )
 
   return (


### PR DESCRIPTION
Replace local useState in VoterContactsProvider with React Query cache-backed state and useMutation. Optimistically updates campaign cache so the progress bar reflects new voter contacts immediately, and invalidates on settle to keep the cache consistent across refreshes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes voter-contact updates to use TanStack Query optimistic cache writes with rollback/invalidation, which can affect campaign data consistency and UI synchronization if the cache shape or mutation flow is wrong.
> 
> **Overview**
> Switches `VoterContactsProvider` from local `useState`/`useEffect` to a React Query cache-backed source of truth derived from `campaign.data.reportedVoterGoals`.
> 
> Adds a `useMutation` around `updateCampaign` with **optimistic updates** to the `CAMPAIGN_QUERY_KEY` cache, including query cancellation, rollback on error, and cache invalidation on settle so UI reflects voter-contact changes immediately while staying consistent after server refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca5fbbe8cf39170316abe707fdf33128e728cac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->