### PR TITLE
[GP-Bot] ENG-7497 Fix scroll-to-top button overlapping input on mobile

### DIFF
--- a/app/dashboard/campaign-assistant/components/ChatInput.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatInput.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { render } from 'helpers/test-utils/render'
+import ChatInput from './ChatInput'
+
+const mockHandleNewInput = vi.fn()
+const mockScrollUp = vi.fn()
+const mockTrackEvent = vi.fn()
+
+vi.mock('app/dashboard/campaign-assistant/components/useChat', () => ({
+  default: () => ({
+    handleNewInput: mockHandleNewInput,
+    loading: false,
+    scrollUp: mockScrollUp,
+  }),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  EVENTS: {
+    AIAssistant: {
+      AskQuestion: 'ai_assistant_ask_question',
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ChatInput', () => {
+  it('renders the input field and scroll up button', () => {
+    render(<ChatInput />)
+
+    expect(
+      screen.getByPlaceholderText('Ask me anything about your campaign...'),
+    ).toBeInTheDocument()
+    // Find the Fab button (scroll up) which has the MuiFab-root class
+    const scrollButton = screen
+      .getAllByRole('button')
+      .find((btn) => btn.classList.contains('MuiFab-root'))
+    expect(scrollButton).toBeDefined()
+  })
+
+  it('calls scrollUp when the Fab button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ChatInput />)
+
+    const scrollButton = screen
+      .getAllByRole('button')
+      .find((btn) => btn.classList.contains('MuiFab-root'))
+    expect(scrollButton).toBeDefined()
+
+    await user.click(scrollButton!)
+    expect(mockScrollUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('submits the form and calls handleNewInput with the text', async () => {
+    const user = userEvent.setup()
+    render(<ChatInput />)
+
+    const input = screen.getByPlaceholderText(
+      'Ask me anything about your campaign...',
+    )
+    await user.type(input, 'test question')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(mockHandleNewInput).toHaveBeenCalledWith('test question')
+    })
+  })
+
+  it('tracks the AskQuestion event on submit', async () => {
+    const user = userEvent.setup()
+    render(<ChatInput />)
+
+    const input = screen.getByPlaceholderText(
+      'Ask me anything about your campaign...',
+    )
+    await user.type(input, 'my campaign question')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('ai_assistant_ask_question', {
+        text: 'my campaign question',
+      })
+    })
+  })
+
+  it('clears the input after submission', async () => {
+    const user = userEvent.setup()
+    render(<ChatInput />)
+
+    const input = screen.getByPlaceholderText(
+      'Ask me anything about your campaign...',
+    ) as HTMLInputElement
+    await user.type(input, 'test question')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(input.value).toBe('')
+    })
+  })
+
+  describe('scroll button positioning', () => {
+    it('has the scroll button container with responsive classes for mobile/desktop layout', () => {
+      render(<ChatInput />)
+
+      const scrollButton = screen
+        .getAllByRole('button')
+        .find((btn) => btn.classList.contains('MuiFab-root'))
+      const scrollButtonContainer = scrollButton?.parentElement
+
+      // Verify the container has the responsive classes:
+      // - flex justify-center mb-2: for mobile (button above input)
+      // - lg:absolute lg:bottom-[10px] lg:pb-6 lg:left-[-40px] lg:mb-0: for desktop (button to left)
+      expect(scrollButtonContainer).toHaveClass('flex')
+      expect(scrollButtonContainer).toHaveClass('justify-center')
+      expect(scrollButtonContainer).toHaveClass('mb-2')
+      expect(scrollButtonContainer).toHaveClass('lg:absolute')
+      expect(scrollButtonContainer).toHaveClass('lg:left-[-40px]')
+    })
+  })
+})
+
+describe('ChatInput when loading', () => {
+  beforeEach(() => {
+    vi.doMock('app/dashboard/campaign-assistant/components/useChat', () => ({
+      default: () => ({
+        handleNewInput: mockHandleNewInput,
+        loading: true,
+        scrollUp: mockScrollUp,
+      }),
+    }))
+  })
+
+  it('shows loading indicator when loading', async () => {
+    // Re-import the component with loading: true mock
+    vi.resetModules()
+    vi.doMock('app/dashboard/campaign-assistant/components/useChat', () => ({
+      default: () => ({
+        handleNewInput: mockHandleNewInput,
+        loading: true,
+        scrollUp: mockScrollUp,
+      }),
+    }))
+    vi.doMock('helpers/analyticsHelper', () => ({
+      trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+      EVENTS: {
+        AIAssistant: {
+          AskQuestion: 'ai_assistant_ask_question',
+        },
+      },
+    }))
+
+    const { default: ChatInputLoading } = await import('./ChatInput')
+    render(<ChatInputLoading />)
+
+    const input = screen.getByPlaceholderText(
+      'Ask me anything about your campaign...',
+    )
+    expect(input).toBeDisabled()
+  })
+})

--- a/app/dashboard/campaign-assistant/components/ChatInput.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatInput.tsx
@@ -24,7 +24,7 @@ const ChatInput = (): React.JSX.Element => {
 
   return (
     <div className="w-full max-w-[960px] px-4 pb-6 self-center relative">
-      <div className="absolute bottom-[10px] pb-6 left-6 min-[1400px]:left-[-40px]">
+      <div className="flex justify-center mb-2 lg:absolute lg:bottom-[10px] lg:pb-6 lg:left-[-40px] lg:mb-0">
         <Fab onClick={scrollUp} size="small" color="primary">
           <MdKeyboardArrowUp className="text-primary" />
         </Fab>


### PR DESCRIPTION
## Summary
- Fixes the "Return to top" Fab button overlapping the chat input field on narrow/mobile screens in the Campaign Assistant page
- The button now displays centered above the input on mobile/tablet (< lg breakpoint) and to the left of the input on desktop (>= lg breakpoint at 1024px)

## Changes
- Modified `ChatInput.tsx`: Changed button container from absolute positioning with `left-6` (which overlapped the input) to using responsive Tailwind classes:
  - Mobile: `flex justify-center mb-2` - centers button above input with margin
  - Desktop (lg+): `lg:absolute lg:bottom-[10px] lg:pb-6 lg:left-[-40px] lg:mb-0` - positioned to the left of the input

## Test plan
- [ ] Visit `/dashboard/campaign-assistant` on desktop (>1024px width) - button should appear to the left of the input
- [ ] Resize browser to narrow width or use mobile viewport - button should appear centered above the input field with no overlap
- [ ] Verify scroll-to-top functionality still works on both mobile and desktop

## ClickUp
https://app.clickup.com/t/86ah23k7t

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout change plus a new unit test; main risk is minor responsive styling regressions across breakpoints.
> 
> **Overview**
> Fixes the Campaign Assistant chat input layout so the scroll-to-top `Fab` no longer overlaps the text field on narrow screens by switching its container to responsive Tailwind positioning (centered above input on mobile, absolute/left on `lg+`).
> 
> Adds `ChatInput.test.tsx` to cover scroll button presence/click behavior, form submission (including analytics event and input clearing), responsive class expectations, and the disabled state while loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac47de8594ce4af1ca53c2a2f55b9b07987c26ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->