### PR TITLE
Remove "(~95% confidence)" from onboarding projected range

### DIFF
--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -275,8 +275,7 @@ const WinNumberHeroCard = ({
           Projected range:{' '}
           <span className="font-semibold text-foreground">
             {numberFormatter(lowEstimate)}–{numberFormatter(highEstimate)}
-          </span>{' '}
-          (~95% confidence)
+          </span>
         </p>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

- Removes the trailing `(~95% confidence)` qualifier from the projected vote range under the win-number hero card in the Path to Victory onboarding step.
- The line now reads `Projected range: XX–YY` instead of `Projected range: XX–YY (~95% confidence)`.

## Why

The `(~95% confidence)` parenthetical wasn't adding value for candidates seeing this for the first time and made the line harder to scan. The visible range (computed at ±15%) already communicates uncertainty.

## Scope

- File: `app/onboarding/components/PathToVictoryStep.tsx` (internal `WinNumberHeroCard` component)
- No logic, no API, no styles changed — pure copy edit (1 insertion, 2 deletions)

## Tests

No tests added. This is a static-string deletion in an internal (non-exported) component with no existing test file, and the surrounding logic is unchanged. Adding a test would require either exporting the internal component or wiring up an API-dependent integration test purely to assert on copy.

## Test plan

- [ ] Visit onboarding Path to Victory step (or trigger via `/onboarding`)
- [ ] Confirm the win-number card shows `Projected range: XX–YY` with no `(~95% confidence)` text
- [ ] Confirm spacing/wrapping looks correct on mobile and desktop widths


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change in an onboarding UI component; no business logic, APIs, or data handling are modified.
> 
> **Overview**
> Removes the `(~95% confidence)` parenthetical from the *Projected range* line in the `WinNumberHeroCard` shown during the Path to Victory onboarding step, leaving only `Projected range: XX–YY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b159343682bf1082df802631e6175de84967af62. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->