### PR TITLE
fix(onboarding): refresh stale data and add instant office selection

### DIFF
--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -124,7 +124,7 @@ describe('OfficeSelectionStep', () => {
     })
   })
 
-  it('hydrates the selected race and forwards full details to onSelect', async () => {
+  it('selects the race optimistically and forwards full details after hydration', async () => {
     mockClientFetch.mockResolvedValueOnce({
       data: [sampleRace()],
       ok: true,
@@ -169,6 +169,11 @@ describe('OfficeSelectionStep', () => {
     })
     fireEvent.click(raceButton)
 
+    // Optimistic select fires synchronously with the click — no await.
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ raceId: 'race-1' }),
+    )
+
     await waitFor(() => {
       expect(mockClientRequest).toHaveBeenCalledWith(
         'GET /v1/elections/race-by-position',
@@ -200,7 +205,58 @@ describe('OfficeSelectionStep', () => {
     })
   })
 
-  it('shows an error snackbar and does not call onSelect when hydration fails', async () => {
+  it('signals hydration via onHydratingChange across the request lifecycle', async () => {
+    mockClientFetch.mockResolvedValueOnce({
+      data: [sampleRace()],
+      ok: true,
+    } as unknown as Awaited<ReturnType<typeof clientFetch>>)
+
+    let resolveHydrate: (value: unknown) => void = () => undefined
+    mockClientRequest.mockImplementationOnce(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveHydrate = resolve
+        }) as ReturnType<typeof clientRequest>,
+    )
+
+    const onHydratingChange = vi.fn()
+    renderStep({ onHydratingChange })
+    fireEvent.change(screen.getByLabelText(/zip code/i), {
+      target: { value: '82001' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /search/i }))
+
+    const raceButton = await screen.findByRole('radio', {
+      name: /city council election date/i,
+    })
+    fireEvent.click(raceButton)
+
+    await waitFor(() => {
+      expect(onHydratingChange).toHaveBeenCalledWith(true)
+    })
+
+    resolveHydrate({
+      data: {
+        id: 'race-server',
+        brPositionId: 'br-pos-1',
+        position: {
+          id: 'pos-1',
+          name: 'City Council',
+          electionFrequencies: [{ frequency: 4 }],
+        },
+        election: { id: 'elec-1', electionDay: '2026-11-03' },
+      },
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+    })
+
+    await waitFor(() => {
+      expect(onHydratingChange).toHaveBeenLastCalledWith(false)
+    })
+  })
+
+  it('reverts the optimistic selection and signals an error when hydration fails', async () => {
     mockClientFetch.mockResolvedValueOnce({
       data: [sampleRace()],
       ok: true,
@@ -221,13 +277,19 @@ describe('OfficeSelectionStep', () => {
     onSelect.mockClear()
     fireEvent.click(raceButton)
 
+    // Optimistic select fires immediately so the radio reflects the click.
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ raceId: 'race-1' }),
+    )
+
     await waitFor(() => {
       expect(mockErrorSnackbar).toHaveBeenCalledWith(
         'Could not load race details. Please try again.',
       )
     })
 
-    expect(onSelect).not.toHaveBeenCalled()
+    // Hydration failure rolls the selection back.
+    expect(onSelect).toHaveBeenLastCalledWith(undefined)
   })
 
   it('hides "I don\'t see my office" until results are showing', async () => {

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -338,12 +338,17 @@ export const OfficeSelectionStep = ({
     pendingHydrationRaceIdRef.current = race.id
     onSelect(toSelectedOffice(race))
     onHydratingChange?.(true)
+    const zipAtClick = submittedZip
     const hydrated = await hydrateRace(race)
 
     // The user may have clicked a different race, deselected, or changed zip
     // while we were hydrating. If so, bail — the newer handler owns state.
     if (pendingHydrationRaceIdRef.current !== race.id) {
-      if (hydrated) hydratedRacesRef.current.set(race.id, hydrated)
+      // Only cache if the zip context still matches; otherwise this result
+      // belongs to a previous zip and would poison cache for the new one.
+      if (hydrated && submittedZip === zipAtClick) {
+        hydratedRacesRef.current.set(race.id, hydrated)
+      }
       return
     }
 

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -13,7 +13,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import Fuse, { type IFuseOptions } from 'fuse.js'
 import { Search } from 'lucide-react'
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useRef } from 'react'
 import { clientFetch } from 'gpApi/clientFetch'
 import { clientRequest } from 'gpApi/typed-request'
 import { apiRoutes } from 'gpApi/routes'
@@ -28,6 +28,7 @@ interface OfficeSelectionStepProps {
   onZipChange: (zip: string) => void
   onSelect: (office: SelectedOffice | undefined) => void
   onCantFindOffice: () => void
+  onHydratingChange?: (isHydrating: boolean) => void
 }
 
 interface FilterOption {
@@ -200,6 +201,7 @@ export const OfficeSelectionStep = ({
   onZipChange,
   onSelect,
   onCantFindOffice,
+  onHydratingChange,
 }: OfficeSelectionStepProps): React.JSX.Element => {
   const [zipInput, setZipInput] = useState(zip ?? '')
   const [submittedZip, setSubmittedZip] = useState<string | undefined>(zip)
@@ -275,14 +277,24 @@ export const OfficeSelectionStep = ({
     setSubmittedZip(cleaned)
     setActiveFilter('')
     setNameFilter('')
+    hydratedRacesRef.current.clear()
+    pendingHydrationRaceIdRef.current = null
     onZipChange(cleaned)
     onSelect(undefined)
+    onHydratingChange?.(false)
   }
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     handleSearch()
   }
+
+  const hydratedRacesRef = useRef<Map<string, Race>>(new Map())
+  // Tracks the most recently clicked race so an in-flight hydration result
+  // for a previously clicked race can detect that it's stale and bail.
+  // Updated synchronously inside the click handler so it doesn't depend on
+  // the parent feeding the new `selected` prop back through a re-render.
+  const pendingHydrationRaceIdRef = useRef<string | null>(null)
 
   const hydrateRace = async (race: Race): Promise<Race | null> => {
     if (!race.brPositionId || !race.election?.electionDay || !submittedZip) {
@@ -307,12 +319,42 @@ export const OfficeSelectionStep = ({
 
   const handleSelectRace = async (race: Race) => {
     if (selected?.raceId === race.id) {
+      pendingHydrationRaceIdRef.current = null
       onSelect(undefined)
+      onHydratingChange?.(false)
       return
     }
+
+    // Cached hydration: previous click on this race already enriched it.
+    const cached = hydratedRacesRef.current.get(race.id)
+    if (cached) {
+      pendingHydrationRaceIdRef.current = null
+      onSelect(toSelectedOffice(cached))
+      onHydratingChange?.(false)
+      return
+    }
+
+    // Optimistic select so the radio reflects the click immediately.
+    pendingHydrationRaceIdRef.current = race.id
+    onSelect(toSelectedOffice(race))
+    onHydratingChange?.(true)
     const hydrated = await hydrateRace(race)
-    if (!hydrated) return
-    onSelect(toSelectedOffice(hydrated))
+
+    // The user may have clicked a different race, deselected, or changed zip
+    // while we were hydrating. If so, bail — the newer handler owns state.
+    if (pendingHydrationRaceIdRef.current !== race.id) {
+      if (hydrated) hydratedRacesRef.current.set(race.id, hydrated)
+      return
+    }
+
+    pendingHydrationRaceIdRef.current = null
+    if (hydrated) {
+      hydratedRacesRef.current.set(race.id, hydrated)
+      onSelect(toSelectedOffice(hydrated))
+    } else {
+      onSelect(undefined)
+    }
+    onHydratingChange?.(false)
   }
 
   const showResults = Boolean(submittedZip) && query.isSuccess
@@ -373,7 +415,9 @@ export const OfficeSelectionStep = ({
                 value={activeFilter}
                 onValueChange={(value) => {
                   setActiveFilter(value)
+                  pendingHydrationRaceIdRef.current = null
                   onSelect(undefined)
+                  onHydratingChange?.(false)
                 }}
               >
                 {filterOptions.map((option) => (

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -383,14 +383,16 @@ export default function OnboardingFlow({
   // Tracking the resolved office (rather than a boolean) lets the
   // path-to-victory effect re-run when the user goes back and changes
   // zip/office, so the new race's metrics replace the previous one.
+  // `||` (not `??`) so an empty-string id falls through to the next option
+  // instead of being treated as a valid identity.
   const officeIdentityKey =
-    answers.structuredOffice?.positionId ??
-    answers.structuredOffice?.raceId ??
+    answers.structuredOffice?.positionId ||
+    answers.structuredOffice?.raceId ||
     (answers.manualOfficeForm
       ? `manual:${answers.manualOfficeForm.state}:${answers.manualOfficeForm.city}:${answers.manualOfficeForm.office}`
       : null)
   const hasResolvedPathToVictory =
-    officeIdentityKey !== null && resolvedP2vOfficeKey === officeIdentityKey
+    Boolean(officeIdentityKey) && resolvedP2vOfficeKey === officeIdentityKey
 
   const visibleSteps = getVisibleOnboardingSteps(ONBOARDING_STEPS, answers)
   const activeIndex = Math.max(

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -216,6 +216,7 @@ interface StepBodyProps {
   answers: OnboardingAnswers
   updateAnswers: (answers: Partial<OnboardingAnswers>) => void
   onCantFindOffice: () => void
+  onOfficeHydratingChange: (isHydrating: boolean) => void
   liveCampaign: Campaign | null
   onP2vLoadingChange: (loading: boolean) => void
   onP2vMetricsResolved: NonNullable<
@@ -230,6 +231,7 @@ const StepBody = ({
   answers,
   updateAnswers,
   onCantFindOffice,
+  onOfficeHydratingChange,
   liveCampaign,
   onP2vLoadingChange,
   onP2vMetricsResolved,
@@ -303,6 +305,7 @@ const StepBody = ({
           })
         }
         onCantFindOffice={onCantFindOffice}
+        onHydratingChange={onOfficeHydratingChange}
       />
     )
   }
@@ -366,14 +369,28 @@ export default function OnboardingFlow({
     firstOnboardingStepId,
   )
   const [isSavingOffice, setIsSavingOffice] = useState(false)
+  const [isHydratingOffice, setIsHydratingOffice] = useState(false)
   const isAdvancingRef = useRef(false)
   const [liveCampaign, setLiveCampaign] = useState<Campaign | null>(
     initialCampaign,
   )
   const [isP2vLoading, setIsP2vLoading] = useState(true)
-  const [hasResolvedPathToVictory, setHasResolvedPathToVictory] =
-    useState(false)
+  const [resolvedP2vOfficeKey, setResolvedP2vOfficeKey] = useState<
+    string | null
+  >(null)
   const queryClient = useQueryClient()
+
+  // Tracking the resolved office (rather than a boolean) lets the
+  // path-to-victory effect re-run when the user goes back and changes
+  // zip/office, so the new race's metrics replace the previous one.
+  const officeIdentityKey =
+    answers.structuredOffice?.positionId ??
+    answers.structuredOffice?.raceId ??
+    (answers.manualOfficeForm
+      ? `manual:${answers.manualOfficeForm.state}:${answers.manualOfficeForm.city}:${answers.manualOfficeForm.office}`
+      : null)
+  const hasResolvedPathToVictory =
+    officeIdentityKey !== null && resolvedP2vOfficeKey === officeIdentityKey
 
   const visibleSteps = getVisibleOnboardingSteps(ONBOARDING_STEPS, answers)
   const activeIndex = Math.max(
@@ -386,13 +403,19 @@ export default function OnboardingFlow({
   const activeStepNumber = activeIndex + 1
   const isActiveStepValid = activeStep.isValid?.({ answers }) ?? true
   const isP2vBlocking = activeStep.id === 'path-to-victory' && isP2vLoading
+  const isOfficeHydrationBlocking =
+    activeStep.id === 'office-selection' && isHydratingOffice
   const p2vOfficeName =
     answers.structuredOffice?.positionName ||
     liveCampaign?.positionName ||
     liveCampaign?.organization?.customPositionName ||
     liveCampaign?.office ||
     null
-  const canContinue = isActiveStepValid && !isSavingOffice && !isP2vBlocking
+  const canContinue =
+    isActiveStepValid &&
+    !isSavingOffice &&
+    !isP2vBlocking &&
+    !isOfficeHydrationBlocking
 
   const handleP2vLoadingChange = useCallback((loading: boolean) => {
     setIsP2vLoading(loading)
@@ -406,7 +429,9 @@ export default function OnboardingFlow({
     (result) => {
       const campaignId = liveCampaign?.id ?? campaign?.id
       if (result.status === 'success') {
-        setHasResolvedPathToVictory(true)
+        if (officeIdentityKey) {
+          setResolvedP2vOfficeKey(officeIdentityKey)
+        }
         trackEvent(EVENTS.Onboarding.PathToVictoryUpdated, {
           campaignId,
           projectedTurnout: result.projectedTurnout,
@@ -426,12 +451,20 @@ export default function OnboardingFlow({
         })
       }
     },
-    [liveCampaign, campaign, user?.id],
+    [liveCampaign, campaign, user?.id, officeIdentityKey],
   )
 
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [activeStepId])
+
+  useEffect(() => {
+    if (activeStepId !== 'office-selection') setIsHydratingOffice(false)
+  }, [activeStepId])
+
+  const handleOfficeHydratingChange = useCallback((hydrating: boolean) => {
+    setIsHydratingOffice(hydrating)
+  }, [])
 
   useEffect(() => {
     if (activeStepId !== 'path-to-victory') return
@@ -943,6 +976,7 @@ export default function OnboardingFlow({
                 answers={answers}
                 updateAnswers={updateAnswers}
                 onCantFindOffice={handleCantFindOffice}
+                onOfficeHydratingChange={handleOfficeHydratingChange}
                 liveCampaign={liveCampaign}
                 onP2vLoadingChange={handleP2vLoadingChange}
                 onP2vMetricsResolved={handleP2vMetricsResolved}

--- a/app/onboarding/components/TopVoterIssuesSection.test.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.test.tsx
@@ -107,6 +107,44 @@ describe('TopVoterIssuesSection', () => {
     ).toBeInTheDocument()
   })
 
+  it('refetches when ballotReadyPositionId changes (no stale cross-office cache)', async () => {
+    api.mockOrdered('GET /v1/onboarding/voter-issues', [
+      {
+        status: 200,
+        data: {
+          issues: [
+            { label: 'Beverly Hills issue', score: 80, priority: 'high' },
+          ],
+        },
+      },
+      {
+        status: 200,
+        data: {
+          issues: [{ label: 'NYC issue', score: 90, priority: 'high' }],
+        },
+      },
+    ])
+
+    const { rerender } = render(
+      <TopVoterIssuesSection
+        ballotReadyPositionId="bh-123"
+        office="Beverly Hills City Council"
+      />,
+    )
+
+    expect(await screen.findByText('Beverly Hills issue')).toBeInTheDocument()
+
+    rerender(
+      <TopVoterIssuesSection
+        ballotReadyPositionId="nyc-456"
+        office="NYC City Council"
+      />,
+    )
+
+    expect(await screen.findByText('NYC issue')).toBeInTheDocument()
+    expect(screen.queryByText('Beverly Hills issue')).not.toBeInTheDocument()
+  })
+
   it('collapses to the first three issues and expands on demand', async () => {
     api.mock('GET /v1/onboarding/voter-issues', {
       status: 200,

--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -17,6 +17,7 @@ import { clientRequest } from 'gpApi/typed-request'
 import { reportErrorToSentry } from '@shared/sentry'
 
 interface TopVoterIssuesSectionProps {
+  ballotReadyPositionId?: string
   city?: string
   state?: string
   office?: string
@@ -71,9 +72,17 @@ const iconForLabel = (label: string): React.JSX.Element => {
   return match ? match.icon : <LuHeart className="size-5" />
 }
 
-const voterIssuesQueryOptions = () =>
+// Endpoint derives district from the org cookie, so the request takes no
+// params. We still key the cache by office identity so navigating back and
+// changing zip/office refetches instead of returning the prior district.
+const voterIssuesQueryOptions = (params: {
+  ballotReadyPositionId?: string
+  city?: string
+  state?: string
+  office?: string
+}) =>
   queryOptions({
-    queryKey: [VOTER_ISSUES_QUERY_KEY] as const,
+    queryKey: [VOTER_ISSUES_QUERY_KEY, params] as const,
     queryFn: () =>
       clientRequest(VOTER_ISSUES_ROUTE, {}).then((res) => res.data),
   })
@@ -92,11 +101,14 @@ const VoterIssuesSkeleton = (): React.JSX.Element => (
 )
 
 export const TopVoterIssuesSection = ({
+  ballotReadyPositionId,
   city,
   state,
   office,
 }: TopVoterIssuesSectionProps): React.JSX.Element | null => {
-  const query = useQuery(voterIssuesQueryOptions())
+  const query = useQuery(
+    voterIssuesQueryOptions({ ballotReadyPositionId, city, state, office }),
+  )
   const [isExpanded, setIsExpanded] = useState(false)
 
   useEffect(() => {

--- a/app/onboarding/components/VoterDemographicsStep.tsx
+++ b/app/onboarding/components/VoterDemographicsStep.tsx
@@ -73,7 +73,12 @@ export const VoterDemographicsStep = ({
 
   return (
     <div className="flex w-full flex-col items-stretch gap-6 text-left">
-      <TopVoterIssuesSection city={city} state={state} office={office} />
+      <TopVoterIssuesSection
+        ballotReadyPositionId={ballotReadyPositionId}
+        city={city}
+        state={state}
+        office={office}
+      />
 
       <div className="space-y-2">
         <h2 className="text-2xl font-semibold text-foreground">


### PR DESCRIPTION
## Summary
- **ENG-10186**: When a user navigated back from path-to-victory / demographics, changed zip + office, and continued, the original race's win number, voter issues, and demographics persisted. Two cache layers were sticky across office changes:
  - `OnboardingFlow` tracked path-to-victory resolution as a boolean, so `/v1/campaigns/mine` (which carries `raceTargetMetrics`) was never refetched. Now keyed on the selected office's `positionId`/`raceId` (or manual-form identity), so changing the office invalidates resolution and the live campaign refetches.
  - `TopVoterIssuesSection` used a constant React Query key. The endpoint derives the district from the org cookie, so request params don't change, but the cache key now varies by office identity to avoid serving the prior district's issues.
- **Office selection UX**: Clicking an office had a perceptible lag because the radio's checked state was bound to `selected?.raceId` and `onSelect` only fired after `GET /v1/elections/race-by-position` round-tripped. Selection is now optimistic — the radio reflects the click instantly. Hydration runs in the background with a per-race cache; the Continue button stays disabled until hydration finishes so we never persist a partially-populated office. A synchronously-tracked `pendingHydrationRaceIdRef` lets stale results bail when the user clicks a different race / changes zip / toggles off mid-flight.

## Test plan
- [ ] On dev: complete onboarding through path-to-victory and demographics for a Beverly Hills zip, navigate back to zip, switch to a NYC zip + office, continue forward — confirm new win number, voter issues, and demographics render
- [ ] Click an office in the selection step and confirm the radio shows checked **immediately** (no waiting for hydration)
- [ ] Confirm Continue is disabled briefly after click while hydration runs, then enables
- [ ] Click an office, then click a different one before the first hydration finishes — confirm only the latest selection is reflected and Continue eventually enables
- [ ] Force a hydration failure (e.g. throttle/network panel) — confirm the snackbar appears and the optimistic selection is cleared
- [ ] Re-clicking an already-hydrated office is instant (cached) and does not re-block Continue
- [ ] `npm run test`, `npm run types`, `npm run lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding step state/caching and adds optimistic selection with async hydration; regressions could block progression or show incorrect office-specific metrics if edge cases slip through.
> 
> **Overview**
> Fixes stale onboarding data when users go back and change ZIP/office by re-keying Path-to-Victory resolution to an *office identity key* (instead of a boolean) and by varying the React Query cache key for `TopVoterIssuesSection` so it refetches per office.
> 
> Improves office-selection UX by making race selection **optimistic** (radio checks immediately), hydrating details in the background with a per-race cache, and adding `onHydratingChange` so `OnboardingFlow` can disable Continue while hydration is in flight and ignore stale hydration results (ZIP/filter/selection changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8258fbdad10d2b5f91eec2251985f536b7a475. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->