### PR TITLE
ENG-10197: expand methodology dialog copy on path-to-victory step

### DIFF
--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -347,7 +347,7 @@ const ProjectionExplanation = ({
                   We analyze voter eligibility, historical voting behavior and
                   election patterns to estimate the likelihood that each voter
                   in your district will turn out in your race. Combining the
-                  voter-level predictions, generate an accurate turnout
+                  voter-level predictions, we generate an accurate turnout
                   projection and win number target tailored specifically to your
                   election.
                 </p>
@@ -363,7 +363,7 @@ const ProjectionExplanation = ({
                   >
                     our blog post
                   </a>
-                  .
+                  {'.'}
                 </p>
               </div>
             </DialogDescription>

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -325,30 +325,47 @@ const ProjectionExplanation = ({
   return (
     <div>
       <div className="mb-3 flex items-center justify-between gap-4">
-        <p className="text-sm font-medium text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Here&apos;s how our projections work:
         </p>
         <Dialog>
-          <DialogTrigger className="cursor-pointer text-sm font-medium text-muted-foreground underline-offset-4 hover:underline">
+          <DialogTrigger className="cursor-pointer text-sm text-muted-foreground underline-offset-4 hover:underline">
             Methodology
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Methodology</DialogTitle>
             </DialogHeader>
-            <DialogDescription>
-              We use the historical voter data, and proprietary neural inference
-              network and data models to provide the most accurate projections
-              possible. Visit our{' '}
-              <a
-                href="https://goodparty.org/team"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-components-input-active hover:underline"
-              >
-                GoodParty Election Data Labs
-              </a>{' '}
-              for more details.
+            <DialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  Our turnout projections are built on a national voter file
+                  covering more than 240 million voters and over 130,000
+                  elections each year.
+                </p>
+                <p>
+                  We analyze voter eligibility, historical voting behavior and
+                  election patterns to estimate the likelihood that each voter
+                  in your district will turn out in your race. Combining the
+                  voter-level predictions, generate an accurate turnout
+                  projection and win number target tailored specifically to your
+                  election.
+                </p>
+                <p>
+                  In 2025, the model&rsquo;s predictions were calibrated within
+                  approximately 1.5 percentage points of actual voter turnout
+                  behavior on average. For more information, see{' '}
+                  <a
+                    href="https://goodparty.org/blog/article/calculate-win-numbers"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-components-input-active hover:underline"
+                  >
+                    our blog post
+                  </a>
+                  .
+                </p>
+              </div>
             </DialogDescription>
           </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- Replace the methodology dialog body with a three-paragraph description covering data scope (240M voters / 130K elections), modeling approach (voter-level turnout likelihood), and 2025 calibration accuracy (~1.5pp).
- Link "our blog post" to https://goodparty.org/blog/article/calculate-win-numbers.
- Use `DialogDescription asChild` wrapping a `<div>` with three `<p>` tags so we get real paragraph spacing without rendering invalid nested `<p>` markup.

## Test plan
- [ ] On step 5 (path-to-victory), open the Methodology dialog and confirm the three paragraphs render with spacing
- [ ] Click "our blog post" — opens https://goodparty.org/blog/article/calculate-win-numbers in a new tab
- [ ] No console warnings about nested `<p>` from React

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: copy-only updates to onboarding UI plus minor markup/class tweaks; no business logic, API behavior, or data handling changes.
> 
> **Overview**
> Updates the Path-to-Victory “Methodology” dialog to a longer, three-paragraph explanation (data scope, modeling approach, and 2025 calibration accuracy) and swaps the link target to `https://goodparty.org/blog/article/calculate-win-numbers`.
> 
> Adjusts dialog body rendering to use `DialogDescription asChild` with a spaced `<div>` (avoiding nested `<p>` issues) and slightly relaxes typography classes by removing `font-medium` from the intro text and trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f42ec84995bacb21e6e9504e5bba8500d4ecd04. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->