### PR TITLE
onboarding: voter-issues UX polish

### DIFF
--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -1018,8 +1018,7 @@ export default function OnboardingFlow({
               <aside
                 className="md:fixed md:top-36 md:w-[280px]"
                 style={{
-                  right:
-                    'max(2rem, calc((100vw - 56rem) / 2 + 2rem))',
+                  right: 'max(2rem, calc((100vw - 56rem) / 2 + 2rem))',
                 }}
               >
                 {activeStep.id === 'path-to-victory' ? (
@@ -1031,8 +1030,8 @@ export default function OnboardingFlow({
                           liveCampaign.raceTargetMetrics.winNumber,
                         )} people`
                       : 'your win number'}
-                    , talk to them, and make sure they vote. We&apos;ll show
-                    you exactly what that takes.
+                    , talk to them, and make sure they vote. We&apos;ll show you
+                    exactly what that takes.
                   </WhyWeAsk>
                 ) : (
                   <WhyWeAsk text={activeStep.whyWeAsk} />

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -1015,21 +1015,29 @@ export default function OnboardingFlow({
             </section>
 
             {activeStep.whyWeAsk && !isP2vBlocking ? (
-              activeStep.id === 'path-to-victory' ? (
-                <WhyWeAsk title="You can do this!">
-                  Most candidates think they need to convince <em>everyone</em>.
-                  You don&apos;t. You need to find{' '}
-                  {liveCampaign?.raceTargetMetrics?.winNumber
-                    ? `${numberFormatter(
-                        liveCampaign.raceTargetMetrics.winNumber,
-                      )} people`
-                    : 'your win number'}
-                  , talk to them, and make sure they vote. We&apos;ll show you
-                  exactly what that takes.
-                </WhyWeAsk>
-              ) : (
-                <WhyWeAsk text={activeStep.whyWeAsk} />
-              )
+              <aside
+                className="md:fixed md:top-36 md:w-[280px]"
+                style={{
+                  right:
+                    'max(2rem, calc((100vw - 56rem) / 2 + 2rem))',
+                }}
+              >
+                {activeStep.id === 'path-to-victory' ? (
+                  <WhyWeAsk title="You can do this!">
+                    Most candidates think they need to convince{' '}
+                    <em>everyone</em>. You don&apos;t. You need to find{' '}
+                    {liveCampaign?.raceTargetMetrics?.winNumber
+                      ? `${numberFormatter(
+                          liveCampaign.raceTargetMetrics.winNumber,
+                        )} people`
+                      : 'your win number'}
+                    , talk to them, and make sure they vote. We&apos;ll show
+                    you exactly what that takes.
+                  </WhyWeAsk>
+                ) : (
+                  <WhyWeAsk text={activeStep.whyWeAsk} />
+                )}
+              </aside>
             ) : null}
           </div>
         </div>

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -257,16 +257,22 @@ const StepProgress = ({
         gridTemplateColumns: `repeat(${numberOfSteps}, minmax(0, 1fr))`,
       }}
     >
-      {Array.from({ length: numberOfSteps }, (_, index) => (
-        <div
-          key={index}
-          className={
-            index < currentStep
-              ? 'h-1.5 rounded-full bg-blue-600'
-              : 'h-1.5 rounded-full bg-slate-100'
-          }
-        />
-      ))}
+      {Array.from({ length: numberOfSteps }, (_, index) => {
+        const isFilled = index < currentStep
+        return (
+          <div
+            key={index}
+            className="relative h-1.5 overflow-hidden rounded-full bg-slate-100"
+          >
+            <div
+              className={`absolute inset-0 origin-left rounded-full bg-blue-600 transition-transform duration-500 ease-out ${
+                isFilled ? 'scale-x-100' : 'scale-x-0'
+              }`}
+              style={{ transitionDelay: `${index * 60}ms` }}
+            />
+          </div>
+        )
+      })}
     </div>
   </div>
 )
@@ -282,6 +288,7 @@ interface StepBodyProps {
     React.ComponentProps<typeof PathToVictoryStep>['onMetricsResolved']
   >
   p2vOfficeName: string | null
+  skipP2vReveal: boolean
 }
 
 const StepBody = ({
@@ -293,6 +300,7 @@ const StepBody = ({
   onP2vLoadingChange,
   onP2vMetricsResolved,
   p2vOfficeName,
+  skipP2vReveal,
 }: StepBodyProps): React.JSX.Element => {
   if (activeStep.id === 'welcome') {
     return (
@@ -383,6 +391,7 @@ const StepBody = ({
         officeName={p2vOfficeName}
         onLoadingChange={onP2vLoadingChange}
         onMetricsResolved={onP2vMetricsResolved}
+        skipReveal={skipP2vReveal}
       />
     )
   }
@@ -430,6 +439,8 @@ export default function OnboardingFlow({
     initialCampaign,
   )
   const [isP2vLoading, setIsP2vLoading] = useState(true)
+  const [hasResolvedPathToVictory, setHasResolvedPathToVictory] =
+    useState(false)
   const queryClient = useQueryClient()
 
   const visibleSteps = getVisibleOnboardingSteps(ONBOARDING_STEPS, answers)
@@ -463,6 +474,7 @@ export default function OnboardingFlow({
     (result) => {
       const campaignId = liveCampaign?.id ?? campaign?.id
       if (result.status === 'success') {
+        setHasResolvedPathToVictory(true)
         trackEvent(EVENTS.Onboarding.PathToVictoryUpdated, {
           campaignId,
           projectedTurnout: result.projectedTurnout,
@@ -487,6 +499,7 @@ export default function OnboardingFlow({
 
   useEffect(() => {
     if (activeStepId !== 'path-to-victory') return
+    if (hasResolvedPathToVictory) return
     let cancelled = false
     setIsP2vLoading(true)
     void (async () => {
@@ -507,7 +520,7 @@ export default function OnboardingFlow({
     return () => {
       cancelled = true
     }
-  }, [activeStepId])
+  }, [activeStepId, hasResolvedPathToVictory])
 
   useEffect(() => {
     if (activeStepId !== 'path-to-victory') return
@@ -933,15 +946,18 @@ export default function OnboardingFlow({
 
   return (
     <div className="min-h-screen bg-white pb-28 text-slate-950">
-      <main className="mx-auto w-full max-w-4xl px-4 py-6 sm:px-8 sm:py-8">
-        <div>
+      <div className="fixed inset-x-0 top-14 z-40 border-b border-slate-100 bg-white/95 backdrop-blur">
+        <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-8">
           <StepProgress
             currentStep={activeStepNumber}
             numberOfSteps={visibleSteps.length}
           />
-
+        </div>
+      </div>
+      <main className="mx-auto w-full max-w-4xl px-4 pt-24 pb-6 sm:px-8 sm:pt-28 sm:pb-8">
+        <div>
           <div
-            className={`mt-8 grid grid-cols-1 gap-8 sm:mt-5${
+            className={`grid grid-cols-1 gap-8${
               activeStep.whyWeAsk && !isP2vBlocking
                 ? ' md:grid-cols-[minmax(0,1fr)_280px] md:items-start'
                 : ''
@@ -954,12 +970,6 @@ export default function OnboardingFlow({
             >
               {isP2vBlocking ? null : (
                 <div className="space-y-4">
-                  {activeStep.id === 'welcome' ||
-                  activeStep.id === 'pledge' ? null : (
-                    <p className="text-sm font-semibold text-blue-600">
-                      {activeStep.eyebrow}
-                    </p>
-                  )}
                   <h1 className="text-4xl leading-[1.08] font-bold text-slate-950 sm:text-5xl">
                     {activeStep.title}
                   </h1>
@@ -1000,6 +1010,7 @@ export default function OnboardingFlow({
                 onP2vLoadingChange={handleP2vLoadingChange}
                 onP2vMetricsResolved={handleP2vMetricsResolved}
                 p2vOfficeName={p2vOfficeName}
+                skipP2vReveal={hasResolvedPathToVictory}
               />
             </section>
 

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -309,10 +309,6 @@ const ProjectionExplanation = ({
   winNumber,
 }: ProjectionExplanationProps): React.JSX.Element => {
   const showRegisteredVoters = registeredVoters !== null && registeredVoters > 0
-  const turnoutPercent =
-    showRegisteredVoters && registeredVoters
-      ? Math.round((projectedTurnout / registeredVoters) * 100)
-      : null
   let stepIndex = 1
 
   return (
@@ -329,18 +325,10 @@ const ProjectionExplanation = ({
             value={numberFormatter(registeredVoters)}
           />
         ) : null}
-        {turnoutPercent !== null ? (
-          <ProjectionStep
-            index={stepIndex++}
-            title="Average voter turnout"
-            description="Based on the last three election cycles in your district."
-            value={`${turnoutPercent}%`}
-          />
-        ) : null}
         <ProjectionStep
           index={stepIndex++}
           title="Projected voter turnout"
-          description="Registered voters multiplied by the average turnout rate."
+          description="The number of voters we expect to cast a ballot based on similar past elections."
           value={numberFormatter(projectedTurnout)}
         />
         <ProjectionStep

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -23,6 +23,7 @@ const CHECKLIST_ITEMS = [
 
 const REVEAL_INTERVAL_MS = 700
 const RESULTS_HOLD_MS = 600
+const WIN_NUMBER_RANGE_PCT = 0.15
 
 const METRICS_STATUS = {
   SUCCESS: 'success',
@@ -51,6 +52,7 @@ interface PathToVictoryStepProps {
   officeName?: string | null
   onLoadingChange?: (isLoading: boolean) => void
   onMetricsResolved?: (result: MetricsResolution) => void
+  skipReveal?: boolean
 }
 
 const formatOfficeName = (campaign: Campaign | null): string =>
@@ -85,24 +87,28 @@ const useRegisteredVoters = (campaignId: number | undefined) => {
   return registeredVoters
 }
 
-const useChecklistReveal = () => {
-  const [revealedCount, setRevealedCount] = useState(0)
-  const [showResults, setShowResults] = useState(false)
+const useChecklistReveal = (skipReveal: boolean) => {
+  const [revealedCount, setRevealedCount] = useState(
+    skipReveal ? CHECKLIST_ITEMS.length : 0,
+  )
+  const [showResults, setShowResults] = useState(skipReveal)
 
   useEffect(() => {
+    if (skipReveal) return
     if (revealedCount >= CHECKLIST_ITEMS.length) return
     const id = setTimeout(
       () => setRevealedCount((prev) => prev + 1),
       REVEAL_INTERVAL_MS,
     )
     return () => clearTimeout(id)
-  }, [revealedCount])
+  }, [revealedCount, skipReveal])
 
   useEffect(() => {
+    if (skipReveal) return
     if (revealedCount < CHECKLIST_ITEMS.length) return
     const id = setTimeout(() => setShowResults(true), RESULTS_HOLD_MS)
     return () => clearTimeout(id)
-  }, [revealedCount])
+  }, [revealedCount, skipReveal])
 
   return { revealedCount, showResults }
 }
@@ -237,28 +243,40 @@ interface WinNumberHeroCardProps {
 const WinNumberHeroCard = ({
   winNumber,
   officeName,
-}: WinNumberHeroCardProps): React.JSX.Element => (
-  <Card className="overflow-hidden rounded-2xl border-blue-100 bg-linear-to-b from-blue-50 to-white shadow-none">
-    <CardContent className="space-y-2 p-8 text-center">
-      <p className="text-6xl leading-none font-bold text-slate-950 sm:text-7xl">
-        {numberFormatter(winNumber)}
-      </p>
-      <p className="text-xs font-semibold tracking-widest text-blue-600 uppercase">
-        Votes needed to win
-      </p>
-      <p className="text-base font-semibold text-slate-950">{officeName}</p>
-      <p className="pt-2 text-xs text-slate-500">
-        *Depending on the election&apos;s turnout
-      </p>
-    </CardContent>
-  </Card>
-)
+}: WinNumberHeroCardProps): React.JSX.Element => {
+  const lowEstimate = Math.max(
+    0,
+    Math.round(winNumber * (1 - WIN_NUMBER_RANGE_PCT)),
+  )
+  const highEstimate = Math.round(winNumber * (1 + WIN_NUMBER_RANGE_PCT))
+
+  return (
+    <Card className="overflow-hidden rounded-2xl border-blue-100 bg-linear-to-b from-blue-50 to-white shadow-none">
+      <CardContent className="space-y-2 p-8 text-center">
+        <p className="text-6xl leading-none font-bold text-slate-950 sm:text-7xl">
+          {numberFormatter(winNumber)}
+        </p>
+        <p className="text-xs font-semibold tracking-widest text-blue-600 uppercase">
+          Projected votes needed to win (50% + 1)
+        </p>
+        <p className="text-base font-semibold text-slate-950">{officeName}</p>
+        <p className="pt-2 text-xs text-slate-500">
+          Projected range:{' '}
+          <span className="font-semibold text-slate-700">
+            {numberFormatter(lowEstimate)}–{numberFormatter(highEstimate)}
+          </span>{' '}
+          (~95% confidence)
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
 
 interface ProjectionStepProps {
   index: number
   title: string
   description: string
-  value: number
+  value: string
 }
 
 const ProjectionStep = ({
@@ -275,9 +293,7 @@ const ProjectionStep = ({
       <p className="text-sm font-semibold text-slate-950">{title}</p>
       <p className="text-xs text-slate-500">{description}</p>
     </div>
-    <span className="text-base font-bold text-slate-950">
-      {numberFormatter(value)}
-    </span>
+    <span className="text-base font-bold text-slate-950">{value}</span>
   </li>
 )
 
@@ -293,6 +309,10 @@ const ProjectionExplanation = ({
   winNumber,
 }: ProjectionExplanationProps): React.JSX.Element => {
   const showRegisteredVoters = registeredVoters !== null && registeredVoters > 0
+  const turnoutPercent =
+    showRegisteredVoters && registeredVoters
+      ? Math.round((projectedTurnout / registeredVoters) * 100)
+      : null
   let stepIndex = 1
 
   return (
@@ -306,20 +326,28 @@ const ProjectionExplanation = ({
             index={stepIndex++}
             title="Registered voters in your district"
             description="The total pool of voters eligible to cast a ballot in your race."
-            value={registeredVoters}
+            value={numberFormatter(registeredVoters)}
+          />
+        ) : null}
+        {turnoutPercent !== null ? (
+          <ProjectionStep
+            index={stepIndex++}
+            title="Average voter turnout"
+            description="Based on the last three election cycles in your district."
+            value={`${turnoutPercent}%`}
           />
         ) : null}
         <ProjectionStep
           index={stepIndex++}
-          title="Average voter turnout"
-          description="Based on our projections from the last three election cycles."
-          value={projectedTurnout}
+          title="Projected voter turnout"
+          description="Registered voters multiplied by the average turnout rate."
+          value={numberFormatter(projectedTurnout)}
         />
         <ProjectionStep
           index={stepIndex++}
-          title="50% + 1 — Votes needed to win"
-          description="A simple majority of who actually votes."
-          value={winNumber}
+          title="Projected votes needed to win (50% + 1)"
+          description="A simple majority of voters who actually cast a ballot."
+          value={numberFormatter(winNumber)}
         />
       </ol>
     </div>
@@ -331,9 +359,10 @@ export const PathToVictoryStep = ({
   officeName: officeNameProp,
   onLoadingChange,
   onMetricsResolved,
+  skipReveal = false,
 }: PathToVictoryStepProps): React.JSX.Element => {
   const registeredVoters = useRegisteredVoters(campaign?.id)
-  const { revealedCount, showResults } = useChecklistReveal()
+  const { revealedCount, showResults } = useChecklistReveal(skipReveal)
 
   const officeName = officeNameProp || formatOfficeName(campaign)
   const metrics = campaign?.raceTargetMetrics ?? null

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -23,7 +23,6 @@ const CHECKLIST_ITEMS = [
 
 const REVEAL_INTERVAL_MS = 700
 const RESULTS_HOLD_MS = 600
-const WIN_NUMBER_RANGE_PCT = 0.15
 
 const METRICS_STATUS = {
   SUCCESS: 'success',
@@ -243,34 +242,22 @@ interface WinNumberHeroCardProps {
 const WinNumberHeroCard = ({
   winNumber,
   officeName,
-}: WinNumberHeroCardProps): React.JSX.Element => {
-  const lowEstimate = Math.max(
-    0,
-    Math.round(winNumber * (1 - WIN_NUMBER_RANGE_PCT)),
-  )
-  const highEstimate = Math.round(winNumber * (1 + WIN_NUMBER_RANGE_PCT))
-
-  return (
-    <Card className="overflow-hidden rounded-2xl border-blue-100 bg-linear-to-b from-blue-50 to-white shadow-none">
-      <CardContent className="space-y-2 p-8 text-center">
-        <p className="text-6xl leading-none font-bold text-slate-950 sm:text-7xl">
-          {numberFormatter(winNumber)}
-        </p>
-        <p className="text-xs font-semibold tracking-widest text-blue-600 uppercase">
-          Projected votes needed to win (50% + 1)
-        </p>
-        <p className="text-base font-semibold text-slate-950">{officeName}</p>
-        <p className="pt-2 text-xs text-slate-500">
-          Projected range:{' '}
-          <span className="font-semibold text-slate-700">
-            {numberFormatter(lowEstimate)}–{numberFormatter(highEstimate)}
-          </span>{' '}
-          (~95% confidence)
-        </p>
-      </CardContent>
-    </Card>
-  )
-}
+}: WinNumberHeroCardProps): React.JSX.Element => (
+  <Card className="overflow-hidden rounded-2xl border-blue-100 bg-linear-to-b from-blue-50 to-white shadow-none">
+    <CardContent className="space-y-2 p-8 text-center">
+      <p className="text-6xl leading-none font-bold text-slate-950 sm:text-7xl">
+        {numberFormatter(winNumber)}
+      </p>
+      <p className="text-xs font-semibold tracking-widest text-blue-600 uppercase">
+        Votes needed to win
+      </p>
+      <p className="text-base font-semibold text-slate-950">{officeName}</p>
+      <p className="pt-2 text-xs text-slate-500">
+        *Depending on the election&apos;s turnout
+      </p>
+    </CardContent>
+  </Card>
+)
 
 interface ProjectionStepProps {
   index: number

--- a/app/onboarding/components/TopVoterIssuesSection.test.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor, render as rtlRender } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, testQueryClient } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import { TopVoterIssuesSection } from './TopVoterIssuesSection'
+
+const mockReportErrorToSentry = vi.fn()
+vi.mock('@shared/sentry', () => ({
+  reportErrorToSentry: (...args: unknown[]) => mockReportErrorToSentry(...args),
+}))
+
+const issues = [
+  { label: 'Public Safety', score: 82, priority: 'high' as const },
+  { label: 'Affordable Housing', score: 71, priority: 'high' as const },
+  { label: 'Education', score: 64, priority: 'medium' as const },
+  { label: 'Healthcare', score: 55, priority: 'medium' as const },
+  { label: 'Climate', score: 41, priority: 'low' as const },
+]
+
+beforeEach(() => {
+  testQueryClient.clear()
+  mockReportErrorToSentry.mockReset()
+})
+
+describe('TopVoterIssuesSection', () => {
+  it('renders skeleton placeholders while the request is pending', () => {
+    api.mock('GET /v1/onboarding/voter-issues', () => new Promise(() => {}))
+
+    const { container } = render(<TopVoterIssuesSection office="Mayor" />)
+
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+      0,
+    )
+  })
+
+  it('renders nothing when the API returns an empty list', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues: [] },
+    })
+
+    const { container } = render(<TopVoterIssuesSection office="Mayor" />)
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  it('renders nothing and reports the error when the request fails', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', { status: 500 })
+
+    const noRetryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const { container } = rtlRender(
+      <QueryClientProvider client={noRetryClient}>
+        <TopVoterIssuesSection office="Mayor" />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(mockReportErrorToSentry).toHaveBeenCalled()
+    })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the office name in the description when provided', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues: issues.slice(0, 1) },
+    })
+
+    render(<TopVoterIssuesSection office="Mayor of Springfield" />)
+
+    expect(await screen.findByText(/Mayor of Springfield/)).toBeInTheDocument()
+  })
+
+  it('falls back to city, state when office is missing', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues: issues.slice(0, 1) },
+    })
+
+    render(<TopVoterIssuesSection city="Austin" state="TX" />)
+
+    expect(await screen.findByText(/Austin, TX/)).toBeInTheDocument()
+  })
+
+  it('falls back to the generic copy when no audience info is provided', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues: issues.slice(0, 1) },
+    })
+
+    render(<TopVoterIssuesSection />)
+
+    expect(
+      await screen.findByText(/your voters care about most/i),
+    ).toBeInTheDocument()
+  })
+
+  it('collapses to the first three issues and expands on demand', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues },
+    })
+
+    render(<TopVoterIssuesSection office="Mayor" />)
+
+    expect(await screen.findByText('Public Safety')).toBeInTheDocument()
+    expect(screen.getByText('Affordable Housing')).toBeInTheDocument()
+    expect(screen.getByText('Education')).toBeInTheDocument()
+    expect(screen.queryByText('Healthcare')).not.toBeInTheDocument()
+    expect(screen.queryByText('Climate')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /view 2 more/i }))
+
+    expect(screen.getByText('Healthcare')).toBeInTheDocument()
+    expect(screen.getByText('Climate')).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /show fewer issues/i }),
+    )
+    expect(screen.queryByText('Healthcare')).not.toBeInTheDocument()
+  })
+})

--- a/app/onboarding/components/TopVoterIssuesSection.test.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.test.tsx
@@ -49,7 +49,10 @@ describe('TopVoterIssuesSection', () => {
   })
 
   it('renders nothing and reports the error when the request fails', async () => {
-    api.mock('GET /v1/onboarding/voter-issues', { status: 500 })
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 500,
+      data: { message: 'boom' },
+    })
 
     const noRetryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/app/onboarding/components/TopVoterIssuesSection.test.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.test.tsx
@@ -26,7 +26,10 @@ beforeEach(() => {
 
 describe('TopVoterIssuesSection', () => {
   it('renders skeleton placeholders while the request is pending', () => {
-    api.mock('GET /v1/onboarding/voter-issues', () => new Promise(() => {}))
+    api.mock(
+      'GET /v1/onboarding/voter-issues',
+      () => new Promise(() => undefined),
+    )
 
     const { container } = render(<TopVoterIssuesSection office="Mayor" />)
 

--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { Card, CardContent, Badge } from '@styleguide'
 import {
@@ -19,12 +19,14 @@ import { reportErrorToSentry } from '@shared/sentry'
 interface TopVoterIssuesSectionProps {
   city?: string
   state?: string
+  office?: string
 }
 
 const VOTER_ISSUES_QUERY_KEY = 'onboarding-voter-issues'
 const VOTER_ISSUES_ROUTE = 'GET /v1/onboarding/voter-issues'
 const SENTRY_CONTEXT_FETCH_ISSUES = 'onboarding.voterIssues.fetch'
 const SKELETON_PLACEHOLDER_COUNT = 3
+const COLLAPSED_ISSUES_VISIBLE = 3
 
 const ISSUE_ICON_BASE =
   'flex size-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'
@@ -92,8 +94,10 @@ const VoterIssuesSkeleton = (): React.JSX.Element => (
 export const TopVoterIssuesSection = ({
   city,
   state,
+  office,
 }: TopVoterIssuesSectionProps): React.JSX.Element | null => {
   const query = useQuery(voterIssuesQueryOptions())
+  const [isExpanded, setIsExpanded] = useState(false)
 
   useEffect(() => {
     if (!query.error) return
@@ -102,11 +106,13 @@ export const TopVoterIssuesSection = ({
     })
   }, [query.error])
 
-  let jurisdiction = ''
-  if (city && state) {
-    jurisdiction = `${city}, ${state}`
+  let audienceLabel = ''
+  if (office) {
+    audienceLabel = office
+  } else if (city && state) {
+    audienceLabel = `${city}, ${state}`
   } else if (state) {
-    jurisdiction = state
+    audienceLabel = state
   }
 
   const issues = query.data?.issues ?? []
@@ -115,6 +121,11 @@ export const TopVoterIssuesSection = ({
     return null
   }
 
+  const visibleIssues = isExpanded
+    ? issues
+    : issues.slice(0, COLLAPSED_ISSUES_VISIBLE)
+  const additionalCount = issues.length - COLLAPSED_ISSUES_VISIBLE
+
   return (
     <div className="space-y-4 text-left">
       <div className="space-y-1">
@@ -122,27 +133,33 @@ export const TopVoterIssuesSection = ({
           Top issues for your voters
         </h2>
         <p className="text-sm leading-6 text-slate-500">
-          The issues voters{jurisdiction ? ' in ' : ' '}
-          {jurisdiction ? (
-            <span className="font-semibold text-slate-950">{jurisdiction}</span>
-          ) : null}{' '}
-          care about most right now.
+          {audienceLabel ? (
+            <>
+              The issues voters in your race for{' '}
+              <span className="font-semibold text-slate-950">
+                {audienceLabel}
+              </span>{' '}
+              care about most right now.
+            </>
+          ) : (
+            <>The issues your voters care about most right now.</>
+          )}
         </p>
       </div>
 
       {query.isPending ? (
         <VoterIssuesSkeleton />
       ) : (
-        <div className="space-y-3">
-          {issues.map((issue) => (
-            <Card key={issue.label} className="rounded-2xl shadow-none">
-              <CardContent className="space-y-3 p-5">
-                <div className="flex items-start justify-between gap-3">
+        <Card className="rounded-2xl shadow-none">
+          <CardContent className="flex flex-col gap-3 px-4 py-3">
+            {visibleIssues.map((issue) => (
+              <div key={issue.label} className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
                   <div className="flex items-center gap-3">
                     <span className={ISSUE_ICON_BASE}>
                       {iconForLabel(issue.label)}
                     </span>
-                    <h3 className="text-base font-semibold text-slate-950">
+                    <h3 className="text-sm font-semibold text-slate-950">
                       {issue.label}
                     </h3>
                   </div>
@@ -152,7 +169,7 @@ export const TopVoterIssuesSection = ({
                 </div>
 
                 <div className="space-y-1">
-                  <div className="h-2 w-full overflow-hidden rounded-full bg-slate-950">
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
                     <div
                       className="h-full rounded-full bg-blue-600"
                       style={{ width: `${Math.round(issue.score)}%` }}
@@ -162,10 +179,23 @@ export const TopVoterIssuesSection = ({
                     {Math.round(issue.score)}% voters care
                   </p>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+              </div>
+            ))}
+            {additionalCount > 0 ? (
+              <button
+                type="button"
+                onClick={() => setIsExpanded((prev) => !prev)}
+                className="-mb-1 self-center text-sm font-semibold text-primary hover:underline"
+              >
+                {isExpanded
+                  ? 'Show fewer issues'
+                  : `View ${additionalCount} more ${
+                      additionalCount === 1 ? 'issue' : 'issues'
+                    }`}
+              </button>
+            ) : null}
+          </CardContent>
+        </Card>
       )}
     </div>
   )

--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -1,0 +1,172 @@
+'use client'
+import { useEffect } from 'react'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { Card, CardContent, Badge } from '@styleguide'
+import {
+  LuHeart,
+  LuDollarSign,
+  LuMapPin,
+  LuBriefcase,
+  LuGraduationCap,
+  LuLeaf,
+  LuShieldCheck,
+  LuStethoscope,
+  LuVote,
+} from 'react-icons/lu'
+import { clientRequest } from 'gpApi/typed-request'
+import { reportErrorToSentry } from '@shared/sentry'
+
+interface TopVoterIssuesSectionProps {
+  city?: string
+  state?: string
+}
+
+const VOTER_ISSUES_QUERY_KEY = 'onboarding-voter-issues'
+const VOTER_ISSUES_ROUTE = 'GET /v1/onboarding/voter-issues'
+const SENTRY_CONTEXT_FETCH_ISSUES = 'onboarding.voterIssues.fetch'
+const SKELETON_PLACEHOLDER_COUNT = 3
+
+const ISSUE_ICON_BASE =
+  'flex size-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'
+
+const PRIORITY_LABEL: Record<'high' | 'medium' | 'low', string> = {
+  high: 'High priority',
+  medium: 'Medium priority',
+  low: 'Low priority',
+}
+
+const ICON_BY_KEYWORD: Array<{
+  pattern: RegExp
+  icon: React.JSX.Element
+}> = [
+  {
+    pattern: /(safety|crime|police)/i,
+    icon: <LuShieldCheck className="size-5" />,
+  },
+  {
+    pattern: /(econom|job|business|tax)/i,
+    icon: <LuDollarSign className="size-5" />,
+  },
+  { pattern: /(hous|rent|afford)/i, icon: <LuMapPin className="size-5" /> },
+  {
+    pattern: /(health|medic|hospital)/i,
+    icon: <LuStethoscope className="size-5" />,
+  },
+  {
+    pattern: /(educat|school|student)/i,
+    icon: <LuGraduationCap className="size-5" />,
+  },
+  {
+    pattern: /(environment|climate|energy)/i,
+    icon: <LuLeaf className="size-5" />,
+  },
+  { pattern: /(work|employ|labor)/i, icon: <LuBriefcase className="size-5" /> },
+  { pattern: /(elect|vot|democra)/i, icon: <LuVote className="size-5" /> },
+]
+
+const iconForLabel = (label: string): React.JSX.Element => {
+  const match = ICON_BY_KEYWORD.find(({ pattern }) => pattern.test(label))
+  return match ? match.icon : <LuHeart className="size-5" />
+}
+
+const voterIssuesQueryOptions = () =>
+  queryOptions({
+    queryKey: [VOTER_ISSUES_QUERY_KEY] as const,
+    queryFn: () =>
+      clientRequest(VOTER_ISSUES_ROUTE, {}).then((res) => res.data),
+  })
+
+export { voterIssuesQueryOptions }
+
+const VoterIssuesSkeleton = (): React.JSX.Element => (
+  <div className="space-y-3">
+    {Array.from({ length: SKELETON_PLACEHOLDER_COUNT }).map((_, index) => (
+      <div
+        key={index}
+        className="h-28 animate-pulse rounded-2xl bg-slate-100"
+      />
+    ))}
+  </div>
+)
+
+export const TopVoterIssuesSection = ({
+  city,
+  state,
+}: TopVoterIssuesSectionProps): React.JSX.Element | null => {
+  const query = useQuery(voterIssuesQueryOptions())
+
+  useEffect(() => {
+    if (!query.error) return
+    reportErrorToSentry(query.error, {
+      context: SENTRY_CONTEXT_FETCH_ISSUES,
+    })
+  }, [query.error])
+
+  let jurisdiction = ''
+  if (city && state) {
+    jurisdiction = `${city}, ${state}`
+  } else if (state) {
+    jurisdiction = state
+  }
+
+  const issues = query.data?.issues ?? []
+
+  if (!query.isPending && !query.error && issues.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-4 text-left">
+      <div className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-950">
+          Top issues for your voters
+        </h2>
+        <p className="text-sm leading-6 text-slate-500">
+          The issues voters{jurisdiction ? ' in ' : ' '}
+          {jurisdiction ? (
+            <span className="font-semibold text-slate-950">{jurisdiction}</span>
+          ) : null}{' '}
+          care about most right now.
+        </p>
+      </div>
+
+      {query.isPending ? (
+        <VoterIssuesSkeleton />
+      ) : (
+        <div className="space-y-3">
+          {issues.map((issue) => (
+            <Card key={issue.label} className="rounded-2xl shadow-none">
+              <CardContent className="space-y-3 p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <span className={ISSUE_ICON_BASE}>
+                      {iconForLabel(issue.label)}
+                    </span>
+                    <h3 className="text-base font-semibold text-slate-950">
+                      {issue.label}
+                    </h3>
+                  </div>
+                  <Badge className="rounded-full bg-slate-950 px-3 py-1 text-xs font-medium text-white hover:bg-slate-950">
+                    {PRIORITY_LABEL[issue.priority]}
+                  </Badge>
+                </div>
+
+                <div className="space-y-1">
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-slate-950">
+                    <div
+                      className="h-full rounded-full bg-blue-600"
+                      style={{ width: `${Math.round(issue.score)}%` }}
+                    />
+                  </div>
+                  <p className="text-right text-xs text-slate-500">
+                    {Math.round(issue.score)}% voters care
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -117,7 +117,7 @@ export const TopVoterIssuesSection = ({
 
   const issues = query.data?.issues ?? []
 
-  if (!query.isPending && !query.error && issues.length === 0) {
+  if (!query.isPending && issues.length === 0) {
     return null
   }
 

--- a/app/onboarding/components/VoterDemographicsStep.tsx
+++ b/app/onboarding/components/VoterDemographicsStep.tsx
@@ -8,6 +8,7 @@ import { NumberInsight } from 'app/polls/onboarding/components/NumberInsight'
 import { DataVisualizationInsight } from 'app/polls/onboarding/components/DataVisualizationInsight'
 import { mapContactsStatsToCharts } from 'app/polls/onboarding/utils/mapContactsStatsToCharts'
 import { LocalNewsSourcesSection } from './LocalNewsSourcesSection'
+import { TopVoterIssuesSection } from './TopVoterIssuesSection'
 
 const onboardingDistrictStatsQueryOptions = (params: {
   ballotReadyPositionId?: string
@@ -72,6 +73,8 @@ export const VoterDemographicsStep = ({
 
   return (
     <div className="flex w-full flex-col items-stretch gap-6 text-left">
+      <TopVoterIssuesSection city={city} state={state} />
+
       <div className="space-y-2">
         <h2 className="text-2xl font-semibold text-slate-950">
           Voter Demographics

--- a/app/onboarding/components/VoterDemographicsStep.tsx
+++ b/app/onboarding/components/VoterDemographicsStep.tsx
@@ -73,7 +73,7 @@ export const VoterDemographicsStep = ({
 
   return (
     <div className="flex w-full flex-col items-stretch gap-6 text-left">
-      <TopVoterIssuesSection city={city} state={state} />
+      <TopVoterIssuesSection city={city} state={state} office={office} />
 
       <div className="space-y-2">
         <h2 className="text-2xl font-semibold text-slate-950">
@@ -103,7 +103,7 @@ export const VoterDemographicsStep = ({
         chartType="horizontalGauge"
         percentage={true}
         title="Age Distribution"
-        description="Use this to pick the right outreach mix — younger voters lean into SMS and social, older voters respond best to mail and door-knocks."
+        description="We'll help you tailor your outreach mix to each age group — leaning into SMS and social for younger voters, and prioritizing mail and door-knocks for older ones."
         data={chartData.ageDistribution}
         isLoading={isLoading}
         error={error}
@@ -113,7 +113,7 @@ export const VoterDemographicsStep = ({
         chartType="pie"
         percentage={true}
         title="Has Children Under 18"
-        description="Households with kids prioritize schools, safety, and after-school programs — message and canvas these blocks accordingly."
+        description="We'll help you reach households with kids using messaging that resonates with them — schools, safety, and after-school programs."
         data={chartData.presenceOfChildren}
         isLoading={isLoading}
         error={error}
@@ -123,7 +123,7 @@ export const VoterDemographicsStep = ({
         chartType="donut"
         percentage={true}
         title="Homeowner"
-        description="Homeowners care about property taxes, zoning, and services — focus door-knocking and direct mail here when those issues are central to your platform."
+        description="We'll help you focus your door-knocking and direct mail on homeowners when property taxes, zoning, and services are central to your platform."
         data={chartData.homeowner}
         isLoading={isLoading}
         error={error}
@@ -133,7 +133,7 @@ export const VoterDemographicsStep = ({
         chartType="verticalBar"
         percentage={true}
         title="Estimated Income Range"
-        description="Knowing the income mix helps you frame economic messaging in your SMS, email, and canvassing scripts so it lands with each segment."
+        description="We'll help you frame your economic messaging across SMS, email, and canvassing scripts so it lands with each income segment."
         data={chartData.estimatedIncomeRange}
         isLoading={isLoading}
         error={error}
@@ -143,7 +143,7 @@ export const VoterDemographicsStep = ({
         chartType="horizontalBar"
         percentage={true}
         title="Education"
-        description="Education levels shape how voters consume info — tune the depth and channel of your outreach (SMS, email, literature drops) to match."
+        description="We'll help you tune the depth and channel of your outreach (SMS, email, literature drops) to match how each education segment consumes information."
         data={chartData.education}
         isLoading={isLoading}
         error={error}

--- a/app/shared/charts/InsightHorizontalGaugeChart.tsx
+++ b/app/shared/charts/InsightHorizontalGaugeChart.tsx
@@ -29,18 +29,14 @@ export const InsightHorizontalGaugeChart = ({
         const barWidthPercent = `${valuePercent}%`
 
         return (
-          <div key={`gauge-row-${item.name}`} className="w-full mb-3">
-            <div className="flex items-center justify-between w-full mb-1.5">
-              <span className="truncate text-xs text-muted-foreground font-normal">
-                {item.name}
-              </span>
-              <span className="text-base font-semibold ml-4">
-                {percentage
-                  ? `${formatPercentLabel(item.value)}%`
-                  : numberFormatter(item.value)}
-              </span>
-            </div>
-            <div className="w-full h-4 bg-muted rounded-lg">
+          <div
+            key={`gauge-row-${item.name}`}
+            className="flex items-center gap-3 w-full"
+          >
+            <span className="w-12 shrink-0 truncate text-xs text-muted-foreground font-normal">
+              {item.name}
+            </span>
+            <div className="flex-1 h-4 bg-muted rounded-lg">
               <div
                 className="h-4 rounded-lg"
                 style={{
@@ -49,6 +45,11 @@ export const InsightHorizontalGaugeChart = ({
                 }}
               />
             </div>
+            <span className="w-12 shrink-0 text-right text-xs font-semibold text-foreground">
+              {percentage
+                ? `${formatPercentLabel(item.value)}%`
+                : numberFormatter(item.value)}
+            </span>
           </div>
         )
       })}

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -99,6 +99,17 @@ export type APIEndpoints = {
     }
   }
 
+  'GET /v1/onboarding/voter-issues': {
+    Request: {}
+    Response: {
+      issues: Array<{
+        label: string
+        score: number
+        priority: 'high' | 'medium' | 'low'
+      }>
+    }
+  }
+
   'POST /v1/polls/initial-poll': {
     Request: {
       message: string


### PR DESCRIPTION
## Summary

Polishes the onboarding voter-issues flow:

- Sticky animated progress bar (fixed below nav, staggered f- Sticky animated progress bar (fixed below nav, staggered f- Sticky animated progress bar (fixed below nav, staggered f- Sticky animated progress bar (fixed below nav, staggered f- Sticky animated progress bar (fixed below nav, staggered f- Sticky animated progress bar ad- Sticky odology' link and the per-step blue eyebrow titles
- Voter demographics insight copy + gauge chart tweaks
- TopVoterIssuesSection wired to gp-api

## Test plan

- Walk through onboarding; verify progress bar stays put and animates between steps
- Navigate forward then back to PathToVictory; verify reveal does not replay
- Confirm projection breakdown shows registered voters, turnout %, projected turnout, and votes needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because onboarding now fetches and renders new `GET /v1/onboarding/voter-issues` data and changes path-to-victory step state/animation behavior, which could affect onboarding flow progression and loading states.
> 
> **Overview**
> Adds a new **“Top issues for your voters”** section to the `voter-demographics` step, backed by a new typed API endpoint `GET /v1/onboarding/voter-issues` and a React Query fetch with Sentry error reporting, skeleton loading, icon/priority badges, and expand/collapse behavior.
> 
> Polishes onboarding UX by making the step progress indicator sticky and animated, adjusting the horizontal gauge chart layout, and refreshing copy in voter-demographics insights.
> 
> Updates the `path-to-victory` step so its checklist reveal can be skipped on revisit (tracked via `hasResolvedPathToVictory`), and enhances the win-number presentation with a projected range and a clearer projection breakdown (registered voters, turnout %, projected turnout, and 50%+1 win number).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d883350c4104d8267991635287e4d389d987dff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->