### PR TITLE
fix(post-auth-redirect): tolerate org fetch race on fresh sign-up

### DIFF
--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import PostAuthRedirectPage from './page'
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: vi.fn(() => ({ isSignedIn: true, isLoaded: true })),
+}))
+
+const mockSetCookie = vi.fn<(name: string, value: string) => void>()
+vi.mock('helpers/cookieHelper', () => ({
+  getCookie: vi.fn(() => false),
+  setCookie: (name: string, value: string) => mockSetCookie(name, value),
+  deleteCookie: vi.fn(),
+}))
+
+let replaceSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  mockSetCookie.mockClear()
+  replaceSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, replace: replaceSpy },
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const orgFixture = {
+  slug: 'org-one',
+  name: 'Org One',
+  positionName: null,
+  position: null,
+  district: null,
+  electedOfficeId: null,
+  campaignId: 1,
+}
+
+describe('PostAuthRedirectPage', () => {
+  it('happy path: orgs returned, resolves to /dashboard for active candidate', async () => {
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
+  })
+
+  it('retry path: first orgs call fails, second succeeds; uses retry orgs', async () => {
+    api.mockOrdered('GET /v1/organizations', [
+      { status: 500, data: { message: 'transient' } },
+      { status: 200, data: { organizations: [orgFixture] } },
+    ])
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'), {
+      timeout: 3000,
+    })
+    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
+  })
+
+  it('double-failure path: both orgs calls fail; falls through to /onboarding/office-selection', async () => {
+    api.mock('GET /v1/organizations', {
+      status: 500,
+      data: { message: 'down' },
+    })
+    api.mock('GET /v1/users/me', { status: 500, data: { message: 'down' } })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 500,
+      data: { message: 'down' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 500,
+      data: { message: 'down' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(
+      () =>
+        expect(replaceSpy).toHaveBeenCalledWith('/onboarding/office-selection'),
+      { timeout: 3000 },
+    )
+    expect(mockSetCookie).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /login when not signed in', async () => {
+    const clerkMod = await import('@clerk/nextjs')
+    vi.mocked(clerkMod.useUser).mockReturnValueOnce({
+      isSignedIn: false,
+      isLoaded: true,
+    } as any)
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/login'))
+  })
+})

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react'
 import { useUser as useClerkUser } from '@clerk/nextjs'
 import { clientRequest } from 'gpApi/typed-request'
+import type { Organization } from 'gpApi/api-endpoints'
 import {
   resolvePostAuthRedirectPath,
   CampaignStatus,
@@ -27,9 +28,26 @@ const PostAuthRedirectPage = () => {
     ranRef.current = true
     ;(async () => {
       try {
-        const {
-          data: { organizations },
-        } = await clientRequest('GET /v1/organizations', {})
+        // First authenticated call after a fresh sign-up may race the gp-api
+        // JIT-provisioning of the local user record. Retry once on failure
+        // before falling back to an empty list.
+        let organizations: Organization[] = []
+        const orgsRes = await clientRequest(
+          'GET /v1/organizations',
+          {},
+          { ignoreResponseError: true },
+        )
+        if (orgsRes.ok) {
+          organizations = orgsRes.data.organizations
+        } else {
+          await new Promise((resolve) => setTimeout(resolve, 500))
+          const retry = await clientRequest(
+            'GET /v1/organizations',
+            {},
+            { ignoreResponseError: true },
+          )
+          if (retry.ok) organizations = retry.data.organizations
+        }
 
         const slug = resolveSlug(organizations)
         if (slug) {
@@ -66,7 +84,9 @@ const PostAuthRedirectPage = () => {
         window.location.replace(path)
       } catch (e) {
         console.error('post-auth-redirect error', e)
-        window.location.replace('/dashboard')
+        // Don't strand new users on a blank /dashboard if the resolver
+        // throws — onboarding is the safe default for unknown state.
+        window.location.replace('/onboarding/office-selection')
       }
     })()
   }, [isSignedIn, isLoaded])


### PR DESCRIPTION
## Problem

New users occasionally landed on a blank `/dashboard` after sign-up (reported by Jesse, fixed for him by manual refresh). Root cause: `post-auth-redirect/page.tsx` made a non-tolerant `GET /v1/organizations` call. On a brand-new account, gp-api JIT-creates the user record on first hit, so the call could fail. The catch then redirected to `/dashboard`, stranding the user there with no campaign.

## Fix

In [`app/post-auth-redirect/page.tsx`](app/post-auth-redirect/page.tsx):

- Wrap the initial `GET /v1/organizations` call with `ignoreResponseError: true` and retry once after 500ms to absorb the JIT-provisioning race.
- Change the catch fallback redirect from `/dashboard` to `/onboarding/office-selection` so users in an unknown state land somewhere recoverable instead of a blank dashboard.

## Notes

- Minimal diff — single file. No changes to `candidateAccess` or other server gates.
- Manual refresh worked for Jesse because by then JIT-provisioning had completed and SSR `candidateAccess` correctly bounced him to onboarding. This fix makes the first attempt do the same.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small client-side control-flow change limited to post-login redirection, mainly affecting new-user edge cases and fallback navigation.
> 
> **Overview**
> Makes the post-auth redirect flow tolerant of a race on fresh sign-up by treating `GET /v1/organizations` as non-fatal, retrying once after a short delay, and proceeding with an empty org list if needed.
> 
> If the redirect resolver still throws, the fallback navigation now goes to **onboarding** (`/onboarding/office-selection`) instead of sending users to a potentially blank `/dashboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a06e81acf1f9b6a9cc452e9b955c757671f4eb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->