### PR TITLE
Prod <- QA

### DIFF
--- a/app/dashboard/outreach/page.tsx
+++ b/app/dashboard/outreach/page.tsx
@@ -7,6 +7,7 @@ import { createOutreach } from 'app/dashboard/outreach/util/createOutreach.util'
 import { serverFetch } from 'gpApi/serverFetch'
 import { apiRoutes } from 'gpApi/routes'
 import { redirect } from 'next/navigation'
+import { getMarketingUrl } from 'helpers/linkhelper'
 import { Outreach } from './hooks/OutreachContext'
 import { TcrCompliance } from 'helpers/types'
 
@@ -34,7 +35,7 @@ export default async function Page(): Promise<React.JSX.Element> {
   const campaign = await fetchUserCampaign()
 
   if (!campaign) {
-    redirect('/run-for-office')
+    redirect(getMarketingUrl('/run-for-office'))
   }
 
   const [outreaches, tcrComplianceResponse] = await Promise.all([

--- a/app/dashboard/profile/components/ProfilePage.tsx
+++ b/app/dashboard/profile/components/ProfilePage.tsx
@@ -1,9 +1,9 @@
 import NotificationSection from 'app/dashboard/profile/components/NotificationSection'
 import ContactInfoSection from './ContactInfoSection'
 import { AccountSettingsSection } from 'app/dashboard/profile/components/AccountSettingsSection'
-import TextingCompliance from 'app/dashboard/profile/texting-compliance/components/TextingCompliance'
 import { User, Website, TcrCompliance, Campaign } from 'helpers/types'
 import DashboardLayout from 'app/dashboard/shared/DashboardLayout'
+import TextingComplianceFeatureFlag from 'app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag'
 
 interface ProfilePageProps {
   user: User
@@ -30,7 +30,7 @@ export default function ProfilePage({
           <ContactInfoSection user={user} />
           {!!campaign && <AccountSettingsSection />}
           {!!campaign && isPro && (
-            <TextingCompliance
+            <TextingComplianceFeatureFlag
               {...{
                 website,
                 domainStatus,

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
@@ -1,0 +1,8 @@
+import { Card } from '@styleguide'
+import { TextingComplianceProps } from 'app/dashboard/profile/texting-compliance/components/TextingCompliance'
+
+export default function TextingComplianceAgentic(
+  _props: TextingComplianceProps,
+): React.JSX.Element {
+  return <Card className="p-4 mt-4">TextingCompliance</Card>
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
@@ -4,5 +4,9 @@ import { TextingComplianceProps } from 'app/dashboard/profile/texting-compliance
 export default function TextingComplianceAgentic(
   _props: TextingComplianceProps,
 ): React.JSX.Element {
-  return <Card className="p-4 mt-4">TextingCompliance</Card>
+  return (
+    <Card className="p-4 mt-4" id="texting-compliance">
+      TextingCompliance
+    </Card>
+  )
 }

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import TextingCompliance, {
+  TextingComplianceProps,
+} from 'app/dashboard/profile/texting-compliance/components/TextingCompliance'
+import TextingComplianceAgentic from './TextingComplianceAgentic'
+
+const TEXT_COMPLIANCE_FEATURE_FLAG_KEY = 'pro-upgrade1'
+
+export default function TextingComplianceFeatureFlag(
+  props: TextingComplianceProps,
+): React.JSX.Element {
+  const { ready, on: textComplianceFeatureFlagEnabled } = useFlagOn(
+    TEXT_COMPLIANCE_FEATURE_FLAG_KEY,
+  )
+
+  if (!ready || !textComplianceFeatureFlagEnabled) {
+    return <TextingCompliance {...props} />
+  }
+
+  return <TextingComplianceAgentic {...props} />
+}

--- a/app/dashboard/profile/texting-compliance/components/TextingCompliance.tsx
+++ b/app/dashboard/profile/texting-compliance/components/TextingCompliance.tsx
@@ -22,7 +22,7 @@ const TDlcNumber = ({ tdlcNumber }: TDlcNumberProps): React.JSX.Element => (
   </div>
 )
 
-interface TextingComplianceProps {
+export interface TextingComplianceProps {
   website?: Website | null
   domainStatus?: string | null
   tcrCompliance?: TcrCompliance | null

--- a/app/dashboard/website/create/page.tsx
+++ b/app/dashboard/website/create/page.tsx
@@ -2,6 +2,7 @@ import pageMetaData from 'helpers/metadataHelper'
 import WebsiteCreatePage from './components/WebsiteCreatePage'
 import { fetchUserWebsite } from 'helpers/fetchUserWebsite'
 import { redirect } from 'next/navigation'
+import { getMarketingUrl } from 'helpers/linkhelper'
 import { WebsiteProvider } from '../components/WebsiteProvider'
 import candidateAccess from '../../shared/candidateAccess'
 import { combineIssues, WEBSITE_STATUS } from '../util/website.util'
@@ -28,7 +29,7 @@ export default async function Page(): Promise<React.JSX.Element> {
   }
 
   if (!campaign) {
-    redirect('/run-for-office')
+    redirect(getMarketingUrl('/run-for-office'))
   }
 
   const issues = await serverLoadCandidatePosition(campaign.id)

--- a/app/onboarding/[slug]/[step]/page.tsx
+++ b/app/onboarding/[slug]/[step]/page.tsx
@@ -39,10 +39,6 @@ export default async function Page({
     pledge = await fetchContentByType<PledgeContent>('pledge')
   }
 
-  if (!campaign) {
-    redirect('/run-for-office')
-  }
-
   const childProps = {
     step: stepInt,
     campaign,

--- a/app/onboarding/shared/getCampaign.ts
+++ b/app/onboarding/shared/getCampaign.ts
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import type { Campaign } from 'helpers/types'
 import { serverRequest } from 'gpApi/server-request'
 import { getServerToken, isTokenExpired } from 'helpers/tokenHelper'
+import { getMarketingUrl } from 'helpers/linkhelper'
 
 interface GetCampaignParams {
   slug: string
@@ -30,12 +31,12 @@ export async function fetchUserCampaign(): Promise<Campaign | null> {
 
 export default async function getCampaign(
   params: GetCampaignParams,
-): Promise<Campaign | false> {
+): Promise<Campaign> {
   const { slug } = params
   const campaign = await fetchUserCampaign()
 
   if (!campaign || campaign.slug !== slug) {
-    redirect('/run-for-office')
+    redirect(getMarketingUrl('/run-for-office'))
   }
   return campaign
 }

--- a/app/shared/layouts/navigation/RightSide.tsx
+++ b/app/shared/layouts/navigation/RightSide.tsx
@@ -51,7 +51,7 @@ const RightSide = (): React.JSX.Element => {
       })
 
       queryClient.clear()
-      await signOut({ redirectUrl: getMarketingUrl('/blog') })
+      await signOut({ redirectUrl: getMarketingUrl('/run-for-office') })
     }
 
     return (

--- a/app/shared/user/ImpersonationBanner.tsx
+++ b/app/shared/user/ImpersonationBanner.tsx
@@ -2,12 +2,14 @@
 
 import { useClerk } from '@clerk/nextjs'
 import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
+import { useUser } from '@shared/hooks/useUser'
 
 const GP_ADMIN_URL = process.env.NEXT_PUBLIC_GP_ADMIN_URL ?? '/'
 
 export default function ImpersonationBanner() {
   const isImpersonating = useIsImpersonating()
   const { signOut } = useClerk()
+  const [user] = useUser()
 
   if (!isImpersonating) return null
 
@@ -18,7 +20,7 @@ export default function ImpersonationBanner() {
 
   return (
     <div className="bg-amber-400 text-black px-4 py-1 text-center text-xs font-medium">
-      You are impersonating this user.{' '}
+      You are impersonating {user?.email ?? 'this user'}.{' '}
       <button
         onClick={handleStopImpersonating}
         className="bg-black text-white border-none rounded px-3 py-1 cursor-pointer ml-2 text-[13px]"

--- a/e2e-tests/tests/core/navigation/continue-setup.spec.ts
+++ b/e2e-tests/tests/core/navigation/continue-setup.spec.ts
@@ -50,7 +50,9 @@ test.describe('Onboarding redirect persistence', () => {
     expect(page.url()).toBe(onboardingUrl)
   })
 
-  test('Finish Later should log out and redirect to blog', async ({ page }) => {
+  test('Finish Later should log out and redirect to /run-for-office', async ({
+    page,
+  }) => {
     await signUpTestUser(page)
 
     const finishLater = page.getByText('Finish Later')
@@ -59,7 +61,8 @@ test.describe('Onboarding redirect persistence', () => {
 
     await page.waitForURL(
       (url) =>
-        !url.toString().includes('localhost') && url.pathname === '/blog',
+        !url.toString().includes('localhost') &&
+        url.pathname === '/run-for-office',
       { timeout: 5000 },
     )
 


### PR DESCRIPTION
This PR releases gp-webapp to Prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes several redirect targets (including onboarding logout) to the marketing `/run-for-office` URL, which can impact core onboarding/dashboard navigation flows. Adds a feature-flagged swap of the Profile texting compliance UI, which could change what Pro users see when the flag is enabled.
> 
> **Overview**
> Standardizes *no-campaign* redirects across dashboard/onboarding to use `getMarketingUrl('/run-for-office')` (Outreach, Website Create, and `getCampaign`), and updates onboarding "Finish Later" sign-out to land on `/run-for-office` instead of `/blog` (with e2e coverage updated).
> 
> Introduces a feature-flag switch (`pro-upgrade1`) for the Profile "Texting Compliance" section via `TextingComplianceFeatureFlag`, with a new placeholder `TextingComplianceAgentic` variant; `TextingComplianceProps` is now exported for reuse. Also updates the impersonation banner copy to include the impersonated user’s email when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c45fd6a64828c6653d0ab3f092af7b95139f6f47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->