### PR TITLE
Eng 7527 candiate profile

### DIFF
--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -1,3 +1,6 @@
+'use client'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import { STEP_STATUS, StepStatus } from '../shared/TextCompliance.types'
 import TextComplianceStep from './TextComplianceStep'
 
@@ -7,33 +10,39 @@ interface Step {
   status: StepStatus
 }
 
-// TODO: make these steps dynamic based on the user's progress
-const STEPS: Step[] = [
-  {
-    title: 'Submit candidate profile',
-    route: '/dashboard/profile/texting-compliance/candidate-profile',
-    status: STEP_STATUS.ACTIVE,
-  },
-  {
-    title: 'Submit election filing details',
-    route: '/dashboard/profile/texting-compliance/election-filing',
-    status: STEP_STATUS.DISABLED,
-  },
-  {
-    title: 'Enter your PIN',
-    route: '/dashboard/profile/texting-compliance/enter-pin',
-    status: STEP_STATUS.DISABLED,
-  },
-]
-
 export default function TextComplianceSteps(): React.JSX.Element {
+  const [campaign] = useCampaign()
+  const candidateProfileComplete = isCandidateProfileComplete(campaign)
+
+  const steps: Step[] = [
+    {
+      title: 'Submit candidate profile',
+      route: '/dashboard/profile/texting-compliance/candidate-profile',
+      status: candidateProfileComplete
+        ? STEP_STATUS.COMPLETED
+        : STEP_STATUS.ACTIVE,
+    },
+    {
+      title: 'Submit election filing details',
+      route: '/dashboard/profile/texting-compliance/election-filing',
+      status: candidateProfileComplete
+        ? STEP_STATUS.ACTIVE
+        : STEP_STATUS.DISABLED,
+    },
+    {
+      title: 'Enter your PIN',
+      route: '/dashboard/profile/texting-compliance/enter-pin',
+      status: STEP_STATUS.DISABLED,
+    },
+  ]
+
   return (
     <div className="border border-gray-200 rounded-lg overflow-hidden mt-6">
-      {STEPS.map((step, index) => (
+      {steps.map((step, index) => (
         <TextComplianceStep
           key={step.route}
           number={index + 1}
-          total={STEPS.length}
+          total={steps.length}
           {...step}
         />
       ))}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -1,5 +1,9 @@
 'use client'
-import { useCampaign } from '@shared/hooks/useCampaign'
+import { useQuery } from '@tanstack/react-query'
+import {
+  getUserWebsite,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
 import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import { STEP_STATUS, StepStatus } from '../shared/TextCompliance.types'
 import TextComplianceStep from './TextComplianceStep'
@@ -11,8 +15,11 @@ interface Step {
 }
 
 export default function TextComplianceSteps(): React.JSX.Element {
-  const [campaign] = useCampaign()
-  const candidateProfileComplete = isCandidateProfileComplete(campaign)
+  const { data: website } = useQuery({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+  const candidateProfileComplete = isCandidateProfileComplete(website)
 
   const steps: Step[] = [
     {
@@ -37,7 +44,7 @@ export default function TextComplianceSteps(): React.JSX.Element {
   ]
 
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden mt-6">
+    <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
       {steps.map((step, index) => (
         <TextComplianceStep
           key={step.route}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -11,7 +11,7 @@ interface Step {
 const STEPS: Step[] = [
   {
     title: 'Submit candidate profile',
-    route: '/dashboard/profile/texting-compliance/submit-candidate-profile',
+    route: '/dashboard/profile/texting-compliance/candidate-profile',
     status: STEP_STATUS.ACTIVE,
   },
   {

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,0 +1,16 @@
+import { Campaign } from 'helpers/types'
+
+export const MIN_BIO_LENGTH = 500
+export const MIN_POLICY_FOCUS_LENGTH = 100
+export const MIN_POLICY_PRIORITIES = 1
+
+export const isCandidateProfileComplete = (
+  campaign: Campaign | null,
+): boolean => {
+  const whyRunning = campaign?.details?.whyRunning?.trim() ?? ''
+  const priorities = campaign?.details?.customIssues ?? []
+  return (
+    whyRunning.length >= MIN_BIO_LENGTH &&
+    priorities.length >= MIN_POLICY_PRIORITIES
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,16 +1,13 @@
-import { Campaign } from 'helpers/types'
+import { Website } from 'helpers/types'
 
 export const MIN_BIO_LENGTH = 500
 export const MIN_POLICY_FOCUS_LENGTH = 100
 export const MIN_POLICY_PRIORITIES = 1
 
 export const isCandidateProfileComplete = (
-  campaign: Campaign | null,
+  website: Website | null | undefined,
 ): boolean => {
-  const whyRunning = campaign?.details?.whyRunning?.trim() ?? ''
-  const priorities = campaign?.details?.customIssues ?? []
-  return (
-    whyRunning.length >= MIN_BIO_LENGTH &&
-    priorities.length >= MIN_POLICY_PRIORITIES
-  )
+  const bio = website?.content?.about?.bio?.trim() ?? ''
+  const issues = website?.content?.about?.issues ?? []
+  return bio.length >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
 }

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,3 +1,4 @@
+import { stripHtml } from 'string-strip-html'
 import { Website } from 'helpers/types'
 
 export const MIN_BIO_LENGTH = 500
@@ -7,7 +8,10 @@ export const MIN_POLICY_PRIORITIES = 1
 export const isCandidateProfileComplete = (
   website: Website | null | undefined,
 ): boolean => {
-  const bio = website?.content?.about?.bio?.trim() ?? ''
+  const rawBio = website?.content?.about?.bio ?? ''
+  const bioPlainLength = rawBio ? stripHtml(rawBio).result.trim().length : 0
   const issues = website?.content?.about?.issues ?? []
-  return bio.length >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
+  return (
+    bioPlainLength >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
+  )
 }

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,11 +1,11 @@
 'use client'
-import { Button, Textarea } from '@styleguide'
+import { Button } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { stripHtml } from 'string-strip-html'
 import {
   createWebsite,
   getUserWebsite,
@@ -21,15 +21,21 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
-const stripIfPresent = (value: string | undefined | null): string =>
-  value ? stripHtml(value).result : ''
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
 
 const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>
   (raw ?? []).map((i) => ({
-    title: stripIfPresent(i.title),
-    description: stripIfPresent(i.description),
+    title: i.title ?? '',
+    description: i.description ?? '',
   }))
 
 export default function CandidateProfile(): React.JSX.Element {
@@ -42,20 +48,22 @@ export default function CandidateProfile(): React.JSX.Element {
   })
 
   const [bio, setBio] = useState('')
+  const [bioPlainLength, setBioPlainLength] = useState(0)
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(stripIfPresent(website.content?.about?.bio))
+    setBio(website.content?.about?.bio ?? '')
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])
 
-  const trimmedBioLength = bio.trim().length
+  const initialBio = website?.content?.about?.bio ?? ''
+
   const canSubmit =
-    trimmedBioLength >= MIN_BIO_LENGTH &&
+    bioPlainLength >= MIN_BIO_LENGTH &&
     issues.length >= MIN_POLICY_PRIORITIES &&
     !submitting
 
@@ -94,19 +102,17 @@ export default function CandidateProfile(): React.JSX.Element {
         </div>
 
         <div className="mt-10">
-          <label htmlFor="why" className="mb-1.5 block text-sm font-medium">
+          <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
-          </label>
-          <Textarea
-            id="why"
-            rows={5}
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-            disabled={submitting}
+          </div>
+          <RichEditor
+            initialText={initialBio}
+            onChangeCallback={setBio}
+            onTextLengthChange={setBioPlainLength}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
-            <span>{trimmedBioLength}</span>
+            <span>{bioPlainLength}</span>
           </div>
         </div>
 

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,0 +1,30 @@
+import { Button, Textarea } from '@styleguide'
+import { ChevronLeft } from 'lucide-react'
+import Link from 'next/link'
+
+export default function CandidateProfile(): React.JSX.Element {
+  return (
+    <div className="flex flex-col h-screen justify-between items-center pt-2 md:pt-4">
+      <div className="max-w-2xl mx-auto p-4 w-full">
+        <div className="flex items-center justify-between">
+          <Link href="/dashboard/profile">
+            <ChevronLeft className="w-6 h-6" />
+          </Link>
+          <div className="md:text-xl">CandidateProfile</div>
+          <div>&nbsp;</div>
+        </div>
+
+        <div className="mt-10">
+          <label htmlFor="why">Why are you running?</label>
+          <Textarea id="why" />
+          <p className="text-sm text-muted-foreground">500 character minimum</p>
+        </div>
+      </div>
+      <div className="max-w-2xl mx-auto p-4 md:p-8 flex justify-end w-full">
+        <Button variant="secondary" type="submit">
+          Submit
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -4,12 +4,15 @@ import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useQueryClient } from '@tanstack/react-query'
-import { useCampaign } from '@shared/hooks/useCampaign'
-import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
-import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  createWebsite,
+  getUserWebsite,
+  updateWebsite,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
 import { useSnackbar } from 'helpers/useSnackbar'
-import { CustomIssue } from 'helpers/types'
+import { Website, WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
@@ -17,47 +20,62 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
+const normalizeIssues = (
+  raw: { title?: string; description?: string }[] | undefined,
+): WebsiteIssue[] =>
+  (raw ?? []).map((i) => ({
+    title: i.title ?? '',
+    description: i.description ?? '',
+  }))
+
 export default function CandidateProfile(): React.JSX.Element {
-  const [campaign] = useCampaign()
   const router = useRouter()
   const queryClient = useQueryClient()
   const { errorSnackbar } = useSnackbar()
+  const { data: website } = useQuery<Website | null>({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
 
-  const [whyRunning, setWhyRunning] = useState('')
-  const [customIssues, setCustomIssues] = useState<CustomIssue[]>([])
+  const [bio, setBio] = useState('')
+  const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
-    if (seededRef.current || !campaign?.details) return
-    setWhyRunning(campaign.details.whyRunning ?? '')
-    setCustomIssues(campaign.details.customIssues ?? [])
+    if (seededRef.current || !website) return
+    setBio(website.content?.about?.bio ?? '')
+    setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
-  }, [campaign])
+  }, [website])
 
-  const trimmedWhyRunningLength = whyRunning.trim().length
+  const trimmedBioLength = bio.trim().length
   const canSubmit =
-    trimmedWhyRunningLength >= MIN_BIO_LENGTH &&
-    customIssues.length >= MIN_POLICY_PRIORITIES &&
+    trimmedBioLength >= MIN_BIO_LENGTH &&
+    issues.length >= MIN_POLICY_PRIORITIES &&
     !submitting
 
   const handleSubmit = async () => {
     if (!canSubmit) return
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
-    const result = await updateCampaign([
-      { key: 'details.whyRunning', value: whyRunning },
-      { key: 'details.customIssues', value: customIssues },
-    ])
-    if (!result) {
+    try {
+      if (!website) {
+        const createResp = await createWebsite()
+        if (!createResp.ok) throw new Error('create failed')
+      }
+      const result = await updateWebsite({
+        about: { ...website?.content?.about, bio, issues },
+      })
+      if (!result || !result.ok) throw new Error('update failed')
+      trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+      await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+      router.push('/dashboard/profile')
+    } catch {
       trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
       errorSnackbar('Failed to save candidate profile. Please try again.')
       setSubmitting(false)
-      return
     }
-    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
-    await queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
-    router.push('/dashboard/profile')
   }
 
   return (
@@ -78,20 +96,20 @@ export default function CandidateProfile(): React.JSX.Element {
           <Textarea
             id="why"
             rows={5}
-            value={whyRunning}
-            onChange={(e) => setWhyRunning(e.target.value)}
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
             disabled={submitting}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
-            <span>{trimmedWhyRunningLength}</span>
+            <span>{trimmedBioLength}</span>
           </div>
         </div>
 
         <div className="mt-8">
           <PolicyPriorities
-            issues={customIssues}
-            onChange={setCustomIssues}
+            issues={issues}
+            onChange={setIssues}
             disabled={submitting}
           />
         </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { stripHtml } from 'string-strip-html'
 import {
   createWebsite,
   getUserWebsite,
@@ -20,12 +21,15 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
+const stripIfPresent = (value: string | undefined | null): string =>
+  value ? stripHtml(value).result : ''
+
 const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>
   (raw ?? []).map((i) => ({
-    title: i.title ?? '',
-    description: i.description ?? '',
+    title: stripIfPresent(i.title),
+    description: stripIfPresent(i.description),
   }))
 
 export default function CandidateProfile(): React.JSX.Element {
@@ -44,7 +48,7 @@ export default function CandidateProfile(): React.JSX.Element {
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(website.content?.about?.bio ?? '')
+    setBio(stripIfPresent(website.content?.about?.bio))
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,27 +1,111 @@
+'use client'
 import { Button, Textarea } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { CustomIssue } from 'helpers/types'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import {
+  MIN_BIO_LENGTH,
+  MIN_POLICY_PRIORITIES,
+} from '../candidateProfile.utils'
+import PolicyPriorities from './PolicyPriorities'
 
 export default function CandidateProfile(): React.JSX.Element {
+  const [campaign] = useCampaign()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+
+  const [whyRunning, setWhyRunning] = useState('')
+  const [customIssues, setCustomIssues] = useState<CustomIssue[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    if (seededRef.current || !campaign?.details) return
+    setWhyRunning(campaign.details.whyRunning ?? '')
+    setCustomIssues(campaign.details.customIssues ?? [])
+    seededRef.current = true
+  }, [campaign])
+
+  const trimmedWhyRunningLength = whyRunning.trim().length
+  const canSubmit =
+    trimmedWhyRunningLength >= MIN_BIO_LENGTH &&
+    customIssues.length >= MIN_POLICY_PRIORITIES &&
+    !submitting
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
+    setSubmitting(true)
+    const result = await updateCampaign([
+      { key: 'details.whyRunning', value: whyRunning },
+      { key: 'details.customIssues', value: customIssues },
+    ])
+    if (!result) {
+      trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
+      errorSnackbar('Failed to save candidate profile. Please try again.')
+      setSubmitting(false)
+      return
+    }
+    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+    await queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
+    router.push('/dashboard/profile')
+  }
+
   return (
-    <div className="flex flex-col h-screen justify-between items-center pt-2 md:pt-4">
-      <div className="max-w-2xl mx-auto p-4 w-full">
+    <div className="flex h-screen flex-col items-center justify-between pt-2 md:pt-4">
+      <div className="mx-auto w-full max-w-2xl p-4">
         <div className="flex items-center justify-between">
-          <Link href="/dashboard/profile">
-            <ChevronLeft className="w-6 h-6" />
+          <Link href="/dashboard/profile" aria-label="Back to profile">
+            <ChevronLeft className="h-6 w-6" />
           </Link>
-          <div className="md:text-xl">CandidateProfile</div>
+          <div className="font-medium md:text-xl">Candidate profile</div>
           <div>&nbsp;</div>
         </div>
 
         <div className="mt-10">
-          <label htmlFor="why">Why are you running?</label>
-          <Textarea id="why" />
-          <p className="text-sm text-muted-foreground">500 character minimum</p>
+          <label htmlFor="why" className="mb-1.5 block text-sm font-medium">
+            Why are you running?
+          </label>
+          <Textarea
+            id="why"
+            rows={5}
+            value={whyRunning}
+            onChange={(e) => setWhyRunning(e.target.value)}
+            disabled={submitting}
+          />
+          <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
+            <span>{MIN_BIO_LENGTH} character minimum</span>
+            <span>{trimmedWhyRunningLength}</span>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <PolicyPriorities
+            issues={customIssues}
+            onChange={setCustomIssues}
+            disabled={submitting}
+          />
         </div>
       </div>
-      <div className="max-w-2xl mx-auto p-4 md:p-8 flex justify-end w-full">
-        <Button variant="secondary" type="submit">
+
+      <div className="mx-auto flex w-full max-w-2xl justify-end p-4 md:p-8">
+        <Button
+          variant="secondary"
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          loading={submitting}
+          loadingText="Submitting"
+        >
           Submit
         </Button>
       </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { Button, Input, Textarea } from '@styleguide'
 import { useState } from 'react'
-import { CustomIssue } from 'helpers/types'
+import { WebsiteIssue } from 'helpers/types'
 import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
 
 interface PolicyFormProps {
-  initial?: CustomIssue
+  initial?: WebsiteIssue
   showDelete: boolean
-  onSave: (issue: CustomIssue) => void
+  onSave: (issue: WebsiteIssue) => void
   onDelete: () => void
 }
 
@@ -18,12 +18,13 @@ export default function PolicyForm({
   onDelete,
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
-  const [position, setPosition] = useState(initial?.position ?? '')
+  const [description, setDescription] = useState(initial?.description ?? '')
 
   const trimmedTitle = title.trim()
-  const trimmedPosition = position.trim()
+  const trimmedDescription = description.trim()
   const canSave =
-    trimmedTitle.length > 0 && trimmedPosition.length >= MIN_POLICY_FOCUS_LENGTH
+    trimmedTitle.length > 0 &&
+    trimmedDescription.length >= MIN_POLICY_FOCUS_LENGTH
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -48,12 +49,12 @@ export default function PolicyForm({
         <Textarea
           id="policy-focus"
           rows={4}
-          value={position}
-          onChange={(e) => setPosition(e.target.value)}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
-          <span>{trimmedPosition.length}</span>
+          <span>{trimmedDescription.length}</span>
         </div>
       </div>
 
@@ -75,7 +76,7 @@ export default function PolicyForm({
           size="medium"
           disabled={!canSave}
           onClick={() =>
-            onSave({ title: trimmedTitle, position: trimmedPosition })
+            onSave({ title: trimmedTitle, description: trimmedDescription })
           }
         >
           Save

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,8 +1,18 @@
 'use client'
-import { Button, Input, Textarea } from '@styleguide'
+import { Button, Input } from '@styleguide'
+import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
 import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
 
 interface PolicyFormProps {
   initial?: WebsiteIssue
@@ -19,12 +29,12 @@ export default function PolicyForm({
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
+  const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
+  const [initialDescription] = useState(initial?.description ?? '')
 
   const trimmedTitle = title.trim()
-  const trimmedDescription = description.trim()
   const canSave =
-    trimmedTitle.length > 0 &&
-    trimmedDescription.length >= MIN_POLICY_FOCUS_LENGTH
+    trimmedTitle.length > 0 && descriptionPlainLength >= MIN_POLICY_FOCUS_LENGTH
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -43,18 +53,15 @@ export default function PolicyForm({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="policy-focus" className="text-sm font-medium">
-          Policy focus
-        </label>
-        <Textarea
-          id="policy-focus"
-          rows={4}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+        <div className="text-sm font-medium">Policy focus</div>
+        <RichEditor
+          initialText={initialDescription}
+          onChangeCallback={setDescription}
+          onTextLengthChange={setDescriptionPlainLength}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
-          <span>{trimmedDescription.length}</span>
+          <span>{descriptionPlainLength}</span>
         </div>
       </div>
 
@@ -75,9 +82,7 @@ export default function PolicyForm({
           type="button"
           size="medium"
           disabled={!canSave}
-          onClick={() =>
-            onSave({ title: trimmedTitle, description: trimmedDescription })
-          }
+          onClick={() => onSave({ title: trimmedTitle, description })}
         >
           Save
         </Button>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { Button, Input, Textarea } from '@styleguide'
+import { useState } from 'react'
+import { CustomIssue } from 'helpers/types'
+import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+
+interface PolicyFormProps {
+  initial?: CustomIssue
+  showDelete: boolean
+  onSave: (issue: CustomIssue) => void
+  onDelete: () => void
+}
+
+export default function PolicyForm({
+  initial,
+  showDelete,
+  onSave,
+  onDelete,
+}: PolicyFormProps): React.JSX.Element {
+  const [title, setTitle] = useState(initial?.title ?? '')
+  const [position, setPosition] = useState(initial?.position ?? '')
+
+  const trimmedTitle = title.trim()
+  const trimmedPosition = position.trim()
+  const canSave =
+    trimmedTitle.length > 0 && trimmedPosition.length >= MIN_POLICY_FOCUS_LENGTH
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <h2 className="text-lg font-semibold">Policy priority</h2>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="policy-title" className="text-sm font-medium">
+          Policy title
+        </label>
+        <Input
+          id="policy-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="policy-focus" className="text-sm font-medium">
+          Policy focus
+        </label>
+        <Textarea
+          id="policy-focus"
+          rows={4}
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
+          <span>{trimmedPosition.length}</span>
+        </div>
+      </div>
+
+      <div className="mt-2 flex items-center justify-between">
+        {showDelete ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="medium"
+            onClick={onDelete}
+          >
+            Delete
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Button
+          type="button"
+          size="medium"
+          disabled={!canSave}
+          onClick={() =>
+            onSave({ title: trimmedTitle, position: trimmedPosition })
+          }
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -6,7 +6,6 @@ import AlertDialog from '@shared/utils/AlertDialog'
 import { CustomIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
-import TextingComplianceHeader from '../../shared/TextingComplianceHeader'
 
 const POLICY_MODAL_MODE = {
   ADD: 'add',
@@ -102,11 +101,9 @@ export default function PolicyPriorities({
 
   return (
     <div>
-      <TextingComplianceHeader>
-        <h5 className="flex-1 text-center md:hidden text-sm font-medium">
-          Your policy priorities
-        </h5>
-      </TextingComplianceHeader>
+      <div className="mb-1.5 block text-sm font-medium">
+        Your policy priorities
+      </div>
       <div className="flex flex-col gap-3">
         {issues.map((issue, index) => (
           <button

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -6,6 +6,7 @@ import AlertDialog from '@shared/utils/AlertDialog'
 import { CustomIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
+import TextingComplianceHeader from '../../shared/TextingComplianceHeader'
 
 const POLICY_MODAL_MODE = {
   ADD: 'add',
@@ -49,8 +50,14 @@ export default function PolicyPriorities({
     setModal({ open: true, mode: POLICY_MODAL_MODE.EDIT, index })
   }
 
-  const handleCancelEdit = () => {
-    if (modal.open) trackEvent(EVENTS.Profile.PolicyPriorities.CancelEdit)
+  const handleCancel = () => {
+    if (modal.open) {
+      trackEvent(
+        modal.mode === POLICY_MODAL_MODE.EDIT
+          ? EVENTS.Profile.PolicyPriorities.CancelEdit
+          : EVENTS.Profile.PolicyPriorities.CancelAdd,
+      )
+    }
     setModal({ open: false })
   }
 
@@ -95,7 +102,11 @@ export default function PolicyPriorities({
 
   return (
     <div>
-      <div className="mb-1.5 text-sm font-medium">Your policy priorities</div>
+      <TextingComplianceHeader>
+        <h5 className="flex-1 text-center md:hidden text-sm font-medium">
+          Your policy priorities
+        </h5>
+      </TextingComplianceHeader>
       <div className="flex flex-col gap-3">
         {issues.map((issue, index) => (
           <button
@@ -130,7 +141,7 @@ export default function PolicyPriorities({
       <ModalOrDrawer
         open={modal.open}
         onOpenChange={(open) => {
-          if (!open) handleCancelEdit()
+          if (!open) handleCancel()
         }}
         title="Policy priority"
       >

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -1,0 +1,156 @@
+'use client'
+import { Pencil, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
+import AlertDialog from '@shared/utils/AlertDialog'
+import { CustomIssue } from 'helpers/types'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import PolicyForm from './PolicyForm'
+
+const POLICY_MODAL_MODE = {
+  ADD: 'add',
+  EDIT: 'edit',
+} as const
+
+type PolicyModalMode =
+  (typeof POLICY_MODAL_MODE)[keyof typeof POLICY_MODAL_MODE]
+
+type ModalState =
+  | { open: false }
+  | { open: true; mode: typeof POLICY_MODAL_MODE.ADD }
+  | { open: true; mode: typeof POLICY_MODAL_MODE.EDIT; index: number }
+
+interface PolicyPrioritiesProps {
+  issues: CustomIssue[]
+  onChange: (issues: CustomIssue[]) => void
+  disabled?: boolean
+}
+
+const buildFormKey = (mode: PolicyModalMode, index?: number): string =>
+  mode === POLICY_MODAL_MODE.EDIT ? `${mode}-${index}` : mode
+
+export default function PolicyPriorities({
+  issues,
+  onChange,
+  disabled,
+}: PolicyPrioritiesProps): React.JSX.Element {
+  const [modal, setModal] = useState<ModalState>({ open: false })
+  const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(
+    null,
+  )
+
+  const handleClickAdd = () => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickAdd)
+    setModal({ open: true, mode: POLICY_MODAL_MODE.ADD })
+  }
+
+  const handleClickEdit = (index: number) => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickEdit)
+    setModal({ open: true, mode: POLICY_MODAL_MODE.EDIT, index })
+  }
+
+  const handleCancelEdit = () => {
+    if (modal.open) trackEvent(EVENTS.Profile.PolicyPriorities.CancelEdit)
+    setModal({ open: false })
+  }
+
+  const handleSave = (issue: CustomIssue) => {
+    if (!modal.open) return
+    if (modal.mode === POLICY_MODAL_MODE.EDIT) {
+      trackEvent(EVENTS.Profile.PolicyPriorities.SubmitEdit)
+      const next = [...issues]
+      next[modal.index] = issue
+      onChange(next)
+    } else {
+      trackEvent(EVENTS.Profile.PolicyPriorities.SubmitAdd)
+      onChange([...issues, issue])
+    }
+    setModal({ open: false })
+  }
+
+  const handleClickDelete = () => {
+    if (!modal.open || modal.mode !== POLICY_MODAL_MODE.EDIT) return
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickDelete)
+    setPendingDeleteIndex(modal.index)
+  }
+
+  const handleCancelDelete = () => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.CancelDelete)
+    setPendingDeleteIndex(null)
+  }
+
+  const handleConfirmDelete = () => {
+    if (pendingDeleteIndex === null) return
+    trackEvent(EVENTS.Profile.PolicyPriorities.SubmitDelete)
+    onChange(issues.filter((_, i) => i !== pendingDeleteIndex))
+    setPendingDeleteIndex(null)
+    setModal({ open: false })
+  }
+
+  const isEditing = modal.open && modal.mode === POLICY_MODAL_MODE.EDIT
+  const initial = isEditing ? issues[modal.index] : undefined
+  const formKey = modal.open
+    ? buildFormKey(modal.mode, isEditing ? modal.index : undefined)
+    : POLICY_MODAL_MODE.ADD
+
+  return (
+    <div>
+      <div className="mb-1.5 text-sm font-medium">Your policy priorities</div>
+      <div className="flex flex-col gap-3">
+        {issues.map((issue, index) => (
+          <button
+            key={index}
+            type="button"
+            disabled={disabled}
+            onClick={() => handleClickEdit(index)}
+            aria-label={`Edit ${issue.title}`}
+            className="flex items-start gap-2 rounded-md border border-input bg-white px-3 py-2 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-base">{issue.title}</div>
+              <div className="truncate text-sm text-foreground">
+                {issue.position}
+              </div>
+            </div>
+            <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={handleClickAdd}
+          aria-label="Add a policy priority"
+          className="flex items-center gap-2 rounded-md border border-dashed border-input bg-white px-3 py-2 text-base text-muted-foreground transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+          Add a policy priority
+        </button>
+      </div>
+
+      <ModalOrDrawer
+        open={modal.open}
+        onOpenChange={(open) => {
+          if (!open) handleCancelEdit()
+        }}
+        title="Policy priority"
+      >
+        <PolicyForm
+          key={formKey}
+          initial={initial}
+          showDelete={isEditing}
+          onSave={handleSave}
+          onDelete={handleClickDelete}
+        />
+      </ModalOrDrawer>
+
+      <AlertDialog
+        open={pendingDeleteIndex !== null}
+        title="Delete policy priority"
+        description="Are you sure you want to delete this policy priority?"
+        proceedLabel="Delete"
+        handleClose={handleCancelDelete}
+        handleProceed={handleConfirmDelete}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
+import { stripHtml } from 'string-strip-html'
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
 import AlertDialog from '@shared/utils/AlertDialog'
 import { WebsiteIssue } from 'helpers/types'
@@ -118,7 +119,7 @@ export default function PolicyPriorities({
             <div className="min-w-0 flex-1">
               <div className="truncate text-base">{issue.title}</div>
               <div className="truncate text-sm text-foreground">
-                {issue.description}
+                {issue.description ? stripHtml(issue.description).result : ''}
               </div>
             </div>
             <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -3,7 +3,7 @@ import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
 import AlertDialog from '@shared/utils/AlertDialog'
-import { CustomIssue } from 'helpers/types'
+import { WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
 
@@ -21,8 +21,8 @@ type ModalState =
   | { open: true; mode: typeof POLICY_MODAL_MODE.EDIT; index: number }
 
 interface PolicyPrioritiesProps {
-  issues: CustomIssue[]
-  onChange: (issues: CustomIssue[]) => void
+  issues: WebsiteIssue[]
+  onChange: (issues: WebsiteIssue[]) => void
   disabled?: boolean
 }
 
@@ -60,7 +60,7 @@ export default function PolicyPriorities({
     setModal({ open: false })
   }
 
-  const handleSave = (issue: CustomIssue) => {
+  const handleSave = (issue: WebsiteIssue) => {
     if (!modal.open) return
     if (modal.mode === POLICY_MODAL_MODE.EDIT) {
       trackEvent(EVENTS.Profile.PolicyPriorities.SubmitEdit)
@@ -78,6 +78,7 @@ export default function PolicyPriorities({
     if (!modal.open || modal.mode !== POLICY_MODAL_MODE.EDIT) return
     trackEvent(EVENTS.Profile.PolicyPriorities.ClickDelete)
     setPendingDeleteIndex(modal.index)
+    setModal({ open: false })
   }
 
   const handleCancelDelete = () => {
@@ -117,7 +118,7 @@ export default function PolicyPriorities({
             <div className="min-w-0 flex-1">
               <div className="truncate text-base">{issue.title}</div>
               <div className="truncate text-sm text-foreground">
-                {issue.position}
+                {issue.description}
               </div>
             </div>
             <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />

--- a/app/dashboard/profile/texting-compliance/candidate-profile/page.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/page.tsx
@@ -1,0 +1,15 @@
+import pageMetaData from 'helpers/metadataHelper'
+import CandidateProfile from './components/CandidateProfile'
+import candidateAccess from 'app/dashboard/shared/candidateAccess'
+
+const meta = pageMetaData({
+  title: 'Candidate Profile | GoodParty.org',
+  description: 'Candidate profile settings for GoodParty.org.',
+})
+export const metadata = meta
+
+export default async function Page(): Promise<React.JSX.Element> {
+  await candidateAccess()
+
+  return <CandidateProfile />
+}

--- a/app/dashboard/website/util/website.util.ts
+++ b/app/dashboard/website/util/website.util.ts
@@ -62,6 +62,18 @@ export async function updateWebsite(
   }
 }
 
+export const USER_WEBSITE_QUERY_KEY = ['user-website']
+
+export async function getUserWebsite(): Promise<Website | null> {
+  try {
+    const resp = await clientFetch<Website>(apiRoutes.website.get)
+    return resp.ok ? resp.data : null
+  } catch (e) {
+    console.error('error', e)
+    return null
+  }
+}
+
 export async function validateVanityPath(
   vanityPath: string,
 ): Promise<ApiResponse<{ available: boolean }>> {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -422,6 +422,21 @@ export const EVENTS = {
       SubmitDelete: 'Profile - Top Issues: Submit Delete',
       CancelDelete: 'Profile - Top Issues: Cancel Delete',
     },
+    PolicyPriorities: {
+      ClickAdd: 'Profile - Policy Priorities: Click Add',
+      ClickEdit: 'Profile - Policy Priorities: Click Edit',
+      SubmitAdd: 'Profile - Policy Priorities: Submit Add',
+      SubmitEdit: 'Profile - Policy Priorities: Submit Edit',
+      CancelEdit: 'Profile - Policy Priorities: Cancel Edit',
+      ClickDelete: 'Profile - Policy Priorities: Click Delete',
+      SubmitDelete: 'Profile - Policy Priorities: Submit Delete',
+      CancelDelete: 'Profile - Policy Priorities: Cancel Delete',
+    },
+    CandidateProfile: {
+      ClickSubmit: 'Profile - Candidate Profile: Click Submit',
+      SubmitSuccess: 'Profile - Candidate Profile: Submit Success',
+      SubmitError: 'Profile - Candidate Profile: Submit Error',
+    },
   },
   Settings: {
     PersonalInfo: {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -427,6 +427,7 @@ export const EVENTS = {
       ClickEdit: 'Profile - Policy Priorities: Click Edit',
       SubmitAdd: 'Profile - Policy Priorities: Submit Add',
       SubmitEdit: 'Profile - Policy Priorities: Submit Edit',
+      CancelAdd: 'Profile - Policy Priorities: Cancel Add',
       CancelEdit: 'Profile - Policy Priorities: Cancel Edit',
       ClickDelete: 'Profile - Policy Priorities: Click Delete',
       SubmitDelete: 'Profile - Policy Priorities: Submit Delete',

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -117,7 +117,6 @@ export interface CampaignDetails {
   pledged?: boolean
   isProUpdatedAt?: number
   customIssues?: CustomIssue[]
-  whyRunning?: string
   runningAgainst?: RunningAgainst[]
   geoLocation?: CampaignGeoLocation
   geoLocationFailed?: boolean

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -117,6 +117,7 @@ export interface CampaignDetails {
   pledged?: boolean
   isProUpdatedAt?: number
   customIssues?: CustomIssue[]
+  whyRunning?: string
   runningAgainst?: RunningAgainst[]
   geoLocation?: CampaignGeoLocation
   geoLocationFailed?: boolean


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Writes user-entered content into persisted website data and uses it to gate the compliance flow, so validation/shape mismatches or fetch failures could block progress or overwrite `about` content.
> 
> **Overview**
> Adds a new Texting Compliance **Candidate Profile** page where users enter a long-form bio and manage “policy priorities” (add/edit/delete via modal) and saves the data into `website.content.about` via `createWebsite`/`updateWebsite`.
> 
> Updates the Texting Compliance steps UI to be **progress-aware** by fetching the user website with a new shared `getUserWebsite` + `USER_WEBSITE_QUERY_KEY` and marking the first step completed/next step enabled when `isCandidateProfileComplete` criteria are met; also adds corresponding analytics events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac35811a89507bb62979ad35b310c1085fc26af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->