### PR TITLE
Eng 7533 pin

### DIFF
--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
@@ -12,10 +12,22 @@ import TextingComplianceApproved from './TextingComplianceApproved'
 import TextingComplianceInReview from './TextingComplianceInReview'
 
 export default function TextingComplianceAgentic(): React.JSX.Element {
-  const { data: tcrCompliance } = useQuery({
+  const { data: tcrCompliance, isPending } = useQuery({
     queryKey: TCR_COMPLIANCE_QUERY_KEY,
     queryFn: getTcrCompliance,
   })
+
+  // Render a placeholder shell while loading so we don't flash the default
+  // steps view to users who are actually approved or pending review.
+  if (isPending) {
+    return (
+      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+        <div className="h-6 w-2/3 animate-pulse rounded-md bg-slate-200" />
+        <div className="h-4 w-full animate-pulse rounded-md bg-slate-200" />
+      </Card>
+    )
+  }
 
   const status = tcrCompliance?.status
 

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
@@ -1,7 +1,48 @@
+'use client'
+
+import { BadgeCheck } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 import { Card } from '@styleguide'
+import {
+  TCR_COMPLIANCE_QUERY_KEY,
+  TCR_COMPLIANCE_STATUS,
+  getTcrCompliance,
+} from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
 import TextComplianceSteps from './TextComplianceSteps'
 
 export default function TextingComplianceAgentic(): React.JSX.Element {
+  const { data: tcrCompliance } = useQuery({
+    queryKey: TCR_COMPLIANCE_QUERY_KEY,
+    queryFn: getTcrCompliance,
+  })
+
+  const status = tcrCompliance?.status
+
+  if (status === TCR_COMPLIANCE_STATUS.APPROVED) {
+    return (
+      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+        <div className="flex items-center gap-2">
+          <BadgeCheck className="h-6 w-6 text-green-600" aria-hidden />
+          <p className="text-lg font-medium">Your campaign is compliant</p>
+        </div>
+      </Card>
+    )
+  }
+
+  if (status === TCR_COMPLIANCE_STATUS.PENDING) {
+    return (
+      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+        <p className="text-lg font-medium">Your application is in review</p>
+        <p className="text-sm text-secondary">
+          This can take 3-7 business days. We will send you an email once your
+          campaign is approved, so you can start sending text messages.
+        </p>
+      </Card>
+    )
+  }
+
   return (
     <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
       <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceAgentic.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { BadgeCheck } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { Card } from '@styleguide'
 import {
@@ -9,6 +8,8 @@ import {
   getTcrCompliance,
 } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
 import TextComplianceSteps from './TextComplianceSteps'
+import TextingComplianceApproved from './TextingComplianceApproved'
+import TextingComplianceInReview from './TextingComplianceInReview'
 
 export default function TextingComplianceAgentic(): React.JSX.Element {
   const { data: tcrCompliance } = useQuery({
@@ -19,28 +20,11 @@ export default function TextingComplianceAgentic(): React.JSX.Element {
   const status = tcrCompliance?.status
 
   if (status === TCR_COMPLIANCE_STATUS.APPROVED) {
-    return (
-      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
-        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
-        <div className="flex items-center gap-2">
-          <BadgeCheck className="h-6 w-6 text-green-600" aria-hidden />
-          <p className="text-lg font-medium">Your campaign is compliant</p>
-        </div>
-      </Card>
-    )
+    return <TextingComplianceApproved />
   }
 
   if (status === TCR_COMPLIANCE_STATUS.PENDING) {
-    return (
-      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
-        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
-        <p className="text-lg font-medium">Your application is in review</p>
-        <p className="text-sm text-secondary">
-          This can take 3-7 business days. We will send you an email once your
-          campaign is approved, so you can start sending text messages.
-        </p>
-      </Card>
-    )
+    return <TextingComplianceInReview />
   }
 
   return (

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceApproved.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceApproved.tsx
@@ -1,0 +1,14 @@
+import { BadgeCheck } from 'lucide-react'
+import { Card } from '@styleguide'
+
+export default function TextingComplianceApproved(): React.JSX.Element {
+  return (
+    <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+      <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+      <div className="flex items-center gap-2">
+        <BadgeCheck className="h-6 w-6 text-green-600" aria-hidden />
+        <p className="text-lg font-medium">Your campaign is compliant</p>
+      </div>
+    </Card>
+  )
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceInReview.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceInReview.tsx
@@ -1,0 +1,14 @@
+import { Card } from '@styleguide'
+
+export default function TextingComplianceInReview(): React.JSX.Element {
+  return (
+    <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+      <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+      <p className="text-lg font-medium">Your application is in review</p>
+      <p className="text-sm text-secondary">
+        This can take 3-7 business days. We will send you an email once your
+        campaign is approved, so you can start sending text messages.
+      </p>
+    </Card>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import { api } from 'helpers/test-utils/api-mocking'
+import type { TcrCompliance, TcrComplianceStatus } from 'helpers/types'
+import EnterPin from './EnterPin'
+
+const mockGetTcrCompliance = vi.fn<() => Promise<TcrCompliance | null>>()
+vi.mock(
+  'app/dashboard/profile/texting-compliance/util/tcrCompliance.util',
+  async (importOriginal) => {
+    const actual = await importOriginal<
+      typeof import('app/dashboard/profile/texting-compliance/util/tcrCompliance.util')
+    >()
+    return {
+      ...actual,
+      getTcrCompliance: () => mockGetTcrCompliance(),
+    }
+  },
+)
+
+const mockSuccessSnackbar = vi.fn()
+const mockErrorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({
+    successSnackbar: mockSuccessSnackbar,
+    errorSnackbar: mockErrorSnackbar,
+  }),
+}))
+
+const mockUseUser = vi.fn(() => [
+  { email: 'jane@example.com' },
+  vi.fn(),
+  false,
+])
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: () => mockUseUser(),
+}))
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
+
+const baseTcrCompliance: TcrCompliance = {
+  id: 'tcr-1',
+  ein: '12-3456789',
+  postalAddress: '123 Main St',
+  committeeName: 'Jane for Council',
+  websiteDomain: 'janeforcouncil.org',
+  filingUrl: 'https://example.com/filing',
+  phone: '5551234567',
+  email: 'jane@example.com',
+  status: 'submitted',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  campaignId: 1,
+}
+
+const tcrWith = (status: TcrComplianceStatus | null): TcrCompliance => ({
+  ...baseTcrCompliance,
+  status,
+})
+
+const getDigitInputs = (): HTMLInputElement[] =>
+  screen
+    .getAllByRole('textbox')
+    .filter((el) =>
+      (el.getAttribute('aria-label') ?? '').startsWith('Digit '),
+    ) as HTMLInputElement[]
+
+const fillPin = async (
+  user: ReturnType<typeof userEvent.setup>,
+  pin: string,
+): Promise<void> => {
+  const inputs = getDigitInputs()
+  for (let i = 0; i < pin.length; i++) {
+    await user.type(inputs[i]!, pin.charAt(i))
+  }
+}
+
+beforeEach(() => {
+  mockGetTcrCompliance.mockReset()
+  mockSuccessSnackbar.mockReset()
+  mockErrorSnackbar.mockReset()
+  mockTrackEvent.mockReset()
+  ;(router.push as ReturnType<typeof vi.fn>).mockClear()
+})
+
+describe('EnterPin — gating', () => {
+  it('renders the PIN form when status is `submitted` (awaiting_pin)', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+    render(<EnterPin />)
+    await waitFor(() => {
+      expect(getDigitInputs()).toHaveLength(6)
+    })
+    expect(
+      screen.getByRole('button', { name: /submit/i }),
+    ).toBeInTheDocument()
+  })
+
+  it.each<[TcrComplianceStatus | null]>([['rejected'], ['error'], [null]])(
+    'renders OutOfStateNotice (not the form) when status is %s',
+    async (status) => {
+      mockGetTcrCompliance.mockResolvedValue(tcrWith(status))
+      render(<EnterPin />)
+      await waitFor(() => {
+        expect(
+          screen.getByText(/this step isn’t available yet/i),
+        ).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('button', { name: /submit/i })).toBeNull()
+      expect(router.push).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each<[TcrComplianceStatus]>([['pending'], ['approved']])(
+    'redirects to /dashboard/profile when status is %s (already past PIN step)',
+    async (status) => {
+      mockGetTcrCompliance.mockResolvedValue(tcrWith(status))
+      render(<EnterPin />)
+      await waitFor(() => {
+        expect(router.push).toHaveBeenCalledWith('/dashboard/profile')
+      })
+      expect(screen.queryByRole('button', { name: /submit/i })).toBeNull()
+    },
+  )
+
+  it('renders OutOfStateNotice when no tcrCompliance record exists', async () => {
+    mockGetTcrCompliance.mockResolvedValue(null)
+    render(<EnterPin />)
+    await waitFor(() => {
+      expect(
+        screen.getByText(/this step isn’t available yet/i),
+      ).toBeInTheDocument()
+    })
+  })
+})
+
+describe('EnterPin — submit flow', () => {
+  it('happy path: submits PIN, fires analytics, invalidates cache, redirects', async () => {
+    const user = userEvent.setup()
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    let receivedBody: { pin?: string } = {}
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      ({ body, params }) => {
+        receivedBody = body
+        expect(params.tcrComplianceId).toBe('tcr-1')
+        return { status: 200, data: undefined }
+      },
+    )
+
+    render(<EnterPin />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    await fillPin(user, '123456')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith('/dashboard/profile')
+    })
+
+    expect(receivedBody).toEqual({ pin: '123456' })
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+    expect(mockSuccessSnackbar).toHaveBeenCalledWith(
+      expect.stringMatching(/PIN submitted/i),
+    )
+    expect(mockErrorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('400 response: renders "PIN didn’t match", no redirect, no snackbar error, form re-enables', async () => {
+    const user = userEvent.setup()
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      { status: 400, data: { message: 'invalid PIN' } },
+    )
+
+    render(<EnterPin />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    await fillPin(user, '123456')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /that PIN didn’t match/i,
+      )
+    })
+
+    expect(router.push).not.toHaveBeenCalled()
+    expect(mockErrorSnackbar).not.toHaveBeenCalled()
+    // Form re-enabled.
+    expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled()
+    expect(getDigitInputs()[0]).not.toBeDisabled()
+  })
+
+  it('500 response: renders generic verify error (does not claim PIN mismatch)', async () => {
+    const user = userEvent.setup()
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      { status: 500, data: { message: 'peerly upstream blew up' } },
+    )
+
+    render(<EnterPin />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    await fillPin(user, '123456')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /couldn’t verify that PIN/i,
+      )
+    })
+    // Should not say "didn't match" — that's reserved for client-validation
+    // errors (4xx), not generic upstream failures.
+    expect(screen.getByRole('alert')).not.toHaveTextContent(/didn’t match/i)
+    // No Peerly internals leaked.
+    expect(screen.queryByText(/peerly/i)).toBeNull()
+    expect(router.push).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
@@ -30,19 +30,16 @@ vi.mock('helpers/useSnackbar', () => ({
   }),
 }))
 
-const mockUseUser = vi.fn(() => [
-  { email: 'jane@example.com' },
-  vi.fn(),
-  false,
-])
+const mockUseUser = vi.fn(() => [{ email: 'jane@example.com' }, vi.fn(), false])
 vi.mock('@shared/hooks/useUser', () => ({
   useUser: () => mockUseUser(),
 }))
 
 const mockTrackEvent = vi.fn()
 vi.mock('helpers/analyticsHelper', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
   return {
     ...actual,
     trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
@@ -101,9 +98,7 @@ describe('EnterPin — gating', () => {
     await waitFor(() => {
       expect(getDigitInputs()).toHaveLength(6)
     })
-    expect(
-      screen.getByRole('button', { name: /submit/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument()
   })
 
   it.each<[TcrComplianceStatus | null]>([['rejected'], ['error'], [null]])(

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { FetchError } from 'ofetch'
+import H2 from '@shared/typography/H2'
+import H5 from '@shared/typography/H5'
+import { clientRequest } from 'gpApi/typed-request'
+import { useUser } from '@shared/hooks/useUser'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import TextingComplianceHeader from 'app/dashboard/profile/texting-compliance/shared/TextingComplianceHeader'
+import {
+  TCR_COMPLIANCE_QUERY_KEY,
+  TCR_COMPLIANCE_STATUS,
+  getTcrCompliance,
+} from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
+import { getPinChannels } from 'app/dashboard/profile/texting-compliance/shared/pinChannels'
+import PinForm from 'app/dashboard/profile/texting-compliance/shared/PinForm'
+
+const PROFILE_ROUTE = '/dashboard/profile'
+
+const REDIRECT_STATUSES: ReadonlyArray<string> = [
+  TCR_COMPLIANCE_STATUS.PENDING,
+  TCR_COMPLIANCE_STATUS.APPROVED,
+]
+
+const isPinMismatch = (e: unknown): boolean =>
+  e instanceof FetchError && (e.status === 400 || e.status === 422)
+
+export default function EnterPin(): React.JSX.Element {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { successSnackbar } = useSnackbar()
+  const [user] = useUser()
+
+  const { data: tcrCompliance, isPending } = useQuery({
+    queryKey: TCR_COMPLIANCE_QUERY_KEY,
+    queryFn: getTcrCompliance,
+  })
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const status = tcrCompliance?.status ?? null
+  const isAwaitingPin = status === TCR_COMPLIANCE_STATUS.SUBMITTED
+  const shouldRedirect = status !== null && REDIRECT_STATUSES.includes(status)
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.push(PROFILE_ROUTE)
+    }
+  }, [shouldRedirect, router])
+
+  const handleSubmit = async (pin: string): Promise<void> => {
+    if (!tcrCompliance) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      // tcrComplianceId is a path param — typed-request strips it from the
+      // body before sending; only `pin` lands in the POST body.
+      await clientRequest(
+        'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+        { tcrComplianceId: tcrCompliance.id, pin },
+      )
+
+      trackEvent(EVENTS.Outreach.DlcCompliance.PinVerificationCompleted, {
+        email: user?.email,
+        dlcComplianceStatus: 'Yes',
+      })
+
+      successSnackbar('PIN submitted — your application is in review.')
+      await queryClient.invalidateQueries({
+        queryKey: TCR_COMPLIANCE_QUERY_KEY,
+      })
+      router.push(PROFILE_ROUTE)
+    } catch (e) {
+      setError(
+        isPinMismatch(e)
+          ? 'That PIN didn’t match. Double-check and try again.'
+          : 'We couldn’t verify that PIN. Please try again.',
+      )
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="bg-white pt-2 md:pt-0">
+      <TextingComplianceHeader>
+        <H5 className="flex-1 text-center md:hidden">Enter your PIN</H5>
+      </TextingComplianceHeader>
+
+      <div className="mx-auto max-w-2xl px-4 py-6 md:px-8 md:py-8">
+        <H2 className="mb-6 hidden md:block">Enter your PIN</H2>
+
+        {isPending || shouldRedirect ? (
+          <div className="text-sm text-gray-500">Loading…</div>
+        ) : !isAwaitingPin ? (
+          <OutOfStateNotice />
+        ) : (
+          <PinForm
+            channels={getPinChannels(tcrCompliance)}
+            onSubmit={handleSubmit}
+            loading={submitting}
+            error={error}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function OutOfStateNotice(): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+      <p>
+        This step isn’t available yet. Complete the previous steps from your
+        profile to continue.
+      </p>
+      <div className="mt-3">
+        <Link href={PROFILE_ROUTE} className="text-blue-600 underline">
+          Back to profile
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/enter-pin/page.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/page.tsx
@@ -1,0 +1,15 @@
+import pageMetaData from 'helpers/metadataHelper'
+import EnterPin from './components/EnterPin'
+import candidateAccess from 'app/dashboard/shared/candidateAccess'
+
+const meta = pageMetaData({
+  title: 'Enter your PIN | GoodParty.org',
+  description: 'Enter your CampaignVerify PIN to complete texting compliance.',
+})
+export const metadata = meta
+
+export default async function Page(): Promise<React.JSX.Element> {
+  await candidateAccess()
+
+  return <EnterPin />
+}

--- a/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
@@ -63,8 +63,11 @@ describe('PinForm', () => {
   it('lists only the channels passed in', () => {
     render(<PinForm channels={['email']} onSubmit={vi.fn()} />)
     expect(
-      screen.getByText(/to either your email from CampaignVerify\./i),
+      screen.getByText(/to your email from CampaignVerify\./i),
     ).toBeInTheDocument()
+    // "either" only makes sense with multiple channels; with one channel it
+    // would misleadingly imply the user has a choice of delivery methods.
+    expect(screen.queryByText(/either/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/phone/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/address/i)).not.toBeInTheDocument()
   })

--- a/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import PinForm from './PinForm'
+
+const getDigitInputs = (): HTMLInputElement[] =>
+  screen
+    .getAllByRole('textbox')
+    .filter((el) =>
+      (el.getAttribute('aria-label') ?? '').startsWith('Digit '),
+    ) as HTMLInputElement[]
+
+describe('PinForm', () => {
+  it('renders 6 digit inputs and autofocuses the first', () => {
+    render(
+      <PinForm channels={['email', 'phone', 'address']} onSubmit={vi.fn()} />,
+    )
+    const inputs = getDigitInputs()
+    expect(inputs).toHaveLength(6)
+    expect(inputs[0]).toHaveFocus()
+  })
+
+  it('auto-advances focus to the next input after each digit', async () => {
+    const user = userEvent.setup()
+    render(<PinForm channels={['email']} onSubmit={vi.fn()} />)
+    const inputs = getDigitInputs()
+    await user.type(inputs[0]!, '1')
+    expect(inputs[1]).toHaveFocus()
+    await user.type(inputs[1]!, '2')
+    expect(inputs[2]).toHaveFocus()
+  })
+
+  it('rejects non-digit input', async () => {
+    const user = userEvent.setup()
+    render(<PinForm channels={['email']} onSubmit={vi.fn()} />)
+    const inputs = getDigitInputs()
+    await user.type(inputs[0]!, 'a')
+    expect(inputs[0]).toHaveValue('')
+  })
+
+  it('moves backwards on Backspace from an empty cell', async () => {
+    const user = userEvent.setup()
+    render(<PinForm channels={['email']} onSubmit={vi.fn()} />)
+    const inputs = getDigitInputs()
+    await user.type(inputs[0]!, '1')
+    await user.keyboard('{Backspace}')
+    expect(inputs[0]).toHaveFocus()
+    expect(inputs[0]).toHaveValue('')
+  })
+
+  it('builds helper text from the provided channels', () => {
+    render(
+      <PinForm channels={['email', 'phone', 'address']} onSubmit={vi.fn()} />,
+    )
+    expect(
+      screen.getByText(
+        /to either your email, phone or address from CampaignVerify\./i,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('lists only the channels passed in', () => {
+    render(<PinForm channels={['email']} onSubmit={vi.fn()} />)
+    expect(
+      screen.getByText(/to either your email from CampaignVerify\./i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/phone/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/address/i)).not.toBeInTheDocument()
+  })
+
+  it('disables submit until all 6 digits are entered', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<PinForm channels={['email']} onSubmit={onSubmit} />)
+    const submit = screen.getByRole('button', { name: /submit/i })
+    expect(submit).toBeDisabled()
+
+    const inputs = getDigitInputs()
+    for (let i = 0; i < 5; i++) {
+      await user.type(inputs[i]!, String(i + 1))
+    }
+    expect(submit).toBeDisabled()
+
+    await user.type(inputs[5]!, '6')
+    expect(submit).toBeEnabled()
+  })
+
+  it('calls onSubmit with the assembled PIN', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<PinForm channels={['email']} onSubmit={onSubmit} />)
+    const inputs = getDigitInputs()
+    for (let i = 0; i < 6; i++) {
+      await user.type(inputs[i]!, String(i + 1))
+    }
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    expect(onSubmit).toHaveBeenCalledWith('123456')
+  })
+
+  it('disables the form while loading', () => {
+    render(
+      <PinForm channels={['email']} onSubmit={vi.fn()} loading />,
+    )
+    const inputs = getDigitInputs()
+    inputs.forEach((input) => expect(input).toBeDisabled())
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+  })
+
+  it('renders an inline error message when provided', () => {
+    render(
+      <PinForm
+        channels={['email']}
+        onSubmit={vi.fn()}
+        error="That PIN didn’t match. Double-check and try again."
+      />,
+    )
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent(
+      /that PIN didn’t match\. Double-check and try again\./i,
+    )
+  })
+
+  it('distributes a pasted code across the inputs', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<PinForm channels={['email']} onSubmit={onSubmit} />)
+    const inputs = getDigitInputs()
+    inputs[0]!.focus()
+    await user.paste('123456')
+    expect(inputs.map((i) => i.value)).toEqual(['1', '2', '3', '4', '5', '6'])
+  })
+})

--- a/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/shared/PinForm.test.tsx
@@ -99,9 +99,7 @@ describe('PinForm', () => {
   })
 
   it('disables the form while loading', () => {
-    render(
-      <PinForm channels={['email']} onSubmit={vi.fn()} loading />,
-    )
+    render(<PinForm channels={['email']} onSubmit={vi.fn()} loading />)
     const inputs = getDigitInputs()
     inputs.forEach((input) => expect(input).toBeDisabled())
     expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()

--- a/app/dashboard/profile/texting-compliance/shared/PinForm.tsx
+++ b/app/dashboard/profile/texting-compliance/shared/PinForm.tsx
@@ -25,7 +25,10 @@ const buildHelperText = (channels: PinChannel[]): string => {
   if (!channelText) {
     return `${baseText} from CampaignVerify.`
   }
-  return `${baseText} to either your ${channelText} from CampaignVerify.`
+  // "either" implies a choice between options, so only use it when there are
+  // multiple channels — with a single channel it's misleading.
+  const connector = channels.length === 1 ? 'to your' : 'to either your'
+  return `${baseText} ${connector} ${channelText} from CampaignVerify.`
 }
 
 interface PinFormProps {

--- a/app/dashboard/profile/texting-compliance/shared/PinForm.tsx
+++ b/app/dashboard/profile/texting-compliance/shared/PinForm.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import {
+  ChangeEvent,
+  ClipboardEvent,
+  FormEvent,
+  KeyboardEvent,
+  useRef,
+  useState,
+} from 'react'
+import Button from '@shared/buttons/Button'
+import {
+  PinChannel,
+  formatPinChannels,
+} from 'app/dashboard/profile/texting-compliance/shared/pinChannels'
+
+const PIN_LENGTH = 6
+
+const emptyDigits = (): string[] => Array(PIN_LENGTH).fill('')
+
+const buildHelperText = (channels: PinChannel[]): string => {
+  const channelText = formatPinChannels(channels)
+  const baseText =
+    'To verify your identity you will be sent a PIN within 2-3 business days'
+  if (!channelText) {
+    return `${baseText} from CampaignVerify.`
+  }
+  return `${baseText} to either your ${channelText} from CampaignVerify.`
+}
+
+interface PinFormProps {
+  channels: PinChannel[]
+  onSubmit: (pin: string) => void | Promise<void>
+  loading?: boolean
+  error?: string | null
+}
+
+export default function PinForm({
+  channels,
+  onSubmit,
+  loading = false,
+  error = null,
+}: PinFormProps): React.JSX.Element {
+  const [digits, setDigits] = useState<string[]>(emptyDigits)
+  const inputsRef = useRef<Array<HTMLInputElement | null>>([])
+
+  const pin = digits.join('')
+  const isComplete = pin.length === PIN_LENGTH && /^\d{6}$/.test(pin)
+
+  const focusInput = (index: number): void => {
+    const target = inputsRef.current[index]
+    if (target) {
+      target.focus()
+      target.select()
+    }
+  }
+
+  const setDigitAt = (index: number, value: string): void => {
+    setDigits((prev) => {
+      const next = [...prev]
+      next[index] = value
+      return next
+    })
+  }
+
+  const handleChange = (
+    index: number,
+    e: ChangeEvent<HTMLInputElement>,
+  ): void => {
+    const raw = e.target.value
+    // Strip any non-digit input (paste of "12 34" etc).
+    const digitsOnly = raw.replace(/\D/g, '')
+
+    if (digitsOnly.length === 0) {
+      setDigitAt(index, '')
+      return
+    }
+
+    // If user pasted multiple digits into one box, distribute across boxes.
+    if (digitsOnly.length > 1) {
+      setDigits((prev) => {
+        const next = [...prev]
+        for (let i = 0; i < digitsOnly.length && index + i < PIN_LENGTH; i++) {
+          next[index + i] = digitsOnly.charAt(i)
+        }
+        return next
+      })
+      const lastFilled = Math.min(index + digitsOnly.length - 1, PIN_LENGTH - 1)
+      const nextFocus = Math.min(lastFilled + 1, PIN_LENGTH - 1)
+      focusInput(nextFocus)
+      return
+    }
+
+    setDigitAt(index, digitsOnly)
+    if (index < PIN_LENGTH - 1) {
+      focusInput(index + 1)
+    }
+  }
+
+  const handleKeyDown = (
+    index: number,
+    e: KeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (e.key === 'Backspace') {
+      if (digits[index]) {
+        setDigitAt(index, '')
+      } else if (index > 0) {
+        focusInput(index - 1)
+        setDigitAt(index - 1, '')
+      }
+      e.preventDefault()
+      return
+    }
+    if (e.key === 'ArrowLeft' && index > 0) {
+      focusInput(index - 1)
+      e.preventDefault()
+      return
+    }
+    if (e.key === 'ArrowRight' && index < PIN_LENGTH - 1) {
+      focusInput(index + 1)
+      e.preventDefault()
+    }
+  }
+
+  const handlePaste = (
+    index: number,
+    e: ClipboardEvent<HTMLInputElement>,
+  ): void => {
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '')
+    if (!pasted) return
+    e.preventDefault()
+    setDigits((prev) => {
+      const next = [...prev]
+      for (let i = 0; i < pasted.length && index + i < PIN_LENGTH; i++) {
+        next[index + i] = pasted.charAt(i)
+      }
+      return next
+    })
+    const target = Math.min(index + pasted.length, PIN_LENGTH - 1)
+    focusInput(target)
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault()
+    if (!isComplete || loading) return
+    await onSubmit(pin)
+  }
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit} noValidate>
+      <fieldset disabled={loading} className="flex flex-col gap-2 border-0 p-0">
+        <legend className="mb-1 text-xs font-medium text-gray-900">PIN</legend>
+        <div className="flex gap-2" role="group" aria-label="PIN digits">
+          {digits.map((digit, index) => (
+            <input
+              key={index}
+              ref={(el) => {
+                inputsRef.current[index] = el
+              }}
+              type="text"
+              inputMode="numeric"
+              autoComplete={index === 0 ? 'one-time-code' : 'off'}
+              maxLength={1}
+              autoFocus={index === 0}
+              value={digit}
+              aria-label={`Digit ${index + 1}`}
+              aria-invalid={Boolean(error) || undefined}
+              onChange={(e) => handleChange(index, e)}
+              onKeyDown={(e) => handleKeyDown(index, e)}
+              onPaste={(e) => handlePaste(index, e)}
+              onFocus={(e) => e.target.select()}
+              className={`h-12 w-full max-w-12 flex-1 rounded-lg border bg-white text-center text-base font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-50 ${
+                error ? 'border-red-500' : 'border-gray-300'
+              }`}
+            />
+          ))}
+        </div>
+        <p className="text-xs text-gray-500">{buildHelperText(channels)}</p>
+        {error && (
+          <p role="alert" className="text-xs text-red-600">
+            {error}
+          </p>
+        )}
+      </fieldset>
+      <div className="flex justify-end">
+        <Button
+          type="submit"
+          color="primary"
+          size="large"
+          disabled={!isComplete || loading}
+          loading={loading}
+        >
+          Submit
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/shared/pinChannels.test.ts
+++ b/app/dashboard/profile/texting-compliance/shared/pinChannels.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { getPinChannels, formatPinChannels } from './pinChannels'
+import type { TcrCompliance } from 'helpers/types'
+
+const baseCompliance: TcrCompliance = {
+  id: 'tcr-1',
+  ein: '12-3456789',
+  postalAddress: '',
+  committeeName: 'Test',
+  websiteDomain: 'example.com',
+  filingUrl: 'https://example.com/filing',
+  phone: '',
+  email: '',
+  status: 'submitted',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  campaignId: 1,
+}
+
+describe('getPinChannels', () => {
+  it('returns an empty list when nothing is filled', () => {
+    expect(getPinChannels(baseCompliance)).toEqual([])
+  })
+
+  it('returns email/phone/address only for filled fields', () => {
+    expect(
+      getPinChannels({
+        ...baseCompliance,
+        email: 'jane@example.com',
+        phone: '5555555555',
+        postalAddress: '',
+      }),
+    ).toEqual(['email', 'phone'])
+  })
+
+  it('returns all three when all are filled', () => {
+    expect(
+      getPinChannels({
+        ...baseCompliance,
+        email: 'jane@example.com',
+        phone: '5555555555',
+        postalAddress: '123 Main St',
+      }),
+    ).toEqual(['email', 'phone', 'address'])
+  })
+
+  it('treats whitespace-only values as empty', () => {
+    expect(
+      getPinChannels({
+        ...baseCompliance,
+        email: '   ',
+        phone: '5555555555',
+      }),
+    ).toEqual(['phone'])
+  })
+
+  it('returns an empty list when given null/undefined', () => {
+    expect(getPinChannels(null)).toEqual([])
+    expect(getPinChannels(undefined)).toEqual([])
+  })
+})
+
+describe('formatPinChannels', () => {
+  it('joins three channels with commas and "or"', () => {
+    expect(formatPinChannels(['email', 'phone', 'address'])).toBe(
+      'email, phone or address',
+    )
+  })
+
+  it('joins two channels with "or"', () => {
+    expect(formatPinChannels(['email', 'phone'])).toBe('email or phone')
+  })
+
+  it('returns a single channel as-is', () => {
+    expect(formatPinChannels(['email'])).toBe('email')
+  })
+
+  it('returns an empty string for no channels', () => {
+    expect(formatPinChannels([])).toBe('')
+  })
+})

--- a/app/dashboard/profile/texting-compliance/shared/pinChannels.ts
+++ b/app/dashboard/profile/texting-compliance/shared/pinChannels.ts
@@ -1,0 +1,27 @@
+import type { TcrCompliance } from 'helpers/types'
+
+export type PinChannel = 'email' | 'phone' | 'address'
+
+const isFilled = (value: string | null | undefined): boolean =>
+  Boolean(value && value.trim().length > 0)
+
+// CampaignVerify only delivers a PIN to the channels the candidate provided
+// on the filing details form, so the helper text should reflect what was
+// actually submitted on the TcrCompliance record.
+export const getPinChannels = (
+  tcrCompliance: TcrCompliance | null | undefined,
+): PinChannel[] => {
+  if (!tcrCompliance) return []
+  const channels: PinChannel[] = []
+  if (isFilled(tcrCompliance.email)) channels.push('email')
+  if (isFilled(tcrCompliance.phone)) channels.push('phone')
+  if (isFilled(tcrCompliance.postalAddress)) channels.push('address')
+  return channels
+}
+
+export const formatPinChannels = (channels: PinChannel[]): string => {
+  if (channels.length === 0) return ''
+  if (channels.length === 1) return channels[0]!
+  if (channels.length === 2) return `${channels[0]} or ${channels[1]}`
+  return `${channels.slice(0, -1).join(', ')} or ${channels[channels.length - 1]}`
+}

--- a/app/dashboard/profile/texting-compliance/shared/pinChannels.ts
+++ b/app/dashboard/profile/texting-compliance/shared/pinChannels.ts
@@ -23,5 +23,7 @@ export const formatPinChannels = (channels: PinChannel[]): string => {
   if (channels.length === 0) return ''
   if (channels.length === 1) return channels[0]!
   if (channels.length === 2) return `${channels[0]} or ${channels[1]}`
-  return `${channels.slice(0, -1).join(', ')} or ${channels[channels.length - 1]}`
+  return `${channels.slice(0, -1).join(', ')} or ${
+    channels[channels.length - 1]
+  }`
 }

--- a/app/dashboard/profile/texting-compliance/submit-pin/components/TextingComplianceSubmitPinPage.tsx
+++ b/app/dashboard/profile/texting-compliance/submit-pin/components/TextingComplianceSubmitPinPage.tsx
@@ -16,10 +16,7 @@ import { apiRoutes } from 'gpApi/routes'
 import { trackEvent } from 'helpers/analyticsHelper'
 import { EVENTS } from 'helpers/analyticsHelper'
 import { useUser } from '@shared/hooks/useUser'
-
-interface TcrCompliance {
-  id: number
-}
+import type { TcrCompliance } from 'helpers/types'
 
 interface TextingComplianceSubmitPinPageProps {
   tcrCompliance: TcrCompliance
@@ -29,7 +26,7 @@ const initialFormState: PinFormData = {
   pin: '',
 }
 
-const submitCvPin = async (tcrComplianceId: number, formData: PinFormData) => {
+const submitCvPin = async (tcrComplianceId: string, formData: PinFormData) => {
   const response = await clientFetch(
     apiRoutes.campaign.tcrCompliance.submitCvPin,
     { ...formData, tcrComplianceId },

--- a/app/dashboard/profile/texting-compliance/submit-pin/page.tsx
+++ b/app/dashboard/profile/texting-compliance/submit-pin/page.tsx
@@ -4,15 +4,12 @@ import { serverFetch } from 'gpApi/serverFetch'
 import { apiRoutes } from 'gpApi/routes'
 import candidateAccess from 'app/dashboard/shared/candidateAccess'
 import { redirect } from 'next/navigation'
+import type { TcrCompliance } from 'helpers/types'
 
 export const dynamic = 'force-dynamic'
 
-interface TcrComplianceData {
-  id: number
-}
-
-const fetchTcrCompliance = async (): Promise<TcrComplianceData> => {
-  const response = await serverFetch<TcrComplianceData>(
+const fetchTcrCompliance = async (): Promise<TcrCompliance> => {
+  const response = await serverFetch<TcrCompliance>(
     apiRoutes.campaign.tcrCompliance.fetch,
   )
   if (!response.ok) {

--- a/app/dashboard/profile/texting-compliance/util/tcrCompliance.util.ts
+++ b/app/dashboard/profile/texting-compliance/util/tcrCompliance.util.ts
@@ -42,7 +42,8 @@ export const getTcrComplianceStatusCompletions = (
 ): TcrComplianceStatusCompletions => {
   const status = tcrCompliance?.status ?? null
   return {
-    filingComplete: status !== null && FILING_COMPLETE_STATUSES.includes(status),
+    filingComplete:
+      status !== null && FILING_COMPLETE_STATUSES.includes(status),
     pinComplete: status !== null && PIN_COMPLETE_STATUSES.includes(status),
   }
 }

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -54,6 +54,13 @@ export type APIEndpoints = {
     }
   }
 
+  'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin': {
+    Request: {
+      pin: string
+    }
+    Response: void
+  }
+
   'GET /v1/elected-office/current': {
     Request: {}
     Response: ElectedOffice


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new PIN verification page and client-side submission flow that calls a new typed API endpoint and changes how texting compliance status is rendered; mistakes could block users from completing compliance or mis-route them.
> 
> **Overview**
> Improves the texting compliance dashboard card to be **status-aware** by fetching TCR compliance via React Query, showing a loading skeleton, and rendering dedicated views for `approved` and `pending` states instead of always showing the default steps.
> 
> Adds a new **Enter PIN** route (`/dashboard/profile/texting-compliance/enter-pin`) with a reusable 6-digit `PinForm` (auto-advance, paste support, inline errors) that submits the CampaignVerify PIN via a new typed endpoint (`POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin`), tracks analytics, invalidates the TCR cache, and redirects appropriately. Includes comprehensive unit tests for the gating logic, form behavior, and error handling, plus a small type alignment in the existing submit-pin flow to use `TcrCompliance`/string ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57c918e05e9c8478e7b1f6e476e1b35a305da1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->