### PR TITLE
Eng 7478 pledge

### DIFF
--- a/app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementPage.tsx
+++ b/app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementPage.tsx
@@ -9,6 +9,7 @@ import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
 import SecondaryButton from '@shared/buttons/SecondaryButton'
 import Link from 'next/link'
+import { TermAndTerminationText } from 'app/dashboard/pro-sign-up/service-agreement/components/TermAndTerminationText'
 import { ServiceAgreementSignatureSection } from 'app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementSignatureSection'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { useCampaignStatus } from '@shared/hooks/useCampaignStatus'
@@ -27,19 +28,35 @@ interface ServiceAgreementPageProps {
 
 const ACKNOWLEDGEMENTS: Acknowledgement[] = [
   {
-    title: 'Independent',
+    title: 'Independent, People-Powered, and Anti-Corruption',
     emoticon: <MdPerson className="mr-2" />,
-    body: 'You must be independent of big money and the two major political parties.',
+    body: (
+      <ul className="list-disc pl-5 space-y-2">
+        <li>
+          <strong>Independent:</strong> You must be independent of big money and
+          the two major political parties.
+        </li>
+        <li>
+          <strong>People-Powered:</strong> Your campaign or administration must
+          be centered on serving the people, only raising funds from real,
+          living people (not corporations or special interests).
+        </li>
+        <li>
+          <strong>Anti-Corruption:</strong> You must serve with integrity,
+          transparency, and be accountable to the people.
+        </li>
+      </ul>
+    ),
   },
   {
-    title: 'People-Powered',
+    title: 'Terms & Termination',
     emoticon: <MdPeople className="mr-2" />,
-    body: 'Your campaign or administration must be centered on serving the people, only raising funds from real, living people (not corporations or special interests).',
+    body: <TermAndTerminationText />,
   },
   {
-    title: 'Anti-Corruption',
+    title: 'Voter Data Privacy',
     emoticon: <MdFlag className="mr-2" />,
-    body: 'You must serve with integrity, transparency, and be accountable to the people.',
+    body: "By signing and agreeing to this Services Agreement, the Data User, certifies that he/she will use any voter file data made accessible to him/her by Good Party LLC, in conformance with all federal, state and local laws whether statutory, regulatory or common law governing use of voter file data in the state or states from which those data are drawn. Data User certifies that voter data use is limited to support for political campaigns and public affairs advocacy. The Data User represents and warrants that he/she has informed himself/herself of all such applicable laws and will use the data provided only in conformity therewith. Data User shall be solely responsible for informing themself of the legal restrictions governing the user of registered voter data and shall abide by all such restrictions. The Data User further acknowledges his/her awareness of special rules for the use of cell phone numbers as governed by the Telephone Consumer Protection Act promulgated by the Federal Communications Commission. Data User represents and warrants that no data supplied by Good Party LLC will be used for immoral or illegal purposes. Good Party LLC provides no warranty, express or implied, as to the accuracy, reliability, utility or completeness of such information. The voter file data is provided on an \"AS IS\" basis. All warranties of any kind, express or implied, including but not limited to the IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, freedom from contamination by computer viruses and non-infringement of proprietary rights ARE DISCLAIMED. Data User should be aware that voter file data can quickly become out-of-date. Data User assumes all responsibility and risk for his/her use of the voter file data provided herein. The Data User shall defend, indemnify, and hold harmless, Good Party LLC and its affiliates and their respective directors, officers, employees, and agents from and against all claims and expenses, including attorneys' fees and court costs, arising out of the any use by Data User of the voter file data supplied herein. The data downloaded from this platform is the exclusive property of L2 INC. Good Party LLC is a licensee. Data User has been granted a limited non-exclusive license to utilize the data downloaded from L2's platform for the allowable purposes. Data User acknowledges that legal privacy requirements may result in individuals requesting that Good Party LLC remove identifying information from its records and share that deletion request with Data User. Good Party LLC will comply with all such requests and Data User agrees to comply with removal of relevant records from its licensed copy of Good Party's data as provided under this agreement.",
   },
 ]
 

--- a/app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementPage.tsx
+++ b/app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementPage.tsx
@@ -9,7 +9,6 @@ import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
 import SecondaryButton from '@shared/buttons/SecondaryButton'
 import Link from 'next/link'
-import { TermAndTerminationText } from 'app/dashboard/pro-sign-up/service-agreement/components/TermAndTerminationText'
 import { ServiceAgreementSignatureSection } from 'app/dashboard/pro-sign-up/service-agreement/components/ServiceAgreementSignatureSection'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { useCampaignStatus } from '@shared/hooks/useCampaignStatus'
@@ -30,17 +29,17 @@ const ACKNOWLEDGEMENTS: Acknowledgement[] = [
   {
     title: 'Independent',
     emoticon: <MdPerson className="mr-2" />,
-    body: 'I confirm that I am running as a 3rd party or non-partisan candidate and my campaign is not registered with either the Republican or the Democratic parties.',
+    body: 'You must be independent of big money and the two major political parties.',
   },
   {
-    title: 'Terms & Termination',
+    title: 'People-Powered',
     emoticon: <MdPeople className="mr-2" />,
-    body: <TermAndTerminationText />,
+    body: 'Your campaign or administration must be centered on serving the people, only raising funds from real, living people (not corporations or special interests).',
   },
   {
-    title: 'Voter Data Privacy',
+    title: 'Anti-Corruption',
     emoticon: <MdFlag className="mr-2" />,
-    body: "By signing and agreeing to this Services Agreement, the Data User, certifies that he/she will use any voter file data made accessible to him/her by Good Party LLC, in conformance with all federal, state and local laws whether statutory, regulatory or common law governing use of voter file data in the state or states from which those data are drawn. Data User certifies that voter data use is limited to support for political campaigns and public affairs advocacy. The Data User represents and warrants that he/she has informed himself/herself of all such applicable laws and will use the data provided only in conformity therewith. Data User shall be solely responsible for informing themself of the legal restrictions governing the user of registered voter data and shall abide by all such restrictions. The Data User further acknowledges his/her awareness of special rules for the use of cell phone numbers as governed by the Telephone Consumer Protection Act promulgated by the Federal Communications Commission. Data User represents and warrants that no data supplied by Good Party LLC will be used for immoral or illegal purposes. Good Party LLC provides no warranty, express or implied, as to the accuracy, reliability, utility or completeness of such information. The voter file data is provided on an \"AS IS\" basis. All warranties of any kind, express or implied, including but not limited to the IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, freedom from contamination by computer viruses and non-infringement of proprietary rights ARE DISCLAIMED. Data User should be aware that voter file data can quickly become out-of-date. Data User assumes all responsibility and risk for his/her use of the voter file data provided herein. The Data User shall defend, indemnify, and hold harmless, Good Party LLC and its affiliates and their respective directors, officers, employees, and agents from and against all claims and expenses, including attorneys' fees and court costs, arising out of the any use by Data User of the voter file data supplied herein. The data downloaded from this platform is the exclusive property of L2 INC. Good Party LLC is a licensee. Data User has been granted a limited non-exclusive license to utilize the data downloaded from L2's platform for the allowable purposes. Data User acknowledges that legal privacy requirements may result in individuals requesting that Good Party LLC remove identifying information from its records and share that deletion request with Data User. Good Party LLC will comply with all such requests and Data User agrees to comply with removal of relevant records from its licensed copy of Good Party's data as provided under this agreement.",
+    body: 'You must serve with integrity, transparency, and be accountable to the people.',
   },
 ]
 

--- a/app/onboarding/[slug]/[step]/components/PledgeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/PledgeStep.tsx
@@ -61,11 +61,8 @@ export default function PledgeStep({ campaign, step }: PledgeStepProps) {
               <H4>Independent</H4>
             </div>
             <Body1>
-              I am on the ballot as a nonpartisan, independent, or third-party
-              candidate. I don&apos;t serve on any boards or organizations
-              affiliated with the Democratic or Republican parties. I am
-              committed to serving the interests of the people regardless of
-              partisan politics.
+              You must be independent of big money and the two major political
+              parties.
             </Body1>
           </div>
 
@@ -75,10 +72,9 @@ export default function PledgeStep({ campaign, step }: PledgeStepProps) {
               <H4>People-Powered</H4>
             </div>
             <Body1>
-              I will focus on solving the problems facing my community, not
-              serving myself or special interests. I will disclose donors and
-              ensure that most of my funding comes from individual donors, not
-              from corporations, unions or other special interests.
+              Your campaign or administration must be centered on serving the
+              people, only raising funds from real, living people (not
+              corporations or special interests).
             </Body1>
           </div>
 
@@ -88,11 +84,8 @@ export default function PledgeStep({ campaign, step }: PledgeStepProps) {
               <H4>Anti-Corruption</H4>
             </div>
             <Body1>
-              I will uphold the highest level of integrity by being open,
-              transparent and accountable about my positions and progress on
-              issues. This means staying connected to, informed by, and
-              responsive to all my constituents using modern tools and data to
-              inform decisions.
+              You must serve with integrity, transparency, and be accountable to
+              the people.
             </Body1>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk copy/UI-only changes to agreement text; no changes to data flow, authentication, or backend interactions.
> 
> **Overview**
> Updates user-facing agreement language in onboarding and Pro sign-up.
> 
> In `ServiceAgreementPage`, replaces the single “Independent” acknowledgement with a combined “Independent, People-Powered, and Anti-Corruption” section presented as a bulleted list. In `PledgeStep`, shortens and aligns the three pledge statements to match this revised wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c74b445c40e07d9f2ab9d0bba2aa923350e026. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->