### PR TITLE
refactor: remove unused TestingRegenerate mock from CampaignManager t…

### DIFF
--- a/app/dashboard/components/campaignManager/CampaignManager.test.tsx
+++ b/app/dashboard/components/campaignManager/CampaignManager.test.tsx
@@ -29,7 +29,6 @@ vi.mock('./ProgressSection', () => ({ default: () => <div>Progress</div> }))
 vi.mock('./FailedToGenerate', () => ({
   FailedToGenerate: () => <div>Failed</div>,
 }))
-vi.mock('./TestingRegenerate', () => ({ default: () => null }))
 vi.mock('../tasks/TasksList', () => ({ default: () => <div>Tasks list</div> }))
 vi.mock('../EmptyState', () => ({ default: () => <div>Empty state</div> }))
 vi.mock('@shared/hooks/VoterContactsProvider', () => ({


### PR DESCRIPTION
…ests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only cleanup that removes an unused module mock; no production code paths change.
> 
> **Overview**
> Removes the unused `./TestingRegenerate` module mock from `CampaignManager.test.tsx`, simplifying the test setup without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0d659136bc861b8874ad0a947dba79cf2c6352. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->