### PR TITLE
Feat: redesign profile page

### DIFF
--- a/app/dashboard/campaign-details/components/DetailsPage.tsx
+++ b/app/dashboard/campaign-details/components/DetailsPage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 import DashboardLayout from '../../shared/DashboardLayout'
 import CampaignSection from './CampaignSection'
 import FunFactSection from './FunFactSection'
@@ -7,6 +8,8 @@ import IssuesSection from './IssuesSection'
 import OfficeSection from './OfficeSection'
 import RunningAgainstSection from './RunningAgainstSection'
 import WhySection from './WhySection'
+import WhyRunningSection from './WhyRunningSection'
+import PolicyPrioritiesSection from './PolicyPrioritiesSection'
 import { CandidatePositionsProvider } from 'app/dashboard/campaign-details/components/issues/CandidatePositionsProvider'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { Campaign, User, CandidatePosition } from 'helpers/types'
@@ -30,6 +33,8 @@ export default function DetailsPage(
 ): React.JSX.Element {
   const [campaign] = useCampaign()
   const campaignProps = { ...props, campaign: campaign ?? undefined }
+  const { ready, enabled } = useProUpgradeFlag()
+  const useNewSections = ready && enabled
 
   return (
     <DashboardLayout {...props}>
@@ -37,10 +42,19 @@ export default function DetailsPage(
         <div className="max-w-[940px] mx-auto bg-gray-50 rounded-xl px-6 py-5">
           {campaign && <CampaignSection {...campaignProps} />}
           <OfficeSection campaign={campaign ?? undefined} />
-          {campaign && <RunningAgainstSection {...campaignProps} />}
-          {campaign && <WhySection {...campaignProps} />}
-          {campaign && <FunFactSection {...campaignProps} />}
-          {campaign && <IssuesSection {...campaignProps} />}
+          {useNewSections ? (
+            <>
+              <WhyRunningSection />
+              <PolicyPrioritiesSection />
+            </>
+          ) : (
+            <>
+              {campaign && <RunningAgainstSection {...campaignProps} />}
+              {campaign && <WhySection {...campaignProps} />}
+              {campaign && <FunFactSection {...campaignProps} />}
+              {campaign && <IssuesSection {...campaignProps} />}
+            </>
+          )}
         </div>
       </CandidatePositionsProvider>
     </DashboardLayout>

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import H3 from '@shared/typography/H3'
+import Body1 from '@shared/typography/Body1'
+import PrimaryButton from '@shared/buttons/PrimaryButton'
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getUserWebsite,
+  saveAboutFields,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { Website, WebsiteIssue } from 'helpers/types'
+import {
+  MIN_POLICY_PRIORITIES,
+  normalizeIssues,
+} from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+import PolicyPriorities from 'app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities'
+
+export default function PolicyPrioritiesSection(): React.JSX.Element {
+  const queryClient = useQueryClient()
+  const { errorSnackbar, successSnackbar } = useSnackbar()
+  const { data: website } = useQuery<Website | null>({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+
+  const [issues, setIssues] = useState<WebsiteIssue[]>([])
+  const [saving, setSaving] = useState(false)
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    if (seededRef.current || !website) return
+    setIssues(normalizeIssues(website.content?.about?.issues))
+    seededRef.current = true
+  }, [website])
+
+  const canSave = issues.length >= MIN_POLICY_PRIORITIES && !saving
+
+  const handleSave = async () => {
+    if (!canSave) return
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickSave)
+    setSaving(true)
+    const ok = await saveAboutFields({ issues }, website)
+    if (!ok) {
+      errorSnackbar('Failed to save policy priorities. Please try again.')
+      setSaving(false)
+      return
+    }
+    await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+    successSnackbar('Policy priorities saved')
+    setSaving(false)
+  }
+
+  return (
+    <section className="border-t pt-6 border-gray-600">
+      <H3>Your policy priorities</H3>
+      <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
+        Tell potential voters about the policy priorities you&apos;ll focus on.
+      </Body1>
+      <PolicyPriorities
+        issues={issues}
+        onChange={setIssues}
+        disabled={saving}
+      />
+      <div className="flex justify-end mt-6 mb-6">
+        <PrimaryButton
+          loading={saving}
+          disabled={!canSave}
+          onClick={handleSave}
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </PrimaryButton>
+      </div>
+    </section>
+  )
+}

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -43,7 +43,7 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
     if (!canSave) return
     trackEvent(EVENTS.Profile.PolicyPriorities.ClickSave)
     setSaving(true)
-    const ok = await saveAboutFields({ issues }, website)
+    const ok = await saveAboutFields({ issues })
     if (!ok) {
       errorSnackbar('Failed to save policy priorities. Please try again.')
       setSaving(false)

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -31,11 +31,12 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
   const [saving, setSaving] = useState(false)
   const seededRef = useRef(false)
 
+  const websiteIssues = website?.content?.about?.issues
   useEffect(() => {
     if (seededRef.current || !website) return
-    setIssues(normalizeIssues(website.content?.about?.issues))
+    setIssues(normalizeIssues(websiteIssues))
     seededRef.current = true
-  }, [website])
+  }, [website, websiteIssues])
 
   const canSave = issues.length >= MIN_POLICY_PRIORITIES && !saving
 

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import H3 from '@shared/typography/H3'
+import Body1 from '@shared/typography/Body1'
+import PrimaryButton from '@shared/buttons/PrimaryButton'
+import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getUserWebsite,
+  saveAboutFields,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { Website } from 'helpers/types'
+import {
+  MIN_BIO_LENGTH,
+  getBioPlainLength,
+} from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
+
+export default function WhyRunningSection(): React.JSX.Element {
+  const queryClient = useQueryClient()
+  const { errorSnackbar, successSnackbar } = useSnackbar()
+  const { data: website } = useQuery<Website | null>({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+
+  const [bio, setBio] = useState('')
+  const [bioPlainLength, setBioPlainLength] = useState(0)
+  const [saving, setSaving] = useState(false)
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    if (seededRef.current || !website) return
+    const initial = website.content?.about?.bio ?? ''
+    setBio(initial)
+    // Seed length up-front so Save isn't falsely disabled before the editor
+    // emits its first onTextLengthChange.
+    setBioPlainLength(getBioPlainLength(initial))
+    seededRef.current = true
+  }, [website])
+
+  const initialBio = website?.content?.about?.bio ?? ''
+  const canSave = bioPlainLength >= MIN_BIO_LENGTH && !saving
+
+  const handleSave = async () => {
+    if (!canSave) return
+    trackEvent(EVENTS.Profile.WhyRunning.ClickSave)
+    setSaving(true)
+    const ok = await saveAboutFields({ bio }, website)
+    if (!ok) {
+      errorSnackbar('Failed to save. Please try again.')
+      setSaving(false)
+      return
+    }
+    await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+    successSnackbar('Bio saved')
+    setSaving(false)
+  }
+
+  return (
+    <section className="border-t pt-6 border-gray-600">
+      <H3>Why are you running?</H3>
+      <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
+        Tell potential voters why you&apos;re running for office.
+      </Body1>
+      <RichEditor
+        initialText={initialBio}
+        onChangeCallback={setBio}
+        onTextLengthChange={setBioPlainLength}
+      />
+      <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
+        <span>{MIN_BIO_LENGTH} character minimum</span>
+        <span>{bioPlainLength}</span>
+      </div>
+      <div className="flex justify-end mt-6 mb-6">
+        <PrimaryButton
+          loading={saving}
+          disabled={!canSave}
+          onClick={handleSave}
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </PrimaryButton>
+      </div>
+    </section>
+  )
+}

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -58,7 +58,7 @@ export default function WhyRunningSection(): React.JSX.Element {
     if (!canSave) return
     trackEvent(EVENTS.Profile.WhyRunning.ClickSave)
     setSaving(true)
-    const ok = await saveAboutFields({ bio }, website)
+    const ok = await saveAboutFields({ bio })
     if (!ok) {
       errorSnackbar('Failed to save. Please try again.')
       setSaving(false)

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -39,6 +39,13 @@ export default function WhyRunningSection(): React.JSX.Element {
   const [bio, setBio] = useState('')
   const [bioPlainLength, setBioPlainLength] = useState(0)
   const [saving, setSaving] = useState(false)
+  // `initialBio` must be captured exactly once and never change afterward.
+  // RichEditor re-pastes its content whenever `initialText` changes by value,
+  // so if we derived it live from the query it would clobber the user's
+  // in-progress edits whenever `invalidateQueries` (after save) triggers a
+  // refetch. `null` means "not seeded yet" so we can defer mounting the
+  // editor until we have the real value.
+  const [initialBio, setInitialBio] = useState<string | null>(null)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -48,10 +55,10 @@ export default function WhyRunningSection(): React.JSX.Element {
     // Seed length up-front so Save isn't falsely disabled before the editor
     // emits its first onTextLengthChange.
     setBioPlainLength(getBioPlainLength(initial))
+    setInitialBio(initial)
     seededRef.current = true
   }, [website])
 
-  const initialBio = website?.content?.about?.bio ?? ''
   const canSave = bioPlainLength >= MIN_BIO_LENGTH && !saving
 
   const handleSave = async () => {
@@ -75,11 +82,13 @@ export default function WhyRunningSection(): React.JSX.Element {
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters why you&apos;re running for office.
       </Body1>
-      <RichEditor
-        initialText={initialBio}
-        onChangeCallback={setBio}
-        onTextLengthChange={setBioPlainLength}
-      />
+      {initialBio !== null && (
+        <RichEditor
+          initialText={initialBio}
+          onChangeCallback={setBio}
+          onTextLengthChange={setBioPlainLength}
+        />
+      )}
       <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
         <span>{MIN_BIO_LENGTH} character minimum</span>
         <span>{bioPlainLength}</span>

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
@@ -1,21 +1,17 @@
 'use client'
 
-import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 import TextingCompliance, {
   TextingComplianceProps,
 } from 'app/dashboard/profile/texting-compliance/components/TextingCompliance'
 import TextingComplianceAgentic from './TextingComplianceAgentic'
 
-const TEXT_COMPLIANCE_FEATURE_FLAG_KEY = 'pro-upgrade1'
-
 export default function TextingComplianceFeatureFlag(
   props: TextingComplianceProps,
 ): React.JSX.Element {
-  const { ready, on: textComplianceFeatureFlagEnabled } = useFlagOn(
-    TEXT_COMPLIANCE_FEATURE_FLAG_KEY,
-  )
+  const { ready, enabled } = useProUpgradeFlag()
 
-  if (!ready || !textComplianceFeatureFlagEnabled) {
+  if (!ready || !enabled) {
     return <TextingCompliance {...props} />
   }
 

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,15 +1,25 @@
 import { stripHtml } from 'string-strip-html'
-import { Website } from 'helpers/types'
+import { Website, WebsiteIssue } from 'helpers/types'
 
 export const MIN_BIO_LENGTH = 500
 export const MIN_POLICY_FOCUS_LENGTH = 100
 export const MIN_POLICY_PRIORITIES = 1
 
+export const getBioPlainLength = (rawBio: string | undefined | null): number =>
+  rawBio ? stripHtml(rawBio).result.trim().length : 0
+
+export const normalizeIssues = (
+  raw: { title?: string; description?: string }[] | undefined,
+): WebsiteIssue[] =>
+  (raw ?? []).map((i) => ({
+    title: i.title ?? '',
+    description: i.description ?? '',
+  }))
+
 export const isCandidateProfileComplete = (
   website: Website | null | undefined,
 ): boolean => {
-  const rawBio = website?.content?.about?.bio ?? ''
-  const bioPlainLength = rawBio ? stripHtml(rawBio).result.trim().length : 0
+  const bioPlainLength = getBioPlainLength(website?.content?.about?.bio)
   const issues = website?.content?.about?.issues ?? []
   return (
     bioPlainLength >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -63,7 +63,7 @@ export default function CandidateProfile(): React.JSX.Element {
     if (!canSubmit) return
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
-    const ok = await saveAboutFields({ bio, issues }, website)
+    const ok = await saveAboutFields({ bio, issues })
     if (!ok) {
       trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
       errorSnackbar('Failed to save candidate profile. Please try again.')

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -7,9 +7,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  createWebsite,
   getUserWebsite,
-  updateWebsite,
+  saveAboutFields,
   USER_WEBSITE_QUERY_KEY,
 } from 'app/dashboard/website/util/website.util'
 import { useSnackbar } from 'helpers/useSnackbar'
@@ -18,6 +17,7 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
   MIN_POLICY_PRIORITIES,
+  normalizeIssues,
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
@@ -29,14 +29,6 @@ const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
     </div>
   ),
 })
-
-const normalizeIssues = (
-  raw: { title?: string; description?: string }[] | undefined,
-): WebsiteIssue[] =>
-  (raw ?? []).map((i) => ({
-    title: i.title ?? '',
-    description: i.description ?? '',
-  }))
 
 export default function CandidateProfile(): React.JSX.Element {
   const router = useRouter()
@@ -71,23 +63,16 @@ export default function CandidateProfile(): React.JSX.Element {
     if (!canSubmit) return
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
-    try {
-      if (!website) {
-        const createResp = await createWebsite()
-        if (!createResp.ok) throw new Error('create failed')
-      }
-      const result = await updateWebsite({
-        about: { ...website?.content?.about, bio, issues },
-      })
-      if (!result || !result.ok) throw new Error('update failed')
-      trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
-      await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
-      router.push('/dashboard/profile')
-    } catch {
+    const ok = await saveAboutFields({ bio, issues }, website)
+    if (!ok) {
       trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
       errorSnackbar('Failed to save candidate profile. Please try again.')
       setSubmitting(false)
+      return
     }
+    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+    await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+    router.push('/dashboard/profile')
   }
 
   return (
@@ -117,6 +102,9 @@ export default function CandidateProfile(): React.JSX.Element {
         </div>
 
         <div className="mt-8">
+          <div className="mb-1.5 block text-sm font-medium">
+            Your policy priorities
+          </div>
           <PolicyPriorities
             issues={issues}
             onChange={setIssues}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -103,9 +103,6 @@ export default function PolicyPriorities({
 
   return (
     <div>
-      <div className="mb-1.5 block text-sm font-medium">
-        Your policy priorities
-      </div>
       <div className="flex flex-col gap-3">
         {issues.map((issue, index) => (
           <button

--- a/app/dashboard/website/util/website.util.test.ts
+++ b/app/dashboard/website/util/website.util.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { apiRoutes } from 'gpApi/routes'
+import type { Website } from 'helpers/types'
+import { saveAboutFields } from './website.util'
+
+const mockClientFetch = vi.fn()
+
+vi.mock('gpApi/clientFetch', () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+}))
+
+const okResponse = <T>(data: T) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  data,
+})
+
+const errorResponse = () => ({
+  ok: false,
+  status: 500,
+  statusText: 'Server Error',
+  data: undefined,
+})
+
+const buildWebsite = (
+  about: NonNullable<Website['content']>['about'] = {},
+): Website => ({
+  id: 1,
+  vanityPath: 'jane-doe',
+  status: 'unpublished',
+  content: { about },
+  domain: null,
+})
+
+describe('saveAboutFields', () => {
+  beforeEach(() => {
+    mockClientFetch.mockReset()
+  })
+
+  describe('when an existing website is provided', () => {
+    it('skips create and only calls update with the merged about payload', async () => {
+      const existing = buildWebsite({
+        bio: 'old bio',
+        issues: [{ title: 'Healthcare', description: 'Universal' }],
+        committee: 'Friends of Jane',
+      })
+      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
+
+      const result = await saveAboutFields({ bio: 'new bio' }, existing)
+
+      expect(result).toBe(true)
+      expect(mockClientFetch).toHaveBeenCalledTimes(1)
+      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
+        about: {
+          bio: 'new bio',
+          issues: [{ title: 'Healthcare', description: 'Universal' }],
+          committee: 'Friends of Jane',
+        },
+      })
+    })
+
+    it('returns false when update fails and does not throw', async () => {
+      const existing = buildWebsite({ bio: 'old' })
+      mockClientFetch.mockResolvedValueOnce(errorResponse())
+
+      const result = await saveAboutFields({ bio: 'new' }, existing)
+
+      expect(result).toBe(false)
+      expect(mockClientFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns false when the update call rejects (resilient to thrown errors)', async () => {
+      const existing = buildWebsite({ bio: 'old' })
+      mockClientFetch.mockRejectedValueOnce(new Error('network down'))
+
+      const result = await saveAboutFields({ bio: 'new' }, existing)
+
+      expect(result).toBe(false)
+    })
+
+    it('treats null content the same as no about', async () => {
+      const existing = {
+        id: 1,
+        vanityPath: 'jane-doe',
+        status: 'unpublished',
+        content: null,
+        domain: null,
+      } as Website
+      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
+
+      const result = await saveAboutFields({ bio: 'new' }, existing)
+
+      expect(result).toBe(true)
+      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
+        about: { bio: 'new' },
+      })
+    })
+
+    it('treats content with no about field as empty about', async () => {
+      const existing = {
+        id: 1,
+        vanityPath: 'jane-doe',
+        status: 'unpublished',
+        content: {},
+        domain: null,
+      } as Website
+      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
+
+      const result = await saveAboutFields({ bio: 'new' }, existing)
+
+      expect(result).toBe(true)
+      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
+        about: { bio: 'new' },
+      })
+    })
+  })
+
+  describe('when no existing website is provided', () => {
+    it('calls create then update and returns true on success', async () => {
+      mockClientFetch
+        .mockResolvedValueOnce(okResponse(buildWebsite()))
+        .mockResolvedValueOnce(okResponse(buildWebsite()))
+
+      const result = await saveAboutFields(
+        { bio: 'fresh', issues: [{ title: 'Edu', description: 'K-12' }] },
+        null,
+      )
+
+      expect(result).toBe(true)
+      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(
+        1,
+        apiRoutes.website.create,
+        {},
+      )
+      expect(mockClientFetch).toHaveBeenNthCalledWith(
+        2,
+        apiRoutes.website.update,
+        {
+          about: {
+            bio: 'fresh',
+            issues: [{ title: 'Edu', description: 'K-12' }],
+          },
+        },
+      )
+    })
+
+    it('treats undefined existing the same as null', async () => {
+      mockClientFetch
+        .mockResolvedValueOnce(okResponse(buildWebsite()))
+        .mockResolvedValueOnce(okResponse(buildWebsite()))
+
+      const result = await saveAboutFields({ bio: 'x' }, undefined)
+
+      expect(result).toBe(true)
+      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns false and does not call update when create fails', async () => {
+      mockClientFetch.mockResolvedValueOnce(errorResponse())
+
+      const result = await saveAboutFields({ bio: 'fresh' }, null)
+
+      expect(result).toBe(false)
+      expect(mockClientFetch).toHaveBeenCalledTimes(1)
+      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.create, {})
+    })
+
+    it('returns false when create rejects and does not call update', async () => {
+      mockClientFetch.mockRejectedValueOnce(new Error('network down'))
+
+      const result = await saveAboutFields({ bio: 'fresh' }, null)
+
+      expect(result).toBe(false)
+      expect(mockClientFetch).toHaveBeenCalledTimes(1)
+      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.create, {})
+    })
+
+    it('returns false when create succeeds but update rejects', async () => {
+      mockClientFetch
+        .mockResolvedValueOnce(okResponse(buildWebsite()))
+        .mockRejectedValueOnce(new Error('network down'))
+
+      const result = await saveAboutFields({ bio: 'fresh' }, null)
+
+      expect(result).toBe(false)
+      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('overwrites an existing field in about with the partial value', async () => {
+    const existing = buildWebsite({
+      bio: 'first',
+      issues: [{ title: 'A', description: 'a' }],
+    })
+    mockClientFetch.mockResolvedValueOnce(okResponse(existing))
+
+    await saveAboutFields(
+      { issues: [{ title: 'B', description: 'b' }] },
+      existing,
+    )
+
+    expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
+      about: {
+        bio: 'first',
+        issues: [{ title: 'B', description: 'b' }],
+      },
+    })
+  })
+})

--- a/app/dashboard/website/util/website.util.test.ts
+++ b/app/dashboard/website/util/website.util.test.ts
@@ -57,13 +57,17 @@ describe('saveAboutFields', () => {
     expect(result).toBe(true)
     expect(mockClientFetch).toHaveBeenCalledTimes(2)
     expect(mockClientFetch).toHaveBeenNthCalledWith(1, apiRoutes.website.get)
-    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
-      about: {
-        bio: 'new bio',
-        issues: [{ title: 'Healthcare', description: 'Universal' }],
-        committee: 'Friends of Jane',
+    expect(mockClientFetch).toHaveBeenNthCalledWith(
+      2,
+      apiRoutes.website.update,
+      {
+        about: {
+          bio: 'new bio',
+          issues: [{ title: 'Healthcare', description: 'Universal' }],
+          committee: 'Friends of Jane',
+        },
       },
-    })
+    )
   })
 
   it('returns false when update fails and does not throw', async () => {
@@ -118,9 +122,13 @@ describe('saveAboutFields', () => {
     const result = await saveAboutFields({ bio: 'new' })
 
     expect(result).toBe(true)
-    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
-      about: { bio: 'new' },
-    })
+    expect(mockClientFetch).toHaveBeenNthCalledWith(
+      2,
+      apiRoutes.website.update,
+      {
+        about: { bio: 'new' },
+      },
+    )
   })
 
   it('overwrites a sibling field already present in the latest about', async () => {
@@ -134,12 +142,16 @@ describe('saveAboutFields', () => {
 
     await saveAboutFields({ issues: [{ title: 'B', description: 'b' }] })
 
-    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
-      about: {
-        bio: 'first',
-        issues: [{ title: 'B', description: 'b' }],
+    expect(mockClientFetch).toHaveBeenNthCalledWith(
+      2,
+      apiRoutes.website.update,
+      {
+        about: {
+          bio: 'first',
+          issues: [{ title: 'B', description: 'b' }],
+        },
       },
-    })
+    )
   })
 
   describe('when no website exists yet', () => {
@@ -204,7 +216,7 @@ describe('saveAboutFields', () => {
   })
 
   describe('concurrency', () => {
-    it('serializes overlapping calls so the second save merges with the first save\'s result', async () => {
+    it("serializes overlapping calls so the second save merges with the first save's result", async () => {
       type Deferred<T> = {
         resolve: (v: T) => void
         promise: Promise<T>

--- a/app/dashboard/website/util/website.util.test.ts
+++ b/app/dashboard/website/util/website.util.test.ts
@@ -33,109 +33,138 @@ const buildWebsite = (
   domain: null,
 })
 
+const flush = async () => {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
 describe('saveAboutFields', () => {
   beforeEach(() => {
     mockClientFetch.mockReset()
   })
 
-  describe('when an existing website is provided', () => {
-    it('skips create and only calls update with the merged about payload', async () => {
-      const existing = buildWebsite({
-        bio: 'old bio',
+  it('fetches the latest server state, then updates with the merged about', async () => {
+    const latest = buildWebsite({
+      bio: 'old bio',
+      issues: [{ title: 'Healthcare', description: 'Universal' }],
+      committee: 'Friends of Jane',
+    })
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(latest))
+      .mockResolvedValueOnce(okResponse(latest))
+
+    const result = await saveAboutFields({ bio: 'new bio' })
+
+    expect(result).toBe(true)
+    expect(mockClientFetch).toHaveBeenCalledTimes(2)
+    expect(mockClientFetch).toHaveBeenNthCalledWith(1, apiRoutes.website.get)
+    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
+      about: {
+        bio: 'new bio',
         issues: [{ title: 'Healthcare', description: 'Universal' }],
         committee: 'Friends of Jane',
-      })
-      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
-
-      const result = await saveAboutFields({ bio: 'new bio' }, existing)
-
-      expect(result).toBe(true)
-      expect(mockClientFetch).toHaveBeenCalledTimes(1)
-      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
-        about: {
-          bio: 'new bio',
-          issues: [{ title: 'Healthcare', description: 'Universal' }],
-          committee: 'Friends of Jane',
-        },
-      })
-    })
-
-    it('returns false when update fails and does not throw', async () => {
-      const existing = buildWebsite({ bio: 'old' })
-      mockClientFetch.mockResolvedValueOnce(errorResponse())
-
-      const result = await saveAboutFields({ bio: 'new' }, existing)
-
-      expect(result).toBe(false)
-      expect(mockClientFetch).toHaveBeenCalledTimes(1)
-    })
-
-    it('returns false when the update call rejects (resilient to thrown errors)', async () => {
-      const existing = buildWebsite({ bio: 'old' })
-      mockClientFetch.mockRejectedValueOnce(new Error('network down'))
-
-      const result = await saveAboutFields({ bio: 'new' }, existing)
-
-      expect(result).toBe(false)
-    })
-
-    it('treats null content the same as no about', async () => {
-      const existing = {
-        id: 1,
-        vanityPath: 'jane-doe',
-        status: 'unpublished',
-        content: null,
-        domain: null,
-      } as Website
-      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
-
-      const result = await saveAboutFields({ bio: 'new' }, existing)
-
-      expect(result).toBe(true)
-      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
-        about: { bio: 'new' },
-      })
-    })
-
-    it('treats content with no about field as empty about', async () => {
-      const existing = {
-        id: 1,
-        vanityPath: 'jane-doe',
-        status: 'unpublished',
-        content: {},
-        domain: null,
-      } as Website
-      mockClientFetch.mockResolvedValueOnce(okResponse(existing))
-
-      const result = await saveAboutFields({ bio: 'new' }, existing)
-
-      expect(result).toBe(true)
-      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
-        about: { bio: 'new' },
-      })
+      },
     })
   })
 
-  describe('when no existing website is provided', () => {
-    it('calls create then update and returns true on success', async () => {
-      mockClientFetch
-        .mockResolvedValueOnce(okResponse(buildWebsite()))
-        .mockResolvedValueOnce(okResponse(buildWebsite()))
+  it('returns false when update fails and does not throw', async () => {
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(buildWebsite({ bio: 'old' })))
+      .mockResolvedValueOnce(errorResponse())
 
-      const result = await saveAboutFields(
-        { bio: 'fresh', issues: [{ title: 'Edu', description: 'K-12' }] },
-        null,
-      )
+    const result = await saveAboutFields({ bio: 'new' })
+
+    expect(result).toBe(false)
+    expect(mockClientFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns false when the update call rejects', async () => {
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(buildWebsite({ bio: 'old' })))
+      .mockRejectedValueOnce(new Error('network down'))
+
+    const result = await saveAboutFields({ bio: 'new' })
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false when the get call rejects (queue is not poisoned)', async () => {
+    mockClientFetch.mockRejectedValueOnce(new Error('network down'))
+
+    const result = await saveAboutFields({ bio: 'new' })
+
+    expect(result).toBe(false)
+
+    // Subsequent calls still work.
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(buildWebsite()))
+      .mockResolvedValueOnce(okResponse(buildWebsite()))
+
+    const next = await saveAboutFields({ bio: 'recovered' })
+    expect(next).toBe(true)
+  })
+
+  it('treats null content the same as no about', async () => {
+    const latest = {
+      id: 1,
+      vanityPath: 'jane-doe',
+      status: 'unpublished',
+      content: null,
+      domain: null,
+    } as Website
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(latest))
+      .mockResolvedValueOnce(okResponse(latest))
+
+    const result = await saveAboutFields({ bio: 'new' })
+
+    expect(result).toBe(true)
+    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
+      about: { bio: 'new' },
+    })
+  })
+
+  it('overwrites a sibling field already present in the latest about', async () => {
+    const latest = buildWebsite({
+      bio: 'first',
+      issues: [{ title: 'A', description: 'a' }],
+    })
+    mockClientFetch
+      .mockResolvedValueOnce(okResponse(latest))
+      .mockResolvedValueOnce(okResponse(latest))
+
+    await saveAboutFields({ issues: [{ title: 'B', description: 'b' }] })
+
+    expect(mockClientFetch).toHaveBeenNthCalledWith(2, apiRoutes.website.update, {
+      about: {
+        bio: 'first',
+        issues: [{ title: 'B', description: 'b' }],
+      },
+    })
+  })
+
+  describe('when no website exists yet', () => {
+    it('creates the website then updates with the partial', async () => {
+      const created = buildWebsite()
+      mockClientFetch
+        .mockResolvedValueOnce(okResponse(null))
+        .mockResolvedValueOnce(okResponse(created))
+        .mockResolvedValueOnce(okResponse(created))
+
+      const result = await saveAboutFields({
+        bio: 'fresh',
+        issues: [{ title: 'Edu', description: 'K-12' }],
+      })
 
       expect(result).toBe(true)
-      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+      expect(mockClientFetch).toHaveBeenCalledTimes(3)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(1, apiRoutes.website.get)
       expect(mockClientFetch).toHaveBeenNthCalledWith(
-        1,
+        2,
         apiRoutes.website.create,
         {},
       )
       expect(mockClientFetch).toHaveBeenNthCalledWith(
-        2,
+        3,
         apiRoutes.website.update,
         {
           about: {
@@ -146,66 +175,115 @@ describe('saveAboutFields', () => {
       )
     })
 
-    it('treats undefined existing the same as null', async () => {
-      mockClientFetch
-        .mockResolvedValueOnce(okResponse(buildWebsite()))
-        .mockResolvedValueOnce(okResponse(buildWebsite()))
-
-      const result = await saveAboutFields({ bio: 'x' }, undefined)
-
-      expect(result).toBe(true)
-      expect(mockClientFetch).toHaveBeenCalledTimes(2)
-    })
-
     it('returns false and does not call update when create fails', async () => {
-      mockClientFetch.mockResolvedValueOnce(errorResponse())
+      mockClientFetch
+        .mockResolvedValueOnce(okResponse(null))
+        .mockResolvedValueOnce(errorResponse())
 
-      const result = await saveAboutFields({ bio: 'fresh' }, null)
+      const result = await saveAboutFields({ bio: 'fresh' })
 
       expect(result).toBe(false)
-      expect(mockClientFetch).toHaveBeenCalledTimes(1)
-      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.create, {})
+      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(
+        2,
+        apiRoutes.website.create,
+        {},
+      )
     })
 
     it('returns false when create rejects and does not call update', async () => {
-      mockClientFetch.mockRejectedValueOnce(new Error('network down'))
-
-      const result = await saveAboutFields({ bio: 'fresh' }, null)
-
-      expect(result).toBe(false)
-      expect(mockClientFetch).toHaveBeenCalledTimes(1)
-      expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.create, {})
-    })
-
-    it('returns false when create succeeds but update rejects', async () => {
       mockClientFetch
-        .mockResolvedValueOnce(okResponse(buildWebsite()))
+        .mockResolvedValueOnce(okResponse(null))
         .mockRejectedValueOnce(new Error('network down'))
 
-      const result = await saveAboutFields({ bio: 'fresh' }, null)
+      const result = await saveAboutFields({ bio: 'fresh' })
 
       expect(result).toBe(false)
       expect(mockClientFetch).toHaveBeenCalledTimes(2)
     })
   })
 
-  it('overwrites an existing field in about with the partial value', async () => {
-    const existing = buildWebsite({
-      bio: 'first',
-      issues: [{ title: 'A', description: 'a' }],
-    })
-    mockClientFetch.mockResolvedValueOnce(okResponse(existing))
+  describe('concurrency', () => {
+    it('serializes overlapping calls so the second save merges with the first save\'s result', async () => {
+      type Deferred<T> = {
+        resolve: (v: T) => void
+        promise: Promise<T>
+      }
+      const defer = <T>(): Deferred<T> => {
+        let resolve!: (v: T) => void
+        const promise = new Promise<T>((r) => (resolve = r))
+        return { resolve, promise }
+      }
 
-    await saveAboutFields(
-      { issues: [{ title: 'B', description: 'b' }] },
-      existing,
-    )
+      const get1 = defer<unknown>()
+      const upd1 = defer<unknown>()
+      const get2 = defer<unknown>()
+      const upd2 = defer<unknown>()
 
-    expect(mockClientFetch).toHaveBeenCalledWith(apiRoutes.website.update, {
-      about: {
-        bio: 'first',
+      mockClientFetch
+        .mockReturnValueOnce(get1.promise)
+        .mockReturnValueOnce(upd1.promise)
+        .mockReturnValueOnce(get2.promise)
+        .mockReturnValueOnce(upd2.promise)
+
+      const before = buildWebsite({
+        bio: 'OLD',
+        issues: [{ title: 'A', description: 'a' }],
+      })
+      const afterBio = buildWebsite({
+        bio: 'NEW',
+        issues: [{ title: 'A', description: 'a' }],
+      })
+
+      const p1 = saveAboutFields({ bio: 'NEW' })
+      const p2 = saveAboutFields({
         issues: [{ title: 'B', description: 'b' }],
-      },
+      })
+
+      // Only the first call's GET is in flight; the second is queued.
+      await flush()
+      expect(mockClientFetch).toHaveBeenCalledTimes(1)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(1, apiRoutes.website.get)
+
+      get1.resolve(okResponse(before))
+      await flush()
+
+      // First call has progressed to its update.
+      expect(mockClientFetch).toHaveBeenCalledTimes(2)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(
+        2,
+        apiRoutes.website.update,
+        { about: { bio: 'NEW', issues: [{ title: 'A', description: 'a' }] } },
+      )
+
+      // Second call must still be queued — its GET has not started.
+      upd1.resolve(okResponse(afterBio))
+      await p1
+      await flush()
+
+      expect(mockClientFetch).toHaveBeenCalledTimes(3)
+      expect(mockClientFetch).toHaveBeenNthCalledWith(3, apiRoutes.website.get)
+
+      // Now the second call's GET reflects the post-first-save state.
+      get2.resolve(okResponse(afterBio))
+      await flush()
+
+      // The second update must merge with the fresh server state, NOT the
+      // stale snapshot the caller may have closed over. Critically, bio must
+      // remain 'NEW' — this is the regression we're guarding against.
+      expect(mockClientFetch).toHaveBeenNthCalledWith(
+        4,
+        apiRoutes.website.update,
+        {
+          about: {
+            bio: 'NEW',
+            issues: [{ title: 'B', description: 'b' }],
+          },
+        },
+      )
+
+      upd2.resolve(okResponse(afterBio))
+      await expect(p2).resolves.toBe(true)
     })
   })
 })

--- a/app/dashboard/website/util/website.util.ts
+++ b/app/dashboard/website/util/website.util.ts
@@ -2,6 +2,9 @@ import { apiRoutes } from 'gpApi/routes'
 import { clientFetch, ApiResponse } from 'gpApi/clientFetch'
 import { isDomainActive } from './domain.util'
 import { NEXT_PUBLIC_CANDIDATES_SITE_BASE } from 'appEnv'
+import type { Website, WebsiteContent, Domain } from 'helpers/types'
+
+type WebsiteAbout = NonNullable<WebsiteContent['about']>
 
 const CANDIDATES_SITE_BASE = NEXT_PUBLIC_CANDIDATES_SITE_BASE
 
@@ -20,8 +23,6 @@ interface CustomIssue {
   title?: string
   position?: string
 }
-
-import type { Website, WebsiteContent, Domain } from 'helpers/types'
 
 interface CombinedIssue {
   title: string
@@ -71,6 +72,25 @@ export async function getUserWebsite(): Promise<Website | null> {
   } catch (e) {
     console.error('error', e)
     return null
+  }
+}
+
+export async function saveAboutFields(
+  partial: Partial<WebsiteAbout>,
+  existing: Website | null | undefined,
+): Promise<boolean> {
+  try {
+    if (!existing) {
+      const createResp = await createWebsite()
+      if (!createResp.ok) return false
+    }
+    const result = await updateWebsite({
+      about: { ...existing?.content?.about, ...partial },
+    })
+    return Boolean(result && result.ok)
+  } catch (e) {
+    console.error('saveAboutFields error', e)
+    return false
   }
 }
 

--- a/app/dashboard/website/util/website.util.ts
+++ b/app/dashboard/website/util/website.util.ts
@@ -75,23 +75,44 @@ export async function getUserWebsite(): Promise<Website | null> {
   }
 }
 
+// Module-level promise chain that serializes overlapping `saveAboutFields`
+// calls. Without this, two concurrent saves from sibling sections (e.g. bio
+// and policy priorities) could each fetch the server state before either
+// update lands, then both PUT a merge based on that pre-update snapshot — the
+// second write would silently revert the field written by the first.
+let saveAboutFieldsQueue: Promise<unknown> = Promise.resolve()
+
+/**
+ * Save a partial slice of `website.content.about`.
+ *
+ * The merge base is always the latest server state (re-fetched here), never a
+ * snapshot from the React Query cache, because sibling sections of the app
+ * save independent slices of the same `about` object and a stale snapshot
+ * would silently overwrite their writes.
+ */
 export async function saveAboutFields(
   partial: Partial<WebsiteAbout>,
-  existing: Website | null | undefined,
 ): Promise<boolean> {
-  try {
-    if (!existing) {
-      const createResp = await createWebsite()
-      if (!createResp.ok) return false
+  const run = async (): Promise<boolean> => {
+    try {
+      let latest = await getUserWebsite()
+      if (!latest) {
+        const createResp = await createWebsite()
+        if (!createResp.ok) return false
+        latest = createResp.data ?? null
+      }
+      const result = await updateWebsite({
+        about: { ...latest?.content?.about, ...partial },
+      })
+      return Boolean(result && result.ok)
+    } catch (e) {
+      console.error('saveAboutFields error', e)
+      return false
     }
-    const result = await updateWebsite({
-      about: { ...existing?.content?.about, ...partial },
-    })
-    return Boolean(result && result.ok)
-  } catch (e) {
-    console.error('saveAboutFields error', e)
-    return false
   }
+  const next = saveAboutFieldsQueue.then(run, run)
+  saveAboutFieldsQueue = next.catch(() => undefined)
+  return next as Promise<boolean>
 }
 
 export async function validateVanityPath(

--- a/app/shared/experiments/proUpgradeFlag.ts
+++ b/app/shared/experiments/proUpgradeFlag.ts
@@ -1,0 +1,13 @@
+import { useFlagOn } from './FeatureFlagsProvider'
+
+export const PRO_UPGRADE_FLAG_KEY = 'pro-upgrade1'
+
+interface UseProUpgradeFlagResult {
+  ready: boolean
+  enabled: boolean
+}
+
+export const useProUpgradeFlag = (): UseProUpgradeFlagResult => {
+  const { ready, on } = useFlagOn(PRO_UPGRADE_FLAG_KEY)
+  return { ready, enabled: on }
+}

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -410,6 +410,9 @@ export const EVENTS = {
     Why: {
       ClickSave: 'Profile - Why Section: Click Save',
     },
+    WhyRunning: {
+      ClickSave: 'Profile - Why Running: Click Save',
+    },
     FunFact: {
       ClickSave: 'Profile - Fun Fact: Click Save',
     },
@@ -432,6 +435,7 @@ export const EVENTS = {
       ClickDelete: 'Profile - Policy Priorities: Click Delete',
       SubmitDelete: 'Profile - Policy Priorities: Submit Delete',
       CancelDelete: 'Profile - Policy Priorities: Cancel Delete',
+      ClickSave: 'Profile - Policy Priorities: Click Save',
     },
     CandidateProfile: {
       ClickSubmit: 'Profile - Candidate Profile: Click Submit',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new profile editing flows that write to `website.content.about` and adds a serialized, fetch-merge-update save helper; mistakes here could cause lost edits or unexpected overwrites despite added tests.
> 
> **Overview**
> Adds a *pro-upgrade* feature-flagged variant of the campaign details profile page that replaces the legacy sections with new editable `WhyRunningSection` and `PolicyPrioritiesSection` components.
> 
> Introduces `saveAboutFields` to safely persist partial updates to `website.content.about` by refetching the latest server state, merging fields, and serializing overlapping saves to prevent race-condition overwrites; updates `CandidateProfile` and the new sections to use it and adds Vitest coverage for error and concurrency cases.
> 
> Centralizes the `pro-upgrade1` flag behind a new `useProUpgradeFlag` hook (used by both campaign details and texting compliance), and adds new analytics events for saving “Why running” and policy priorities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfa213bf10ed78d6ff0bd122f2866609e975871. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->