### PR TITLE
fix: Correct font family and weights in awareness detail modal

### DIFF
--- a/app/dashboard/components/tasks/AwarenessDetailModal.tsx
+++ b/app/dashboard/components/tasks/AwarenessDetailModal.tsx
@@ -27,19 +27,21 @@ export default function AwarenessDetailModal({
       description={description || 'Task details'}
       dialogClassName="max-w-md"
     >
-      <div className="flex flex-col gap-4 p-4 md:p-1">
-        <div>
-          <h3 className="text-lg font-semibold">{title}</h3>
+      <div className="flex flex-col gap-4 font-opensans p-4 md:p-1">
+        <div className="flex flex-col gap-1.5 text-center md:text-left">
+          <h3 className="text-lg font-semibold leading-none text-base-foreground">
+            {title}
+          </h3>
           {description && (
-            <p className="mt-1 text-sm text-base-muted-foreground">
+            <p className="text-sm font-normal leading-5 text-base-muted-foreground">
               {description}
             </p>
           )}
         </div>
 
         {formattedDate && (
-          <div className="flex items-center gap-2 text-sm">
-            <CalendarCheck className="h-4 w-4 text-base-muted-foreground" />
+          <div className="flex items-center gap-2 text-sm font-normal text-base-foreground">
+            <CalendarCheck className="h-4 w-4 shrink-0" />
             <span>{formattedDate}</span>
           </div>
         )}


### PR DESCRIPTION
## Summary

Fixes typography discrepancies in `AwarenessDetailModal` to match Figma designs

## Changes

- Added `font-opensans` to the modal wrapper so the correct font family (Open Sans) is applied
- Title: `text-lg font-semibold leading-none text-base-foreground` (Open Sans SemiBold 18/18)
- Description: `text-sm font-normal leading-5 text-base-muted-foreground` (Open Sans Regular 14/20)
- Header changed to `gap-1.5` flex column (6px gap per Figma)
- Date row uses `text-base-foreground` to match Figma icon/text color
- Mobile drawer centers the header (`text-center md:text-left`) to match drawer design

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts Tailwind typography/layout classes with no logic or data flow changes.
> 
> **Overview**
> Updates `AwarenessDetailModal` styling to match design specs by applying `font-opensans`, tightening header spacing, and setting explicit font weights/line-heights for title and description.
> 
> Adjusts alignment and colors for responsiveness (centered header on mobile) and normalizes the date row/icon styling (including `shrink-0` on the calendar icon).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f645a18991c70f1d43b175049dcaaa9f43b6b9b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->