### PR TITLE
remove client-side pro_upgrade_complete event fire from purchase success page

### DIFF
--- a/app/dashboard/pro-sign-up/success/components/PurchaseSuccessPage.tsx
+++ b/app/dashboard/pro-sign-up/success/components/PurchaseSuccessPage.tsx
@@ -1,18 +1,14 @@
 'use client'
 import H1 from '@shared/typography/H1'
 import Body2 from '@shared/typography/Body2'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { FocusedExperienceWrapper } from 'app/dashboard/shared/FocusedExperienceWrapper'
 import Link from 'next/link'
 import SecondaryButton from '@shared/buttons/SecondaryButton'
 import Image from 'next/image'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
-import { trackEvent } from 'helpers/analyticsHelper'
 
 const PurchaseSuccessPage = (): React.JSX.Element => {
-  useEffect(() => {
-    trackEvent('pro_upgrade_complete', { pro: true })
-  }, [])
   return (
     <FocusedExperienceWrapper className="flex flex-col items-center">
       <Image


### PR DESCRIPTION
Removes the client-side pro_upgrade_complete Amplitude event from PurchaseSuccessPage, now that gp-api PR #1563 (ENG-10204) fires this event from the Stripe subscription webhook. The webhook-based fire tracks reliably regardless of whether the success page renders, eliminating the previous gap where users who closed the tab before the redirect — or hit any client-side render failure — were never counted. Keeping the useEffect here would now double-count every upgrade, so this PR removes the redundant client trigger along with its useEffect and trackEvent imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a redundant client-side analytics event fire and related imports, with no impact to purchase flow or data writes.
> 
> **Overview**
> Removes the client-side `pro_upgrade_complete` analytics tracking from `PurchaseSuccessPage` by deleting the `useEffect` that called `trackEvent` and cleaning up the unused imports.
> 
> This prevents double-counting upgrades now that the event is emitted elsewhere (e.g., server-side/webhook).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f4e0aa7d7b7d44f09aab1af0c892731c2880bab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->