### PR TITLE
ENG-7570 handle blocked Pro renewal checkout

### DIFF
--- a/app/dashboard/pro-sign-up/purchase-redirect/components/PurchaseRedirectPage.tsx
+++ b/app/dashboard/pro-sign-up/purchase-redirect/components/PurchaseRedirectPage.tsx
@@ -11,13 +11,45 @@ import { clientFetch } from 'gpApi/clientFetch'
 import { apiRoutes } from 'gpApi/routes'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 
-const doRedirect = async (currentTimeoutId: NodeJS.Timeout | null) => {
+type CheckoutErrorBody = { errorCode?: string; message?: string }
+
+type CheckoutError =
+  | { type: 'electionDateInvalid'; message: string }
+  | { type: 'generic'; message: string }
+
+const ELECTION_DATE_ERROR_CODE = 'CAMPAIGN_ELECTION_DATE_INVALID'
+
+const doRedirect = async (
+  currentTimeoutId: NodeJS.Timeout | null,
+  setError: (error: CheckoutError) => void,
+) => {
   if (currentTimeoutId) {
     clearTimeout(currentTimeoutId)
   }
   try {
-    const resp = await clientFetch(apiRoutes.payments.createCheckoutSession)
-    const { redirectUrl } = (resp.data as { redirectUrl?: string }) || {}
+    const resp = await clientFetch<{ redirectUrl?: string }>(
+      apiRoutes.payments.createCheckoutSession,
+    )
+    if (!resp.ok) {
+      const body = (resp.data as CheckoutErrorBody | undefined) ?? {}
+      setError(
+        body.errorCode === ELECTION_DATE_ERROR_CODE
+          ? {
+              type: 'electionDateInvalid',
+              message:
+                body.message ??
+                'Your campaign election date is missing or in the past.',
+            }
+          : {
+              type: 'generic',
+              message:
+                body.message ??
+                'We could not start your Pro checkout. Please try again.',
+            },
+      )
+      return
+    }
+    const { redirectUrl } = resp.data || {}
     await updateUser()
     if (redirectUrl) {
       window.location.href = redirectUrl
@@ -26,6 +58,10 @@ const doRedirect = async (currentTimeoutId: NodeJS.Timeout | null) => {
     }
   } catch (e) {
     console.error('error when creating checkout session.', e)
+    setError({
+      type: 'generic',
+      message: 'We could not start your Pro checkout. Please try again.',
+    })
   }
 }
 
@@ -39,6 +75,7 @@ const PurchaseRedirectPage = ({
   redirectDelaySecs,
 }: PurchaseRedirectPageProps): React.JSX.Element => {
   const [countdown, setCountdown] = useState(Number(redirectDelaySecs))
+  const [error, setError] = useState<CheckoutError | null>(null)
   const [currentTimeoutId, setCurrentTimeoutId] =
     useState<NodeJS.Timeout | null>(null)
 
@@ -49,20 +86,50 @@ const PurchaseRedirectPage = ({
   }
 
   useEffect(() => {
+    if (error) return
     if (countdown === 0) {
-      doRedirect(currentTimeoutId)
+      doRedirect(currentTimeoutId, setError)
     } else {
       killTimeout()
       setCurrentTimeoutId(setTimeout(() => setCountdown(countdown - 1), 1000))
     }
 
     return () => killTimeout()
-  }, [countdown])
+  }, [countdown, error])
 
   return (
     <FocusedExperienceWrapper>
       {campaign?.isPro ? (
         <AlreadyProUserPrompt />
+      ) : error ? (
+        <div className="text-center">
+          <H1 className="mb-4">
+            {error.type === 'electionDateInvalid'
+              ? 'Update your election date to renew Pro'
+              : 'Something went wrong'}
+          </H1>
+          <Body2 className="mb-8">{error.message}</Body2>
+          {error.type === 'electionDateInvalid' ? (
+            <PrimaryButton
+              className="w-full md:w-auto"
+              onClick={() => {
+                window.location.href = '/dashboard/campaign-details'
+              }}
+            >
+              Update campaign details
+            </PrimaryButton>
+          ) : (
+            <PrimaryButton
+              className="w-full md:w-auto"
+              onClick={() => {
+                setError(null)
+                setCountdown(Number(redirectDelaySecs))
+              }}
+            >
+              Try again
+            </PrimaryButton>
+          )}
+        </div>
       ) : (
         <div className="text-center">
           <Image
@@ -86,7 +153,7 @@ const PurchaseRedirectPage = ({
             className="w-full md:w-auto"
             onClick={() => {
               trackEvent(EVENTS.ProUpgrade.ClickGoToStripe)
-              doRedirect(currentTimeoutId)
+              doRedirect(currentTimeoutId, setError)
             }}
           >
             Go to Stripe

--- a/app/dashboard/pro-sign-up/purchase-redirect/components/PurchaseRedirectPage.tsx
+++ b/app/dashboard/pro-sign-up/purchase-redirect/components/PurchaseRedirectPage.tsx
@@ -13,15 +13,11 @@ import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 
 type CheckoutErrorBody = { errorCode?: string; message?: string }
 
-type CheckoutError =
-  | { type: 'electionDateInvalid'; message: string }
-  | { type: 'generic'; message: string }
-
 const ELECTION_DATE_ERROR_CODE = 'CAMPAIGN_ELECTION_DATE_INVALID'
 
 const doRedirect = async (
   currentTimeoutId: NodeJS.Timeout | null,
-  setError: (error: CheckoutError) => void,
+  setElectionDateError: (message: string) => void,
 ) => {
   if (currentTimeoutId) {
     clearTimeout(currentTimeoutId)
@@ -32,21 +28,12 @@ const doRedirect = async (
     )
     if (!resp.ok) {
       const body = (resp.data as CheckoutErrorBody | undefined) ?? {}
-      setError(
-        body.errorCode === ELECTION_DATE_ERROR_CODE
-          ? {
-              type: 'electionDateInvalid',
-              message:
-                body.message ??
-                'Your campaign election date is missing or in the past.',
-            }
-          : {
-              type: 'generic',
-              message:
-                body.message ??
-                'We could not start your Pro checkout. Please try again.',
-            },
-      )
+      if (body.errorCode === ELECTION_DATE_ERROR_CODE) {
+        setElectionDateError(
+          body.message ??
+            'Your campaign election date is missing or in the past.',
+        )
+      }
       return
     }
     const { redirectUrl } = resp.data || {}
@@ -58,10 +45,6 @@ const doRedirect = async (
     }
   } catch (e) {
     console.error('error when creating checkout session.', e)
-    setError({
-      type: 'generic',
-      message: 'We could not start your Pro checkout. Please try again.',
-    })
   }
 }
 
@@ -75,7 +58,9 @@ const PurchaseRedirectPage = ({
   redirectDelaySecs,
 }: PurchaseRedirectPageProps): React.JSX.Element => {
   const [countdown, setCountdown] = useState(Number(redirectDelaySecs))
-  const [error, setError] = useState<CheckoutError | null>(null)
+  const [electionDateError, setElectionDateError] = useState<string | null>(
+    null,
+  )
   const [currentTimeoutId, setCurrentTimeoutId] =
     useState<NodeJS.Timeout | null>(null)
 
@@ -86,49 +71,33 @@ const PurchaseRedirectPage = ({
   }
 
   useEffect(() => {
-    if (error) return
+    if (electionDateError) return
     if (countdown === 0) {
-      doRedirect(currentTimeoutId, setError)
+      doRedirect(currentTimeoutId, setElectionDateError)
     } else {
       killTimeout()
       setCurrentTimeoutId(setTimeout(() => setCountdown(countdown - 1), 1000))
     }
 
     return () => killTimeout()
-  }, [countdown, error])
+  }, [countdown, electionDateError])
 
   return (
     <FocusedExperienceWrapper>
       {campaign?.isPro ? (
         <AlreadyProUserPrompt />
-      ) : error ? (
+      ) : electionDateError ? (
         <div className="text-center">
-          <H1 className="mb-4">
-            {error.type === 'electionDateInvalid'
-              ? 'Update your election date to renew Pro'
-              : 'Something went wrong'}
-          </H1>
-          <Body2 className="mb-8">{error.message}</Body2>
-          {error.type === 'electionDateInvalid' ? (
-            <PrimaryButton
-              className="w-full md:w-auto"
-              onClick={() => {
-                window.location.href = '/dashboard/campaign-details'
-              }}
-            >
-              Update campaign details
-            </PrimaryButton>
-          ) : (
-            <PrimaryButton
-              className="w-full md:w-auto"
-              onClick={() => {
-                setError(null)
-                setCountdown(Number(redirectDelaySecs))
-              }}
-            >
-              Try again
-            </PrimaryButton>
-          )}
+          <H1 className="mb-4">Update your election date to renew Pro</H1>
+          <Body2 className="mb-8">{electionDateError}</Body2>
+          <PrimaryButton
+            className="w-full md:w-auto"
+            onClick={() => {
+              window.location.href = '/dashboard/campaign-details'
+            }}
+          >
+            Update campaign details
+          </PrimaryButton>
         </div>
       ) : (
         <div className="text-center">
@@ -153,7 +122,7 @@ const PurchaseRedirectPage = ({
             className="w-full md:w-auto"
             onClick={() => {
               trackEvent(EVENTS.ProUpgrade.ClickGoToStripe)
-              doRedirect(currentTimeoutId, setError)
+              doRedirect(currentTimeoutId, setElectionDateError)
             }}
           >
             Go to Stripe


### PR DESCRIPTION
## Summary
- Handle the API's `CAMPAIGN_ELECTION_DATE_INVALID` response on the Pro purchase redirect page.
- Stop silently swallowing that blocked checkout case and show a minimal message directing the user to update campaign details.
- Keep generic checkout failures on the previous behavior path without adding extra UI.

## User Impact
Users with missing or past election dates will not be sent to Stripe. They will see a simple prompt to update their election date before renewing Pro.

## Validation
- `npx eslint app/dashboard/pro-sign-up/purchase-redirect/components/PurchaseRedirectPage.tsx --quiet`
