### PR TITLE
fix(post-auth-redirect): restore Onboarding - Registration Completed tracking

### DIFF
--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -5,7 +5,13 @@ import { api } from 'helpers/test-utils/api-mocking'
 import PostAuthRedirectPage from './page'
 
 vi.mock('@clerk/nextjs', () => ({
-  useUser: vi.fn(() => ({ isSignedIn: true, isLoaded: true })),
+  useUser: vi.fn(() => ({
+    isSignedIn: true,
+    isLoaded: true,
+    user: {
+      primaryEmailAddress: { emailAddress: 'clerk-fallback@example.com' },
+    },
+  })),
 }))
 
 const mockSetCookie = vi.fn<(name: string, value: string) => void>()
@@ -15,15 +21,30 @@ vi.mock('helpers/cookieHelper', () => ({
   deleteCookie: vi.fn(),
 }))
 
+const mockTrackRegistration =
+  vi.fn<(args: { userId: string; email?: string }) => void>()
+vi.mock('helpers/analyticsHelper', () => ({
+  trackRegistrationCompleted: (args: { userId: string; email?: string }) =>
+    mockTrackRegistration(args),
+}))
+vi.mock('@shared/utils/analytics', () => ({
+  getReadyAnalytics: vi.fn().mockResolvedValue(null),
+}))
+
 let replaceSpy: ReturnType<typeof vi.fn>
+
+const setLocation = (search = '') => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, replace: replaceSpy, search },
+  })
+}
 
 beforeEach(() => {
   mockSetCookie.mockClear()
+  mockTrackRegistration.mockClear()
   replaceSpy = vi.fn()
-  Object.defineProperty(window, 'location', {
-    configurable: true,
-    value: { ...window.location, replace: replaceSpy },
-  })
+  setLocation('')
 })
 
 afterEach(() => {
@@ -120,5 +141,60 @@ describe('PostAuthRedirectPage', () => {
     render(<PostAuthRedirectPage />)
 
     await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/login'))
+  })
+
+  it('signup source: fires trackRegistrationCompleted with gp-api id and email', async () => {
+    setLocation('?source=signup')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', {
+      status: 200,
+      data: { id: 42, email: 'new-user@example.com', roles: [] } as any,
+    })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+    expect(mockTrackRegistration).toHaveBeenCalledTimes(1)
+    expect(mockTrackRegistration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: '42',
+        email: 'new-user@example.com',
+      }),
+    )
+  })
+
+  it('login (no source param): does not fire trackRegistrationCompleted', async () => {
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', {
+      status: 200,
+      data: { id: 42, email: 'returning@example.com', roles: [] } as any,
+    })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+    expect(mockTrackRegistration).not.toHaveBeenCalled()
   })
 })

--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -143,7 +143,7 @@ describe('PostAuthRedirectPage', () => {
     await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/login'))
   })
 
-  it('signup source: fires trackRegistrationCompleted with gp-api id and email', async () => {
+  it('signup source + fresh createdAt: fires trackRegistrationCompleted', async () => {
     setLocation('?source=signup')
     api.mock('GET /v1/organizations', {
       status: 200,
@@ -151,7 +151,12 @@ describe('PostAuthRedirectPage', () => {
     })
     api.mock('GET /v1/users/me', {
       status: 200,
-      data: { id: 42, email: 'new-user@example.com', roles: [] } as any,
+      data: {
+        id: 42,
+        email: 'new-user@example.com',
+        roles: [],
+        createdAt: new Date().toISOString(),
+      } as any,
     })
     api.mock('GET /v1/campaigns/mine/status', {
       status: 200,
@@ -174,6 +179,36 @@ describe('PostAuthRedirectPage', () => {
     )
   })
 
+  it('signup source + stale createdAt: does NOT fire (URL-tampering guard)', async () => {
+    setLocation('?source=signup')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', {
+      status: 200,
+      data: {
+        id: 42,
+        email: 'old-user@example.com',
+        roles: [],
+        createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      } as any,
+    })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+    expect(mockTrackRegistration).not.toHaveBeenCalled()
+  })
+
   it('login (no source param): does not fire trackRegistrationCompleted', async () => {
     api.mock('GET /v1/organizations', {
       status: 200,
@@ -181,7 +216,12 @@ describe('PostAuthRedirectPage', () => {
     })
     api.mock('GET /v1/users/me', {
       status: 200,
-      data: { id: 42, email: 'returning@example.com', roles: [] } as any,
+      data: {
+        id: 42,
+        email: 'returning@example.com',
+        roles: [],
+        createdAt: new Date().toISOString(),
+      } as any,
     })
     api.mock('GET /v1/campaigns/mine/status', {
       status: 200,

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -76,23 +76,35 @@ const PostAuthRedirectPage = () => {
           : null
         const hasElectedOffice = electedRes.ok
 
-        // Fire the registration event only when the redirect originated from
-        // the sign-up route. <SignUp /> sets ?source=signup; <SignIn /> does
-        // not, so this fires once per fresh registration and never on login.
-        if (
-          userRes.ok &&
+        // Fire the registration event only on a true fresh sign-up. The
+        // ?source=signup hint set by <SignUp /> is just a re-fire guard for
+        // back-to-back logout/login; the authoritative gate is the gp-api
+        // user record's createdAt, which is server-set at JIT-provisioning
+        // and cannot be forged by crafting a URL.
+        const REGISTRATION_FRESHNESS_MS = 5 * 60 * 1000
+        const sourceIsSignup =
           new URLSearchParams(window.location.search).get('source') === 'signup'
-        ) {
+        if (userRes.ok && sourceIsSignup) {
           try {
-            const userData = userRes.data as { id: number; email?: string }
-            await trackRegistrationCompleted({
-              analytics: getReadyAnalytics(),
-              userId: String(userData.id),
-              email:
-                userData.email ||
-                clerkUser?.primaryEmailAddress?.emailAddress ||
-                '',
-            })
+            const userData = userRes.data as {
+              id: number
+              email?: string
+              createdAt: string | Date
+            }
+            const createdAtMs = new Date(userData.createdAt).getTime()
+            const isFreshlyCreated =
+              Number.isFinite(createdAtMs) &&
+              Date.now() - createdAtMs < REGISTRATION_FRESHNESS_MS
+            if (isFreshlyCreated) {
+              await trackRegistrationCompleted({
+                analytics: getReadyAnalytics(),
+                userId: String(userData.id),
+                email:
+                  userData.email ||
+                  clerkUser?.primaryEmailAddress?.emailAddress ||
+                  '',
+              })
+            }
           } catch (e) {
             console.error('registration tracking error', e)
           }

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -11,10 +11,12 @@ import {
 import { setCookie } from 'helpers/cookieHelper'
 import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { resolveSlug } from '@shared/hooks/useSelectedOrgSlug'
+import { trackRegistrationCompleted } from 'helpers/analyticsHelper'
+import { getReadyAnalytics } from '@shared/utils/analytics'
 import { LoaderCircle } from 'lucide-react'
 
 const PostAuthRedirectPage = () => {
-  const { isSignedIn, isLoaded } = useClerkUser()
+  const { isSignedIn, isLoaded, user: clerkUser } = useClerkUser()
   const ranRef = useRef(false)
 
   useEffect(() => {
@@ -73,6 +75,28 @@ const PostAuthRedirectPage = () => {
           ? (statusRes.data as CampaignStatus)
           : null
         const hasElectedOffice = electedRes.ok
+
+        // Fire the registration event only when the redirect originated from
+        // the sign-up route. <SignUp /> sets ?source=signup; <SignIn /> does
+        // not, so this fires once per fresh registration and never on login.
+        if (
+          userRes.ok &&
+          new URLSearchParams(window.location.search).get('source') === 'signup'
+        ) {
+          try {
+            const userData = userRes.data as { id: number; email?: string }
+            await trackRegistrationCompleted({
+              analytics: getReadyAnalytics(),
+              userId: String(userData.id),
+              email:
+                userData.email ||
+                clerkUser?.primaryEmailAddress?.emailAddress ||
+                '',
+            })
+          } catch (e) {
+            console.error('registration tracking error', e)
+          }
+        }
 
         const path = resolvePostAuthRedirectPath(
           user,

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -19,7 +19,10 @@ export default async function SignUpPage() {
 
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-64px)] py-8">
-      <SignUp fallbackRedirectUrl="/post-auth-redirect" routing="hash" />
+      <SignUp
+        fallbackRedirectUrl="/post-auth-redirect?source=signup"
+        routing="hash"
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- The Amplitude/Segment event `Onboarding - Registration Completed` stopped firing on **2026-04-20** when auth was cut over to Clerk (#1524). Pre-cutover it was a frontend Segment call from the now-removed custom sign-up form. The helper (`trackRegistrationCompleted`) and analytics bootstrap (`getReadyAnalytics`) are still in the codebase — only the call site was gone.
- Restored the event by re-firing the existing helper from `app/post-auth-redirect/page.tsx`, gated by a `?source=signup` query param that `<SignUp />` now sets via `fallbackRedirectUrl`. `<SignIn />` is unchanged, so the event fires once on fresh registration and never on login.
- Wrapped the tracking call in `try/catch` so a Segment failure can never block the redirect. Falls back to Clerk's `primaryEmailAddress` if gp-api's email is missing, mirroring the original `user.email || email` behavior.

## Test plan

- [x] `npx vitest run app/post-auth-redirect/page.test.tsx` — 6/6 pass (4 existing + 2 new: signup-fires, login-doesnt-fire).
- [x] `npx vitest run helpers/analyticsHelper.test.ts` — 3/3 pass.
- [x] Prettier clean on changed files.
- [ ] Local smoke against dev API: sign up with a fresh email at `/sign-up`, confirm one Segment `track` for `Onboarding - Registration Completed` plus a paired `identify`. Then log out and back in via `/login` — confirm no event fires.
- [ ] Post-deploy: confirm event reappears in Segment/Amplitude debugger; compare daily counts against new-user signups in gp-api.

## Out of scope (follow-up)

- Backfilling the 2026-04-20 → deploy gap would need a one-time backend job over Clerk users created in that window, emitting server-side Segment events.
- A Clerk `user.created` webhook would be more reliable than the frontend call but loses UTM/anonymousId attribution — separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a gated analytics call during post-auth redirect, wrapped in `try/catch` so failures shouldn’t block navigation.
> 
> **Overview**
> Restores firing the `Onboarding - Registration Completed` event after Clerk sign-up by adding a `trackRegistrationCompleted` call in `app/post-auth-redirect/page.tsx`, gated to only run when `?source=signup` is present.
> 
> Updates the Clerk `SignUp` flow to append `?source=signup` to the `fallbackRedirectUrl`, and extends `post-auth-redirect` tests to cover the signup-tracks vs login-does-not behavior (including a Clerk email fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91175bd97e04c9693f1a7a21d88bbf895c9823b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->