### PR TITLE
feat(onboarding): track Know Your Voters step completion (ENG-10200)

### DIFF
--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -787,6 +787,11 @@ export default function OnboardingFlow({
         winNumber: trackedCampaign?.raceTargetMetrics?.winNumber ?? 0,
       })
     }
+    if (activeStep.id === 'voter-demographics') {
+      trackEvent(EVENTS.Onboarding.KnowYourVotersCompleted, {
+        campaignId: campaign?.id,
+      })
+    }
     if (
       activeStep.id === 'office-selection' &&
       answers.structuredOffice &&

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -90,6 +90,7 @@ export const EVENTS = {
     },
     WelcomeCompleted: 'Onboarding - Welcome Completed',
     BallotStatusCompleted: 'Onboarding - Ballot Status Completed',
+    KnowYourVotersCompleted: 'Onboarding - Know Your Voters Completed',
     PartySelectionCompleted: 'Onboarding - Party Selection Completed',
     OfficeSelectionCompleted: 'Onboarding - Office Selection Completed',
     PathToVictoryUpdated: 'Onboarding - Path To Victory Updated',


### PR DESCRIPTION
## Summary
- Adds `EVENTS.Onboarding.KnowYourVotersCompleted` (`Onboarding - Know Your Voters Completed`) and fires it from `runGoNext()` when the user clicks Continue on the `voter-demographics` step.
- Closes the missing-event gap in the [Amplitude onboarding funnel](https://app.amplitude.com/analytics/goodparty/chart/2cg3h26m?sharingId=Uxqe2u7o&source=copy+url) flagged in [ENG-10200](https://app.clickup.com/t/86ahbkpdk).

## Test plan
- [ ] Run through the onboarding flow locally up to the "Here's everything to know about your voters" page, click Continue, and confirm `Onboarding - Know Your Voters Completed` fires once with `campaignId` in the analytics debugger.
- [ ] Verify the existing structured-office path still advances to the pledge step (no regressions in `runGoNext` ordering).
- [ ] Confirm the manual-office path skips this step (it has `shouldSkip: officePath === 'manual'`) and therefore does not fire the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new analytics event constant and emits it on step advance without changing onboarding state or persistence logic.
> 
> **Overview**
> Adds a new onboarding analytics event, `EVENTS.Onboarding.KnowYourVotersCompleted` (`Onboarding - Know Your Voters Completed`).
> 
> Emits this event from `OnboardingFlow.runGoNext()` when the user continues past the `voter-demographics` step, including `campaignId` in the tracked properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7b82338a8a54299da1a8107c3fb0dc4477cd8a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->