### PR TITLE
updated contact link on /profile page to use marketing url - ENG-7337

### DIFF
--- a/app/dashboard/profile/components/AccountSettingsSection.tsx
+++ b/app/dashboard/profile/components/AccountSettingsSection.tsx
@@ -10,6 +10,7 @@ import { useCampaign } from '@shared/hooks/useCampaign'
 import { useUser } from '@shared/hooks/useUser'
 import { AccountSettingsButton } from 'app/dashboard/profile/components/AccountSettingsButton'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { getMarketingUrl } from 'helpers/linkhelper'
 import { useEffect } from 'react'
 import { identifyUser } from '@shared/utils/analytics'
 
@@ -57,7 +58,7 @@ export const AccountSettingsSection = (): React.JSX.Element => {
               Need help?
               <Link
                 className="ml-1 underline text-info-main"
-                href="/contact"
+                href={getMarketingUrl('/contact')}
                 onClick={() =>
                   trackEvent(EVENTS.Settings.Account.ClickSendEmail)
                 }


### PR DESCRIPTION
updated contact link on /profile page to use marketing url instead of relative url that 404s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a single navigation link; no auth/data-path logic impacted.
> 
> **Overview**
> Fixes the Profile `AccountSettingsSection` “Send us an email” link by swapping the relative `href="/contact"` for `href={getMarketingUrl('/contact')}`, ensuring it resolves to the marketing site domain (and avoiding a 404).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3de2f3f38b4aee9930dbd49bc3d3e7fe15a473. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->