### PR TITLE
Meeting briefing AI disclaimer

### DIFF
--- a/app/dashboard/briefings/[date]/components/BriefingDetailPage.tsx
+++ b/app/dashboard/briefings/[date]/components/BriefingDetailPage.tsx
@@ -111,6 +111,18 @@ export default function BriefingDetailPage({
               {briefing.footer.preparedBy} &middot;{' '}
               {briefing.footer.contactNote}
             </p>
+
+            {/* Disclaimer */}
+            <div className="mt-6 mx-auto max-w-lg rounded-lg border border-border bg-muted/50 px-5 py-4 text-center">
+              <p className="text-xs font-medium text-muted-foreground">
+                Briefings are AI-generated and still in beta
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground/70">
+                Double-check anything you&apos;ll act on against the sources.
+                Your feedback shapes how we improve. We enjoy hearing from all
+                our users.
+              </p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Meeting briefing AI disclaimer
<img width="1754" height="1042" alt="Screenshot 2026-04-21 at 4 40 07 PM" src="https://github.com/user-attachments/assets/5cc7d6a8-1971-47be-97e7-9752cd290147" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds static disclaimer copy to the briefing detail view; no behavior, data flow, or security-sensitive logic is modified.
> 
> **Overview**
> Adds a new disclaimer section to `BriefingDetailPage` beneath the existing footer, informing users that briefings are AI-generated/in beta and encouraging verification against sources and feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7ebf0ae2209acb953c34cd37c159ae77443738. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->