### PR TITLE
fix(onboarding): refetch campaign on /dashboard after pledge [ENG-10187]

### DIFF
--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -26,6 +26,7 @@ import {
 
 const ONBOARDING_STEP_COMPLETE = 'onboarding-complete'
 import { useCampaign } from '@shared/hooks/useCampaign'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 import { useUser } from '@shared/hooks/useUser'
 import { clientRequest } from 'gpApi/typed-request'
 import { clientFetch } from 'gpApi/clientFetch'
@@ -624,6 +625,12 @@ export default function OnboardingFlow({
     if (!newCampaign) return false
     setCookie(ORG_SLUG_COOKIE, `campaign-${newCampaign.id}`)
     setLiveCampaign(newCampaign)
+    // CampaignProvider cached the prior 404 (no campaign yet) for this
+    // session. POST /campaigns returns the bare campaign without
+    // raceTargetMetrics — those are only computed by GET /campaigns/mine —
+    // so we invalidate instead of seeding the cache, forcing the next read
+    // to refetch the fully-hydrated record.
+    void queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
     await identifyUser(user?.id, {
       ...trackingProperties,
       officeType: office.level,
@@ -716,6 +723,7 @@ export default function OnboardingFlow({
     if (!newCampaign) return false
     setCookie(ORG_SLUG_COOKIE, `campaign-${newCampaign.id}`)
     setLiveCampaign(newCampaign)
+    void queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
     await identifyUser(user?.id, {
       ...trackingProperties,
       officeType: 'manual',
@@ -785,6 +793,11 @@ export default function OnboardingFlow({
       })
       return false
     }
+    // Launch flips isActive + recomputes raceTargetMetrics on the next read.
+    // Invalidate so /dashboard's CampaignProvider refetches the hydrated
+    // campaign instead of serving the stale (or missing-metrics) entry that
+    // was cached earlier in this session.
+    void queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
     trackEvent(EVENTS.Onboarding.PledgeStep.Completed)
     trackEvent(EVENTS.Onboarding.PledgeCompleted, {
       pledgeVersion: PLEDGE_VERSION,


### PR DESCRIPTION
## Summary
- After a user finishes onboarding and accepts the pledge, `/dashboard` was stuck. Two surface symptoms came from the same root cause:
  - **Flag off** (`DashboardPage`): "Loading your dashboard" animation forever, or `EmptyState` ("We're currently gathering the necessary data for…") that never advanced.
  - **Flag on** (`CampaignManager`): white screen for ~10s before a forced refresh — the original ticket repro.
- Root cause: `CampaignProvider` caches `GET /v1/campaigns/mine` under a 5-minute stale time. The cache gets seeded early in onboarding (typically with the 404 `null` while the user has no campaign yet) and nothing during the flow marks it stale. By the time `/dashboard` mounts, react-query happily serves the cached `null` / metrics-less entry and ignores the freshly hydrated `initialData` from PageWrapper's SSR fetch. `useCampaign()` returns `null`, the dashboard never finds `raceTargetMetrics`, and the user is parked on the loading/empty state.
- Fix: invalidate the `['campaign']` query at the three moments the campaign actually changes server-side, so the next read refetches the fully-hydrated record (the only one that includes `raceTargetMetrics`):
  - after `createCampaignWithOffice` in `persistStructuredOffice`
  - after `createCampaignWithOffice` in `persistManualOffice`
  - after `clientFetch(apiRoutes.campaign.launch)` in `persistPledgeAndComplete`
- Behavior post-fix:
  - **Flag off:** dashboard refetches on mount, `contactGoals` is truthy, `TasksList` renders.
  - **Flag on:** `CampaignManager` has a non-null `campaign` on first render, kicks off `useTaskGenerationStream`, lands on the calculating modal → tasks.
- Single file changed (`OnboardingFlow.tsx`), +13 lines including comments and one import.

## Test plan
- [ ] Sign up as a fresh user, pick "I'm just testing out the product", complete onboarding through the structured-office path, accept the pledge — confirm `/dashboard` lands on `TasksList` (or the calculating modal → tasks if the flag is on), no stuck `Loading your dashboard` / `EmptyState`
- [ ] Same flow but pick a manual office via "I don't see my office" — confirm the dashboard renders without getting stuck
- [ ] Existing-campaign user goes through onboarding a second time (the original ENG-10187 repro path) — confirm post-pledge dashboard refetches and shows current data
- [ ] `npm run test`, `npm run types`, `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding-to-dashboard transition by forcing react-query cache invalidation; risk is limited but could cause extra refetches or reveal issues if query keys differ across providers.
> 
> **Overview**
> Fixes a post-onboarding `/dashboard` stall caused by `CampaignProvider` serving a cached `null`/partial campaign.
> 
> `OnboardingFlow` now invalidates the `CAMPAIGN_QUERY_KEY` react-query entry after creating a campaign (both structured and manual office paths) and after launching the campaign on pledge completion, ensuring the next dashboard read refetches the fully-hydrated campaign (including metrics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a682d3c259eea729d333b05aeb548366e0b02b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->