### PR TITLE
feat: nested Claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm run storybook        # Component library on :6006
 
 ## Architecture
 
-Next.js 15 App Router deployed on Vercel. Calls gp-api (NestJS backend on ECS) and election-api for data.
+Next.js 15 App Router deployed on Vercel. Calls gp-api (NestJS backend on ECS) and election-api for data. Full overview: `docs/architecture.md`.
 
 ### Deployment
 
@@ -34,43 +34,11 @@ Vercel auto-deploys on push. Branch mapping:
 - `master` → `goodparty.org` (API: `api.goodparty.org`)
 - PR branches → Vercel preview environments
 
-### Top-level routes (`app/`)
-
-- `dashboard/` - Candidate dashboard (campaign tools, polls, voter outreach, website, contacts, content, meetings)
-- `admin/` - Admin tools
-- `polls/` - Public poll results
-- `onboarding/` - Post-signup onboarding flow
-- `login/`, `sign-up/`, `logout/`, `post-auth-redirect/`, `impersonate/` - Auth + session flows
-- `api/` - Next.js route handlers (proxy + webhooks)
-- `shared/` - Providers, hooks, UI atoms, utils shared across routes
-- `layout.tsx`, `page.tsx`, `error.tsx`, `global-error.tsx`, `not-found.tsx` - App Router roots
-
-### API clients
-
-Two systems coexist in `gpApi/`. **The typed system is canonical for new code.** The legacy fetch helpers are `@deprecated` and being migrated out.
-
-- Typed: `clientRequest` / `serverRequest`, routes in `gpApi/api-endpoints.ts`. Throws on non-2xx. Always attach auth (cookie / Bearer token).
-- Legacy (deprecated): `gpFetch`, `clientFetch`, `serverFetch`, routes in `gpApi/routes.ts`. Returns `T | Response | false`, never throws.
-- Still valid: `unAuthFetch` for genuinely public endpoints — it attaches no credentials, and the typed helpers have no anonymous equivalent yet.
-
-Full reference + decision tree: `docs/api-clients.md` and `gpApi/CLAUDE.md`. To add an endpoint or migrate a legacy call, see `.claude/skills/`.
-
-### State Management
-
-React Context providers wrap the app (in `app/shared/hooks/`):
-
-- `UserProvider` - Auth state, loaded from cookie
-- `CampaignProvider` - Current campaign, refreshes on user change
-- `FeatureFlagsProvider` - Amplitude experiments
-- React Query (`@tanstack/react-query`) with 5min stale time for data fetching
-
-### Auth
-
-JWT stored in HTTP-only cookie by gp-api. Frontend includes it via `credentials: 'include'`. User loaded on mount in `UserProvider`. Protected routes check user context and redirect to login.
-
 ### Environment Config
 
 `appEnv.ts` exports all env-derived constants: `API_ROOT`, `ELECTION_API_ROOT`, `APP_BASE`, `IS_PROD`, `IS_LOCAL`, etc. Defaults point to dev API when env vars are unset.
+
+(Auth, providers, API clients, and module shape live in `docs/architecture.md` and the per-area `CLAUDE.md` files — see the pointer table below.)
 
 ## Testing
 
@@ -131,13 +99,24 @@ When the active step or view changes in a multi-step flow, always reset scroll p
 - **Backend logs → Grafana Cloud Loki.** `{service_name="gp-api", deployment_environment_name="dev|qa|prod"}`. https://goodparty.grafana.net.
 - Recipe for reproducing a Sentry issue locally: `docs/debugging.md`.
 
-## Docs
+## Pointer table — when in doubt
 
-- `docs/api-clients.md` - Typed vs legacy fetch, decision tree
-- `docs/testing.md` - Vitest patterns, MSW mocking
-- `docs/debugging.md` - Sentry / Loki, repro recipe
-- `gpApi/CLAUDE.md` - Working in the gpApi/ directory
-- `app/dashboard/website/README.md` - Website feature layout
+| Doing | Read |
+|-------|------|
+| Overall architecture / stack / module shape | `docs/architecture.md` |
+| Auth (cookie/JWT, server vs client, impersonation) | `docs/architecture.md` § Auth |
+| Adding or migrating an API call | `docs/api-clients.md` + `gpApi/CLAUDE.md` |
+| Writing a unit/component test | `docs/testing.md` |
+| Reproducing a Sentry issue locally | `docs/debugging.md` |
+| State / providers / React Query patterns | `docs/state-management.md` |
+| Adding or removing a feature flag | `docs/feature-flags.md` |
+| Working inside a dashboard feature | `app/dashboard/<feature>/CLAUDE.md` |
+| Working in `app/admin/`, `app/onboarding/`, or `app/shared/` | nested `CLAUDE.md` in that dir |
+| Working with helpers | `helpers/CLAUDE.md` |
+| Working in `gpApi/` | `gpApi/CLAUDE.md` |
+| Writing or running E2E tests | `e2e-tests/CLAUDE.md` (and `e2e-tests/README.md`) |
+| AI rule-by-rule code review | `ai-rules/` (git submodule) |
+| Website feature internals | `app/dashboard/website/README.md` |
 
 ## Code Style
 

--- a/app/admin/CLAUDE.md
+++ b/app/admin/CLAUDE.md
@@ -1,0 +1,30 @@
+# app/admin/
+
+Internal admin tools. GoodParty staff use this to manage users, impersonate candidates for support, and trigger account-recovery actions. Not exposed to candidates.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `shared/ImpersonateAction.tsx` | Per-user "impersonate" action — flips session to view as that user |
+| `shared/sendSetPasswordEmail.ts` | Triggers password-reset email for a user |
+| `users/components/ResendPasswordEmailAction.tsx` | Resend password-set email from the user list |
+| `shared/` | Layout, table primitives, access guards used across admin pages |
+
+## Patterns
+
+- **Admin gating**: routes here are reachable only by users with admin role. Auth/role check happens in `app/shared/user/UserProvider.tsx` and at the page level — don't rely on the URL alone.
+- **Impersonation** uses the `ImpersonateUser` provider in `app/shared/user/`. After kicking off, the global `ImpersonationBanner` shows on every page until exited.
+- **Server actions** (`shared/sendSetPasswordEmail.ts`) call gp-api directly via `serverRequest`; admin actions tend to be one-shot rather than form-driven.
+
+## Gotchas
+
+- `app/shared/user/ImpersonatingTracker.tsx` and `ImpersonationBanner.tsx` are the global hooks for impersonation state — don't roll your own banner / exit flow inside admin.
+- Admin routes are mostly server-rendered; resist the urge to add heavy client state. If you need a form, follow the pattern in `users/`.
+- Adding a new admin action: cross-cutting actions live in `shared/`, list-page actions in `users/components/`. Reuse `shared/` primitives. Keep actions discoverable from the user list page.
+
+## Related
+
+- `app/shared/user/UserProvider.tsx`, `ImpersonateUserProvider.tsx`, `ImpersonationBanner.tsx`.
+- `app/impersonate/` — public route used to enter impersonation by token.
+- `helpers/authHelper.ts` — role checks.

--- a/app/dashboard/CLAUDE.md
+++ b/app/dashboard/CLAUDE.md
@@ -1,0 +1,33 @@
+# app/dashboard/
+
+The candidate dashboard. Authenticated shell that hosts campaign tools, polls, voter outreach, content, and admin-adjacent flows. Every route under `dashboard/` runs inside `DashboardLayout` and assumes a logged-in user with a current campaign.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Dashboard home — campaign overview |
+| `shared/DashboardLayout.tsx` | Layout wrapper — sidebar, header, auth gating |
+| `shared/DashboardMenu.tsx` | Sidebar nav items (per-feature visibility lives here) |
+| `shared/candidateAccess.ts` + `serveAccess.ts` | Access predicates (`canViewX` helpers) — client + server variants |
+| `shared/ProUpgradeModal.tsx` / `ProUpgradePrompt.tsx` | Pro-tier gating UI |
+| `components/` | Cross-feature dashboard widgets (alert banners, progress bars, `campaignManager/`) |
+
+## Patterns
+
+- **Per-feature dirs** under `dashboard/` own their own routes, components, and (sometimes) hooks. Keep cross-feature components in `dashboard/components/` and cross-feature primitives/access checks in `dashboard/shared/`.
+- **Access gating**: use `candidateAccess.ts` from client code, `serveAccess.ts` from server components. Don't read the user object directly to gate UI — go through the helpers so rules stay in one place.
+- **Pro-only features** wrap their content in `ProUpgradeModal` / `ProUpgradePrompt`. Free users see the prompt; pro users see the feature.
+- **Sidebar visibility** is driven by the menu config in `DashboardMenu.tsx` — adding a feature route means adding a menu entry there too.
+
+## Gotchas
+
+- The directory has more subdirs than the sidebar exposes (`account/`, `briefings/`, `campaign-details/`, `campaign-plan/`, `election-result/`, `pro-sign-up/`, `profile/`, `purchase/`, `questions/`, `upgrade-to-pro/`, `voter-records/`). These are mostly internal flows / sub-pages reached from within other features — don't assume "directory exists" means "menu item exists."
+- `dashboard/shared/` and `dashboard/components/` overlap in spirit. Convention: `shared/` = layout, access, modals reused across features; `components/` = card-style widgets composed onto pages. Check both before adding a new file.
+- `DashboardLayout` enforces auth. Pages don't need their own redirect-to-login logic.
+
+## Related
+
+- Feature dirs each have their own `CLAUDE.md` — start there if you're working in `outreach/`, `polls/`, `website/`, etc.
+- `app/shared/user/UserProvider.tsx` — auth state the layout reads.
+- `app/shared/hooks/CampaignProvider.tsx` — current campaign context.

--- a/app/dashboard/campaign-assistant/CLAUDE.md
+++ b/app/dashboard/campaign-assistant/CLAUDE.md
@@ -1,0 +1,35 @@
+# app/dashboard/campaign-assistant/
+
+AI campaign assistant chat. Threaded conversations with an LLM that has campaign context (positions, audience, content). Note: the dir is `campaign-assistant/` even though the tech design refers to it as "campaign-tools."
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Route entry |
+| `components/CampaignAssistantPage.tsx` | Top-level layout — sidebar (history) + main chat panel |
+| `components/Chat.tsx` | The active conversation — message list + composer |
+| `components/ChatProvider.tsx` + `useChat.ts` | Feature context — current thread, send/stream actions |
+| `components/ChatInput.tsx` | Composer (text + attachments) |
+| `components/ChatMessage.tsx` | Message rendering (user, assistant, system) |
+| `components/ChatHistory*.tsx` | Sidebar — grouped past threads |
+| `components/ChatFeedback.tsx` | 👍 / 👎 / written feedback per assistant turn |
+| `components/ajaxActions.ts` | gp-api calls — send, fetch history, post feedback |
+
+## Patterns
+
+- **`ChatProvider` owns the thread**. Components read messages and call `send` via context (`useChat`), not props.
+- **Streaming** comes back from gp-api; `components/ajaxActions.ts` handles the stream and pushes deltas into the provider.
+- **History grouping** (Today / Yesterday / This week / older) is computed in `components/ChatHistoryGroup.tsx` from message timestamps.
+- Feedback (`components/ChatFeedback.tsx`) writes to a separate gp-api endpoint — it's not part of the message itself.
+
+## Gotchas
+
+- This is the dashboard chat. The candidate-facing public chat (if any) lives elsewhere — don't reuse `ChatProvider` outside this dir without checking.
+- `components/ajaxActions.ts` is feature-local and mixes typed + legacy fetchers — port to typed (`clientRequest`) when touching, see `gpApi/CLAUDE.md`.
+- Long histories are paginated server-side — don't load all threads at once when adding new history features.
+
+## Related
+
+- `gpApi/api-endpoints.ts` — chat endpoints.
+- `app/shared/experiments/` — gating for assistant features behind feature flags.

--- a/app/dashboard/contacts/CLAUDE.md
+++ b/app/dashboard/contacts/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/dashboard/contacts/
+
+Voter contact management. Browse the campaign's voter file, segment audiences, and drill into individual voter records. Powers audience selection for outreach.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `[[...attr]]/page.tsx` | Single catch-all route — sub-views are query/path slugs handled inside |
+| `[[...attr]]/components/` | Top-level layout + tab content |
+| `[[...attr]]/components/segments/` | Saved audience segments (list, create, edit) |
+| `[[...attr]]/components/person/` | Individual voter detail (`PersonOverlay.tsx`) |
+| `[[...attr]]/components/configs/` | Filter / column configuration UI |
+| `[[...attr]]/components/shared/` | Cross-tab primitives (table, filter chips) |
+| `[[...attr]]/hooks/` | Data fetching hooks for voter file pages |
+
+## Patterns
+
+- **One catch-all route** (`[[...attr]]`) — all "tabs" (people, segments, settings) are handled inside that route's components, not as separate Next.js routes. Easier to share filter state.
+- **Filters and segments are distinct**: filters are ephemeral (current view); segments are saved (named, reused in outreach). Don't conflate.
+- **Voter file fetching** uses `helpers/createVoterFileFilter.ts` to build the filter payload — keep that helper as the single shape source.
+- The `PersonOverlay` is a side-panel detail view that opens over the table; route-level navigation isn't used to drill in.
+
+## Gotchas
+
+- Optional catch-all route (`[[...attr]]`) means `/dashboard/contacts` and `/dashboard/contacts/whatever` both render the same page — sub-routing is internal.
+- Voter-file payloads can be huge — pagination + cursor are mandatory; never request without them.
+- A feature flag gates parts of `PersonOverlay` (see `app/shared/experiments/`).
+
+## Related
+
+- `helpers/createVoterFileFilter.ts` — filter payload builder.
+- `app/dashboard/outreach/` — consumer of saved segments.
+- `gpApi/api-endpoints.ts` — voter-file endpoints.

--- a/app/dashboard/content/CLAUDE.md
+++ b/app/dashboard/content/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/dashboard/content/
+
+Content library and AI-assisted content generation. Campaigns produce social posts, emails, scripts, and other artifacts via templates + LLM, then save / rename / export them.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Route entry |
+| `components/ContentPage.tsx` | Top-level layout (My Content + Templates) |
+| `components/MyContent.tsx` | User's saved content list |
+| `components/TemplatesList.tsx` | Available content templates |
+| `components/NewContentFlow.tsx` | Multi-step generation flow (template → input fields → generate) |
+| `components/InputFieldsModal.tsx` | Per-template form (dynamic fields) |
+| `components/Actions.tsx`, `RenameAction.tsx`, `DeleteAction.tsx`, `TranslateAction.tsx` | Per-item actions |
+| `components/ContentTutorial.tsx` (+ `.css`) | First-time-user walkthrough |
+| `[slug]/` | Single content item view / editor |
+
+## Patterns
+
+- **Template-driven generation**: each template defines its own input fields (fetched from gp-api). `InputFieldsModal` renders them dynamically — don't hardcode fields per template.
+- **Helpers do the AI work**: `helpers/generateAIContent.ts`, `helpers/getAiTemplatesFromCategories.ts`, `helpers/fetchPromptInputFields.ts`, `helpers/getNewAiContentSectionKey.ts`.
+- **Action menu** (`components/Actions.tsx`) is composed of self-contained `*Action.tsx` components — pattern matches `outreach/components/OutreachActions.tsx`.
+
+## Gotchas
+
+- `components/ContentTutorial.css` is a rare hand-written CSS file (most styling is Tailwind via design tokens). Don't extend it — prefer Tailwind for new code.
+- `[slug]` is the single-item route; editor lives there. Don't add editors at the list-page level.
+- Generated content is saved server-side; this UI mostly orchestrates `helpers/generateAIContent.ts` calls.
+
+## Related
+
+- `helpers/generateAIContent.ts`, `helpers/buildAiContentSections.ts`, `helpers/getAiTemplatesFromCategories.ts`.
+- `app/dashboard/website/` also generates AI content via the same helpers.

--- a/app/dashboard/door-knocking/CLAUDE.md
+++ b/app/dashboard/door-knocking/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/dashboard/door-knocking/
+
+Door-knocking / canvassing dashboard. Tracks volunteer interactions logged in the field, summarizes by day / rating / survey, and lets campaigns design custom door-knocking surveys.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Route entry |
+| `components/DoorKnockingPage.tsx` | Top-level layout |
+| `shared/DoorKnockingTabs.tsx` | Tab navigation (overview / surveys / individual record) |
+| `components/InteractionsByDay.tsx` | Time-series chart |
+| `components/InteractionsSummary.tsx` + `InteractionsSummaryPie.tsx` | Aggregate counts + breakdown chart |
+| `components/RatingSummary.tsx` | Voter sentiment distribution |
+| `components/interactionsColors.ts` | Color tokens for charts (single source) |
+| `surveys/` | Custom survey designer (per-campaign question sets) |
+| `shared/` | Cross-tab primitives |
+| `components/` | Page-level widgets |
+
+## Patterns
+
+- **Charts use shared color tokens** from `components/interactionsColors.ts` — keep palette centralized; don't inline hex values.
+- **Surveys are campaign-scoped**: each campaign authors its own survey questions, used by canvassers in the field. Survey CRUD lives in `surveys/`.
+- **Aggregations come from gp-api**, not computed client-side. The components display rather than compute.
+
+## Gotchas
+
+- "Door-knocking" data is sourced from third-party canvassing tools (eCanvasser etc.) via gp-api — there's no in-app way to log a knock from this UI.
+- `components/interactionsColors.ts` is the only place colors should be defined for charts in this feature.
+
+## Related
+
+- `app/shared/hooks/EcanvasserProvider.tsx` + `EcanvasserSurveyProvider.tsx` — eCanvasser auth/data.
+- `helpers/` — eCanvasser-related helpers if any are added (currently none specific).

--- a/app/dashboard/outreach/CLAUDE.md
+++ b/app/dashboard/outreach/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/dashboard/outreach/
+
+Voter outreach hub. Lets a campaign create text/voicemail/script outreach to voter audiences and tracks impact. Note: the directory is `outreach/` even though the tech design refers to it as "voter-outreach."
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Route entry — renders `OutreachPage` |
+| `components/OutreachPage.tsx` | Top-level layout for the feature |
+| `hooks/OutreachContext.tsx` | Feature-level context — current outreach selection, audience filters |
+| `components/OutreachCreateCards.tsx` / `OutreachCreateCard.tsx` | Channel picker (text, voicemail, etc.) |
+| `components/OutreachActions.tsx` + `*ActionOption.tsx` | Per-channel actions (download audience, copy script) |
+| `components/OutreachImpact.tsx` | Sent / delivered metrics |
+| `hooks/` | Feature-local hooks (audience fetching, scheduling) |
+| `util/` | Pure helpers — message templating, audience shaping |
+| `constants.tsx` | Channel definitions, status labels |
+
+## Patterns
+
+- **Context-driven**: `OutreachContext` holds the selected outreach + audience. Components read from context rather than threading props through the action menus.
+- **Action options compose**: each `*ActionOption.tsx` is a self-contained menu item (icon + label + handler). New channels = new option components, registered in `OutreachActions`.
+- **Audience downloads** go through `helpers/createOutreach.ts` and `helpers/createP2pPhoneList.ts` — don't reinvent the file shape.
+
+## Gotchas
+
+- The `FreeTextsBanner` nag is part of free-tier gating — check `app/dashboard/shared/ProUpgradeModal.tsx` rules before changing it.
+- Scheduled-send logic lives in `helpers/scheduleVoterMessagingCampaign.ts`, not in this dir.
+- Status labels in `constants.tsx` are mirrored on gp-api — keep them in sync if either side changes.
+
+## Related
+
+- `helpers/createOutreach.ts`, `helpers/createP2pPhoneList.ts`, `helpers/scheduleVoterMessagingCampaign.ts`.
+- `gpApi/outreach.api.ts` + `gpApi/types/outreach.types.ts` — shared shapes.

--- a/app/dashboard/polls/CLAUDE.md
+++ b/app/dashboard/polls/CLAUDE.md
@@ -1,0 +1,31 @@
+# app/dashboard/polls/
+
+Custom polling. Campaigns commission AI-assisted polls of their district, pay (Stripe), and view results. Public poll-share pages live separately under `app/polls/`.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Polls list — `PollsPage` + `PollsTable` |
+| `create/` | Multi-step poll creation flow |
+| `[id]/` | Poll detail + extension flows (`expand/`, `expand-payment/`, `expand-payment-success/`, `expand-review/`, `issue/`) |
+| `components/` | List-page widgets (`PollPreview`, `PollImageUpload`, `StatusBadge`, scheduled-date selector) |
+| `shared/components/` + `shared/hooks/` | Reused across create + detail (form fields, validation hooks) |
+
+## Patterns
+
+- **`[id]/expand*` are payment sub-flows**, not separate pages — a campaign extends an existing poll's reach by paying more. Each step (review → payment → success) is its own route.
+- **Status badge** semantics live in `components/StatusBadge.tsx` — single source of truth for status colors / labels.
+- **Image upload** pattern (`PollImageUpload`) is poll-specific; for general uploads use shared inputs from `app/shared/inputs/`.
+- Stripe checkout-session redirect pattern (not Stripe Elements) — payment flows hand off to gp-api, return via `expand-payment-success`.
+
+## Gotchas
+
+- The public poll-results page (`/polls/[slug]`) lives at `app/polls/`, NOT here. Don't conflate dashboard poll detail with the public share view.
+- `shared/` here is poll-feature-shared, not app-wide shared. App-wide stuff is at `app/shared/`.
+- Poll status transitions (draft → scheduled → running → complete) are gp-api-driven; the dashboard reflects state, doesn't drive it.
+
+## Related
+
+- `app/polls/` — public poll-share pages.
+- `app/shared/inputs/` — generic form inputs the create flow uses.

--- a/app/dashboard/website/CLAUDE.md
+++ b/app/dashboard/website/CLAUDE.md
@@ -1,6 +1,6 @@
 # app/dashboard/website/
 
-Candidate website builder. Lets a campaign create a public site, edit content sections, and connect a custom domain. Public visitor view lives outside this dir under `app/(candidate)/`.
+Candidate website builder. Lets a campaign create a public site, edit content sections, and connect a custom domain. Public visitor view does not currently live under a dedicated route group in this repo.
 
 ## Key files
 

--- a/app/dashboard/website/CLAUDE.md
+++ b/app/dashboard/website/CLAUDE.md
@@ -1,0 +1,33 @@
+# app/dashboard/website/
+
+Candidate website builder. Lets a campaign create a public site, edit content sections, and connect a custom domain. Public visitor view lives outside this dir under `app/(candidate)/`.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `create/` | First-time setup flow — name, slug, theme |
+| `editor/` | Section-by-section editor (the bulk of the feature) |
+| `domain/` | Custom domain connection / DNS instructions |
+| `shared/` | Cross-flow helpers, constants, types |
+| `components/` | Page-level scaffolding (header, footer, save bar) |
+| `util/` | Pure helpers (slug validation, content shaping) |
+| `README.md` | Full feature layout — read this before substantial changes |
+
+## Patterns
+
+- **Three sub-flows, one feature**: `create/`, `editor/`, `domain/` are sibling routes under `/dashboard/website/`. They share state through `shared/` rather than via context — most flows are short-lived single-page interactions.
+- **AI-generated content** flows through `helpers/buildAiContentSections.ts` and friends; the editor surfaces "regenerate" actions but the heavy lifting is in `helpers/`.
+- **Slug uniqueness** is checked at create-time against gp-api; treat the slug as immutable once a site is published.
+
+## Gotchas
+
+- The public-facing candidate site is rendered from `app/(candidate)/` (route group), NOT from this dir. Editing site appearance often touches both.
+- `editor/` has its own `components/` subdir — don't confuse with `dashboard/website/components/`. The former is editor-internal; the latter is feature-wide.
+- Domain DNS state has multiple "verifying / verified / failed" sub-states — see `domain/components/` rather than rolling your own status logic.
+
+## Related
+
+- `app/(candidate)/` — the public website pages this feature edits.
+- `helpers/buildAiContentSections.ts`, `helpers/generateAIContent.ts` — AI content generation.
+- `app/dashboard/website/README.md` — pre-existing feature notes.

--- a/app/onboarding/CLAUDE.md
+++ b/app/onboarding/CLAUDE.md
@@ -1,0 +1,34 @@
+# app/onboarding/
+
+Post-signup onboarding flow. New users land here after registration to pick the office they're running for, fill in basic campaign info, and reach a "complete" state that hands off to the dashboard.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `page.tsx` | Route entry — redirects to first step |
+| `[slug]/[step]/` | Dynamic route — `slug` = section, `step` = step within section |
+| `onboarding.consts.ts` | Step IDs (`REGISTRATION`, `STEP_1`, `STEP_2`, `STEP_3`, `COMPLETE`) |
+| `components/onboardingConfig.ts` | Step definitions / order — single source for what each step renders |
+| `components/OnboardingFlow.tsx` | Top-level controller — current step, navigation |
+| `components/OfficeSelectionStep.tsx` + `ManualOfficeEntryStep.tsx` | Office-selection UX (search + manual fallback) |
+| `components/onboardingHelpers.ts`, `onboardingTypes.ts` | Pure helpers + types |
+| `shared/` | Layout, stepper, modal, ajax helpers |
+| `office-selection/` | Office-selection page bits used inside the flow |
+
+## Patterns
+
+- **Step-driven flow**: each step is config-defined in `onboardingConfig.ts`. To add a step, add it to the config — `OnboardingFlow` picks it up. Don't add new routes by hand.
+- **Reset scroll** on step change — handled by the layout per the root CLAUDE.md navigation rule.
+- **Two office-selection paths**: search (`OfficeSelectionStep`) and manual entry (`ManualOfficeEntryStep`). Manual is the fallback when search fails — keep both.
+
+## Gotchas
+
+- `[slug]/[step]/` route is dynamic; URLs look like `/onboarding/onboarding-1/...`. Don't link to `step` numerically — go through the constants.
+- Tests exist for the office-selection steps — run them when changing office logic (`OfficeSelectionStep.test.tsx`, `ManualOfficeEntryStep.test.tsx`, `OnboardingFlow.test.tsx`).
+- Versioning helper (`shared/useVerisons.ts`) — note the typo, don't auto-rename without grepping callers.
+
+## Related
+
+- `app/post-auth-redirect/` — decides whether to send users into onboarding vs dashboard.
+- `helpers/resolvePostAuthRedirectPath.util.ts` — same logic, server side.

--- a/app/shared/CLAUDE.md
+++ b/app/shared/CLAUDE.md
@@ -1,0 +1,36 @@
+# app/shared/
+
+Cross-route building blocks: providers, hooks, UI primitives, layouts, and feature-flag plumbing. Imported as `@shared/*` (alias maps to `app/shared/*`).
+
+## Key files
+
+| Subdir / file | Role |
+|---------------|------|
+| `user/UserProvider.tsx` | Auth state — loaded from cookie, exposed to the tree |
+| `user/ImpersonateUserProvider.tsx`, `ImpersonationBanner.tsx`, `ImpersonatingTracker.tsx` | Impersonation state + global UI |
+| `user/CampaignStatusProvider.tsx` | Campaign-level status flag |
+| `hooks/CampaignProvider.tsx` + `useCampaign.ts` | Current campaign context |
+| `hooks/VoterContactsProvider.tsx` | Voter-contact data shared across dashboard features |
+| `experiments/FeatureFlagsProvider.tsx`, `FeatureFlagGuard.tsx` | Amplitude feature flags + JSX gate |
+| `layouts/`, `cards/`, `inputs/`, `buttons/`, `typography/`, `ui/` | Reusable primitives |
+| `query-client.tsx` | React Query client + provider |
+| `materialTheme.ts`, `sentry.tsx`, `AmplitudeInit.tsx` | App bootstrap pieces |
+
+## Patterns
+
+- **Providers compose at the root** (`app/layout.tsx`). Don't re-wrap providers inside features; consume via the matching `use*` hook.
+- **Feature flags**: gate UI with `<FeatureFlagGuard flagKey="..."/>` or `useFlagOn(key)` (boolean) / `useFeatureFlags()` (full variant). See `docs/feature-flags.md`.
+- **Path alias** `@shared/*` is mandatory in this dir — never deep-relative-import (`../../shared/...`) into here.
+- **UI primitives**: raw atoms (`Button`, `Input`, `Label`, etc.) live in `@styleguide` and should always be imported from there. The `cards/`, `inputs/`, `buttons/`, `typography/`, `ui/` dirs under `app/shared/` are app-specific compositions on top of those atoms — reach for them only when the styleguide doesn't already provide what you need.
+
+## Gotchas
+
+- **Adding a provider here is a tree-wide change.** Confirm scope before introducing new context — most features should use a feature-local provider instead.
+- `app/shared/utils/` (deeply nested) is a small utility bag distinct from top-level `helpers/` — when in doubt, prefer `helpers/` for new pure helpers (see `helpers/CLAUDE.md`).
+- `query-client.tsx` defines stale time / retry policy — changing it affects every `useQuery` in the app.
+
+## Related
+
+- Root `CLAUDE.md` — `state-management` and `auth` overview.
+- `docs/state-management.md` — provider order + when to use which.
+- `docs/feature-flags.md` — feature-flag patterns.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,13 +50,13 @@ JWT in HTTP-only cookie issued by gp-api. Frontend attaches it via `credentials:
 
 ## Cross-service edges
 
-| Direction | Service | Protocol | Auth |
-|-----------|---------|----------|------|
-| outbound | gp-api (NestJS, ECS) | HTTP via `clientRequest` / `serverRequest` | Cookie or Bearer |
-| outbound | election-api | HTTP | Configured baseURL |
-| outbound | Stripe (Checkout Sessions, redirect) | HTTP via gp-api | gp-api owns Stripe keys |
-| outbound | Amplitude | JS SDK | Public key |
-| outbound | Sentry | JS SDK | Public DSN |
+| Direction | Service                              | Protocol                                   | Auth                    |
+| --------- | ------------------------------------ | ------------------------------------------ | ----------------------- |
+| outbound  | gp-api (NestJS, ECS)                 | HTTP via `clientRequest` / `serverRequest` | Cookie or Bearer        |
+| outbound  | election-api                         | HTTP                                       | Configured baseURL      |
+| outbound  | Stripe (Checkout Sessions, redirect) | HTTP via gp-api                            | gp-api owns Stripe keys |
+| outbound  | Amplitude                            | JS SDK                                     | Public key              |
+| outbound  | Sentry                               | JS SDK                                     | Public DSN              |
 
 Shared types flow through hand-rolled `Request`/`Response` declarations on `gpApi/api-endpoints.ts`. Some shapes are mirrored in `gpApi/types/`. There is no auto-generated contract package between gp-webapp and gp-api today.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# Architecture
+
+A pointer-heavy doc. Detailed conventions live in `CLAUDE.md` and feature-level `CLAUDE.md` files under `app/`.
+
+## Stack
+
+- **Next.js 15** App Router on Vercel (React 19)
+- **TanStack React Query 5** (5-minute stale time) for server-state caching
+- **Tailwind CSS v4** + custom design tokens (`styleguide/design-tokens.css`, `styleguide/tailwind-theme.css`)
+- **MUI 7** for some legacy material primitives; new code prefers `@styleguide`
+- **Clerk** for auth widgets (e2e setup), session JWT issued by gp-api
+- **Amplitude** for analytics + feature flags
+- **Sentry** for error reporting (`@sentry/nextjs`)
+- **Vitest** + jsdom + React Testing Library for unit/component tests
+- **Playwright** for end-to-end tests (`e2e-tests/`)
+
+## Module shape
+
+```
+app/
+  (candidate)/                # public candidate website (route group)
+  dashboard/
+    <feature>/                # one dir per feature, owns its routes + components
+      page.tsx
+      components/
+      hooks/
+      shared/
+    shared/                   # cross-feature dashboard primitives + access guards
+    components/                # cross-feature dashboard widgets
+  admin/                      # internal staff tools
+  onboarding/                 # post-signup flow (step-driven)
+  shared/                     # app-wide providers, hooks, UI primitives
+  api/                        # Next.js route handlers (proxy + webhooks)
+gpApi/                        # API client layer (typed + legacy)
+helpers/                      # ~50 cross-cutting utilities (grab-bag)
+e2e-tests/                    # Playwright suite (separate workspace)
+docs/                         # this directory
+ai-rules/                     # git submodule of org-wide AI rules
+```
+
+`app/dashboard/polls/` is a clean reference feature — copy that structure for new dashboard features.
+
+## Auth
+
+JWT in HTTP-only cookie issued by gp-api. Frontend attaches it via `credentials: 'include'`.
+
+- `app/shared/user/UserProvider.tsx` loads the user on mount and exposes it via context.
+- Server components / route handlers use `helpers/userServerHelper.ts` and `gpApi/server-request.ts` (Bearer via `getServerToken()`).
+- Impersonation: `app/shared/user/ImpersonateUserProvider.tsx` + global `ImpersonationBanner`. Entered via `/impersonate/<token>`.
+
+## Cross-service edges
+
+| Direction | Service | Protocol | Auth |
+|-----------|---------|----------|------|
+| outbound | gp-api (NestJS, ECS) | HTTP via `clientRequest` / `serverRequest` | Cookie or Bearer |
+| outbound | election-api | HTTP | Configured baseURL |
+| outbound | Stripe (Checkout Sessions, redirect) | HTTP via gp-api | gp-api owns Stripe keys |
+| outbound | Amplitude | JS SDK | Public key |
+| outbound | Sentry | JS SDK | Public DSN |
+
+Shared types flow through hand-rolled `Request`/`Response` declarations on `gpApi/api-endpoints.ts`. Some shapes are mirrored in `gpApi/types/`. There is no auto-generated contract package between gp-webapp and gp-api today.
+
+## Bootstrap
+
+- `app/layout.tsx` — root layout, mounts every provider in `app/shared/`.
+- `app/shared/AmplitudeInit.tsx`, `sentry.tsx`, `materialTheme.ts` — third-party init.
+- `appEnv.ts` (repo root) — env constants. Defaults point at the dev API.
+
+## Key patterns
+
+- **Typed gp-api client is canonical.** Legacy `clientFetch` / `serverFetch` are deprecated. See `gpApi/CLAUDE.md` and `docs/api-clients.md`.
+- **Feature-level CLAUDE.md files** live next to each major feature dir — read those before working in that feature. The root `CLAUDE.md` keeps repo-wide rules (commands, deployment, code style, styleguide) and a pointer table for everything else.
+- **Design tokens, not raw hex.** See root `CLAUDE.md` § Design Tokens.
+- **State management**: see `docs/state-management.md`.
+- **Feature flags**: see `docs/feature-flags.md`.
+
+## ADRs
+
+None yet — add `docs/adr/` if/when non-obvious decisions need to be captured.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ A pointer-heavy doc. Detailed conventions live in `CLAUDE.md` and feature-level 
 
 ```
 app/
-  (candidate)/                # public candidate website (route group)
+  (candidate)/                # public candidate website (route group) — not yet present in this repo
   dashboard/
     <feature>/                # one dir per feature, owns its routes + components
       page.tsx

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -5,7 +5,10 @@ Feature flags are powered by **Amplitude Experiment**. The provider in `app/shar
 ## Hooks
 
 ```ts
-import { useFeatureFlags, useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import {
+  useFeatureFlags,
+  useFlagOn,
+} from '@shared/experiments/FeatureFlagsProvider'
 
 // Boolean check — most common use case
 const { ready, on } = useFlagOn('my-feature-key')

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,84 @@
+# Feature Flags
+
+Feature flags are powered by **Amplitude Experiment**. The provider in `app/shared/experiments/FeatureFlagsProvider.tsx` boots the SDK with the current user's traits and exposes hooks for reading variants.
+
+## Hooks
+
+```ts
+import { useFeatureFlags, useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+
+// Boolean check — most common use case
+const { ready, on } = useFlagOn('my-feature-key')
+if (!ready) return <Spinner />
+return on ? <NewUI /> : <OldUI />
+
+// Full variant (e.g. multi-arm experiment)
+const { ready, variant } = useFeatureFlags()
+const v = variant('my-feature-key')
+// v.value: undefined | 'control' | 'treatment-a' | ...
+```
+
+`useFlagOn(key)` is the right default. Reach for `useFeatureFlags` only when you need the variant payload, all flags at once, or to fire an explicit `exposure()`.
+
+## Components
+
+### `FeatureFlagGuard`
+
+Redirects away from a route if the flag is off. Use as a route-level wrapper:
+
+```tsx
+import FeatureFlagGuard from '@shared/experiments/FeatureFlagGuard'
+
+export default function Page() {
+  return (
+    <FeatureFlagGuard flagKey="my-feature-key" redirectTo="/dashboard">
+      <MyFeature />
+    </FeatureFlagGuard>
+  )
+}
+```
+
+While the flag is loading, the guard renders a centered spinner. While the flag is off, it returns `null` and triggers a `router.replace`.
+
+## Per-flag wrapper hooks
+
+When a flag is read in many places, wrap it once and export a named hook so the key is centralized. Example: `app/shared/experiments/proUpgradeFlag.ts`:
+
+```ts
+export const PRO_UPGRADE_FLAG_KEY = 'pro-upgrade1'
+
+export const useProUpgradeFlag = () => {
+  const { ready, on } = useFlagOn(PRO_UPGRADE_FLAG_KEY)
+  return { ready, enabled: on }
+}
+```
+
+This keeps the key out of feature code and gives you one place to remove the flag when the experiment ends.
+
+## User traits
+
+The provider builds an Amplitude `ExperimentUser` from the current user via `helpers/buildUserTraits.ts`. When the user changes (login / logout / impersonation), the provider clears its cache and re-fetches variants. Don't try to manually re-init.
+
+## Server-side flags
+
+Server components currently can't read Amplitude experiments — the provider is client-only. If you need server-side gating, gate at the gp-api layer or pass the flag down to a `'use client'` boundary.
+
+## Adding a new flag
+
+1. Create the flag in Amplitude Experiment with a stable key (kebab-case, e.g. `outreach-bulk-send`).
+2. If the key is read in more than one component, add a wrapper hook under `app/shared/experiments/`.
+3. Use `useFlagOn(key)` (or your wrapper) at the call site.
+4. **Removing the flag**: delete the wrapper hook + key constant, then grep for stragglers.
+
+## Anti-patterns
+
+- Don't read flags during render without the `ready` check — variant defaults to `undefined` while loading and you'll flash the wrong branch.
+- Don't keep flags around forever. Once an experiment ships, delete the gate.
+- Don't gate critical security checks behind a feature flag — gate the UX, but enforce auth/permission in `app/dashboard/shared/candidateAccess.ts` (client) / `serveAccess.ts` (server) and at gp-api.
+
+## Related
+
+- `app/shared/experiments/FeatureFlagsProvider.tsx` — provider + hooks.
+- `app/shared/experiments/FeatureFlagGuard.tsx` — route-level guard.
+- `helpers/buildUserTraits.ts` — user traits passed to Amplitude.
+- `appEnv.ts` — `NEXT_PUBLIC_AMPLITUDE_API_KEY`.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -12,16 +12,16 @@ There is no Redux / Zustand / Jotai. Don't add one.
 
 Mounted at the root in `app/layout.tsx` (or close to it). Order matters — children of a provider can read its context.
 
-| Provider | File | Purpose |
-|----------|------|---------|
-| `UserProvider` | `app/shared/user/UserProvider.tsx` | Auth state, loaded from cookie. Most app code starts here. |
-| `ImpersonateUserProvider` | `app/shared/user/ImpersonateUserProvider.tsx` | Impersonation state — drives the global banner. |
-| `CampaignProvider` | `app/shared/hooks/CampaignProvider.tsx` | Current campaign. Refreshes on user change. |
-| `CampaignStatusProvider` | `app/shared/user/CampaignStatusProvider.tsx` | Campaign-level status flag. |
-| `FeatureFlagsProvider` | `app/shared/experiments/FeatureFlagsProvider.tsx` | Amplitude experiments — see `docs/feature-flags.md`. |
-| `QueryClientProvider` | `app/shared/query-client.tsx` | React Query client. |
-| `Snackbar` | `app/shared/utils/Snackbar.tsx` | App-wide toast surface. Use `helpers/useSnackbar.ts`. |
-| `NavigationProvider` | `app/shared/layouts/navigation/NavigationProvider.tsx` | Sidebar / nav state. |
+| Provider                  | File                                                   | Purpose                                                    |
+| ------------------------- | ------------------------------------------------------ | ---------------------------------------------------------- |
+| `UserProvider`            | `app/shared/user/UserProvider.tsx`                     | Auth state, loaded from cookie. Most app code starts here. |
+| `ImpersonateUserProvider` | `app/shared/user/ImpersonateUserProvider.tsx`          | Impersonation state — drives the global banner.            |
+| `CampaignProvider`        | `app/shared/hooks/CampaignProvider.tsx`                | Current campaign. Refreshes on user change.                |
+| `CampaignStatusProvider`  | `app/shared/user/CampaignStatusProvider.tsx`           | Campaign-level status flag.                                |
+| `FeatureFlagsProvider`    | `app/shared/experiments/FeatureFlagsProvider.tsx`      | Amplitude experiments — see `docs/feature-flags.md`.       |
+| `QueryClientProvider`     | `app/shared/query-client.tsx`                          | React Query client.                                        |
+| `Snackbar`                | `app/shared/utils/Snackbar.tsx`                        | App-wide toast surface. Use `helpers/useSnackbar.ts`.      |
+| `NavigationProvider`      | `app/shared/layouts/navigation/NavigationProvider.tsx` | Sidebar / nav state.                                       |
 
 ## Feature-local providers
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -1,0 +1,65 @@
+# State Management
+
+Three layers, in order of "which to reach for first":
+
+1. **Local component state** (`useState` / `useReducer`) — for ephemeral UI state (open/closed, draft input). Default for anything not shared across components.
+2. **Server cache via React Query** — for anything fetched from gp-api. The `QueryClient` is configured in `app/shared/query-client.tsx` with a 5-minute stale time. Mutations should `invalidateQueries` on the relevant keys.
+3. **React Context providers** — for cross-route state that doesn't fit a server cache: current user, current campaign, current organization, feature flags.
+
+There is no Redux / Zustand / Jotai. Don't add one.
+
+## App-wide providers
+
+Mounted at the root in `app/layout.tsx` (or close to it). Order matters — children of a provider can read its context.
+
+| Provider | File | Purpose |
+|----------|------|---------|
+| `UserProvider` | `app/shared/user/UserProvider.tsx` | Auth state, loaded from cookie. Most app code starts here. |
+| `ImpersonateUserProvider` | `app/shared/user/ImpersonateUserProvider.tsx` | Impersonation state — drives the global banner. |
+| `CampaignProvider` | `app/shared/hooks/CampaignProvider.tsx` | Current campaign. Refreshes on user change. |
+| `CampaignStatusProvider` | `app/shared/user/CampaignStatusProvider.tsx` | Campaign-level status flag. |
+| `FeatureFlagsProvider` | `app/shared/experiments/FeatureFlagsProvider.tsx` | Amplitude experiments — see `docs/feature-flags.md`. |
+| `QueryClientProvider` | `app/shared/query-client.tsx` | React Query client. |
+| `Snackbar` | `app/shared/utils/Snackbar.tsx` | App-wide toast surface. Use `helpers/useSnackbar.ts`. |
+| `NavigationProvider` | `app/shared/layouts/navigation/NavigationProvider.tsx` | Sidebar / nav state. |
+
+## Feature-local providers
+
+When state is bound to a single feature, wrap that feature — don't pollute the root tree. Examples:
+
+- `app/dashboard/campaign-assistant/components/ChatProvider.tsx` — current chat thread + send action.
+- `app/dashboard/outreach/hooks/OutreachContext.tsx` — selected outreach + audience filters.
+- `app/shared/hooks/VoterContactsProvider.tsx` — voter-contact data; mounted by features that need it.
+
+## Reading the user
+
+```ts
+import { useUser } from '@shared/hooks/useUser'
+
+const [user, setUser, loading] = useUser()
+// user:    User | null   (null until the cookie request resolves)
+// setUser: (user?) => void
+// loading: boolean       (true on first render — gate UI on this to avoid
+//                         flashing the logged-out branch during hydration)
+```
+
+Server components: `helpers/userServerHelper.ts` (reads cookie via `next/headers`).
+
+## React Query conventions
+
+- Query keys follow `[entity, scope, params]` shape (e.g. `['campaign', campaignId, 'status']`). Keep them stable.
+- 5-minute stale time is the default; override per query only with a reason.
+- After mutations, invalidate the smallest affected key. Don't `invalidateQueries()` with no key — it nukes the whole cache.
+
+## When to add a new provider
+
+- It's needed by ≥3 unrelated routes/features and isn't fetchable.
+- It's intrinsically global (e.g. theme, auth).
+
+If it's only used by one feature, keep it in that feature's dir. Adding a provider at `app/shared/` is a tree-wide change — confirm scope before doing it.
+
+## Anti-patterns
+
+- Don't store fetched server data in context — let React Query own it.
+- Don't deep-relative-import providers (`../../../shared/user/UserProvider`). Use the `@shared/*` alias.
+- Don't re-wrap an already-mounted provider inside a feature.

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -1,0 +1,49 @@
+# e2e-tests/
+
+End-to-end tests using Playwright. Runs against a deployed environment (local app, dev, qa, prod). Separate from Vitest unit/component tests under `helpers/test-utils/`.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `playwright.config.ts` | Playwright config — testDir is `./tests`, BASE_URL required, visual diff thresholds tuned for CI |
+| `global-setup.ts` | One-shot `clerkSetup()` before tests run |
+| `tests/core/` | Cross-cutting tests (auth, navigation, public pages) |
+| `tests/app/` | Feature-area tests mirroring `app/` (`organizations/`, `polls/`, `website/`, `contacts/`, `content/`, `dashboard/`, `profile/`, `mobile/`, `ai/`) |
+| `tests/utils/` | Test-only helpers (selectors, factories) |
+| `tests/__visual_snapshots__/` | Pixel snapshots — versioned per-platform |
+| `src/fixtures/` | Static fixtures (PDFs, images, JSON poll results) |
+| `src/helpers/` | Reusable test helpers (clerk, navigation, account, organizations, contacts, visual, wait, data) |
+| `.env.example` | Required env (`BASE_URL`, secrets per `#devs-only`) |
+
+## Patterns
+
+- **One config, many environments.** Set `BASE_URL` in `.env` to point at local / dev / qa. Tests fail-fast if missing.
+- **Authenticated flows** use Clerk via `@clerk/testing/playwright`. `clerkSetup()` runs once in `global-setup.ts`; per-test sign-in helpers live in `src/helpers/clerk.helper.ts`.
+- **Visual diffs**: thresholds are deliberately permissive (`maxDiffPixels: 25000`, ratio `0.045`) to absorb font/layout drift across machines. Tighten only with a clear reason.
+- **Mirroring**: a feature dir under `app/` should have a matching dir under `tests/app/`. Add tests in the matching dir, not at the top of `tests/`.
+
+## Running
+
+```bash
+# From repo root
+npm run test:e2e                                   # all tests, headless
+# From this dir (e2e-tests/)
+npx playwright test                                # all
+npx playwright test tests/core/pages/blog.spec.ts  # one file
+npx playwright test polls                          # name pattern
+npm run test:visual:update                         # refresh visual snapshots (use carefully)
+```
+
+Some tests need AWS auth: `aws sso login --profile gp-engineer`.
+
+## Gotchas
+
+- **Visual snapshots are platform-specific** — refreshing them on a Mac may not match CI Linux. Prefer letting CI regenerate via PR if you change UI.
+- `BASE_URL` is enforced in `playwright.config.ts` — there's no default. Configure `.env` first.
+- Don't import from `app/` or `helpers/` here. This dir is a separate workspace with its own `tsconfig` and no Next runtime — pulling in app code drags in client-only modules (`next/navigation`, the `@shared/*` alias, MUI, etc.) that fail to resolve under Playwright. Put shared test-side helpers in `e2e-tests/src/helpers/` instead.
+
+## Related
+
+- `e2e-tests/README.md` — onboarding + setup details (env vars, secret handoff).
+- `docs/testing.md` — Vitest (unit/component) testing.

--- a/gpApi/CLAUDE.md
+++ b/gpApi/CLAUDE.md
@@ -1,6 +1,17 @@
 # gpApi/
 
-Two API client systems live here. The **typed system is canonical**; the legacy fetch helpers are deprecated and being migrated out file-by-file.
+API client layer. Two systems coexist — the **typed system is canonical**; the legacy fetch helpers are deprecated and being migrated out file-by-file.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `api-endpoints.ts` | `APIEndpoints` registry — keys are `'METHOD /path/:param'`, values define `Request` / `Response`. **Cross-repo contract with gp-api — confirm before editing.** |
+| `typed-request.ts` | `clientRequest<Route>(route, payload)` — browser. Throws on non-2xx. |
+| `server-request.ts` | `serverRequest<Route>(route, payload)` — server components / route handlers / `'use server'`. |
+| `unAuthFetch.ts` | Public endpoints. Sends no cookie / no Bearer — keep using for genuinely anonymous calls. |
+| `gpFetch.ts`, `clientFetch.ts`, `serverFetch.ts`, `routes.ts` | Legacy. **Do not use in new code.** |
+| `outreach.api.ts`, `types/outreach.types.ts` | Feature-specific bindings + shared shapes. |
 
 ## Use this for new code
 
@@ -68,11 +79,11 @@ These return polymorphic `T | Response | false` and never throw — callers must
    })
    ```
 
+Full recipe: `.claude/skills/add-typed-endpoint.md`.
+
 ## Migrating a legacy call
 
-See `.claude/skills/migrate-legacy-fetch.md` for the step-by-step.
-
-Short version:
+The endpoint-add recipe above is also the migration recipe. Short version:
 
 1. Find the `routes.ts` entry for the call (`url`, `method`).
 2. Add a corresponding `'METHOD /path'` entry to `APIEndpoints`.
@@ -86,7 +97,7 @@ Short version:
 | -------- | --------------------------- | --------------------------------------------------- |
 | Where    | Browser / client components | Server components / route handlers / `'use server'` |
 | baseURL  | `/api` (Next.js rewrite)    | `API_ROOT` (direct to gp-api)                       |
-| Auth     | Cookie via `credentials`    | Bearer token via `getServerToken()`                 |
+| Auth     | Cookie via `credentials`    | Bearer via `getServerToken()`                       |
 | Org slug | Cookie → `x-organization`   | `next/headers` cookies → `x-organization`           |
 
 If you call from a context where `next/headers` is unavailable, use `clientRequest`.
@@ -96,7 +107,22 @@ If you call from a context where `next/headers` is unavailable, use `clientReque
 - **Typed system**: throws `FetchError` on non-2xx; caller wraps in try/catch.
 - **Legacy system**: returns `Response` on non-2xx, `false` on parse failure, never throws. New code should not depend on this.
 
+## Gotchas
+
+- **`api-endpoints.ts` is a cross-repo contract** with gp-api. Don't change request/response shapes without coordinating.
+- **Don't add to `routes.ts`** — it's the legacy registry. New routes go in `api-endpoints.ts`.
+- **Path params share one object** with the body/query payload. The runtime strips path params from the body/query before sending — don't pre-strip them yourself.
+- **Test mocks are typed against `APIEndpoints` keys** — the same string you call drives the mock.
+- **`unAuthFetch` is not deprecated.** The typed helpers always attach credentials; it's the only anonymous variant.
+- **Legacy returns `T | Response | false`, never throws.** New code shouldn't depend on that contract — port to typed first.
+
 ## Out-of-scope here
 
 - Adding new entries to `routes.ts` — add to `api-endpoints.ts` instead.
 - Wrapping legacy helpers with retry/error utilities — port the call to the typed system first.
+
+## Related
+
+- `docs/api-clients.md` — full decision tree, examples.
+- `helpers/test-utils/api-mocking.ts` — MSW mocker with typed routes.
+- `.claude/skills/add-typed-endpoint.md` — endpoint-add recipe (also the basis for legacy migration).

--- a/helpers/CLAUDE.md
+++ b/helpers/CLAUDE.md
@@ -1,0 +1,38 @@
+# helpers/
+
+Top-level utility grab-bag. ~50 files of pure helpers + a few thin gp-api wrappers. **Already large** — root CLAUDE.md flags adding new helpers here as "ask first." Check for an existing helper before adding.
+
+## Key files
+
+Grouped by category:
+
+| Category | Files |
+|----------|-------|
+| Auth / users / cookies | `authHelper.ts`, `userHelper.ts`, `userServerHelper.ts`, `cookieHelper.ts`, `tokenHelper.ts`, `clerkErrors.ts` |
+| Campaigns / candidates | `campaignHelper.ts`, `candidateHelper.tsx`, `campaignOfficeFields.ts`, `fetchCampaignStatus.ts` |
+| Voter / outreach data shaping | `createOutreach.ts`, `createP2pPhoneList.ts`, `createVoterFileFilter.ts`, `scheduleVoterMessagingCampaign.ts`, `voterFileDownload.ts` |
+| AI content | `buildAiContentSections.ts`, `generateAIContent.ts`, `getAiTemplatesFromCategories.ts`, `getNewAiContentSectionKey.ts`, `fetchPromptInputFields.ts`, `setRequiresQuestionsOnTemplates.ts` |
+| Analytics / segment | `analyticsHelper.ts`, `buildUserTraits.ts`, `segmentHelper.ts` |
+| Routing / redirects | `resolvePostAuthRedirectPath.util.ts`, `linkhelper.ts`, `metadataHelper.ts`, `urlIncludesPath.ts`, `URLSearchParamsToObject.ts`, `handleApiRequestRewrite.ts` |
+| Date / number / string / object | `dateHelper.ts`, `dateColumnSort.ts`, `numberHelper.ts`, `stringHelper.ts`, `objectHelper.ts`, `debounceHelper.ts` |
+| Forms / validation | `validations.ts`, `packageFormData.ts`, `extractApiErrorInfo.ts` |
+| State / common | `statesHelper.ts` (US states), `articleHelper.ts`, `useSnackbar.ts`, `purchaseTypes.ts`, `types.ts` |
+| Test utilities | `test-utils/` (`render.tsx`, `api-mocking.ts`, `router-mocking.ts`), `test-users.ts` |
+
+## Patterns
+
+- **Pure functions** preferred. Hooks are an exception — they live here only when reused across features (e.g. `useSnackbar.ts`).
+- **Server-only helpers** carry a `*ServerHelper.ts` or `.util.ts` suffix when they call `serverRequest` or use `next/headers`. Don't import these from client components.
+- **Tests live alongside** the helper as `*.test.ts`. Add one when you add behavior worth pinning.
+- **Naming convention** is mostly `xxxHelper.ts`, but several files (e.g. `linkhelper.ts`, `createOutreach.ts`) don't follow it — match the existing neighborhood, don't rename.
+
+## Gotchas
+
+- **It's a 50+ file dumping ground.** Before adding a new helper, grep for the same idea — it likely exists. If unsure, ask.
+- `linkhelper.ts` is lowercase (legacy). Don't rename casually — many imports.
+- `test-utils/` is the canonical Vitest helper set; don't duplicate. See `docs/testing.md`.
+
+## Related
+
+- `app/shared/utils/` — small utility bag inside `app/shared/`. Convention: prefer this dir for new pure helpers; reserve `app/shared/utils/` for app-shell-internal bits.
+- `gpApi/CLAUDE.md` — fetch-helper rules.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that reorganize developer guidance; no runtime code paths are modified.
> 
> **Overview**
> Reorganizes repository guidance by **moving detailed architectural/state/auth/client conventions out of the root `CLAUDE.md`** into new focused docs (`docs/architecture.md`, `docs/state-management.md`, `docs/feature-flags.md`) and replacing the removed sections with a concise pointer table.
> 
> Adds **nested `CLAUDE.md` files** across major areas (`app/admin`, `app/dashboard` and key dashboard features, `app/onboarding`, `app/shared`, `helpers/`, `e2e-tests/`) to document local patterns/gotchas, and expands `gpApi/CLAUDE.md` with a clearer “key files/gotchas/migration” reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7dade54f2351896161432536dbabfcf24c104a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->