### PR TITLE
updating user impersonation banner to display user email

### DIFF
--- a/app/shared/user/ImpersonationBanner.tsx
+++ b/app/shared/user/ImpersonationBanner.tsx
@@ -2,12 +2,14 @@
 
 import { useClerk } from '@clerk/nextjs'
 import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
+import { useUser } from '@shared/hooks/useUser'
 
 const GP_ADMIN_URL = process.env.NEXT_PUBLIC_GP_ADMIN_URL ?? '/'
 
 export default function ImpersonationBanner() {
   const isImpersonating = useIsImpersonating()
   const { signOut } = useClerk()
+  const [user] = useUser()
 
   if (!isImpersonating) return null
 
@@ -18,7 +20,7 @@ export default function ImpersonationBanner() {
 
   return (
     <div className="bg-amber-400 text-black px-4 py-1 text-center text-xs font-medium">
-      You are impersonating this user.{' '}
+      You are impersonating {user?.email ?? 'this user'}.{' '}
       <button
         onClick={handleStopImpersonating}
         className="bg-black text-white border-none rounded px-3 py-1 cursor-pointer ml-2 text-[13px]"


### PR DESCRIPTION
### Summary 
Added the user email to the impersonation display banner with a this user fallback if for some reason the email isn't there. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reads from existing user context to display an email, with a safe fallback when unavailable.
> 
> **Overview**
> Updates `ImpersonationBanner` to display the impersonated user’s email address by pulling `user` from `useUser()`, falling back to `"this user"` when the email is missing. The stop-impersonation behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607c5c3e17bb9c46caa39823f2e00488e8f65e28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->