### PR TITLE
DES: drop icons from top voter issues list

### DIFF
--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -2,17 +2,6 @@
 import { useEffect, useState } from 'react'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { Card, CardContent, Badge } from '@styleguide'
-import {
-  LuHeart,
-  LuDollarSign,
-  LuMapPin,
-  LuBriefcase,
-  LuGraduationCap,
-  LuLeaf,
-  LuShieldCheck,
-  LuStethoscope,
-  LuVote,
-} from 'react-icons/lu'
 import { clientRequest } from 'gpApi/typed-request'
 import { reportErrorToSentry } from '@shared/sentry'
 
@@ -29,47 +18,10 @@ const SENTRY_CONTEXT_FETCH_ISSUES = 'onboarding.voterIssues.fetch'
 const SKELETON_PLACEHOLDER_COUNT = 3
 const COLLAPSED_ISSUES_VISIBLE = 3
 
-const ISSUE_ICON_BASE =
-  'flex size-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'
-
 const PRIORITY_LABEL: Record<'high' | 'medium' | 'low', string> = {
   high: 'High priority',
   medium: 'Medium priority',
   low: 'Low priority',
-}
-
-const ICON_BY_KEYWORD: Array<{
-  pattern: RegExp
-  icon: React.JSX.Element
-}> = [
-  {
-    pattern: /(safety|crime|police)/i,
-    icon: <LuShieldCheck className="size-5" />,
-  },
-  {
-    pattern: /(econom|job|business|tax)/i,
-    icon: <LuDollarSign className="size-5" />,
-  },
-  { pattern: /(hous|rent|afford)/i, icon: <LuMapPin className="size-5" /> },
-  {
-    pattern: /(health|medic|hospital)/i,
-    icon: <LuStethoscope className="size-5" />,
-  },
-  {
-    pattern: /(educat|school|student)/i,
-    icon: <LuGraduationCap className="size-5" />,
-  },
-  {
-    pattern: /(environment|climate|energy)/i,
-    icon: <LuLeaf className="size-5" />,
-  },
-  { pattern: /(work|employ|labor)/i, icon: <LuBriefcase className="size-5" /> },
-  { pattern: /(elect|vot|democra)/i, icon: <LuVote className="size-5" /> },
-]
-
-const iconForLabel = (label: string): React.JSX.Element => {
-  const match = ICON_BY_KEYWORD.find(({ pattern }) => pattern.test(label))
-  return match ? match.icon : <LuHeart className="size-5" />
 }
 
 // Endpoint derives district from the org cookie, so the request takes no
@@ -167,14 +119,9 @@ export const TopVoterIssuesSection = ({
             {visibleIssues.map((issue) => (
               <div key={issue.label} className="space-y-2">
                 <div className="flex items-center justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <span className={ISSUE_ICON_BASE}>
-                      {iconForLabel(issue.label)}
-                    </span>
-                    <h3 className="text-sm font-semibold text-slate-950">
-                      {issue.label}
-                    </h3>
-                  </div>
+                  <h3 className="text-base font-semibold text-foreground">
+                    {issue.label}
+                  </h3>
                   {issue.priority === 'high' ? (
                     <Badge variant="soft">
                       {PRIORITY_LABEL[issue.priority]}


### PR DESCRIPTION
## Summary
- Remove the keyword-mapped icon column rendered before each issue heading on the onboarding voter-demographics step.
- Drop the now-unused supporting code: `ICON_BY_KEYWORD` map, `iconForLabel` helper, `ISSUE_ICON_BASE` class, and the `react-icons/lu` imports.
- Bump the issue heading to `text-base text-foreground` so the title still anchors the row without the icon.

Net: 56 lines removed, 3 added.

## Test plan
- [ ] On the voter-demographics step, each issue row now shows just the title (left) and optional "High priority" badge (right) — no icon
- [ ] No icons in the layout at any width
- [ ] Issue heading reads as the dominant text in each row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes decorative icons and adjusts typography; no API, state, or data-handling behavior changes.
> 
> **Overview**
> **Simplifies the onboarding “Top issues for your voters” list UI** by removing the keyword-based icon column (and all related `react-icons` imports and helper code).
> 
> Updates the issue heading styling to `text-base text-foreground` so the row remains visually anchored while keeping the existing priority badge and score bar behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1361323e1818f9ec1e4ebb760ba6422056ff4b1e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->