### PR TITLE
prod release May-4-2026

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,10 @@
   "plugins": ["react", "unused-imports", "@stylistic"],
   "extends": [
     "next/core-web-vitals",
-    "plugin:mdx/recommended",
+    "plugin:mdx/recommended"
     // "plugin:jsx-a11y/recommended" TODO: turn on when ready to enforce a11y rules
-    "plugin:storybook/recommended"
+    // Storybook ESLint v10+ is ESM-only and breaks ESLint 8's CJS config loader; re-add when on ESLint 9 flat config.
+    // "plugin:storybook/recommended"
   ],
   "settings": {
     "mdx/code-blocks": true,
@@ -75,6 +76,7 @@
       "plugins": ["@typescript-eslint"],
       "parser": "@typescript-eslint/parser",
       "rules": {
+        "react-hooks/rules-of-hooks": "off",
         "@typescript-eslint/no-unused-expressions": "off",
         "@typescript-eslint/no-useless-constructor": "error",
         "@typescript-eslint/no-empty-function": "error",

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ invalid_urls.csv
 # AI Tools
 /.ai/
 /.cursor
+.superpowers/
 .claude/settings.json
 .claude/settings.local.json
 .claude/cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,3 +15,6 @@ public/
 CLAUDE.md
 ai-rules/
 test-results/
+.clerk/
+e2e-tests/playwright-report/
+e2e-tests/test-results/

--- a/app/dashboard/campaign-details/components/OfficeSection.tsx
+++ b/app/dashboard/campaign-details/components/OfficeSection.tsx
@@ -52,7 +52,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
     } else {
       setState({
         office: positionName,
-        state: organization.position?.state || '',
+        state: organization?.position?.state || '',
         electionDate: '',
         primaryElectionDate: '',
         officeTermLength: '',
@@ -81,7 +81,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
   return (
     <section
       className={
-        organization.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
+        organization?.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
       }
     >
       <H3 className="pb-6">Office Details</H3>
@@ -90,7 +90,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
         <CampaignOfficeInputFields
           values={state}
           hiddenFields={
-            organization.electedOfficeId
+            organization?.electedOfficeId
               ? ['electionDate', 'primaryElectionDate', 'officeTermLength']
               : []
           }
@@ -104,7 +104,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
         show={showModal}
         onClose={() => setShowModal(false)}
         onSelect={handleUpdate}
-        organizationSlug={organization.slug}
+        organizationSlug={organization?.slug}
       />
     </section>
   )

--- a/app/dashboard/profile/components/AccountSettingsSection.tsx
+++ b/app/dashboard/profile/components/AccountSettingsSection.tsx
@@ -10,6 +10,7 @@ import { useCampaign } from '@shared/hooks/useCampaign'
 import { useUser } from '@shared/hooks/useUser'
 import { AccountSettingsButton } from 'app/dashboard/profile/components/AccountSettingsButton'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { getMarketingUrl } from 'helpers/linkhelper'
 import { useEffect } from 'react'
 import { identifyUser } from '@shared/utils/analytics'
 
@@ -57,7 +58,7 @@ export const AccountSettingsSection = (): React.JSX.Element => {
               Need help?
               <Link
                 className="ml-1 underline text-info-main"
-                href="/contact"
+                href={getMarketingUrl('/contact')}
                 onClick={() =>
                   trackEvent(EVENTS.Settings.Account.ClickSendEmail)
                 }

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -1,3 +1,6 @@
+'use client'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import { STEP_STATUS, StepStatus } from '../shared/TextCompliance.types'
 import TextComplianceStep from './TextComplianceStep'
 
@@ -7,33 +10,39 @@ interface Step {
   status: StepStatus
 }
 
-// TODO: make these steps dynamic based on the user's progress
-const STEPS: Step[] = [
-  {
-    title: 'Submit candidate profile',
-    route: '/dashboard/profile/texting-compliance/candidate-profile',
-    status: STEP_STATUS.ACTIVE,
-  },
-  {
-    title: 'Submit election filing details',
-    route: '/dashboard/profile/texting-compliance/election-filing',
-    status: STEP_STATUS.DISABLED,
-  },
-  {
-    title: 'Enter your PIN',
-    route: '/dashboard/profile/texting-compliance/enter-pin',
-    status: STEP_STATUS.DISABLED,
-  },
-]
-
 export default function TextComplianceSteps(): React.JSX.Element {
+  const [campaign] = useCampaign()
+  const candidateProfileComplete = isCandidateProfileComplete(campaign)
+
+  const steps: Step[] = [
+    {
+      title: 'Submit candidate profile',
+      route: '/dashboard/profile/texting-compliance/candidate-profile',
+      status: candidateProfileComplete
+        ? STEP_STATUS.COMPLETED
+        : STEP_STATUS.ACTIVE,
+    },
+    {
+      title: 'Submit election filing details',
+      route: '/dashboard/profile/texting-compliance/election-filing',
+      status: candidateProfileComplete
+        ? STEP_STATUS.ACTIVE
+        : STEP_STATUS.DISABLED,
+    },
+    {
+      title: 'Enter your PIN',
+      route: '/dashboard/profile/texting-compliance/enter-pin',
+      status: STEP_STATUS.DISABLED,
+    },
+  ]
+
   return (
     <div className="border border-gray-200 rounded-lg overflow-hidden mt-6">
-      {STEPS.map((step, index) => (
+      {steps.map((step, index) => (
         <TextComplianceStep
           key={step.route}
           number={index + 1}
-          total={STEPS.length}
+          total={steps.length}
           {...step}
         />
       ))}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -1,5 +1,9 @@
 'use client'
-import { useCampaign } from '@shared/hooks/useCampaign'
+import { useQuery } from '@tanstack/react-query'
+import {
+  getUserWebsite,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
 import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import { STEP_STATUS, StepStatus } from '../shared/TextCompliance.types'
 import TextComplianceStep from './TextComplianceStep'
@@ -11,8 +15,11 @@ interface Step {
 }
 
 export default function TextComplianceSteps(): React.JSX.Element {
-  const [campaign] = useCampaign()
-  const candidateProfileComplete = isCandidateProfileComplete(campaign)
+  const { data: website } = useQuery({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+  const candidateProfileComplete = isCandidateProfileComplete(website)
 
   const steps: Step[] = [
     {
@@ -37,7 +44,7 @@ export default function TextComplianceSteps(): React.JSX.Element {
   ]
 
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden mt-6">
+    <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
       {steps.map((step, index) => (
         <TextComplianceStep
           key={step.route}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextComplianceSteps.tsx
@@ -11,7 +11,7 @@ interface Step {
 const STEPS: Step[] = [
   {
     title: 'Submit candidate profile',
-    route: '/dashboard/profile/texting-compliance/submit-candidate-profile',
+    route: '/dashboard/profile/texting-compliance/candidate-profile',
     status: STEP_STATUS.ACTIVE,
   },
   {

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,0 +1,16 @@
+import { Campaign } from 'helpers/types'
+
+export const MIN_BIO_LENGTH = 500
+export const MIN_POLICY_FOCUS_LENGTH = 100
+export const MIN_POLICY_PRIORITIES = 1
+
+export const isCandidateProfileComplete = (
+  campaign: Campaign | null,
+): boolean => {
+  const whyRunning = campaign?.details?.whyRunning?.trim() ?? ''
+  const priorities = campaign?.details?.customIssues ?? []
+  return (
+    whyRunning.length >= MIN_BIO_LENGTH &&
+    priorities.length >= MIN_POLICY_PRIORITIES
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,16 +1,13 @@
-import { Campaign } from 'helpers/types'
+import { Website } from 'helpers/types'
 
 export const MIN_BIO_LENGTH = 500
 export const MIN_POLICY_FOCUS_LENGTH = 100
 export const MIN_POLICY_PRIORITIES = 1
 
 export const isCandidateProfileComplete = (
-  campaign: Campaign | null,
+  website: Website | null | undefined,
 ): boolean => {
-  const whyRunning = campaign?.details?.whyRunning?.trim() ?? ''
-  const priorities = campaign?.details?.customIssues ?? []
-  return (
-    whyRunning.length >= MIN_BIO_LENGTH &&
-    priorities.length >= MIN_POLICY_PRIORITIES
-  )
+  const bio = website?.content?.about?.bio?.trim() ?? ''
+  const issues = website?.content?.about?.issues ?? []
+  return bio.length >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
 }

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -1,3 +1,4 @@
+import { stripHtml } from 'string-strip-html'
 import { Website } from 'helpers/types'
 
 export const MIN_BIO_LENGTH = 500
@@ -7,7 +8,10 @@ export const MIN_POLICY_PRIORITIES = 1
 export const isCandidateProfileComplete = (
   website: Website | null | undefined,
 ): boolean => {
-  const bio = website?.content?.about?.bio?.trim() ?? ''
+  const rawBio = website?.content?.about?.bio ?? ''
+  const bioPlainLength = rawBio ? stripHtml(rawBio).result.trim().length : 0
   const issues = website?.content?.about?.issues ?? []
-  return bio.length >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
+  return (
+    bioPlainLength >= MIN_BIO_LENGTH && issues.length >= MIN_POLICY_PRIORITIES
+  )
 }

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,11 +1,11 @@
 'use client'
-import { Button, Textarea } from '@styleguide'
+import { Button } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
+import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { stripHtml } from 'string-strip-html'
 import {
   createWebsite,
   getUserWebsite,
@@ -21,15 +21,21 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
-const stripIfPresent = (value: string | undefined | null): string =>
-  value ? stripHtml(value).result : ''
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
 
 const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>
   (raw ?? []).map((i) => ({
-    title: stripIfPresent(i.title),
-    description: stripIfPresent(i.description),
+    title: i.title ?? '',
+    description: i.description ?? '',
   }))
 
 export default function CandidateProfile(): React.JSX.Element {
@@ -42,20 +48,22 @@ export default function CandidateProfile(): React.JSX.Element {
   })
 
   const [bio, setBio] = useState('')
+  const [bioPlainLength, setBioPlainLength] = useState(0)
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(stripIfPresent(website.content?.about?.bio))
+    setBio(website.content?.about?.bio ?? '')
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])
 
-  const trimmedBioLength = bio.trim().length
+  const initialBio = website?.content?.about?.bio ?? ''
+
   const canSubmit =
-    trimmedBioLength >= MIN_BIO_LENGTH &&
+    bioPlainLength >= MIN_BIO_LENGTH &&
     issues.length >= MIN_POLICY_PRIORITIES &&
     !submitting
 
@@ -94,19 +102,17 @@ export default function CandidateProfile(): React.JSX.Element {
         </div>
 
         <div className="mt-10">
-          <label htmlFor="why" className="mb-1.5 block text-sm font-medium">
+          <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
-          </label>
-          <Textarea
-            id="why"
-            rows={5}
-            value={bio}
-            onChange={(e) => setBio(e.target.value)}
-            disabled={submitting}
+          </div>
+          <RichEditor
+            initialText={initialBio}
+            onChangeCallback={setBio}
+            onTextLengthChange={setBioPlainLength}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
-            <span>{trimmedBioLength}</span>
+            <span>{bioPlainLength}</span>
           </div>
         </div>
 

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,0 +1,30 @@
+import { Button, Textarea } from '@styleguide'
+import { ChevronLeft } from 'lucide-react'
+import Link from 'next/link'
+
+export default function CandidateProfile(): React.JSX.Element {
+  return (
+    <div className="flex flex-col h-screen justify-between items-center pt-2 md:pt-4">
+      <div className="max-w-2xl mx-auto p-4 w-full">
+        <div className="flex items-center justify-between">
+          <Link href="/dashboard/profile">
+            <ChevronLeft className="w-6 h-6" />
+          </Link>
+          <div className="md:text-xl">CandidateProfile</div>
+          <div>&nbsp;</div>
+        </div>
+
+        <div className="mt-10">
+          <label htmlFor="why">Why are you running?</label>
+          <Textarea id="why" />
+          <p className="text-sm text-muted-foreground">500 character minimum</p>
+        </div>
+      </div>
+      <div className="max-w-2xl mx-auto p-4 md:p-8 flex justify-end w-full">
+        <Button variant="secondary" type="submit">
+          Submit
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -4,12 +4,15 @@ import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useQueryClient } from '@tanstack/react-query'
-import { useCampaign } from '@shared/hooks/useCampaign'
-import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
-import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  createWebsite,
+  getUserWebsite,
+  updateWebsite,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
 import { useSnackbar } from 'helpers/useSnackbar'
-import { CustomIssue } from 'helpers/types'
+import { Website, WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
@@ -17,47 +20,62 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
+const normalizeIssues = (
+  raw: { title?: string; description?: string }[] | undefined,
+): WebsiteIssue[] =>
+  (raw ?? []).map((i) => ({
+    title: i.title ?? '',
+    description: i.description ?? '',
+  }))
+
 export default function CandidateProfile(): React.JSX.Element {
-  const [campaign] = useCampaign()
   const router = useRouter()
   const queryClient = useQueryClient()
   const { errorSnackbar } = useSnackbar()
+  const { data: website } = useQuery<Website | null>({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
 
-  const [whyRunning, setWhyRunning] = useState('')
-  const [customIssues, setCustomIssues] = useState<CustomIssue[]>([])
+  const [bio, setBio] = useState('')
+  const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
-    if (seededRef.current || !campaign?.details) return
-    setWhyRunning(campaign.details.whyRunning ?? '')
-    setCustomIssues(campaign.details.customIssues ?? [])
+    if (seededRef.current || !website) return
+    setBio(website.content?.about?.bio ?? '')
+    setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
-  }, [campaign])
+  }, [website])
 
-  const trimmedWhyRunningLength = whyRunning.trim().length
+  const trimmedBioLength = bio.trim().length
   const canSubmit =
-    trimmedWhyRunningLength >= MIN_BIO_LENGTH &&
-    customIssues.length >= MIN_POLICY_PRIORITIES &&
+    trimmedBioLength >= MIN_BIO_LENGTH &&
+    issues.length >= MIN_POLICY_PRIORITIES &&
     !submitting
 
   const handleSubmit = async () => {
     if (!canSubmit) return
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
-    const result = await updateCampaign([
-      { key: 'details.whyRunning', value: whyRunning },
-      { key: 'details.customIssues', value: customIssues },
-    ])
-    if (!result) {
+    try {
+      if (!website) {
+        const createResp = await createWebsite()
+        if (!createResp.ok) throw new Error('create failed')
+      }
+      const result = await updateWebsite({
+        about: { ...website?.content?.about, bio, issues },
+      })
+      if (!result || !result.ok) throw new Error('update failed')
+      trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+      await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+      router.push('/dashboard/profile')
+    } catch {
       trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
       errorSnackbar('Failed to save candidate profile. Please try again.')
       setSubmitting(false)
-      return
     }
-    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
-    await queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
-    router.push('/dashboard/profile')
   }
 
   return (
@@ -78,20 +96,20 @@ export default function CandidateProfile(): React.JSX.Element {
           <Textarea
             id="why"
             rows={5}
-            value={whyRunning}
-            onChange={(e) => setWhyRunning(e.target.value)}
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
             disabled={submitting}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
-            <span>{trimmedWhyRunningLength}</span>
+            <span>{trimmedBioLength}</span>
           </div>
         </div>
 
         <div className="mt-8">
           <PolicyPriorities
-            issues={customIssues}
-            onChange={setCustomIssues}
+            issues={issues}
+            onChange={setIssues}
             disabled={submitting}
           />
         </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { stripHtml } from 'string-strip-html'
 import {
   createWebsite,
   getUserWebsite,
@@ -20,12 +21,15 @@ import {
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
 
+const stripIfPresent = (value: string | undefined | null): string =>
+  value ? stripHtml(value).result : ''
+
 const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>
   (raw ?? []).map((i) => ({
-    title: i.title ?? '',
-    description: i.description ?? '',
+    title: stripIfPresent(i.title),
+    description: stripIfPresent(i.description),
   }))
 
 export default function CandidateProfile(): React.JSX.Element {
@@ -44,7 +48,7 @@ export default function CandidateProfile(): React.JSX.Element {
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(website.content?.about?.bio ?? '')
+    setBio(stripIfPresent(website.content?.about?.bio))
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,27 +1,111 @@
+'use client'
 import { Button, Textarea } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { CustomIssue } from 'helpers/types'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import {
+  MIN_BIO_LENGTH,
+  MIN_POLICY_PRIORITIES,
+} from '../candidateProfile.utils'
+import PolicyPriorities from './PolicyPriorities'
 
 export default function CandidateProfile(): React.JSX.Element {
+  const [campaign] = useCampaign()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+
+  const [whyRunning, setWhyRunning] = useState('')
+  const [customIssues, setCustomIssues] = useState<CustomIssue[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    if (seededRef.current || !campaign?.details) return
+    setWhyRunning(campaign.details.whyRunning ?? '')
+    setCustomIssues(campaign.details.customIssues ?? [])
+    seededRef.current = true
+  }, [campaign])
+
+  const trimmedWhyRunningLength = whyRunning.trim().length
+  const canSubmit =
+    trimmedWhyRunningLength >= MIN_BIO_LENGTH &&
+    customIssues.length >= MIN_POLICY_PRIORITIES &&
+    !submitting
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return
+    trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
+    setSubmitting(true)
+    const result = await updateCampaign([
+      { key: 'details.whyRunning', value: whyRunning },
+      { key: 'details.customIssues', value: customIssues },
+    ])
+    if (!result) {
+      trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
+      errorSnackbar('Failed to save candidate profile. Please try again.')
+      setSubmitting(false)
+      return
+    }
+    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+    await queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
+    router.push('/dashboard/profile')
+  }
+
   return (
-    <div className="flex flex-col h-screen justify-between items-center pt-2 md:pt-4">
-      <div className="max-w-2xl mx-auto p-4 w-full">
+    <div className="flex h-screen flex-col items-center justify-between pt-2 md:pt-4">
+      <div className="mx-auto w-full max-w-2xl p-4">
         <div className="flex items-center justify-between">
-          <Link href="/dashboard/profile">
-            <ChevronLeft className="w-6 h-6" />
+          <Link href="/dashboard/profile" aria-label="Back to profile">
+            <ChevronLeft className="h-6 w-6" />
           </Link>
-          <div className="md:text-xl">CandidateProfile</div>
+          <div className="font-medium md:text-xl">Candidate profile</div>
           <div>&nbsp;</div>
         </div>
 
         <div className="mt-10">
-          <label htmlFor="why">Why are you running?</label>
-          <Textarea id="why" />
-          <p className="text-sm text-muted-foreground">500 character minimum</p>
+          <label htmlFor="why" className="mb-1.5 block text-sm font-medium">
+            Why are you running?
+          </label>
+          <Textarea
+            id="why"
+            rows={5}
+            value={whyRunning}
+            onChange={(e) => setWhyRunning(e.target.value)}
+            disabled={submitting}
+          />
+          <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
+            <span>{MIN_BIO_LENGTH} character minimum</span>
+            <span>{trimmedWhyRunningLength}</span>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <PolicyPriorities
+            issues={customIssues}
+            onChange={setCustomIssues}
+            disabled={submitting}
+          />
         </div>
       </div>
-      <div className="max-w-2xl mx-auto p-4 md:p-8 flex justify-end w-full">
-        <Button variant="secondary" type="submit">
+
+      <div className="mx-auto flex w-full max-w-2xl justify-end p-4 md:p-8">
+        <Button
+          variant="secondary"
+          type="button"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          loading={submitting}
+          loadingText="Submitting"
+        >
           Submit
         </Button>
       </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { Button, Input, Textarea } from '@styleguide'
 import { useState } from 'react'
-import { CustomIssue } from 'helpers/types'
+import { WebsiteIssue } from 'helpers/types'
 import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
 
 interface PolicyFormProps {
-  initial?: CustomIssue
+  initial?: WebsiteIssue
   showDelete: boolean
-  onSave: (issue: CustomIssue) => void
+  onSave: (issue: WebsiteIssue) => void
   onDelete: () => void
 }
 
@@ -18,12 +18,13 @@ export default function PolicyForm({
   onDelete,
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
-  const [position, setPosition] = useState(initial?.position ?? '')
+  const [description, setDescription] = useState(initial?.description ?? '')
 
   const trimmedTitle = title.trim()
-  const trimmedPosition = position.trim()
+  const trimmedDescription = description.trim()
   const canSave =
-    trimmedTitle.length > 0 && trimmedPosition.length >= MIN_POLICY_FOCUS_LENGTH
+    trimmedTitle.length > 0 &&
+    trimmedDescription.length >= MIN_POLICY_FOCUS_LENGTH
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -48,12 +49,12 @@ export default function PolicyForm({
         <Textarea
           id="policy-focus"
           rows={4}
-          value={position}
-          onChange={(e) => setPosition(e.target.value)}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
-          <span>{trimmedPosition.length}</span>
+          <span>{trimmedDescription.length}</span>
         </div>
       </div>
 
@@ -75,7 +76,7 @@ export default function PolicyForm({
           size="medium"
           disabled={!canSave}
           onClick={() =>
-            onSave({ title: trimmedTitle, position: trimmedPosition })
+            onSave({ title: trimmedTitle, description: trimmedDescription })
           }
         >
           Save

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,8 +1,18 @@
 'use client'
-import { Button, Input, Textarea } from '@styleguide'
+import { Button, Input } from '@styleguide'
+import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
 import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
 
 interface PolicyFormProps {
   initial?: WebsiteIssue
@@ -19,12 +29,12 @@ export default function PolicyForm({
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
+  const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
+  const [initialDescription] = useState(initial?.description ?? '')
 
   const trimmedTitle = title.trim()
-  const trimmedDescription = description.trim()
   const canSave =
-    trimmedTitle.length > 0 &&
-    trimmedDescription.length >= MIN_POLICY_FOCUS_LENGTH
+    trimmedTitle.length > 0 && descriptionPlainLength >= MIN_POLICY_FOCUS_LENGTH
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -43,18 +53,15 @@ export default function PolicyForm({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="policy-focus" className="text-sm font-medium">
-          Policy focus
-        </label>
-        <Textarea
-          id="policy-focus"
-          rows={4}
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+        <div className="text-sm font-medium">Policy focus</div>
+        <RichEditor
+          initialText={initialDescription}
+          onChangeCallback={setDescription}
+          onTextLengthChange={setDescriptionPlainLength}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
-          <span>{trimmedDescription.length}</span>
+          <span>{descriptionPlainLength}</span>
         </div>
       </div>
 
@@ -75,9 +82,7 @@ export default function PolicyForm({
           type="button"
           size="medium"
           disabled={!canSave}
-          onClick={() =>
-            onSave({ title: trimmedTitle, description: trimmedDescription })
-          }
+          onClick={() => onSave({ title: trimmedTitle, description })}
         >
           Save
         </Button>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,0 +1,86 @@
+'use client'
+import { Button, Input, Textarea } from '@styleguide'
+import { useState } from 'react'
+import { CustomIssue } from 'helpers/types'
+import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+
+interface PolicyFormProps {
+  initial?: CustomIssue
+  showDelete: boolean
+  onSave: (issue: CustomIssue) => void
+  onDelete: () => void
+}
+
+export default function PolicyForm({
+  initial,
+  showDelete,
+  onSave,
+  onDelete,
+}: PolicyFormProps): React.JSX.Element {
+  const [title, setTitle] = useState(initial?.title ?? '')
+  const [position, setPosition] = useState(initial?.position ?? '')
+
+  const trimmedTitle = title.trim()
+  const trimmedPosition = position.trim()
+  const canSave =
+    trimmedTitle.length > 0 && trimmedPosition.length >= MIN_POLICY_FOCUS_LENGTH
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <h2 className="text-lg font-semibold">Policy priority</h2>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="policy-title" className="text-sm font-medium">
+          Policy title
+        </label>
+        <Input
+          id="policy-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="policy-focus" className="text-sm font-medium">
+          Policy focus
+        </label>
+        <Textarea
+          id="policy-focus"
+          rows={4}
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
+          <span>{trimmedPosition.length}</span>
+        </div>
+      </div>
+
+      <div className="mt-2 flex items-center justify-between">
+        {showDelete ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="medium"
+            onClick={onDelete}
+          >
+            Delete
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Button
+          type="button"
+          size="medium"
+          disabled={!canSave}
+          onClick={() =>
+            onSave({ title: trimmedTitle, position: trimmedPosition })
+          }
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -6,7 +6,6 @@ import AlertDialog from '@shared/utils/AlertDialog'
 import { CustomIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
-import TextingComplianceHeader from '../../shared/TextingComplianceHeader'
 
 const POLICY_MODAL_MODE = {
   ADD: 'add',
@@ -102,11 +101,9 @@ export default function PolicyPriorities({
 
   return (
     <div>
-      <TextingComplianceHeader>
-        <h5 className="flex-1 text-center md:hidden text-sm font-medium">
-          Your policy priorities
-        </h5>
-      </TextingComplianceHeader>
+      <div className="mb-1.5 block text-sm font-medium">
+        Your policy priorities
+      </div>
       <div className="flex flex-col gap-3">
         {issues.map((issue, index) => (
           <button

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -6,6 +6,7 @@ import AlertDialog from '@shared/utils/AlertDialog'
 import { CustomIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
+import TextingComplianceHeader from '../../shared/TextingComplianceHeader'
 
 const POLICY_MODAL_MODE = {
   ADD: 'add',
@@ -49,8 +50,14 @@ export default function PolicyPriorities({
     setModal({ open: true, mode: POLICY_MODAL_MODE.EDIT, index })
   }
 
-  const handleCancelEdit = () => {
-    if (modal.open) trackEvent(EVENTS.Profile.PolicyPriorities.CancelEdit)
+  const handleCancel = () => {
+    if (modal.open) {
+      trackEvent(
+        modal.mode === POLICY_MODAL_MODE.EDIT
+          ? EVENTS.Profile.PolicyPriorities.CancelEdit
+          : EVENTS.Profile.PolicyPriorities.CancelAdd,
+      )
+    }
     setModal({ open: false })
   }
 
@@ -95,7 +102,11 @@ export default function PolicyPriorities({
 
   return (
     <div>
-      <div className="mb-1.5 text-sm font-medium">Your policy priorities</div>
+      <TextingComplianceHeader>
+        <h5 className="flex-1 text-center md:hidden text-sm font-medium">
+          Your policy priorities
+        </h5>
+      </TextingComplianceHeader>
       <div className="flex flex-col gap-3">
         {issues.map((issue, index) => (
           <button
@@ -130,7 +141,7 @@ export default function PolicyPriorities({
       <ModalOrDrawer
         open={modal.open}
         onOpenChange={(open) => {
-          if (!open) handleCancelEdit()
+          if (!open) handleCancel()
         }}
         title="Policy priority"
       >

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -1,0 +1,156 @@
+'use client'
+import { Pencil, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
+import AlertDialog from '@shared/utils/AlertDialog'
+import { CustomIssue } from 'helpers/types'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import PolicyForm from './PolicyForm'
+
+const POLICY_MODAL_MODE = {
+  ADD: 'add',
+  EDIT: 'edit',
+} as const
+
+type PolicyModalMode =
+  (typeof POLICY_MODAL_MODE)[keyof typeof POLICY_MODAL_MODE]
+
+type ModalState =
+  | { open: false }
+  | { open: true; mode: typeof POLICY_MODAL_MODE.ADD }
+  | { open: true; mode: typeof POLICY_MODAL_MODE.EDIT; index: number }
+
+interface PolicyPrioritiesProps {
+  issues: CustomIssue[]
+  onChange: (issues: CustomIssue[]) => void
+  disabled?: boolean
+}
+
+const buildFormKey = (mode: PolicyModalMode, index?: number): string =>
+  mode === POLICY_MODAL_MODE.EDIT ? `${mode}-${index}` : mode
+
+export default function PolicyPriorities({
+  issues,
+  onChange,
+  disabled,
+}: PolicyPrioritiesProps): React.JSX.Element {
+  const [modal, setModal] = useState<ModalState>({ open: false })
+  const [pendingDeleteIndex, setPendingDeleteIndex] = useState<number | null>(
+    null,
+  )
+
+  const handleClickAdd = () => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickAdd)
+    setModal({ open: true, mode: POLICY_MODAL_MODE.ADD })
+  }
+
+  const handleClickEdit = (index: number) => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickEdit)
+    setModal({ open: true, mode: POLICY_MODAL_MODE.EDIT, index })
+  }
+
+  const handleCancelEdit = () => {
+    if (modal.open) trackEvent(EVENTS.Profile.PolicyPriorities.CancelEdit)
+    setModal({ open: false })
+  }
+
+  const handleSave = (issue: CustomIssue) => {
+    if (!modal.open) return
+    if (modal.mode === POLICY_MODAL_MODE.EDIT) {
+      trackEvent(EVENTS.Profile.PolicyPriorities.SubmitEdit)
+      const next = [...issues]
+      next[modal.index] = issue
+      onChange(next)
+    } else {
+      trackEvent(EVENTS.Profile.PolicyPriorities.SubmitAdd)
+      onChange([...issues, issue])
+    }
+    setModal({ open: false })
+  }
+
+  const handleClickDelete = () => {
+    if (!modal.open || modal.mode !== POLICY_MODAL_MODE.EDIT) return
+    trackEvent(EVENTS.Profile.PolicyPriorities.ClickDelete)
+    setPendingDeleteIndex(modal.index)
+  }
+
+  const handleCancelDelete = () => {
+    trackEvent(EVENTS.Profile.PolicyPriorities.CancelDelete)
+    setPendingDeleteIndex(null)
+  }
+
+  const handleConfirmDelete = () => {
+    if (pendingDeleteIndex === null) return
+    trackEvent(EVENTS.Profile.PolicyPriorities.SubmitDelete)
+    onChange(issues.filter((_, i) => i !== pendingDeleteIndex))
+    setPendingDeleteIndex(null)
+    setModal({ open: false })
+  }
+
+  const isEditing = modal.open && modal.mode === POLICY_MODAL_MODE.EDIT
+  const initial = isEditing ? issues[modal.index] : undefined
+  const formKey = modal.open
+    ? buildFormKey(modal.mode, isEditing ? modal.index : undefined)
+    : POLICY_MODAL_MODE.ADD
+
+  return (
+    <div>
+      <div className="mb-1.5 text-sm font-medium">Your policy priorities</div>
+      <div className="flex flex-col gap-3">
+        {issues.map((issue, index) => (
+          <button
+            key={index}
+            type="button"
+            disabled={disabled}
+            onClick={() => handleClickEdit(index)}
+            aria-label={`Edit ${issue.title}`}
+            className="flex items-start gap-2 rounded-md border border-input bg-white px-3 py-2 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-base">{issue.title}</div>
+              <div className="truncate text-sm text-foreground">
+                {issue.position}
+              </div>
+            </div>
+            <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={handleClickAdd}
+          aria-label="Add a policy priority"
+          className="flex items-center gap-2 rounded-md border border-dashed border-input bg-white px-3 py-2 text-base text-muted-foreground transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Plus className="h-4 w-4" aria-hidden />
+          Add a policy priority
+        </button>
+      </div>
+
+      <ModalOrDrawer
+        open={modal.open}
+        onOpenChange={(open) => {
+          if (!open) handleCancelEdit()
+        }}
+        title="Policy priority"
+      >
+        <PolicyForm
+          key={formKey}
+          initial={initial}
+          showDelete={isEditing}
+          onSave={handleSave}
+          onDelete={handleClickDelete}
+        />
+      </ModalOrDrawer>
+
+      <AlertDialog
+        open={pendingDeleteIndex !== null}
+        title="Delete policy priority"
+        description="Are you sure you want to delete this policy priority?"
+        proceedLabel="Delete"
+        handleClose={handleCancelDelete}
+        handleProceed={handleConfirmDelete}
+      />
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
+import { stripHtml } from 'string-strip-html'
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
 import AlertDialog from '@shared/utils/AlertDialog'
 import { WebsiteIssue } from 'helpers/types'
@@ -118,7 +119,7 @@ export default function PolicyPriorities({
             <div className="min-w-0 flex-1">
               <div className="truncate text-base">{issue.title}</div>
               <div className="truncate text-sm text-foreground">
-                {issue.description}
+                {issue.description ? stripHtml(issue.description).result : ''}
               </div>
             </div>
             <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities.tsx
@@ -3,7 +3,7 @@ import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
 import AlertDialog from '@shared/utils/AlertDialog'
-import { CustomIssue } from 'helpers/types'
+import { WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import PolicyForm from './PolicyForm'
 
@@ -21,8 +21,8 @@ type ModalState =
   | { open: true; mode: typeof POLICY_MODAL_MODE.EDIT; index: number }
 
 interface PolicyPrioritiesProps {
-  issues: CustomIssue[]
-  onChange: (issues: CustomIssue[]) => void
+  issues: WebsiteIssue[]
+  onChange: (issues: WebsiteIssue[]) => void
   disabled?: boolean
 }
 
@@ -60,7 +60,7 @@ export default function PolicyPriorities({
     setModal({ open: false })
   }
 
-  const handleSave = (issue: CustomIssue) => {
+  const handleSave = (issue: WebsiteIssue) => {
     if (!modal.open) return
     if (modal.mode === POLICY_MODAL_MODE.EDIT) {
       trackEvent(EVENTS.Profile.PolicyPriorities.SubmitEdit)
@@ -78,6 +78,7 @@ export default function PolicyPriorities({
     if (!modal.open || modal.mode !== POLICY_MODAL_MODE.EDIT) return
     trackEvent(EVENTS.Profile.PolicyPriorities.ClickDelete)
     setPendingDeleteIndex(modal.index)
+    setModal({ open: false })
   }
 
   const handleCancelDelete = () => {
@@ -117,7 +118,7 @@ export default function PolicyPriorities({
             <div className="min-w-0 flex-1">
               <div className="truncate text-base">{issue.title}</div>
               <div className="truncate text-sm text-foreground">
-                {issue.position}
+                {issue.description}
               </div>
             </div>
             <Pencil className="mt-1 h-4 w-4 shrink-0" aria-hidden />

--- a/app/dashboard/profile/texting-compliance/candidate-profile/page.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/page.tsx
@@ -1,0 +1,15 @@
+import pageMetaData from 'helpers/metadataHelper'
+import CandidateProfile from './components/CandidateProfile'
+import candidateAccess from 'app/dashboard/shared/candidateAccess'
+
+const meta = pageMetaData({
+  title: 'Candidate Profile | GoodParty.org',
+  description: 'Candidate profile settings for GoodParty.org.',
+})
+export const metadata = meta
+
+export default async function Page(): Promise<React.JSX.Element> {
+  await candidateAccess()
+
+  return <CandidateProfile />
+}

--- a/app/dashboard/shared/DashboardLayout.tsx
+++ b/app/dashboard/shared/DashboardLayout.tsx
@@ -90,7 +90,7 @@ const DashboardLayout = ({
               campaign={activeCampaign}
               user={user}
               pathname={currentPath || undefined}
-              isElectedOffice={!!organization.electedOfficeId}
+              isElectedOffice={!!organization?.electedOfficeId}
             />
             {children}
           </div>

--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -36,6 +36,7 @@ import { useEffect, useMemo } from 'react'
 import { syncEcanvasser } from '@shared/utils/syncEcanvasser'
 import Image from 'next/image'
 import { useUser } from '@shared/hooks/useUser'
+import { useUser as useClerkUser } from '@clerk/nextjs'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useElectedOffice } from '@shared/hooks/useElectedOffice'
 import { Campaign } from 'helpers/types'
@@ -301,7 +302,13 @@ const NewNavMenu = ({
   pathname: string | null
 }) => {
   const [user] = useUser()
+  const { user: clerkUser, isLoaded: isClerkUserLoaded } = useClerkUser()
   const { setOpenMobile, isMobile } = useSidebar()
+
+  const menuFirstName =
+    (isClerkUserLoaded && clerkUser?.firstName?.trim()) || user?.firstName || ''
+  const menuLastName =
+    (isClerkUserLoaded && clerkUser?.lastName?.trim()) || user?.lastName || ''
 
   const organization = useOrganization()
 
@@ -469,7 +476,7 @@ const NewNavMenu = ({
                         data-testid="user-menu-name"
                         className="truncate text-sm font-semibold"
                       >
-                        {user?.firstName} {user?.lastName}
+                        {menuFirstName} {menuLastName}
                       </span>
                       <span className="truncate text-xs">Manage account</span>
                     </div>

--- a/app/dashboard/shared/candidateAccess.test.ts
+++ b/app/dashboard/shared/candidateAccess.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Organization } from 'gpApi/api-endpoints'
+import candidateAccess from './candidateAccess'
+
+const {
+  mockAuth,
+  mockHeadersGet,
+  mockRedirect,
+  mockGetCurrentUserOrganizations,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockHeadersGet: vi.fn(),
+  mockRedirect: vi.fn(),
+  mockGetCurrentUserOrganizations: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}))
+
+vi.mock('next/headers', () => ({
+  headers: () =>
+    Promise.resolve({
+      get: (name: string) => mockHeadersGet(name),
+    }),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => mockRedirect(url),
+}))
+
+vi.mock('helpers/getCurrentUserOrganizations', () => ({
+  getCurrentUserOrganizations: () => mockGetCurrentUserOrganizations(),
+}))
+
+const minimalOrg: Organization = {
+  slug: 'campaign-1',
+  name: '2026 Campaign',
+  positionName: null,
+  position: null,
+  district: null,
+  electedOfficeId: null,
+  campaignId: 1,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRedirect.mockImplementation(() => undefined as never)
+  mockGetCurrentUserOrganizations.mockResolvedValue([minimalOrg])
+})
+
+describe('candidateAccess', () => {
+  it('redirects to sign-up when there is no Clerk userId', async () => {
+    mockAuth.mockResolvedValue({ userId: null, actor: null })
+
+    await candidateAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith('/sign-up')
+    expect(mockGetCurrentUserOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('redirects orgless users away from /dashboard to office selection', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user_2abc',
+      actor: { sub: 'admin' },
+    })
+    mockHeadersGet.mockImplementation((name) =>
+      name === 'x-pathname' ? '/dashboard' : null,
+    )
+    mockGetCurrentUserOrganizations.mockResolvedValue([])
+
+    await candidateAccess()
+
+    expect(mockGetCurrentUserOrganizations).toHaveBeenCalledOnce()
+    expect(mockRedirect).toHaveBeenCalledWith('/onboarding/office-selection')
+  })
+
+  it('does not fetch organizations or redirect for orgless non-dashboard routes', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user_2abc',
+      actor: { sub: 'admin' },
+    })
+    mockHeadersGet.mockImplementation((name) =>
+      name === 'x-pathname' ? '/polls/welcome' : null,
+    )
+
+    await candidateAccess()
+
+    expect(mockGetCurrentUserOrganizations).not.toHaveBeenCalled()
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect to office selection when user has organizations on dashboard', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user_2abc',
+      actor: { sub: 'admin' },
+    })
+    mockHeadersGet.mockImplementation((name) =>
+      name === 'x-pathname' ? '/dashboard/campaign-details' : null,
+    )
+    mockGetCurrentUserOrganizations.mockResolvedValue([minimalOrg])
+
+    await candidateAccess()
+
+    expect(mockGetCurrentUserOrganizations).toHaveBeenCalledOnce()
+    expect(mockRedirect).not.toHaveBeenCalledWith(
+      '/onboarding/office-selection',
+    )
+  })
+})

--- a/app/dashboard/shared/candidateAccess.ts
+++ b/app/dashboard/shared/candidateAccess.ts
@@ -1,8 +1,10 @@
 import { auth } from '@clerk/nextjs/server'
+import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { isRedirectError } from 'next/dist/client/components/redirect-error'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
+import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
 import { getServerUser } from 'helpers/userServerHelper'
 import {
   resolvePostAuthRedirectPath,
@@ -47,6 +49,16 @@ export default async function candidateAccess(): Promise<void> {
 
   if (!userId) {
     return redirect('/sign-up')
+  }
+
+  // `candidateAccess` is also used by non-dashboard routes (e.g. `/polls/*`); only
+  // bounce orgless users away from `/dashboard` where the UI assumes an organization.
+  const pathname = (await headers()).get('x-pathname') ?? ''
+  if (pathname.startsWith('/dashboard')) {
+    const organizations = await getCurrentUserOrganizations()
+    if (organizations.length === 0) {
+      return redirect('/onboarding/office-selection')
+    }
   }
 
   // Skip the legacy token check for impersonated sessions — actor tokens are Clerk JWTs

--- a/app/dashboard/website/util/website.util.ts
+++ b/app/dashboard/website/util/website.util.ts
@@ -62,6 +62,18 @@ export async function updateWebsite(
   }
 }
 
+export const USER_WEBSITE_QUERY_KEY = ['user-website']
+
+export async function getUserWebsite(): Promise<Website | null> {
+  try {
+    const resp = await clientFetch<Website>(apiRoutes.website.get)
+    return resp.ok ? resp.data : null
+  } catch (e) {
+    console.error('error', e)
+    return null
+  }
+}
+
 export async function validateVanityPath(
   vanityPath: string,
 ): Promise<ApiResponse<{ available: boolean }>> {

--- a/app/shared/layouts/PageWrapper.tsx
+++ b/app/shared/layouts/PageWrapper.tsx
@@ -18,7 +18,7 @@ import { SentryIdentifier } from '@shared/sentry'
 import AmplitudeInit from '@shared/AmplitudeInit'
 import { ImpersonatingTracker } from '@shared/user/ImpersonatingTracker'
 import { OrganizationProvider } from '@shared/organization-picker'
-import { serverRequest } from 'gpApi/server-request'
+import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
 import { ClerkProvider } from '@clerk/nextjs'
 import { auth } from '@clerk/nextjs/server'
 import { ReactQueryProvider } from '@shared/query-client'
@@ -37,13 +37,7 @@ const PageWrapper = async ({
   const [pathname, campaign, organizations] = await Promise.all([
     getReqPathname(),
     isAuthed ? fetchUserCampaign() : Promise.resolve(null),
-    isAuthed
-      ? serverRequest(
-          'GET /v1/organizations',
-          {},
-          { ignoreResponseError: true },
-        ).then((res) => (res.ok ? res.data.organizations : []))
-      : Promise.resolve([]),
+    isAuthed ? getCurrentUserOrganizations() : Promise.resolve([]),
   ])
 
   return (

--- a/app/shared/organization-picker.test.tsx
+++ b/app/shared/organization-picker.test.tsx
@@ -79,7 +79,7 @@ describe('OrganizationProvider', () => {
   it('provides the first organization as default when no cookie is set', () => {
     const Probe = () => {
       const org = useOrganization()
-      return <div data-testid="org">{org.slug}</div>
+      return <div data-testid="org">{org?.slug}</div>
     }
 
     render(
@@ -99,7 +99,7 @@ describe('OrganizationProvider', () => {
 
     const Probe = () => {
       const org = useOrganization()
-      return <div data-testid="org">{org.slug}</div>
+      return <div data-testid="org">{org?.slug}</div>
     }
 
     render(
@@ -118,7 +118,7 @@ describe('OrganizationProvider', () => {
 
     const Probe = () => {
       const org = useOrganization()
-      return <div data-testid="org">{org.slug}</div>
+      return <div data-testid="org">{org?.slug}</div>
     }
 
     render(
@@ -139,6 +139,22 @@ describe('OrganizationProvider', () => {
     )
 
     expect(screen.getByTestId('child')).toHaveTextContent('hello')
+  })
+
+  it('does not throw when reading electedOfficeId with no organizations (dashboard layout pattern)', () => {
+    const Probe = () => {
+      const organization = useOrganization()
+      const isElectedOffice = !!organization?.electedOfficeId
+      return <div data-testid="elected">{String(isElectedOffice)}</div>
+    }
+
+    render(
+      <OrganizationProvider initialOrganizations={[]}>
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    expect(screen.getByTestId('elected')).toHaveTextContent('false')
   })
 
   it('throws when useOrganization is used outside the provider', () => {

--- a/app/shared/organization-picker.tsx
+++ b/app/shared/organization-picker.tsx
@@ -33,13 +33,13 @@ const SHARED_PATHS = ['/dashboard/profile', '/dashboard/campaign-details']
 
 interface OrganizationContextValue {
   organizations: Organization[]
-  selected: Organization
+  selected: Organization | undefined
   setSelectedSlug: (slug: string) => void
 }
 
 const OrganizationContext = createContext<OrganizationContextValue | null>(null)
 
-export const useOrganization = () => {
+export const useOrganization = (): Organization | undefined => {
   const ctx = useContext(OrganizationContext)
   if (!ctx) {
     throw new Error('useOrganization must be used within OrganizationProvider')
@@ -112,7 +112,7 @@ export const OrganizationProvider = ({
     <OrganizationContext.Provider
       value={{
         organizations,
-        selected: selectedOrganization!,
+        selected: selectedOrganization,
         setSelectedSlug,
       }}
     >
@@ -130,7 +130,7 @@ export const OrganizationPicker = () => {
   const [campaign] = useCampaign()
   const pathname = usePathname()
 
-  if (!ctx || ctx.organizations.length === 0) return null
+  if (!ctx || ctx.organizations.length === 0 || !ctx.selected) return null
 
   const { organizations, selected, setSelectedSlug } = ctx
 

--- a/app/shared/user/ImpersonationBanner.test.tsx
+++ b/app/shared/user/ImpersonationBanner.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
+import { useUser } from '@shared/hooks/useUser'
+import { useClerk, useAuth } from '@clerk/nextjs'
+import { useSnackbar } from 'helpers/useSnackbar'
+import ImpersonationBanner from './ImpersonationBanner'
+
+const mockClientRequest = vi.fn()
+vi.mock('gpApi/typed-request', () => ({
+  clientRequest: (...args: unknown[]) => mockClientRequest(...args),
+}))
+
+const mockSignOut = vi.fn()
+const mockSetActive = vi.fn()
+const mockSignInCreate = vi.fn()
+const mockErrorSnackbar = vi.fn()
+
+vi.mock('@shared/hooks/useIsImpersonating', () => ({
+  useIsImpersonating: vi.fn(),
+}))
+
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useClerk: vi.fn(),
+  useAuth: vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: vi.fn(),
+}))
+
+beforeEach(() => {
+  mockClientRequest.mockReset()
+  mockSignOut.mockReset().mockResolvedValue(undefined)
+  mockSetActive.mockReset().mockResolvedValue(undefined)
+  mockSignInCreate.mockReset().mockResolvedValue({
+    status: 'complete',
+    createdSessionId: 'session-123',
+  })
+  mockErrorSnackbar.mockReset()
+
+  vi.mocked(useIsImpersonating).mockReturnValue(false)
+  vi.mocked(useClerk).mockReturnValue({
+    signOut: mockSignOut,
+    client: { signIn: { create: mockSignInCreate } },
+    setActive: mockSetActive,
+    loaded: true,
+  } as any)
+  vi.mocked(useAuth).mockReturnValue({
+    actor: { sub: 'admin-clerk-id' },
+  } as any)
+  vi.mocked(useUser).mockReturnValue([
+    { email: 'target@example.com' } as any,
+    vi.fn(),
+    false,
+  ])
+  vi.mocked(useSnackbar).mockReturnValue({
+    errorSnackbar: mockErrorSnackbar,
+    successSnackbar: vi.fn(),
+  } as any)
+})
+
+describe('ImpersonationBanner', () => {
+  it('renders nothing when not impersonating', () => {
+    render(<ImpersonationBanner />)
+    expect(screen.queryByText(/impersonating/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the impersonated user email', () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    render(<ImpersonationBanner />)
+    expect(screen.getByText('target@example.com')).toBeInTheDocument()
+  })
+
+  it('falls back to "this user" when email is unavailable', () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    vi.mocked(useUser).mockReturnValue([null, vi.fn(), false])
+    render(<ImpersonationBanner />)
+    expect(screen.getByText('this user')).toBeInTheDocument()
+  })
+
+  it('opens search dialog when Switch User is clicked', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+    render(<ImpersonationBanner />)
+
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+
+    expect(screen.getByPlaceholderText(/search by email/i)).toBeInTheDocument()
+  })
+
+  it('closes dialog when Escape is pressed', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+    render(<ImpersonationBanner />)
+
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+    expect(screen.getByPlaceholderText(/search by email/i)).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(
+      screen.queryByPlaceholderText(/search by email/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows search results after typing', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+
+    mockClientRequest.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: [{ id: 5, email: 'found@example.com', name: 'Found User' }],
+    })
+
+    render(<ImpersonationBanner />)
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+    await user.type(screen.getByPlaceholderText(/search by email/i), 'found')
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('found@example.com')).toBeInTheDocument()
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  it('shows "No user found" when search returns null', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+
+    mockClientRequest.mockResolvedValue({ ok: true, status: 200, data: null })
+
+    render(<ImpersonationBanner />)
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+    await user.type(screen.getByPlaceholderText(/search by email/i), 'nobody')
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/no user found/i)).toBeInTheDocument()
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  it('swaps impersonation when a result is clicked', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+
+    mockClientRequest.mockImplementation((route: string) => {
+      if (route === 'GET /v1/admin/users/search') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          data: [{ id: 7, email: 'new@example.com', name: null }],
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        data: { token: 'actor-token-xyz' },
+      })
+    })
+
+    render(<ImpersonationBanner />)
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+    await user.type(screen.getByPlaceholderText(/search by email/i), 'new')
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('new@example.com')).toBeInTheDocument()
+      },
+      { timeout: 2000 },
+    )
+
+    await user.click(screen.getByText('new@example.com'))
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /switch user/i,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled()
+    })
+    expect(mockSignInCreate).toHaveBeenCalledWith({
+      strategy: 'ticket',
+      ticket: 'actor-token-xyz',
+    })
+    expect(mockSetActive).toHaveBeenCalledWith({ session: 'session-123' })
+  })
+
+  it('shows error snackbar when impersonation swap fails', async () => {
+    vi.mocked(useIsImpersonating).mockReturnValue(true)
+    const user = userEvent.setup()
+
+    mockClientRequest.mockImplementation((route: string) => {
+      if (route === 'GET /v1/admin/users/search') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          data: [{ id: 7, email: 'new@example.com', name: null }],
+        })
+      }
+      return Promise.resolve({ ok: false, status: 500, data: null })
+    })
+
+    render(<ImpersonationBanner />)
+    await user.click(screen.getByRole('button', { name: /switch user/i }))
+    await user.type(screen.getByPlaceholderText(/search by email/i), 'new')
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('new@example.com')).toBeInTheDocument()
+      },
+      { timeout: 2000 },
+    )
+
+    await user.click(screen.getByText('new@example.com'))
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /switch user/i,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockErrorSnackbar).toHaveBeenCalled()
+    })
+    expect(mockSignOut).not.toHaveBeenCalled()
+  })
+})

--- a/app/shared/user/ImpersonationBanner.tsx
+++ b/app/shared/user/ImpersonationBanner.tsx
@@ -3,30 +3,204 @@
 import { useClerk } from '@clerk/nextjs'
 import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
 import { useUser } from '@shared/hooks/useUser'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { clientRequest } from 'gpApi/typed-request'
+import { useState, useRef, useCallback } from 'react'
+import { ArrowLeftRight, Ban } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@styleguide/components/ui/dialog'
+import { Button } from '@styleguide/components/ui/button'
+import { Input } from '@styleguide/components/ui/input'
+import { cn } from '@styleguide/lib/utils'
 
 const GP_ADMIN_URL = process.env.NEXT_PUBLIC_GP_ADMIN_URL ?? '/'
 
+type SearchResult = { id: number; email: string; name: string | null }
+
 export default function ImpersonationBanner() {
   const isImpersonating = useIsImpersonating()
-  const { signOut } = useClerk()
+  const { signOut, client, setActive } = useClerk()
   const [user] = useUser()
+  const { errorSnackbar } = useSnackbar()
 
-  if (!isImpersonating) return null
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [selected, setSelected] = useState<SearchResult | null>(null)
+  const [swapping, setSwapping] = useState(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  const handleSearch = useCallback((value: string) => {
+    setQuery(value)
+    setSelected(null)
+    clearTimeout(debounceRef.current)
+    if (!value.trim()) {
+      setResults([])
+      return
+    }
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true)
+      try {
+        const resp = await clientRequest('GET /v1/admin/users/search', {
+          email: value,
+        })
+        if (resp.ok) {
+          setResults(resp.data)
+        }
+      } finally {
+        setSearching(false)
+      }
+    }, 300)
+  }, [])
+
+  async function handleSwap() {
+    if (!selected) return
+    setSwapping(true)
+    try {
+      const resp = await clientRequest(
+        'POST /v1/admin/users/impersonate/:userId',
+        { userId: String(selected.id) },
+      )
+      if (!resp.ok) {
+        errorSnackbar('Failed to switch impersonation')
+        return
+      }
+      const { token } = resp.data
+      await signOut()
+      const result = await client.signIn.create({
+        strategy: 'ticket',
+        ticket: token,
+      })
+      if (result.status !== 'complete' || !result.createdSessionId) {
+        throw new Error('Impersonation sign-in incomplete')
+      }
+      await setActive({ session: result.createdSessionId })
+      window.location.href = '/dashboard'
+    } catch {
+      errorSnackbar('Failed to switch impersonation')
+    } finally {
+      setSwapping(false)
+    }
+  }
 
   async function handleStopImpersonating() {
     await signOut()
     window.location.href = GP_ADMIN_URL
   }
 
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (!next) {
+      setQuery('')
+      setResults([])
+      setSelected(null)
+    }
+  }
+
+  if (!isImpersonating) return null
+
   return (
-    <div className="bg-amber-400 text-black px-4 py-1 text-center text-xs font-medium">
-      You are impersonating {user?.email ?? 'this user'}.{' '}
-      <button
-        onClick={handleStopImpersonating}
-        className="bg-black text-white border-none rounded px-3 py-1 cursor-pointer ml-2 text-[13px]"
-      >
-        Stop Impersonating
-      </button>
-    </div>
+    <>
+      <div className="bg-amber-400 text-black px-4 py-2 text-center text-xs font-medium flex flex-col items-center gap-2">
+        <span>
+          You are impersonating <strong>{user?.email ?? 'this user'}</strong>
+        </span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="xSmall"
+            onClick={() => setOpen(true)}
+            className="bg-green-600 text-white border-green-600 hover:bg-green-700 hover:border-green-700"
+          >
+            <ArrowLeftRight />
+            Switch User
+          </Button>
+          <Button
+            variant="destructive"
+            size="xSmall"
+            onClick={handleStopImpersonating}
+          >
+            <Ban />
+            Stop Impersonating
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Switch Impersonation</DialogTitle>
+            <DialogDescription>
+              Currently impersonating <strong>{user?.email}</strong>.<br />
+              Search for a user to switch to.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <Input
+              autoFocus
+              placeholder="Search by email..."
+              value={query}
+              onChange={(e) => handleSearch(e.target.value)}
+            />
+            {searching && (
+              <p className="text-sm text-muted-foreground">Searching...</p>
+            )}
+            {!searching && query && results.length === 0 && (
+              <p className="text-sm text-muted-foreground">No user found</p>
+            )}
+            {results.length > 0 && (
+              <div className="border rounded-md divide-y max-h-48 overflow-y-auto">
+                {results.map((r) => (
+                  <button
+                    key={r.id}
+                    onClick={() => setSelected(r)}
+                    className={cn(
+                      'w-full text-left px-3 py-2 text-sm hover:bg-muted transition-colors',
+                      selected?.id === r.id && 'bg-primary/10 font-medium',
+                    )}
+                  >
+                    <div className="truncate">{r.email}</div>
+                    {r.name && (
+                      <div className="text-muted-foreground text-xs truncate">
+                        {r.name}
+                      </div>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+            {selected && (
+              <p className="text-sm text-muted-foreground break-all">
+                Switching to:{' '}
+                <strong className="text-foreground">{selected.email}</strong>
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!selected || swapping}
+              loading={swapping}
+              loadingText="Switching..."
+              onClick={handleSwap}
+              className="w-48"
+            >
+              Switch User
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -102,8 +102,13 @@ export type APIEndpoints = {
     Response: { organizations: AdminOrganization[] }
   }
 
+  'GET /v1/admin/users/search': {
+    Request: { email: string }
+    Response: { id: number; email: string; name: string | null }[]
+  }
+
   'POST /v1/admin/users/impersonate/:userId': {
-    Request: {}
+    Request: { actorEmail?: string }
     Response: { token: string }
   }
 

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -422,6 +422,21 @@ export const EVENTS = {
       SubmitDelete: 'Profile - Top Issues: Submit Delete',
       CancelDelete: 'Profile - Top Issues: Cancel Delete',
     },
+    PolicyPriorities: {
+      ClickAdd: 'Profile - Policy Priorities: Click Add',
+      ClickEdit: 'Profile - Policy Priorities: Click Edit',
+      SubmitAdd: 'Profile - Policy Priorities: Submit Add',
+      SubmitEdit: 'Profile - Policy Priorities: Submit Edit',
+      CancelEdit: 'Profile - Policy Priorities: Cancel Edit',
+      ClickDelete: 'Profile - Policy Priorities: Click Delete',
+      SubmitDelete: 'Profile - Policy Priorities: Submit Delete',
+      CancelDelete: 'Profile - Policy Priorities: Cancel Delete',
+    },
+    CandidateProfile: {
+      ClickSubmit: 'Profile - Candidate Profile: Click Submit',
+      SubmitSuccess: 'Profile - Candidate Profile: Submit Success',
+      SubmitError: 'Profile - Candidate Profile: Submit Error',
+    },
   },
   Settings: {
     PersonalInfo: {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -427,6 +427,7 @@ export const EVENTS = {
       ClickEdit: 'Profile - Policy Priorities: Click Edit',
       SubmitAdd: 'Profile - Policy Priorities: Submit Add',
       SubmitEdit: 'Profile - Policy Priorities: Submit Edit',
+      CancelAdd: 'Profile - Policy Priorities: Cancel Add',
       CancelEdit: 'Profile - Policy Priorities: Cancel Edit',
       ClickDelete: 'Profile - Policy Priorities: Click Delete',
       SubmitDelete: 'Profile - Policy Priorities: Submit Delete',

--- a/helpers/getCurrentUserOrganizations.ts
+++ b/helpers/getCurrentUserOrganizations.ts
@@ -1,0 +1,18 @@
+import { cache } from 'react'
+import { serverRequest } from 'gpApi/server-request'
+import type { Organization } from 'gpApi/api-endpoints'
+
+/**
+ * Request-scoped fetch of the signed-in user's organizations.
+ * Dedupes with React `cache()` when multiple server components call it in the same render.
+ */
+export const getCurrentUserOrganizations = cache(
+  async (): Promise<Organization[]> => {
+    const resp = await serverRequest(
+      'GET /v1/organizations',
+      {},
+      { ignoreResponseError: true },
+    )
+    return resp.ok ? resp.data.organizations : []
+  },
+)

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -117,7 +117,6 @@ export interface CampaignDetails {
   pledged?: boolean
   isProUpdatedAt?: number
   customIssues?: CustomIssue[]
-  whyRunning?: string
   runningAgainst?: RunningAgainst[]
   geoLocation?: CampaignGeoLocation
   geoLocationFailed?: boolean

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -117,6 +117,7 @@ export interface CampaignDetails {
   pledged?: boolean
   isProUpdatedAt?: number
   customIssues?: CustomIssue[]
+  whyRunning?: string
   runningAgainst?: RunningAgainst[]
   geoLocation?: CampaignGeoLocation
   geoLocationFailed?: boolean

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,6 @@
         "eslint-config-next": "^15.2.4",
         "eslint-plugin-mdx": "^2.1.0",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-storybook": "^10.2.10",
         "eslint-plugin-unused-imports": "^4.1.4",
         "jsdom": "^28.0.0",
         "madge": "^8.0.0",
@@ -16195,20 +16194,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-storybook": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.3.4.tgz",
-      "integrity": "sha512-6jRb9ucYWKRkbuxpN+83YA3wAWuKn6rp+OVXivy0FPa82v8eciHG8OidbznmzrfcRJYkNWUb7GrPjG/rf4Vqaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.48.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8",
-        "storybook": "^10.3.4"
       }
     },
     "node_modules/eslint-plugin-unused-imports": {

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "eslint-config-next": "^15.2.4",
     "eslint-plugin-mdx": "^2.1.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-storybook": "^10.2.10",
     "eslint-plugin-unused-imports": "^4.1.4",
     "jsdom": "^28.0.0",
     "madge": "^8.0.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new profile-completion flow and admin impersonation switching, and changes organization selection/nullability and dashboard gating logic; regressions could affect navigation, access redirects, and admin sessions.
> 
> **Overview**
> Adds a new *Texting Compliance* “Candidate profile” step that is dynamically marked complete/active based on the user’s website content, plus a new `/dashboard/profile/texting-compliance/candidate-profile` page to edit and submit a bio and policy priorities (persisted via website create/update and tracked with new analytics events).
> 
> Hardens dashboard behavior when an organization is missing by making `useOrganization()` return `undefined`, updating callers to use optional chaining, and adding server-side `candidateAccess` logic to redirect org-less users hitting `/dashboard*` to office selection (with new request-scoped `getCurrentUserOrganizations()` helper and tests).
> 
> Enhances the impersonation banner to support searching and switching impersonated users via new admin API endpoints, and updates the dashboard menu to prefer Clerk user names when available. Also adjusts tooling configs (disable Storybook ESLint plugin on ESLint 8, expand ignores) and removes `eslint-plugin-storybook` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8adb9be4ca99e6d93d6b0caae0873dc4650e61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->