### PR TITLE
Prototype: campaign plan onboarding + dashboard payoff (preview only)

### DIFF
--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
-import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
 import type { TcrCompliance } from 'helpers/types'
 import CampaignManager from './campaignManager/CampaignManager'
-
-const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
 
 interface DashboardContentProps {
   pathname: string
@@ -16,22 +12,7 @@ interface DashboardContentProps {
 
 export default function DashboardContent({
   pathname,
-  tasks,
   tcrCompliance,
 }: DashboardContentProps): React.JSX.Element {
-  const { ready, on: aiCampaignManagerEnabled } = useFlagOn(
-    AI_CAMPAIGN_MANAGER_FLAG_KEY,
-  )
-
-  if (ready && aiCampaignManagerEnabled) {
-    return <CampaignManager pathname={pathname} tcrCompliance={tcrCompliance} />
-  }
-
-  return (
-    <DashboardPage
-      pathname={pathname}
-      tasks={tasks}
-      tcrCompliance={tcrCompliance}
-    />
-  )
+  return <CampaignManager pathname={pathname} tcrCompliance={tcrCompliance} />
 }

--- a/app/dashboard/components/campaignManager/CountsInfoModal.tsx
+++ b/app/dashboard/components/campaignManager/CountsInfoModal.tsx
@@ -1,8 +1,39 @@
+import { useEffect, useState } from 'react'
 import { noop } from '@shared/utils/noop'
 import { numberFormatter } from 'helpers/numberHelper'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { ModalOrDrawer } from '@shared/ui/ModalOrDrawer'
+import { clientRequest } from 'gpApi/typed-request'
+import { reportErrorToSentry } from '@shared/sentry'
 import { RaceTargetMetrics } from 'helpers/types'
+
+const CONTACTS_STATS_ROUTE = 'GET /v1/contacts/stats'
+
+const useRegisteredVoters = (enabled: boolean) => {
+  const [registeredVoters, setRegisteredVoters] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    clientRequest(CONTACTS_STATS_ROUTE, {})
+      .then((res) => {
+        if (cancelled) return
+        setRegisteredVoters(res.data?.totalConstituents ?? null)
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        setRegisteredVoters(null)
+        reportErrorToSentry(error, {
+          context: 'dashboard.countsInfoModal.fetchContactsStats',
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return registeredVoters
+}
 
 interface CountsInfoModalProps {
   open?: boolean
@@ -15,8 +46,9 @@ export const CountsInfoModal = ({
   setOpen = noop,
   raceTargetMetrics,
 }: CountsInfoModalProps): React.JSX.Element => {
-  const { projectedTurnout, voterContactGoal, winNumber } =
-    raceTargetMetrics ?? {}
+  const { projectedTurnout, winNumber } = raceTargetMetrics ?? {}
+  const registeredVoters = useRegisteredVoters(open)
+  const showRegisteredVoters = registeredVoters !== null && registeredVoters > 0
 
   return (
     <ModalOrDrawer
@@ -27,46 +59,62 @@ export const CountsInfoModal = ({
           setOpen()
         }
       }}
-      title="Voter contacts needed"
+      title="Projected votes needed to win"
       dialogClassName="min-w-[80vw] lg:min-w-[540px] max-w-2xl"
       drawerClassName="px-4 pb-8"
     >
       <div className="p-2 font-opensans">
-        <div className="text-lg font-semibold">Voter contacts needed</div>
+        <div className="text-lg font-semibold">
+          Projected votes needed to win
+        </div>
         <div className="mt-1.5 text-sm text-muted-foreground">
-          A voter contact is when you make a meaningful contact with a voter.
-          This could be a text message, robocall, talking to them in person,
-          etc. To turn someone into your voter we recommend contacting them{' '}
-          <span className="inline font-semibold">5</span> times across channels.
+          This is how many votes you need to win the seat. We use a conservative
+          target: 50% of the voters we expect to cast a ballot, plus one more
+          vote.
         </div>
 
         <div className="mt-4 text-base font-semibold">
           How we calculate this number
         </div>
         <ol className="mt-1.5 list-decimal list-outside pl-5 space-y-2 text-sm [&>li]:list-item">
+          {showRegisteredVoters ? (
+            <li>
+              There are{' '}
+              <span className="font-semibold">
+                {numberFormatter(registeredVoters)}
+              </span>{' '}
+              registered voters in your district. That&rsquo;s everyone who
+              could cast a ballot.
+            </li>
+          ) : null}
           <li>
-            We expect{' '}
+            Of those, we expect{' '}
             <span className="font-semibold">
               {numberFormatter(projectedTurnout)}
             </span>{' '}
-            people to vote on trends from similar previous elections in this
-            district.
+            to actually vote, based on past elections like yours.
           </li>
           <li>
-            You need{' '}
+            To win, you need{' '}
             <span className="font-semibold">{numberFormatter(winNumber)}</span>{' '}
-            votes to win with <span className="font-semibold">50%</span> of the
-            votes.
-          </li>
-          <li>
-            To do that, you need to make{' '}
-            <span className="font-semibold">
-              {numberFormatter(voterContactGoal)}
-            </span>{' '}
-            voter contacts (<span className="font-semibold">5x</span> your votes
-            needed to win).
+            of those voters on your side. That&rsquo;s just over half (
+            <span className="font-semibold">50% + 1</span>).
           </li>
         </ol>
+
+        <div className="mt-4 text-xs text-muted-foreground">
+          Our turnout predictions come from a national voter file with more than
+          240 million voters. To learn more, read{' '}
+          <a
+            href="https://goodparty.org/blog/article/calculate-win-numbers"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            our blog post
+          </a>
+          .
+        </div>
       </div>
     </ModalOrDrawer>
   )

--- a/app/dashboard/components/campaignManager/HeaderSection.tsx
+++ b/app/dashboard/components/campaignManager/HeaderSection.tsx
@@ -2,7 +2,7 @@
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useUser } from '@shared/hooks/useUser'
 import { getNextElection } from 'helpers/campaignHelper'
-import { timeToNextElection } from 'helpers/dateHelper'
+import { dateUsHelper, timeToNextElection } from 'helpers/dateHelper'
 
 export default function HeaderSection() {
   const [user] = useUser()
@@ -13,6 +13,9 @@ export default function HeaderSection() {
   const electionLabel = nextElection?.isPrimary
     ? 'Primary Election'
     : 'General Election'
+  const formattedElectionDate = nextElection?.nextElectionDate
+    ? dateUsHelper(nextElection.nextElectionDate)
+    : ''
 
   return (
     <div className="flex flex-col gap-1">
@@ -23,7 +26,9 @@ export default function HeaderSection() {
         {timeUntilElection === 'election-day'
           ? 'Today is Election Day!'
           : timeUntilElection &&
-            `${timeUntilElection} until your ${electionLabel}`}
+            `${timeUntilElection} until your ${electionLabel}${
+              formattedElectionDate ? ` on ${formattedElectionDate}` : ''
+            }`}
       </div>
     </div>
   )

--- a/app/dashboard/components/campaignManager/ProgressSection.test.tsx
+++ b/app/dashboard/components/campaignManager/ProgressSection.test.tsx
@@ -46,12 +46,12 @@ vi.mock('@styleguide', async (importOriginal) => {
   }
 })
 
-const makeCampaign = (voterContactGoal = 1000): Campaign =>
+const makeCampaign = (winNumber = 1000): Campaign =>
   ({
     raceTargetMetrics: {
       projectedTurnout: 0,
-      winNumber: 0,
-      voterContactGoal,
+      winNumber,
+      voterContactGoal: winNumber * 5,
     },
   } as unknown as Campaign)
 
@@ -85,26 +85,28 @@ const renderWithProviders = (
   )
 
 describe('ProgressSection', () => {
-  it('displays formatted contacted and needed counts', () => {
+  it('displays likely votes (contacts / 5) and the win number needed', () => {
     renderWithProviders(
-      makeCampaign(5000),
+      makeCampaign(1000),
       makeVoterContacts({ doorKnocking: 100, calls: 200 }),
     )
-    expect(screen.getByText('300 voters contacted')).toBeInTheDocument()
+    // 300 contacts ÷ 5 = 60 likely votes
+    expect(screen.getByText('60 likely votes')).toBeInTheDocument()
     expect(
-      screen.getByText('5,000 voter contacts needed to win'),
+      screen.getByText('1,000 likely votes needed to win'),
     ).toBeInTheDocument()
   })
 
-  it('displays zero contacted when no voter contacts reported', () => {
+  it('displays zero likely votes when no voter contacts reported', () => {
     renderWithProviders(makeCampaign(1000), makeVoterContacts())
-    expect(screen.getByText('0 voters contacted')).toBeInTheDocument()
+    expect(screen.getByText('0 likely votes')).toBeInTheDocument()
   })
 
-  it('caps progress bar at 100% when contacted exceeds needed', () => {
+  it('caps progress bar at 100% when likely votes exceed needed', () => {
+    // 5 contacts → 1 likely vote; needed = 1 → progress hits 100% at 5 contacts.
     renderWithProviders(
-      makeCampaign(100),
-      makeVoterContacts({ doorKnocking: 200 }),
+      makeCampaign(1),
+      makeVoterContacts({ doorKnocking: 1000 }),
     )
     const progressBar = screen.getByRole('progressbar')
     expect(progressBar.getAttribute('aria-valuenow')).toBe('100')
@@ -125,20 +127,22 @@ describe('ProgressSection', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    await user.click(screen.getByText('1,000 voter contacts needed to win'))
+    await user.click(screen.getByText('1,000 likely votes needed to win'))
 
     expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(screen.getByText('Voter contacts needed')).toBeInTheDocument()
+    expect(
+      screen.getAllByText('Projected votes needed to win').length,
+    ).toBeGreaterThan(0)
   })
 
   it('closes info modal when clicking the needed-to-win text again', async () => {
     const user = userEvent.setup()
     renderWithProviders(makeCampaign(1000))
 
-    await user.click(screen.getByText('1,000 voter contacts needed to win'))
+    await user.click(screen.getByText('1,000 likely votes needed to win'))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
 
-    await user.click(screen.getByText('1,000 voter contacts needed to win'))
+    await user.click(screen.getByText('1,000 likely votes needed to win'))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })

--- a/app/dashboard/components/campaignManager/ProgressSection.tsx
+++ b/app/dashboard/components/campaignManager/ProgressSection.tsx
@@ -10,6 +10,10 @@ import { Info } from 'lucide-react'
 import { CountsInfoModal } from './CountsInfoModal'
 import { RecordVoterContactsModal } from './RecordVoterContactsModal'
 
+// Industry rule of thumb: roughly 5 voter contacts (texts or robocalls)
+// translate to 1 likely vote.
+const CONTACTS_PER_LIKELY_VOTE = 5
+
 export default function ProgressSection() {
   const [campaign] = useCampaign()
   const [modalOpen, setModalOpen] = useState(false)
@@ -19,11 +23,10 @@ export default function ProgressSection() {
   const toggleRecordModalOpen = () => setRecordModalOpen(!recordModalOpen)
 
   const [reportedVoterGoals] = useVoterContacts()
-  const { needed, contacted } = calculateVoterContactCounts(
-    p2vData,
-    reportedVoterGoals,
-  )
-  const progress = needed > 0 ? Math.min((contacted / needed) * 100, 100) : 0
+  const { contacted } = calculateVoterContactCounts(p2vData, reportedVoterGoals)
+  const needed = p2vData?.winNumber ?? 0
+  const likelyVotes = Math.floor(contacted / CONTACTS_PER_LIKELY_VOTE)
+  const progress = needed > 0 ? Math.min((likelyVotes / needed) * 100, 100) : 0
   return (
     <Card className="gap-0 p-0">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 border-b p-6">
@@ -40,12 +43,12 @@ export default function ProgressSection() {
       <div className="flex flex-col gap-3 p-6">
         <Progress value={progress} className="w-full" />
         <div className="flex w-full flex-wrap justify-between items-center gap-x-4 gap-y-1 text-sm font-normal font-opensans">
-          <div>{numberFormatter(contacted)} voters contacted</div>
+          <div>{numberFormatter(likelyVotes)} likely votes</div>
           <div
             onClick={toggleModalOpen}
             className="cursor-pointer flex items-center gap-2"
           >
-            <div>{numberFormatter(needed)} voter contacts needed to win</div>
+            <div>{numberFormatter(needed)} likely votes needed to win</div>
             <Info className="inline-block" size={16} />
           </div>
         </div>

--- a/app/dashboard/components/tasks/TasksList.tsx
+++ b/app/dashboard/components/tasks/TasksList.tsx
@@ -579,7 +579,7 @@ const TasksList = ({
           <>
             <div className="flex flex-wrap gap-y-1 justify-between items-baseline border-b px-6 py-6">
               <div className="text-lg font-semibold font-opensans">
-                Campaign plan
+                Top priorities
               </div>
               <button
                 type="button"

--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -17,6 +17,7 @@ import {
   Circle,
   CircleUserRound,
   ClipboardList,
+  Compass,
   DoorClosed,
   ExternalLink,
   FileText,
@@ -100,6 +101,15 @@ const DEFAULT_MENU_ITEMS: MenuItem[] = [
     v2Category: 'campaign',
     id: 'campaign-tracker-dashboard',
     onClick: () => trackEvent(EVENTS.Navigation.Dashboard.ClickDashboard),
+  },
+  {
+    label: 'Campaign plan',
+    icon: <Compass />,
+    v2Icon: Compass,
+    link: '/dashboard/strategy',
+    v2Category: 'campaign',
+    id: 'strategy-dashboard',
+    onClick: () => trackEvent(EVENTS.Navigation.Dashboard.ClickStrategy),
   },
   {
     label: 'Voter Outreach',

--- a/app/dashboard/strategy/components/CampaignPlanPdf.tsx
+++ b/app/dashboard/strategy/components/CampaignPlanPdf.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable jsx-a11y/alt-text */
+import type { ReactNode } from 'react'
 import {
   Document,
   Font,
@@ -6,30 +7,63 @@ import {
   Path,
   StyleSheet,
   Svg,
-  Text,
+  Text as PdfText,
   View,
 } from '@react-pdf/renderer'
+import type { Style } from '@react-pdf/types'
 import type { PlanData } from './planContent'
 
-// Open Sans (matches the app's typography). TTF files served from jsdelivr's
-// mirror of @fontsource/open-sans.
+// fontkit (used by @react-pdf/renderer) applies OpenType ligature substitution
+// by default. With Open Sans this produces visible character drops in the PDF
+// ("filed" → "fled", "first" → "frst"). Inserting a Zero-Width Non-Joiner
+// between f and a following i/l/f/t/b/h/j/k tells the layout engine to skip
+// the ligature lookup, so each letter renders as its own glyph. ZWNJ has no
+// width and no visible representation.
+const ZWNJ = '‌'
+const defeatLigatures = (s: string): string =>
+  s.replace(/(f)(?=[iflbhjkt])/gi, `$1${ZWNJ}`)
+
+const processChildren = (children: ReactNode): ReactNode => {
+  if (typeof children === 'string') return defeatLigatures(children)
+  if (Array.isArray(children)) return children.map(processChildren)
+  return children
+}
+
+interface TextProps {
+  children?: ReactNode
+  style?: Style | Style[]
+  fixed?: boolean
+  break?: boolean
+  wrap?: boolean
+  render?: (props: {
+    pageNumber: number
+    totalPages: number
+  }) => React.ReactNode
+}
+const Text = ({ children, ...rest }: TextProps): React.JSX.Element => (
+  <PdfText {...rest}>{processChildren(children)}</PdfText>
+)
+
+// Open Sans (matches the app's typography). TTF files from the official
+// googlefonts/opensans repo via jsdelivr. The full-charset TTFs include the
+// ligature glyphs (U+FB01–FB04) that fontkit's GSUB substitution needs.
 Font.register({
   family: 'Open Sans',
   fonts: [
     {
-      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-400-normal.woff',
+      src: 'https://cdn.jsdelivr.net/gh/googlefonts/opensans@main/fonts/ttf/OpenSans-Regular.ttf',
       fontWeight: 'normal',
     },
     {
-      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-600-normal.woff',
+      src: 'https://cdn.jsdelivr.net/gh/googlefonts/opensans@main/fonts/ttf/OpenSans-SemiBold.ttf',
       fontWeight: 'semibold',
     },
     {
-      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-700-normal.woff',
+      src: 'https://cdn.jsdelivr.net/gh/googlefonts/opensans@main/fonts/ttf/OpenSans-Bold.ttf',
       fontWeight: 'bold',
     },
     {
-      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-400-italic.woff',
+      src: 'https://cdn.jsdelivr.net/gh/googlefonts/opensans@main/fonts/ttf/OpenSans-Italic.ttf',
       fontStyle: 'italic',
     },
   ],
@@ -55,50 +89,59 @@ const styles = StyleSheet.create({
   },
   coverWrapper: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    textAlign: 'center',
+    paddingTop: 160,
   },
-  coverHeader: { alignItems: 'center', marginBottom: 32 },
+  coverHeader: { alignItems: 'center' },
   wordmark: {
     fontSize: 22,
     fontWeight: 'bold',
     color: COLORS.text,
-    marginTop: 14,
+    lineHeight: 1.2,
   },
   wordmarkTagline: {
     fontSize: 9,
     letterSpacing: 2,
     color: COLORS.muted,
-    marginTop: 6,
     textTransform: 'uppercase',
+    lineHeight: 1.2,
   },
+  coverHeaderInner: { alignItems: 'center', gap: 6 },
   coverDivider: {
     width: '100%',
     height: 1,
     backgroundColor: COLORS.divider,
     marginVertical: 32,
   },
+  coverTitleBlock: { alignItems: 'center', gap: 8 },
   coverEyebrow: {
     fontSize: 28,
     fontWeight: 'bold',
     letterSpacing: 4,
     textTransform: 'uppercase',
-    marginBottom: 18,
+    textAlign: 'center',
+    lineHeight: 1.2,
   },
   coverCandidate: {
     fontSize: 22,
     fontWeight: 'bold',
     color: COLORS.brand,
-    marginBottom: 4,
+    textAlign: 'center',
+    lineHeight: 1.2,
   },
-  coverRace: { fontSize: 14, marginBottom: 4 },
-  coverLocation: { fontSize: 12, color: COLORS.muted },
+  coverRace: { fontSize: 14, textAlign: 'center', lineHeight: 1.3 },
+  coverLocation: {
+    fontSize: 12,
+    color: COLORS.muted,
+    textAlign: 'center',
+    lineHeight: 1.3,
+  },
   coverElection: {
     fontSize: 11,
     color: COLORS.muted,
     fontStyle: 'italic',
-    marginTop: 10,
+    textAlign: 'center',
+    lineHeight: 1.3,
+    marginTop: 6,
   },
   coverFooter: {
     position: 'absolute',
@@ -139,6 +182,22 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 14,
   },
+  tocTitle: { fontSize: 28, fontWeight: 'bold', marginBottom: 20 },
+  tocRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    marginBottom: 10,
+  },
+  tocLabel: { fontSize: 12, lineHeight: 1.2 },
+  tocDots: {
+    flex: 1,
+    borderBottomWidth: 1,
+    borderBottomStyle: 'dotted',
+    borderBottomColor: COLORS.muted,
+    marginHorizontal: 6,
+    marginBottom: 3,
+  },
+  tocPage: { fontSize: 12, lineHeight: 1.2, minWidth: 24, textAlign: 'right' },
   subTitle: {
     fontSize: 12,
     fontWeight: 'bold',
@@ -164,6 +223,7 @@ const styles = StyleSheet.create({
   },
   bulletDot: { width: 8, fontSize: 10 },
   bulletText: { flex: 1, fontSize: 10, lineHeight: 1.5 },
+  defText: { fontSize: 10, lineHeight: 1.5 },
   defTerm: { fontWeight: 'bold' },
   table: {
     borderTopWidth: 1,
@@ -206,14 +266,23 @@ const styles = StyleSheet.create({
   },
   footer: {
     position: 'absolute',
-    bottom: 32,
+    bottom: 24,
     left: 56,
     right: 56,
+  },
+  footerDivider: {
+    height: 1,
+    backgroundColor: COLORS.divider,
+    marginBottom: 10,
+  },
+  footerRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    fontSize: 8,
-    color: COLORS.muted,
+    alignItems: 'center',
   },
+  footerText: { fontSize: 9, color: COLORS.muted },
+  footerPageBold: { fontSize: 9, color: COLORS.text, fontWeight: 'bold' },
+  footerPageGroup: { flexDirection: 'row', alignItems: 'baseline' },
   glossary: {
     borderTopWidth: 1,
     borderTopColor: COLORS.divider,
@@ -277,10 +346,24 @@ const PageHeader = ({ plan }: PageHeaderProps): React.JSX.Element => (
 
 const PageFooter = (): React.JSX.Element => (
   <View style={styles.footer} fixed>
-    <Text>Prepared by GoodParty.org</Text>
-    <Text
-      render={({ pageNumber, totalPages }) => `${pageNumber} of ${totalPages}`}
-    />
+    <View style={styles.footerDivider} />
+    <View style={styles.footerRow}>
+      <Text style={styles.footerText}>
+        Prepared by GoodParty.org • Empowering people to run, win, and serve
+      </Text>
+      <View style={styles.footerPageGroup}>
+        <Text style={styles.footerText}>Page </Text>
+        <Text
+          style={styles.footerPageBold}
+          render={({ pageNumber }) => `${pageNumber}`}
+        />
+        <Text style={styles.footerText}> of </Text>
+        <Text
+          style={styles.footerPageBold}
+          render={({ totalPages }) => `${totalPages}`}
+        />
+      </View>
+    </View>
   </View>
 )
 
@@ -296,6 +379,32 @@ const SectionHeader = ({
   <View>
     <Text style={styles.sectionEyebrow}>Section {number}</Text>
     <Text style={styles.sectionTitle}>{title}</Text>
+  </View>
+)
+
+const TOC_ENTRIES: { label: string; page: number }[] = [
+  { label: 'Executive Summary', page: 3 },
+  { label: '1. Strategic Landscape', page: 5 },
+  { label: '2. Electoral Goals & Key Metrics', page: 6 },
+  { label: '3. Campaign Timeline', page: 7 },
+  { label: '4. Recommended Budget', page: 8 },
+  { label: '5. Community Engagement & Earned Media', page: 9 },
+  { label: '6. Voter Contact Plan', page: 10 },
+  { label: '7. Measurement & Accountability', page: 11 },
+  { label: '8. Methodology & Data Sources', page: 12 },
+  { label: '9. Glossary', page: 13 },
+]
+
+const TableOfContents = (): React.JSX.Element => (
+  <View>
+    <Text style={styles.tocTitle}>Table of Contents</Text>
+    {TOC_ENTRIES.map((entry) => (
+      <View key={entry.label} style={styles.tocRow}>
+        <Text style={styles.tocLabel}>{entry.label}</Text>
+        <View style={styles.tocDots} />
+        <Text style={styles.tocPage}>{entry.page}</Text>
+      </View>
+    ))}
   </View>
 )
 
@@ -322,7 +431,7 @@ const DefinitionList = ({ items }: DefinitionListProps): React.JSX.Element => (
   <View>
     {items.map((item) => (
       <View key={item.title} style={{ marginBottom: 6 }}>
-        <Text style={styles.bulletText}>
+        <Text style={styles.defText}>
           <Text style={styles.defTerm}>{item.title}</Text>{' '}
           <Text style={{ color: COLORS.muted }}>{item.body}</Text>
         </Text>
@@ -381,33 +490,45 @@ export const CampaignPlanPdf = ({
       <View style={styles.coverWrapper}>
         <View style={styles.coverHeader}>
           <Logo size={70} />
-          <Text style={styles.wordmark}>GoodParty.org</Text>
-          <Text style={styles.wordmarkTagline}>
-            Empowering people to run, win, and serve
-          </Text>
+          <View style={{ height: 14 }} />
+          <View style={styles.coverHeaderInner}>
+            <Text style={styles.wordmark}>GoodParty.org</Text>
+            <Text style={styles.wordmarkTagline}>
+              Empowering people to run, win, and serve
+            </Text>
+          </View>
         </View>
 
         <View style={styles.coverDivider} />
 
-        <Text style={styles.coverEyebrow}>Campaign Plan</Text>
-        <Text style={styles.coverCandidate}>{plan.candidateName}</Text>
-        {plan.race ? (
-          <Text style={styles.coverRace}>for {plan.race}</Text>
-        ) : null}
-        {plan.location ? (
-          <Text style={styles.coverLocation}>{plan.location}</Text>
-        ) : null}
-        {plan.electionDate ? (
-          <Text style={styles.coverElection}>
-            Election Day: {plan.electionDate}
-          </Text>
-        ) : null}
+        <View style={styles.coverTitleBlock}>
+          <Text style={styles.coverEyebrow}>Campaign Plan</Text>
+          <Text style={styles.coverCandidate}>{plan.candidateName}</Text>
+          {plan.race ? (
+            <Text style={styles.coverRace}>for {plan.race}</Text>
+          ) : null}
+          {plan.location ? (
+            <Text style={styles.coverLocation}>{plan.location}</Text>
+          ) : null}
+          {plan.electionDate ? (
+            <Text style={styles.coverElection}>
+              Election Day: {plan.electionDate}
+            </Text>
+          ) : null}
+        </View>
       </View>
 
       <Text style={styles.coverFooter}>
         Plan prepared by GoodParty.org&apos;s Win Campaign Intelligence System
         using public voter data and historical election results.
       </Text>
+    </Page>
+
+    {/* Table of Contents */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <TableOfContents />
+      <PageFooter />
     </Page>
 
     {/* 1. Executive Summary */}

--- a/app/dashboard/strategy/components/CampaignPlanPdf.tsx
+++ b/app/dashboard/strategy/components/CampaignPlanPdf.tsx
@@ -503,12 +503,12 @@ export const CampaignPlanPdf = ({
 
         <View style={styles.coverTitleBlock}>
           <Text style={styles.coverEyebrow}>Campaign Plan</Text>
-          <Text style={styles.coverCandidate}>{plan.candidateName}</Text>
-          {plan.race ? (
-            <Text style={styles.coverRace}>for {plan.race}</Text>
-          ) : null}
-          {plan.location ? (
-            <Text style={styles.coverLocation}>{plan.location}</Text>
+          <Text style={styles.coverCandidate}>
+            {plan.candidateName}
+            {plan.race ? ` for ${plan.race}` : ''}
+          </Text>
+          {plan.districtName ? (
+            <Text style={styles.coverRace}>{plan.districtName}</Text>
           ) : null}
           {plan.electionDate ? (
             <Text style={styles.coverElection}>
@@ -519,8 +519,9 @@ export const CampaignPlanPdf = ({
       </View>
 
       <Text style={styles.coverFooter}>
-        Plan prepared by GoodParty.org&apos;s Win Campaign Intelligence System
-        using public voter data and historical election results.
+        Campaign plan prepared for {plan.candidateName} on{' '}
+        {plan.planGenerationDate} by GoodParty.org&apos;s Campaign Intelligence
+        System using public voter data and historical election results.
       </Text>
     </Page>
 
@@ -536,43 +537,40 @@ export const CampaignPlanPdf = ({
       <PageHeader plan={plan} />
       <SectionHeader number={1} title="Executive Summary" />
       <Text style={styles.paraMuted}>
-        This page is the whole plan in one view. If the candidate reads nothing
-        else, read this.
+        This is the whole plan in one view. If you read nothing else, read
+        this.
       </Text>
 
+      {/*
+        The Race intro has three variants in the source doc; only variant 2
+        (>= 1 opponent, no incumbent) is rendered here, locked to 2 opponents
+        for this prototype. See planContent.ts and PlanSections.tsx for the
+        full variant list.
+      */}
       <Text style={styles.subTitle}>The Race</Text>
       <Text style={styles.para}>
-        {plan.candidateName} is running for {plan.race}
-        {plan.location ? ` in ${plan.location}` : ''}. The race is nonpartisan
-        with {plan.opponentCount} opponents. Election Day is {plan.electionDate}
-        . Because the electorate is small and no party cue appears on the
-        ballot, the race is decided by name recognition and turnout, not
-        ideological persuasion.
+        You are running for {plan.race} representing {plan.districtName}. As of{' '}
+        {plan.planGenerationDate}, the race is a nonpartisan election with 2
+        opponents. Election Day is {plan.electionDate}. Because the electorate
+        is small and no party cue appears on the ballot, the race is decided by
+        name recognition and turnout, not by ideological persuasion.
       </Text>
 
-      <Text style={styles.subTitle}>The Win Condition</Text>
+      <Text style={styles.subTitle}>Projected Votes to Win</Text>
       <Text style={styles.para}>
         Our modeling projects voter turnout of{' '}
-        {plan.projectedTurnout.toLocaleString('en-US')} (±10%), putting the
-        threshold for a guaranteed win at{' '}
-        {plan.winNumber.toLocaleString('en-US')} votes, a conservative 50% + 1
-        target. Hitting that target requires{' '}
-        {plan.voterContactGoal.toLocaleString('en-US')} quality voter touches
-        across the cycle, delivered through matched phone data plus in-person
-        visibility and earned media.
+        {plan.projectedTurnout.toLocaleString('en-US')} voters, putting the
+        threshold for a win at {plan.winNumber.toLocaleString('en-US')} votes, a
+        simple majority of voters (50% + 1) who actually cast a ballot. This is
+        the lowest amount of votes we project you need to win your election;
+        the plan below will guide you toward surpassing that number. Hitting
+        that target requires {plan.voterContactGoal.toLocaleString('en-US')}{' '}
+        voter contacts across the cycle (roughly 5 contacts per targeted
+        voter).
       </Text>
 
-      <Text style={styles.subTitle}>Strategy at a Glance</Text>
-      <DefinitionList items={plan.strategyBullets} />
-
-      <Text style={styles.subTitle}>Key Numbers</Text>
-      <Table
-        columns={[
-          { label: 'Metric', flex: 2 },
-          { label: 'Target', flex: 1, bold: true },
-        ]}
-        rows={plan.keyNumbers.map((n) => [n.metric, n.target])}
-      />
+      <Text style={styles.subTitle}>Campaign Plan at a Glance</Text>
+      <DefinitionList items={plan.planAtAGlance} />
 
       <PageFooter />
     </Page>
@@ -581,18 +579,26 @@ export const CampaignPlanPdf = ({
     <Page size="LETTER" style={styles.page}>
       <PageHeader plan={plan} />
 
-      <Text style={styles.subTitle}>Timeline Highlights</Text>
-      <BulletList
-        items={plan.timelineHighlights.map(
-          (h) => `${h.date}. ${h.description}`,
-        )}
+      <Text style={styles.subTitle}>Key Campaign Targets</Text>
+      <Table
+        columns={[
+          { label: 'Metric', flex: 2 },
+          { label: 'Target', flex: 1, bold: true },
+        ]}
+        rows={plan.keyCampaignTargets.map((t) => [t.metric, t.target])}
       />
 
-      <Text style={styles.subTitle}>What You Must Commit Personally</Text>
-      <BulletList items={plan.candidateCommitments} />
+      <Text style={styles.subTitle}>Key Dates</Text>
+      <BulletList
+        items={plan.keyDates.map((d) => `${d.date}. ${d.description}`)}
+      />
 
-      <Text style={styles.subTitle}>Biggest Risks</Text>
-      <DefinitionList items={plan.biggestRisks} />
+      <Text style={styles.paraMuted}>
+        The race is mapped by your opponents, your projected votes to win, and
+        your timeline. What shapes everything else is you. Continue to your
+        Campaign HQ and we&apos;ll help rebuild this plan around you
+        specifically.
+      </Text>
 
       <PageFooter />
     </Page>
@@ -602,10 +608,9 @@ export const CampaignPlanPdf = ({
       <PageHeader plan={plan} />
       <SectionHeader number={2} title="Strategic Landscape" />
       <Text style={styles.para}>
-        Your district is a small, often nonpartisan electorate where name
-        recognition and turnout, not ideological persuasion, decide most races.
-        The following opportunities and challenges are framed against that
-        reality.
+        {plan.districtName} is an electorate where name recognition and turnout
+        (not ideological persuasion) decide most races. The following
+        opportunities and challenges are framed against that reality.
       </Text>
 
       <Text style={styles.subTitle}>Opportunities</Text>
@@ -614,13 +619,33 @@ export const CampaignPlanPdf = ({
       <Text style={styles.subTitle}>Challenges</Text>
       <DefinitionList items={plan.challenges} />
 
-      <Text style={styles.subTitle}>Competitive Read</Text>
-      <Text style={styles.para}>
-        This plan is deliberately opponent-agnostic. The campaign should produce
-        a brief opponent memo covering each opponent&apos;s name-recognition
-        baseline, their top one or two public positions, and any obvious
-        coalitions they are courting. Until that memo exists, the plan assumes a
-        neutral split and optimizes for your own turnout.
+      {plan.opponents.length > 0 ? (
+        <>
+          <Text style={styles.subTitle}>Opposition Research</Text>
+          {plan.opponents.map((opp) => (
+            <View key={opp.name} style={{ marginBottom: 8 }}>
+              <Text style={[styles.defText, styles.defTerm]}>{opp.name}</Text>
+              <BulletList
+                items={[
+                  `Party: ${opp.party}`,
+                  ...(opp.isIncumbent
+                    ? [
+                        `Incumbent — received ${opp.lastVoteShare} of the vote last cycle`,
+                      ]
+                    : []),
+                  ...opp.positions.map((p) => `Position: ${p}`),
+                  ...opp.websites.map((w) => `Website: ${w}`),
+                ]}
+              />
+            </View>
+          ))}
+        </>
+      ) : null}
+
+      <Text style={styles.paraMuted}>
+        The strategic landscape is drawn from public data and historical
+        election results. Head to your Campaign HQ to share your platform and
+        we&apos;ll reframe the opportunities and challenges around it.
       </Text>
 
       <PageFooter />
@@ -683,9 +708,9 @@ export const CampaignPlanPdf = ({
         columns={[
           { label: 'Date', flex: 1.4 },
           { label: 'Milestone', flex: 3 },
-          { label: 'Owner / Notes', flex: 2, muted: true },
+          { label: 'Notes', flex: 2, muted: true },
         ]}
-        rows={plan.timeline.map((t) => [t.date, t.milestone, t.owner])}
+        rows={plan.timeline.map((t) => [t.date, t.milestone, t.notes])}
       />
 
       <PageFooter />
@@ -698,10 +723,9 @@ export const CampaignPlanPdf = ({
       <Text style={styles.para}>
         The recommended total campaign budget is approximately $
         {plan.totalBudget.toLocaleString('en-US')}, calculated from a
-        cost-per-vote benchmark of roughly $3 to $4 per targeted voter across
-        all digital and phone channels, rounded for planning clarity. Every
-        dollar should be directed toward high-impact outreach that drives name
-        recognition and turnout.
+        cost-per-campaign benchmark across all channels. Every dollar should be
+        directed toward high-impact contact that drives name recognition and
+        turnout.
       </Text>
 
       <Text style={styles.subTitle}>Line-Item Breakdown</Text>
@@ -718,8 +742,21 @@ export const CampaignPlanPdf = ({
         ])}
       />
 
-      <Text style={styles.subTitle}>What This Budget Does Not Cover</Text>
-      <DefinitionList items={plan.budgetNotCovered} />
+      <Text style={styles.subTitle}>How to Raise This</Text>
+      <Text style={styles.para}>
+        ${plan.totalBudget.toLocaleString('en-US')} sounds like real money. For
+        most candidates at this level, it comes from a surprisingly small
+        number of people, typically 20 to 40 donors giving $25 to $100 each.
+        The right fundraising mix is candidate-specific, but the default
+        starting mix for a race like yours looks like this:
+      </Text>
+      <Table
+        columns={[
+          { label: 'Source', flex: 2 },
+          { label: 'Share', flex: 1, bold: true },
+        ]}
+        rows={plan.fundraisingMix.map((f) => [f.source, f.share])}
+      />
 
       <PageFooter />
     </Page>
@@ -735,31 +772,47 @@ export const CampaignPlanPdf = ({
         channel at this budget.
       </Text>
 
-      <Text style={styles.subTitle}>Civic Events</Text>
+      <Text style={styles.subTitle}>Community Events</Text>
       <Table
         columns={[
           { label: 'Event', flex: 2 },
+          { label: 'Address', flex: 2, muted: true },
           { label: 'Date', flex: 1 },
           { label: 'Why It Matters', flex: 3, muted: true },
         ]}
-        rows={plan.civicEvents.map((e) => [e.event, e.date, e.why])}
+        rows={plan.civicEvents.map((e) => [
+          e.event,
+          e.address,
+          e.date,
+          e.why,
+        ])}
       />
 
-      <Text style={styles.subTitle}>Press / Media Outlets</Text>
+      <Text style={styles.subTitle}>Press & Media Outlets</Text>
+      <Text style={styles.para}>
+        Target at least one earned-media placement per week between{' '}
+        {plan.contactWindowStart || '{12_weeks_before_election_date}'} and{' '}
+        {plan.electionDate || '{election_date}'}.
+      </Text>
       <Table
         columns={[
           { label: 'Outlet', flex: 2 },
           { label: 'Type', flex: 2, muted: true },
           { label: 'Pitch Angle', flex: 3, muted: true },
+          { label: 'Contact', flex: 2, muted: true },
         ]}
-        rows={plan.pressOutlets.map((o) => [o.outlet, o.type, o.angle])}
+        rows={plan.pressOutlets.map((o) => [
+          o.outlet,
+          o.type,
+          o.angle,
+          o.contact,
+        ])}
       />
 
-      <Text style={styles.para}>
-        Target at least one earned-media placement per week during the final
-        month. Prepare a single-page fact sheet and two short op-ed drafts
-        (under 200 words) that can be tailored quickly to each outlet&apos;s
-        editorial voice.
+      <Text style={styles.paraMuted}>
+        These are your highest-value rooms and your best media targets. Tell us
+        why you&apos;re running in Campaign HQ and we&apos;ll turn this list
+        into talking points and a press pitch.
       </Text>
 
       <PageFooter />
@@ -771,44 +824,36 @@ export const CampaignPlanPdf = ({
       <SectionHeader number={7} title="Voter Contact Plan" />
       <Text style={styles.para}>
         The contact cadence below is designed so every likely voter receives at
-        least one introductory touch before mail ballots arrive, at least one
-        deadline reminder, and at least one Election-Day push. Peer-to-peer
-        texts are the primary workhorse. Robocalls layer on top to catch
-        landline-only voters.
+        least one introductory voter contact, at least one persuasion voter
+        contact, at least one early vote reminder, and at least one Election
+        Day push. Texts are the primary workhorse; robocalls layer on top to
+        catch landline-only voters.
       </Text>
 
       <Table
         columns={[
-          { label: 'Date', flex: 1.2 },
-          { label: 'Tactic', flex: 1.2 },
-          { label: 'Audience', flex: 1.6, muted: true },
-          { label: 'Purpose', flex: 2.5, muted: true },
-          { label: 'Format', flex: 1.5, muted: true },
+          { label: 'Date', flex: 1.4 },
+          { label: 'Tactic', flex: 1.2, bold: true },
+          { label: 'Purpose', flex: 3, muted: true },
         ]}
-        rows={plan.contactSchedule.map((s) => [
-          s.date,
-          s.tactic,
-          s.audience,
-          s.purpose,
-          s.format,
-        ])}
+        rows={plan.contactSchedule.map((s) => [s.date, s.tactic, s.purpose])}
       />
 
-      <Text style={styles.subTitle}>Expected Yield</Text>
+      <Text style={styles.subTitle}>Expected Outcome</Text>
       <Text style={styles.para}>
-        Across these sends, the plan produces approximately{' '}
-        {plan.voterContactGoal.toLocaleString('en-US')} quality touches against
-        your voter universe, an average of roughly {plan.averageTouchesPerVoter}{' '}
-        contacts per likely voter. Expected realized contact (accounting for
-        deliverability and answer rates) is 60 to 70 percent of attempts.
+        Across 7 voter contact campaigns, this plan produces over{' '}
+        {plan.voterContactGoal.toLocaleString('en-US')} voter contacts against
+        the group of {plan.winNumber.toLocaleString('en-US')} voters, more than
+        the 5 contacts per likely voter. Expected realized contact (accounting
+        for deliverability and answer rates) is ~60–70% of voter contacts,
+        which clears the threshold for reliable name recognition in a
+        nonpartisan race.
       </Text>
 
-      <Text style={styles.subTitle}>Message Discipline</Text>
-      <Text style={styles.para}>
-        Every send should carry the same three elements: your name in the first
-        line, one concrete local issue (the same issue every time), and a single
-        clear ask (register, request a ballot, vote on Election Day). Variation
-        across sends dilutes recognition. Consistency is the point.
+      <Text style={styles.paraMuted}>
+        This plan puts you in front of every likely voter at the right moment.
+        Once you share your issues in Campaign HQ, we&apos;ll help you build
+        the message for each campaign so all you need to do is schedule it.
       </Text>
 
       <PageFooter />
@@ -819,19 +864,27 @@ export const CampaignPlanPdf = ({
       <PageHeader plan={plan} />
       <SectionHeader number={8} title="Measurement & Accountability" />
       <Text style={styles.para}>
-        Your campaign manager should review the KPI dashboard every Monday and
-        report variances against target the same day. The goal is not to hit
-        every number exactly, but to catch trends early enough to reallocate
-        effort.
+        Every week, log into your Campaign HQ to check your progress. We
+        estimate the number of likely votes you are on track to receive based
+        on the activity you complete. For every 5 voter contacts you make, we
+        count that as 1 likely vote in your election.
+      </Text>
+      <Text style={styles.para}>
+        This number will grow as you work through your voter contact plan. It
+        will never reach 100% — that is by design. No campaign plan can
+        guarantee an outcome, and there is always another action you can take
+        to increase your chances of winning. What this will do is show you
+        clearly whether you are on pace, ahead, or behind, and give you time
+        to adjust before it is too late.
       </Text>
 
-      <Table
-        columns={[
-          { label: 'KPI', flex: 2.5 },
-          { label: 'Target', flex: 2, bold: true },
-          { label: 'Review Cadence', flex: 1.6, muted: true },
+      <Text style={styles.subTitle}>How to read your progress</Text>
+      <BulletList
+        items={[
+          'If your likely votes are tracking toward your projected votes to win, stay the course.',
+          'If you are falling behind, prioritize scheduling your next text or robocall campaign and look for additional outreach opportunities.',
+          'Check in at least once a week — small gaps caught early are easy to close; the same gap caught in the final week is not.',
         ]}
-        rows={plan.kpis.map((k) => [k.kpi, k.target, k.cadence])}
       />
 
       <PageFooter />

--- a/app/dashboard/strategy/components/CampaignPlanPdf.tsx
+++ b/app/dashboard/strategy/components/CampaignPlanPdf.tsx
@@ -1,0 +1,793 @@
+/* eslint-disable jsx-a11y/alt-text */
+import {
+  Document,
+  Font,
+  Page,
+  Path,
+  StyleSheet,
+  Svg,
+  Text,
+  View,
+} from '@react-pdf/renderer'
+import type { PlanData } from './planContent'
+
+// Open Sans (matches the app's typography). TTF files served from jsdelivr's
+// mirror of @fontsource/open-sans.
+Font.register({
+  family: 'Open Sans',
+  fonts: [
+    {
+      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-400-normal.woff',
+      fontWeight: 'normal',
+    },
+    {
+      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-600-normal.woff',
+      fontWeight: 'semibold',
+    },
+    {
+      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-700-normal.woff',
+      fontWeight: 'bold',
+    },
+    {
+      src: 'https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5.0.21/files/open-sans-latin-400-italic.woff',
+      fontStyle: 'italic',
+    },
+  ],
+})
+
+const COLORS = {
+  text: '#0a0a0a',
+  muted: '#737373',
+  brand: '#2563eb',
+  divider: '#e5e7eb',
+  tableHead: '#f5f5f5',
+}
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: 56,
+    paddingBottom: 64,
+    paddingHorizontal: 56,
+    fontFamily: 'Open Sans',
+    fontSize: 10,
+    color: COLORS.text,
+    lineHeight: 1.5,
+  },
+  coverWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  coverHeader: { alignItems: 'center', marginBottom: 32 },
+  wordmark: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: COLORS.text,
+    marginTop: 14,
+  },
+  wordmarkTagline: {
+    fontSize: 9,
+    letterSpacing: 2,
+    color: COLORS.muted,
+    marginTop: 6,
+    textTransform: 'uppercase',
+  },
+  coverDivider: {
+    width: '100%',
+    height: 1,
+    backgroundColor: COLORS.divider,
+    marginVertical: 32,
+  },
+  coverEyebrow: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    letterSpacing: 4,
+    textTransform: 'uppercase',
+    marginBottom: 18,
+  },
+  coverCandidate: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: COLORS.brand,
+    marginBottom: 4,
+  },
+  coverRace: { fontSize: 14, marginBottom: 4 },
+  coverLocation: { fontSize: 12, color: COLORS.muted },
+  coverElection: {
+    fontSize: 11,
+    color: COLORS.muted,
+    fontStyle: 'italic',
+    marginTop: 10,
+  },
+  coverFooter: {
+    position: 'absolute',
+    bottom: 56,
+    left: 56,
+    right: 56,
+    textAlign: 'center',
+    fontSize: 9,
+    color: COLORS.muted,
+    fontStyle: 'italic',
+  },
+  pageHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.divider,
+    paddingBottom: 8,
+    marginBottom: 18,
+  },
+  pageHeaderBrand: { flexDirection: 'row', alignItems: 'center' },
+  pageHeaderBrandText: {
+    fontSize: 10,
+    fontWeight: 'bold',
+    marginLeft: 6,
+  },
+  pageHeaderRace: { fontSize: 9, color: COLORS.muted },
+  sectionEyebrow: {
+    fontSize: 8,
+    letterSpacing: 2,
+    color: COLORS.brand,
+    textTransform: 'uppercase',
+    marginBottom: 4,
+    fontWeight: 'semibold',
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 14,
+  },
+  subTitle: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    marginTop: 14,
+    marginBottom: 6,
+  },
+  para: {
+    fontSize: 10,
+    lineHeight: 1.55,
+    color: COLORS.text,
+    marginBottom: 8,
+  },
+  paraMuted: {
+    fontSize: 10,
+    lineHeight: 1.55,
+    color: COLORS.muted,
+    marginBottom: 8,
+    fontStyle: 'italic',
+  },
+  bullet: {
+    flexDirection: 'row',
+    marginBottom: 4,
+  },
+  bulletDot: { width: 8, fontSize: 10 },
+  bulletText: { flex: 1, fontSize: 10, lineHeight: 1.5 },
+  defTerm: { fontWeight: 'bold' },
+  table: {
+    borderTopWidth: 1,
+    borderTopColor: COLORS.divider,
+    marginTop: 4,
+  },
+  tableHead: {
+    flexDirection: 'row',
+    backgroundColor: COLORS.tableHead,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.divider,
+  },
+  tableHeadCell: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    fontSize: 9,
+    fontWeight: 'bold',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.divider,
+  },
+  tableCell: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    fontSize: 9,
+  },
+  tableCellBold: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    fontSize: 9,
+    fontWeight: 'bold',
+  },
+  tableCellMuted: {
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    fontSize: 9,
+    color: COLORS.muted,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 32,
+    left: 56,
+    right: 56,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    fontSize: 8,
+    color: COLORS.muted,
+  },
+  glossary: {
+    borderTopWidth: 1,
+    borderTopColor: COLORS.divider,
+  },
+  glossaryRow: {
+    flexDirection: 'row',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.divider,
+  },
+  glossaryTerm: {
+    width: 150,
+    paddingRight: 12,
+    fontSize: 10,
+    fontWeight: 'bold',
+  },
+  glossaryDef: { flex: 1, fontSize: 10, color: COLORS.muted, lineHeight: 1.5 },
+})
+
+interface LogoProps {
+  size?: number
+}
+
+const Logo = ({ size = 56 }: LogoProps): React.JSX.Element => {
+  const width = size
+  const height = (size / 160) * 130
+  return (
+    <Svg width={width} height={height} viewBox="0 0 160 130">
+      <Path
+        d="M80.014 123.163C112.708 107.269 134.411 89.4353 145.494 71.1394C154.822 55.6157 156.023 40.554 150.112 28.0795C144.755 16.8063 133.95 8.76726 121.389 6.64199C107.998 4.42431 94.4216 9.13688 83.7084 20.8721L79.9217 24.9378L76.1351 20.8721C65.3295 9.13688 51.7533 4.42431 38.4541 6.64199C25.9861 8.67486 15.0881 16.8063 9.73147 28.0795C3.82072 40.4616 5.02134 55.6157 14.3493 71.1394C25.4319 89.4353 47.1356 107.269 79.8294 123.163H80.014Z"
+        fill="#FFFFFF"
+      />
+      <Path
+        fillRule="evenodd"
+        d="M80.0134 15.882C68.0995 3.40753 52.7686 -1.95188 37.5299 0.635414C23.0301 3.0379 10.4697 12.3707 4.18954 25.4919C-2.73713 40.184 -1.07479 57.5559 9.17668 74.3733C21.0905 94.1476 44.0871 112.628 77.3351 128.706L80.0134 130L82.6918 128.706C115.94 112.536 138.844 94.0552 150.85 74.3733C161.009 57.5559 162.764 40.184 155.837 25.4919C149.557 12.2782 136.997 3.0379 122.497 0.635414C107.258 -1.85947 91.9272 3.40753 80.0134 15.882ZM71.609 25.2147C62.0964 14.8656 50.5519 11.077 39.4693 12.9251C28.9408 14.6807 19.7975 21.5185 15.3645 30.8513C10.562 41.0156 11.2085 53.8597 19.7052 67.9974C29.5872 84.3528 49.259 100.985 79.9211 116.232C110.583 100.985 130.163 84.3528 140.137 67.9974C148.726 53.8597 149.28 41.0156 144.478 30.8513C140.045 21.4261 130.901 14.6807 120.373 12.9251C109.29 11.077 97.7456 14.8656 88.233 25.2147L79.9211 34.2702L71.609 25.2147Z"
+        fill="#DC1438"
+      />
+      <Path
+        d="M76.6892 78.5324L67.8232 83.1525C66.8996 83.6146 65.7913 83.2449 65.3295 82.4133C65.1448 82.0437 65.0524 81.6741 65.1448 81.2121L66.8073 71.5097C67.1767 69.1996 66.4378 66.8896 64.7754 65.3187L57.5717 58.3885C56.8329 57.6492 56.8329 56.5404 57.5717 55.8012C57.8488 55.524 58.2182 55.3392 58.6799 55.2468L68.6543 53.8607C70.9632 53.4911 72.9951 52.105 74.011 49.9797L78.444 41.109C78.9058 40.185 80.0141 39.8154 80.9377 40.2774C81.3071 40.4622 81.5841 40.7394 81.7688 41.109L86.2018 49.9797C87.2178 52.0126 89.2496 53.4911 91.5585 53.8607L101.533 55.2468C102.549 55.4316 103.288 56.3556 103.103 57.2796C103.103 57.6492 102.826 58.0188 102.549 58.296L95.3451 65.2263C93.6827 66.7971 92.8515 69.1997 93.3133 71.4174L94.9757 81.1197C95.1604 82.1361 94.5139 83.0602 93.498 83.245C93.1286 83.245 92.6668 83.2449 92.2973 83.0601L83.4313 78.44C81.3071 77.3311 78.8135 77.3311 76.7817 78.44L76.6892 78.5324Z"
+        fill="#0048C2"
+      />
+    </Svg>
+  )
+}
+
+interface PageHeaderProps {
+  plan: PlanData
+}
+
+const PageHeader = ({ plan }: PageHeaderProps): React.JSX.Element => (
+  <View style={styles.pageHeader} fixed>
+    <View style={styles.pageHeaderBrand}>
+      <Logo size={16} />
+      <Text style={styles.pageHeaderBrandText}>GoodParty.org</Text>
+    </View>
+    <Text style={styles.pageHeaderRace}>
+      {plan.candidateName} • {plan.race}
+    </Text>
+  </View>
+)
+
+const PageFooter = (): React.JSX.Element => (
+  <View style={styles.footer} fixed>
+    <Text>Prepared by GoodParty.org</Text>
+    <Text
+      render={({ pageNumber, totalPages }) => `${pageNumber} of ${totalPages}`}
+    />
+  </View>
+)
+
+interface SectionHeaderProps {
+  number: number
+  title: string
+}
+
+const SectionHeader = ({
+  number,
+  title,
+}: SectionHeaderProps): React.JSX.Element => (
+  <View>
+    <Text style={styles.sectionEyebrow}>Section {number}</Text>
+    <Text style={styles.sectionTitle}>{title}</Text>
+  </View>
+)
+
+interface BulletListProps {
+  items: string[]
+}
+
+const BulletList = ({ items }: BulletListProps): React.JSX.Element => (
+  <View>
+    {items.map((item) => (
+      <View key={item} style={styles.bullet} wrap={false}>
+        <Text style={styles.bulletDot}>•</Text>
+        <Text style={styles.bulletText}>{item}</Text>
+      </View>
+    ))}
+  </View>
+)
+
+interface DefinitionListProps {
+  items: { title: string; body: string }[]
+}
+
+const DefinitionList = ({ items }: DefinitionListProps): React.JSX.Element => (
+  <View>
+    {items.map((item) => (
+      <View key={item.title} style={{ marginBottom: 6 }}>
+        <Text style={styles.bulletText}>
+          <Text style={styles.defTerm}>{item.title}</Text>{' '}
+          <Text style={{ color: COLORS.muted }}>{item.body}</Text>
+        </Text>
+      </View>
+    ))}
+  </View>
+)
+
+interface TableProps {
+  columns: { label: string; flex?: number; bold?: boolean; muted?: boolean }[]
+  rows: string[][]
+}
+
+const Table = ({ columns, rows }: TableProps): React.JSX.Element => (
+  <View style={styles.table}>
+    <View style={styles.tableHead}>
+      {columns.map((col) => (
+        <Text
+          key={col.label}
+          style={[styles.tableHeadCell, { flex: col.flex ?? 1 }]}
+        >
+          {col.label}
+        </Text>
+      ))}
+    </View>
+    {rows.map((row, rIdx) => (
+      <View key={rIdx} style={styles.tableRow} wrap={false}>
+        {row.map((cell, cIdx) => {
+          const col = columns[cIdx]
+          const cellStyle = col?.bold
+            ? styles.tableCellBold
+            : col?.muted
+            ? styles.tableCellMuted
+            : styles.tableCell
+          return (
+            <Text key={cIdx} style={[cellStyle, { flex: col?.flex ?? 1 }]}>
+              {cell}
+            </Text>
+          )
+        })}
+      </View>
+    ))}
+  </View>
+)
+
+interface CampaignPlanPdfProps {
+  plan: PlanData
+}
+
+export const CampaignPlanPdf = ({
+  plan,
+}: CampaignPlanPdfProps): React.JSX.Element => (
+  <Document title="Campaign Plan" author="GoodParty.org">
+    {/* Cover */}
+    <Page size="LETTER" style={styles.page}>
+      <View style={styles.coverWrapper}>
+        <View style={styles.coverHeader}>
+          <Logo size={70} />
+          <Text style={styles.wordmark}>GoodParty.org</Text>
+          <Text style={styles.wordmarkTagline}>
+            Empowering people to run, win, and serve
+          </Text>
+        </View>
+
+        <View style={styles.coverDivider} />
+
+        <Text style={styles.coverEyebrow}>Campaign Plan</Text>
+        <Text style={styles.coverCandidate}>{plan.candidateName}</Text>
+        {plan.race ? (
+          <Text style={styles.coverRace}>for {plan.race}</Text>
+        ) : null}
+        {plan.location ? (
+          <Text style={styles.coverLocation}>{plan.location}</Text>
+        ) : null}
+        {plan.electionDate ? (
+          <Text style={styles.coverElection}>
+            Election Day: {plan.electionDate}
+          </Text>
+        ) : null}
+      </View>
+
+      <Text style={styles.coverFooter}>
+        Plan prepared by GoodParty.org&apos;s Win Campaign Intelligence System
+        using public voter data and historical election results.
+      </Text>
+    </Page>
+
+    {/* 1. Executive Summary */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={1} title="Executive Summary" />
+      <Text style={styles.paraMuted}>
+        This page is the whole plan in one view. If the candidate reads nothing
+        else, read this.
+      </Text>
+
+      <Text style={styles.subTitle}>The Race</Text>
+      <Text style={styles.para}>
+        {plan.candidateName} is running for {plan.race}
+        {plan.location ? ` in ${plan.location}` : ''}. The race is nonpartisan
+        with {plan.opponentCount} opponents. Election Day is {plan.electionDate}
+        . Because the electorate is small and no party cue appears on the
+        ballot, the race is decided by name recognition and turnout, not
+        ideological persuasion.
+      </Text>
+
+      <Text style={styles.subTitle}>The Win Condition</Text>
+      <Text style={styles.para}>
+        Our modeling projects voter turnout of{' '}
+        {plan.projectedTurnout.toLocaleString('en-US')} (±10%), putting the
+        threshold for a guaranteed win at{' '}
+        {plan.winNumber.toLocaleString('en-US')} votes, a conservative 50% + 1
+        target. Hitting that target requires{' '}
+        {plan.voterContactGoal.toLocaleString('en-US')} quality voter touches
+        across the cycle, delivered through matched phone data plus in-person
+        visibility and earned media.
+      </Text>
+
+      <Text style={styles.subTitle}>Strategy at a Glance</Text>
+      <DefinitionList items={plan.strategyBullets} />
+
+      <Text style={styles.subTitle}>Key Numbers</Text>
+      <Table
+        columns={[
+          { label: 'Metric', flex: 2 },
+          { label: 'Target', flex: 1, bold: true },
+        ]}
+        rows={plan.keyNumbers.map((n) => [n.metric, n.target])}
+      />
+
+      <PageFooter />
+    </Page>
+
+    {/* Executive Summary continued */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+
+      <Text style={styles.subTitle}>Timeline Highlights</Text>
+      <BulletList
+        items={plan.timelineHighlights.map(
+          (h) => `${h.date}. ${h.description}`,
+        )}
+      />
+
+      <Text style={styles.subTitle}>What You Must Commit Personally</Text>
+      <BulletList items={plan.candidateCommitments} />
+
+      <Text style={styles.subTitle}>Biggest Risks</Text>
+      <DefinitionList items={plan.biggestRisks} />
+
+      <PageFooter />
+    </Page>
+
+    {/* 2. Strategic Landscape */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={2} title="Strategic Landscape" />
+      <Text style={styles.para}>
+        Your district is a small, often nonpartisan electorate where name
+        recognition and turnout, not ideological persuasion, decide most races.
+        The following opportunities and challenges are framed against that
+        reality.
+      </Text>
+
+      <Text style={styles.subTitle}>Opportunities</Text>
+      <DefinitionList items={plan.opportunities} />
+
+      <Text style={styles.subTitle}>Challenges</Text>
+      <DefinitionList items={plan.challenges} />
+
+      <Text style={styles.subTitle}>Competitive Read</Text>
+      <Text style={styles.para}>
+        This plan is deliberately opponent-agnostic. The campaign should produce
+        a brief opponent memo covering each opponent&apos;s name-recognition
+        baseline, their top one or two public positions, and any obvious
+        coalitions they are courting. Until that memo exists, the plan assumes a
+        neutral split and optimizes for your own turnout.
+      </Text>
+
+      <PageFooter />
+    </Page>
+
+    {/* 3. Electoral Goals & Key Metrics */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={3} title="Electoral Goals & Key Metrics" />
+      <Text style={styles.para}>
+        These are the numbers the campaign will manage against. Each metric
+        includes its data source and the sensitivity we apply when
+        re-forecasting weekly.
+      </Text>
+
+      <Table
+        columns={[
+          { label: 'Metric', flex: 2 },
+          { label: 'Target', flex: 1, bold: true },
+          { label: 'Source / Formula', flex: 3, muted: true },
+        ]}
+        rows={plan.metrics.map((m) => [m.metric, m.target, m.source])}
+      />
+
+      <Text style={styles.subTitle}>Why 5x the Win Number?</Text>
+      <Text style={styles.para}>
+        The industry convention to plan for roughly five voter-contact attempts
+        per vote needed comes from two realities. First, not every attempt
+        reaches the voter. Second, voters typically need multiple exposures
+        before a name or message sticks. For a{' '}
+        {plan.winNumber.toLocaleString('en-US')}-vote target,{' '}
+        {plan.voterContactGoal.toLocaleString('en-US')} attempts yields roughly
+        two to three actual, memorable contacts per likely voter, the minimum
+        for reliable name recognition.
+      </Text>
+
+      <Text style={styles.subTitle}>Why a Volunteer-Hour Target?</Text>
+      <Text style={styles.para}>
+        Volunteer capacity, not money, is the binding constraint on most
+        small-precinct campaigns. The {plan.volunteerHourTarget}-hour floor is a
+        conservative estimate of what it takes to personally cover the
+        civic-event schedule, run a small door-knocking program, and monitor
+        Election Day operations.
+      </Text>
+
+      <PageFooter />
+    </Page>
+
+    {/* 4. Campaign Timeline */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={4} title="Campaign Timeline" />
+      <Text style={styles.para}>
+        Dates below are the hard gates the campaign must hit. Each is followed
+        by an internal working deadline (one week earlier wherever possible) to
+        preserve a buffer.
+      </Text>
+
+      <Table
+        columns={[
+          { label: 'Date', flex: 1.4 },
+          { label: 'Milestone', flex: 3 },
+          { label: 'Owner / Notes', flex: 2, muted: true },
+        ]}
+        rows={plan.timeline.map((t) => [t.date, t.milestone, t.owner])}
+      />
+
+      <PageFooter />
+    </Page>
+
+    {/* 5. Recommended Budget */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={5} title="Recommended Budget" />
+      <Text style={styles.para}>
+        The recommended total campaign budget is approximately $
+        {plan.totalBudget.toLocaleString('en-US')}, calculated from a
+        cost-per-vote benchmark of roughly $3 to $4 per targeted voter across
+        all digital and phone channels, rounded for planning clarity. Every
+        dollar should be directed toward high-impact outreach that drives name
+        recognition and turnout.
+      </Text>
+
+      <Text style={styles.subTitle}>Line-Item Breakdown</Text>
+      <Table
+        columns={[
+          { label: 'Category', flex: 2 },
+          { label: 'Amount', flex: 1, bold: true },
+          { label: 'Rationale', flex: 3, muted: true },
+        ]}
+        rows={plan.budgetLineItems.map((b) => [
+          b.category,
+          b.amount,
+          b.rationale,
+        ])}
+      />
+
+      <Text style={styles.subTitle}>What This Budget Does Not Cover</Text>
+      <DefinitionList items={plan.budgetNotCovered} />
+
+      <PageFooter />
+    </Page>
+
+    {/* 6. Community Engagement & Earned Media */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={6} title="Community Engagement & Earned Media" />
+      <Text style={styles.para}>
+        Earned media and in-person visibility are the highest-ROI channels in a
+        race this size. A single mention in a local outlet or a strong showing
+        at a civic association meeting can move more voters than any paid
+        channel at this budget.
+      </Text>
+
+      <Text style={styles.subTitle}>Civic Events</Text>
+      <Table
+        columns={[
+          { label: 'Event', flex: 2 },
+          { label: 'Date', flex: 1 },
+          { label: 'Why It Matters', flex: 3, muted: true },
+        ]}
+        rows={plan.civicEvents.map((e) => [e.event, e.date, e.why])}
+      />
+
+      <Text style={styles.subTitle}>Press / Media Outlets</Text>
+      <Table
+        columns={[
+          { label: 'Outlet', flex: 2 },
+          { label: 'Type', flex: 2, muted: true },
+          { label: 'Pitch Angle', flex: 3, muted: true },
+        ]}
+        rows={plan.pressOutlets.map((o) => [o.outlet, o.type, o.angle])}
+      />
+
+      <Text style={styles.para}>
+        Target at least one earned-media placement per week during the final
+        month. Prepare a single-page fact sheet and two short op-ed drafts
+        (under 200 words) that can be tailored quickly to each outlet&apos;s
+        editorial voice.
+      </Text>
+
+      <PageFooter />
+    </Page>
+
+    {/* 7. Voter Contact Plan */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={7} title="Voter Contact Plan" />
+      <Text style={styles.para}>
+        The contact cadence below is designed so every likely voter receives at
+        least one introductory touch before mail ballots arrive, at least one
+        deadline reminder, and at least one Election-Day push. Peer-to-peer
+        texts are the primary workhorse. Robocalls layer on top to catch
+        landline-only voters.
+      </Text>
+
+      <Table
+        columns={[
+          { label: 'Date', flex: 1.2 },
+          { label: 'Tactic', flex: 1.2 },
+          { label: 'Audience', flex: 1.6, muted: true },
+          { label: 'Purpose', flex: 2.5, muted: true },
+          { label: 'Format', flex: 1.5, muted: true },
+        ]}
+        rows={plan.contactSchedule.map((s) => [
+          s.date,
+          s.tactic,
+          s.audience,
+          s.purpose,
+          s.format,
+        ])}
+      />
+
+      <Text style={styles.subTitle}>Expected Yield</Text>
+      <Text style={styles.para}>
+        Across these sends, the plan produces approximately{' '}
+        {plan.voterContactGoal.toLocaleString('en-US')} quality touches against
+        your voter universe, an average of roughly {plan.averageTouchesPerVoter}{' '}
+        contacts per likely voter. Expected realized contact (accounting for
+        deliverability and answer rates) is 60 to 70 percent of attempts.
+      </Text>
+
+      <Text style={styles.subTitle}>Message Discipline</Text>
+      <Text style={styles.para}>
+        Every send should carry the same three elements: your name in the first
+        line, one concrete local issue (the same issue every time), and a single
+        clear ask (register, request a ballot, vote on Election Day). Variation
+        across sends dilutes recognition. Consistency is the point.
+      </Text>
+
+      <PageFooter />
+    </Page>
+
+    {/* 8. Measurement & Accountability */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={8} title="Measurement & Accountability" />
+      <Text style={styles.para}>
+        Your campaign manager should review the KPI dashboard every Monday and
+        report variances against target the same day. The goal is not to hit
+        every number exactly, but to catch trends early enough to reallocate
+        effort.
+      </Text>
+
+      <Table
+        columns={[
+          { label: 'KPI', flex: 2.5 },
+          { label: 'Target', flex: 2, bold: true },
+          { label: 'Review Cadence', flex: 1.6, muted: true },
+        ]}
+        rows={plan.kpis.map((k) => [k.kpi, k.target, k.cadence])}
+      />
+
+      <PageFooter />
+    </Page>
+
+    {/* 9. Methodology & Data Sources */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={9} title="Methodology & Data Sources" />
+      <Text style={styles.para}>
+        This plan was produced by GoodParty.org&apos;s automated
+        campaign-intelligence pipeline. Every metric in this document is an
+        estimate derived from the sources below. Where applicable, we include a
+        best-estimate confidence interval so you can understand how firm each
+        number is.
+      </Text>
+
+      <Text style={styles.subTitle}>Data Sources</Text>
+      <Table
+        columns={[
+          { label: 'Metric', flex: 2 },
+          { label: 'Source', flex: 3, muted: true },
+          { label: 'Last Updated', flex: 1.4, muted: true },
+        ]}
+        rows={plan.dataSources.map((d) => [d.metric, d.source, d.lastUpdated])}
+      />
+
+      <Text style={styles.subTitle}>Key Assumptions</Text>
+      <BulletList items={plan.keyAssumptions} />
+
+      <PageFooter />
+    </Page>
+
+    {/* Methodology continued */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+
+      <Text style={styles.subTitle}>Confidence & Standard Error</Text>
+      <Table
+        columns={[
+          { label: 'Estimate', flex: 2.5 },
+          { label: 'Point Value', flex: 1.2, bold: true },
+          { label: 'Estimated Range', flex: 1.8, muted: true },
+          { label: 'Notes', flex: 2.5, muted: true },
+        ]}
+        rows={plan.confidenceEstimates.map((c) => [
+          c.estimate,
+          c.pointValue,
+          c.range,
+          c.notes,
+        ])}
+      />
+      <Text style={styles.paraMuted}>
+        Standard-error ranges reflect modeling uncertainty only. They do not
+        account for late-breaking external events. Treat the point values as
+        planning numbers and revisit weekly as turnout signals harden.
+      </Text>
+
+      <Text style={styles.subTitle}>What This Plan Does Not Do</Text>
+      <BulletList items={plan.planDoesNotDo} />
+
+      <PageFooter />
+    </Page>
+
+    {/* 10. Glossary */}
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader plan={plan} />
+      <SectionHeader number={10} title="Glossary" />
+      <View style={styles.glossary}>
+        {plan.glossary.map((g) => (
+          <View key={g.term} style={styles.glossaryRow} wrap={false}>
+            <Text style={styles.glossaryTerm}>{g.term}</Text>
+            <Text style={styles.glossaryDef}>{g.definition}</Text>
+          </View>
+        ))}
+      </View>
+      <PageFooter />
+    </Page>
+  </Document>
+)

--- a/app/dashboard/strategy/components/PlanInputs.tsx
+++ b/app/dashboard/strategy/components/PlanInputs.tsx
@@ -1,0 +1,279 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import {
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+} from '@styleguide'
+import { numberFormatter } from 'helpers/numberHelper'
+import type { PlanData } from './planContent'
+
+interface Volunteer {
+  id: string
+  name: string
+  hoursPerWeek: number
+}
+
+interface PlanInputsProps {
+  plan: PlanData
+}
+
+const formatDollars = (value: number): string =>
+  `$${numberFormatter(Math.round(value))}`
+
+const Gap = ({
+  children,
+}: {
+  children: React.ReactNode
+}): React.JSX.Element => (
+  <p className="text-xs text-muted-foreground">{children}</p>
+)
+
+const PlanInputs = ({ plan }: PlanInputsProps): React.JSX.Element => {
+  const [ballotStatus, setBallotStatus] = useState<'on-ballot' | 'not-yet'>(
+    'not-yet',
+  )
+  const [budgetRaised, setBudgetRaised] = useState('')
+  const [candidateHours, setCandidateHours] = useState('')
+  const [volunteers, setVolunteers] = useState<Volunteer[]>([])
+  const [newVolunteerName, setNewVolunteerName] = useState('')
+  const [newVolunteerHours, setNewVolunteerHours] = useState('')
+
+  const budgetRaisedNum = Number.parseFloat(budgetRaised)
+  const budgetValid = Number.isFinite(budgetRaisedNum) && budgetRaisedNum >= 0
+  const budgetGap = budgetValid
+    ? Math.max(0, plan.totalBudget - budgetRaisedNum)
+    : null
+
+  const candidateHoursNum = Number.parseFloat(candidateHours)
+  const candidateHoursValid =
+    Number.isFinite(candidateHoursNum) && candidateHoursNum >= 0
+  const candidateHoursGap = candidateHoursValid
+    ? Math.max(0, plan.candidateHoursPerWeek - candidateHoursNum)
+    : null
+
+  const totalVolunteerHours = volunteers.reduce(
+    (sum, v) => sum + (Number.isFinite(v.hoursPerWeek) ? v.hoursPerWeek : 0),
+    0,
+  )
+  const volunteerHoursGap = Math.max(
+    0,
+    plan.volunteerHoursPerWeek - totalVolunteerHours,
+  )
+
+  const handleAddVolunteer = () => {
+    const name = newVolunteerName.trim()
+    const hours = Number.parseFloat(newVolunteerHours)
+    if (!name || !Number.isFinite(hours) || hours <= 0) return
+    setVolunteers((prev) => [
+      ...prev,
+      {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        name,
+        hoursPerWeek: hours,
+      },
+    ])
+    setNewVolunteerName('')
+    setNewVolunteerHours('')
+  }
+
+  const handleRemoveVolunteer = (id: string) => {
+    setVolunteers((prev) => prev.filter((v) => v.id !== id))
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-foreground">
+            Where you are
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Tell us where things stand. We&apos;ll show you the gap to plan.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Are you on the ballot yet?</Label>
+          <RadioGroup
+            value={ballotStatus}
+            onValueChange={(v) =>
+              setBallotStatus(v === 'on-ballot' ? 'on-ballot' : 'not-yet')
+            }
+            className="flex gap-6"
+          >
+            <Label
+              htmlFor="ballot-on"
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <RadioGroupItem id="ballot-on" value="on-ballot" />
+              <span className="text-sm text-foreground">Yes, I&apos;m on</span>
+            </Label>
+            <Label
+              htmlFor="ballot-not-yet"
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <RadioGroupItem id="ballot-not-yet" value="not-yet" />
+              <span className="text-sm text-foreground">Not yet</span>
+            </Label>
+          </RadioGroup>
+          {ballotStatus === 'not-yet' && plan.filingDeadline ? (
+            <Gap>
+              Filing deadline:{' '}
+              <span className="font-semibold text-foreground">
+                {plan.filingDeadline}
+              </span>
+              . File before this date.
+            </Gap>
+          ) : null}
+          {ballotStatus === 'on-ballot' ? (
+            <Gap>You&apos;re cleared. Focus shifts to voter contact.</Gap>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="plan-budget-raised">
+            How much have you raised so far?
+          </Label>
+          <Input
+            id="plan-budget-raised"
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step="1"
+            placeholder="0"
+            value={budgetRaised}
+            onChange={(e) => setBudgetRaised(e.target.value)}
+          />
+          {budgetValid && budgetGap !== null ? (
+            <Gap>
+              {budgetGap === 0
+                ? `You're at or above the ${formatDollars(
+                    plan.totalBudget,
+                  )} target. Nice.`
+                : `Plan target: ${formatDollars(
+                    plan.totalBudget,
+                  )}. You need ${formatDollars(budgetGap)} more.`}
+            </Gap>
+          ) : (
+            <Gap>
+              Plan target:{' '}
+              <span className="font-semibold text-foreground">
+                {formatDollars(plan.totalBudget)}
+              </span>
+            </Gap>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="plan-candidate-hours">
+            Your canvassing hours per week
+          </Label>
+          <Input
+            id="plan-candidate-hours"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step="1"
+            placeholder="0"
+            value={candidateHours}
+            onChange={(e) => setCandidateHours(e.target.value)}
+          />
+          {candidateHoursValid && candidateHoursGap !== null ? (
+            <Gap>
+              {candidateHoursGap === 0
+                ? `You're at the ${plan.candidateHoursPerWeek}-hour target. Nice.`
+                : `Plan target: ${plan.candidateHoursPerWeek} hrs/week. You're ${candidateHoursGap} short.`}
+            </Gap>
+          ) : (
+            <Gap>
+              Plan target:{' '}
+              <span className="font-semibold text-foreground">
+                {plan.candidateHoursPerWeek} hrs/week
+              </span>
+            </Gap>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <Label>Your volunteers</Label>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Plan needs about{' '}
+              <span className="font-semibold text-foreground">
+                {plan.volunteerHoursPerWeek} volunteer hrs/week
+              </span>{' '}
+              to cover the doors you can&apos;t.
+            </p>
+          </div>
+
+          {volunteers.length > 0 ? (
+            <ul className="divide-y divide-base-border rounded-xl border border-base-border">
+              {volunteers.map((v) => (
+                <li
+                  key={v.id}
+                  className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+                >
+                  <div>
+                    <p className="font-medium text-foreground">{v.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {v.hoursPerWeek} hrs/week
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveVolunteer(v.id)}
+                    aria-label={`Remove ${v.name}`}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_120px_auto]">
+            <Input
+              type="text"
+              placeholder="Volunteer name"
+              value={newVolunteerName}
+              onChange={(e) => setNewVolunteerName(e.target.value)}
+            />
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step="1"
+              placeholder="Hrs/week"
+              value={newVolunteerHours}
+              onChange={(e) => setNewVolunteerHours(e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              icon={<Plus className="size-4" />}
+              onClick={handleAddVolunteer}
+            >
+              Add
+            </Button>
+          </div>
+
+          <Gap>
+            {volunteerHoursGap === 0
+              ? `You have ${totalVolunteerHours} volunteer hrs/week. You're at target.`
+              : `You have ${totalVolunteerHours} volunteer hrs/week. You need ${volunteerHoursGap} more.`}
+          </Gap>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PlanInputs

--- a/app/dashboard/strategy/components/PlanSectionNav.tsx
+++ b/app/dashboard/strategy/components/PlanSectionNav.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Download, Share2 } from 'lucide-react'
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@styleguide'
+
+export interface PlanSectionRef {
+  id: string
+  label: string
+}
+
+interface PlanSectionNavProps {
+  sections: PlanSectionRef[]
+  onDownload?: () => void
+  onShare?: () => void
+  downloading?: boolean
+  onStuckChange?: (stuck: boolean) => void
+}
+
+// Triggers a section as "active" when its top sits in the upper half of the
+// viewport, below the sticky nav.
+const OBSERVER_ROOT_MARGIN = '-120px 0px -55% 0px'
+
+const PlanSectionNav = ({
+  sections,
+  onDownload,
+  onShare,
+  downloading,
+  onStuckChange,
+}: PlanSectionNavProps): React.JSX.Element => {
+  const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? '')
+  const [isStuck, setIsStuck] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const onScroll = () => {
+      const top = el.getBoundingClientRect().top
+      setIsStuck(top <= 0)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  useEffect(() => {
+    onStuckChange?.(isStuck)
+  }, [isStuck, onStuckChange])
+
+  useEffect(() => {
+    if (sections.length === 0) return
+
+    const elements = sections
+      .map((s) => document.getElementById(s.id))
+      .filter((el): el is HTMLElement => el !== null)
+
+    if (elements.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort(
+            (a, b) =>
+              a.target.getBoundingClientRect().top -
+              b.target.getBoundingClientRect().top,
+          )
+        if (visible[0]) {
+          setActiveId(visible[0].target.id)
+        }
+      },
+      { rootMargin: OBSERVER_ROOT_MARGIN, threshold: 0 },
+    )
+
+    elements.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [sections])
+
+  const handleChange = (value: string) => {
+    setActiveId(value)
+    const el = document.getElementById(value)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={
+        isStuck
+          ? 'sticky top-0 z-30 mx-[calc(50%-50vw)] w-screen border-b border-base-border bg-base-surface'
+          : 'sticky top-0 z-30 rounded-xl border border-base-border bg-base-surface px-3 py-2 shadow-sm'
+      }
+    >
+      <div
+        className={
+          isStuck
+            ? 'mx-auto flex w-full max-w-4xl items-center gap-3 px-4 py-2 sm:px-8'
+            : ''
+        }
+      >
+        <div className={isStuck ? 'min-w-0 flex-1' : ''}>
+          <p className="px-1 pt-1 text-xs font-medium text-muted-foreground">
+            Jump to
+          </p>
+          <Select value={activeId} onValueChange={handleChange}>
+            <SelectTrigger className="h-10 w-full border-none px-1 shadow-none focus-visible:ring-0">
+              <SelectValue placeholder="Jump to a section" />
+            </SelectTrigger>
+            <SelectContent>
+              {sections.map((s) => (
+                <SelectItem key={s.id} value={s.id}>
+                  {s.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {isStuck && (onDownload || onShare) ? (
+          <div className="flex shrink-0 items-center gap-1">
+            {onDownload ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="medium"
+                icon={<Download className="size-5" />}
+                onClick={onDownload}
+                loading={downloading}
+                aria-label="Download campaign plan"
+              />
+            ) : null}
+            {onShare ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="medium"
+                icon={<Share2 className="size-5" />}
+                onClick={onShare}
+                aria-label="Share campaign plan"
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default PlanSectionNav

--- a/app/dashboard/strategy/components/PlanSections.tsx
+++ b/app/dashboard/strategy/components/PlanSections.tsx
@@ -26,11 +26,8 @@ const Section = ({
   children,
   transition,
 }: SectionProps): React.JSX.Element => (
-  <section
-    id={id}
-    className="scroll-mt-24 border-t border-base-border pt-12 first-of-type:border-t-0 first-of-type:pt-0"
-  >
-    <header className="mb-2 space-y-4">
+  <section id={id} className="scroll-mt-24">
+    <header className="mb-2 space-y-2">
       <p className="text-xs font-semibold tracking-widest text-components-input-active uppercase">
         Section {number}
       </p>
@@ -38,11 +35,12 @@ const Section = ({
         {title}
       </h2>
     </header>
-    <div className="space-y-8 text-left">{children}</div>
+    <div className="space-y-6 text-left">{children}</div>
     {transition ? (
-      <p className="mt-8 border-t border-base-border pt-8 text-sm italic text-muted-foreground">
-        {transition}
-      </p>
+      <>
+        <hr className="mt-8 border-t border-base-border" />
+        <p className="mt-8 text-sm text-muted-foreground">{transition}</p>
+      </>
     ) : null}
   </section>
 )
@@ -156,7 +154,7 @@ const PlanSections = ({
       onStuckChange={onStuckChange}
     />
 
-    <div className="mt-8 space-y-16">
+    <div className="mt-8 space-y-12">
       {/* 1. Executive Summary */}
       <Section
         id="plan-section-1"

--- a/app/dashboard/strategy/components/PlanSections.tsx
+++ b/app/dashboard/strategy/components/PlanSections.tsx
@@ -16,6 +16,7 @@ interface SectionProps {
   number: number
   title: string
   children: React.ReactNode
+  transition?: React.ReactNode
 }
 
 const Section = ({
@@ -23,6 +24,7 @@ const Section = ({
   number,
   title,
   children,
+  transition,
 }: SectionProps): React.JSX.Element => (
   <section
     id={id}
@@ -37,6 +39,11 @@ const Section = ({
       </h2>
     </header>
     <div className="space-y-8 text-left">{children}</div>
+    {transition ? (
+      <p className="mt-8 border-t border-base-border pt-8 text-sm italic text-muted-foreground">
+        {transition}
+      </p>
+    ) : null}
   </section>
 )
 
@@ -151,64 +158,104 @@ const PlanSections = ({
 
     <div className="mt-8 space-y-16">
       {/* 1. Executive Summary */}
-      <Section id="plan-section-1" number={1} title="Executive Summary">
+      <Section
+        id="plan-section-1"
+        number={1}
+        title="Executive Summary"
+        transition="The race is mapped by your opponents, your projected votes to win, and your timeline. What shapes everything else is you: the issues you're running on, the people and money you can mobilize, and where you are right now in your campaign. Continue to your Campaign HQ and we'll help rebuild this plan around you specifically."
+      >
         <p className="text-sm text-muted-foreground">
           This is the whole plan in one view. If you read nothing else, read
           this.
         </p>
 
-        <Subsection title="Your Race">
+        {/*
+          The Race intro has three variants in the source doc (see ClickUp
+          "Campaign Plan Template"):
+            1. Uncontested race — no opponents.
+            2. Race with >= 1 opponent, no incumbent (rendered below, locked to
+               2 opponents for this prototype).
+            3. Race with >= 1 opponent including an incumbent — references
+               `incumbent_name`.
+          When opponent / incumbent data lands on the campaign object, swap
+          on `plan.opponents` / `plan.opponentCount` to pick the right
+          paragraph and replace the literal "2 opponents" below.
+        */}
+        <Subsection title="The Race">
           <p>
             You are running for{' '}
-            <span className="font-semibold text-foreground">{plan.race}</span>
-            {plan.location ? ` in ${plan.location}` : ''}. The race is
-            nonpartisan with {plan.opponentCount} opponents. Election Day is{' '}
+            <span className="font-semibold text-foreground">{plan.race}</span>{' '}
+            representing{' '}
+            <span className="font-semibold text-foreground">
+              {plan.districtName}
+            </span>
+            . As of{' '}
+            <span className="font-semibold text-foreground">
+              {plan.planGenerationDate}
+            </span>
+            , the race is a nonpartisan election with{' '}
+            <span className="font-semibold text-foreground">2 opponents</span>.
+            Election Day is{' '}
             <span className="font-semibold text-foreground">
               {plan.electionDate}
             </span>
             . Because the electorate is small and no party cue appears on the
-            ballot, the race is decided by name recognition and turnout, not
+            ballot, the race is decided by name recognition and turnout, not by
             ideological persuasion.
           </p>
         </Subsection>
 
-        <Subsection title="Your Win Condition">
+        <Subsection title="Projected Votes to Win">
           <p>
-            We project voter turnout of{' '}
+            Our modeling projects voter turnout of{' '}
             <span className="font-semibold text-foreground">
-              {plan.projectedTurnout.toLocaleString('en-US')} (±10%)
-            </span>
-            , which puts your threshold for a guaranteed win at{' '}
+              {plan.projectedTurnout.toLocaleString('en-US')} voters
+            </span>{' '}
+            (
+            <a
+              href="https://goodparty.org/blog/article/calculate-win-numbers"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-components-input-active hover:underline"
+            >
+              we were within 1.5 percentage points on average
+            </a>
+            ), putting the threshold for a win at{' '}
             <span className="font-semibold text-foreground">
               {plan.winNumber.toLocaleString('en-US')} votes
             </span>
-            , a conservative 50% + 1 target. Hitting that target requires{' '}
+            , a simple majority of voters (50% + 1) who actually cast a ballot.
+            This is the lowest amount of votes we project you need to win your
+            election; our campaign plan below will guide you toward surpassing
+            that number. Hitting that target requires{' '}
             <span className="font-semibold text-foreground">
-              {plan.voterContactGoal.toLocaleString('en-US')} quality voter
-              touches
+              {plan.voterContactGoal.toLocaleString('en-US')} voter contacts
             </span>{' '}
-            across the cycle, delivered through matched phone data plus
-            in-person visibility and earned media.
+            across the cycle (roughly 5 contacts per targeted voter).
           </p>
         </Subsection>
 
-        <Subsection title="Strategy at a Glance">
-          <DefinitionList items={plan.strategyBullets} />
+        <Subsection title="Campaign Plan at a Glance">
+          <DefinitionList items={plan.planAtAGlance} />
         </Subsection>
 
-        <Subsection title="Key Numbers">
+        <Subsection title="Key Campaign Targets">
+          <p className="text-sm text-muted-foreground">
+            These are the targets that will help you keep your campaign on
+            track.
+          </p>
           <KeyValueTable
-            rows={plan.keyNumbers.map((n) => ({
-              label: n.metric,
-              value: n.target,
+            rows={plan.keyCampaignTargets.map((t) => ({
+              label: t.metric,
+              value: t.target,
             }))}
           />
         </Subsection>
 
-        <Subsection title="Timeline Highlights">
+        <Subsection title="Key Dates">
           <ul className="space-y-2 text-sm">
-            {plan.timelineHighlights.map((row) => (
-              <li key={row.date}>
+            {plan.keyDates.map((row) => (
+              <li key={`${row.date}-${row.description}`}>
                 <span className="font-semibold text-foreground">
                   {row.date}.
                 </span>{' '}
@@ -217,27 +264,22 @@ const PlanSections = ({
             ))}
           </ul>
         </Subsection>
-
-        <Subsection title="What You Must Commit Personally">
-          <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
-            {plan.candidateCommitments.map((c) => (
-              <li key={c}>{c}</li>
-            ))}
-          </ul>
-        </Subsection>
-
-        <Subsection title="Biggest Risks">
-          <DefinitionList items={plan.biggestRisks} />
-        </Subsection>
       </Section>
 
       {/* 2. Strategic Landscape */}
-      <Section id="plan-section-2" number={2} title="Strategic Landscape">
+      <Section
+        id="plan-section-2"
+        number={2}
+        title="Strategic Landscape"
+        transition="The strategic landscape is drawn from public data and historical election results. What it can't yet account for is the issues you're championing and how you stack up against your opponents. Head to your Campaign HQ to provide us with that information, and we'll reframe the opportunities and challenges around your platform."
+      >
         <p className="text-sm text-muted-foreground">
-          Your district is a small, often nonpartisan electorate where name
-          recognition and turnout, not ideological persuasion, decide most
-          races. The following opportunities and challenges are framed against
-          that reality.
+          <span className="font-semibold text-foreground">
+            {plan.districtName}
+          </span>{' '}
+          is an electorate where name recognition and turnout (not ideological
+          persuasion) decide most races. The following opportunities and
+          challenges are framed against that reality.
         </p>
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
           <Subsection title="Opportunities">
@@ -247,15 +289,44 @@ const PlanSections = ({
             <DefinitionList items={plan.challenges} />
           </Subsection>
         </div>
-        <Subsection title="Competitive Read">
-          <p>
-            This plan is deliberately opponent-agnostic. You should produce a
-            brief opponent memo covering each opponent&apos;s name-recognition
-            baseline, their top one or two public positions, and any obvious
-            coalitions they are courting. Until that memo exists, the plan
-            assumes a neutral split and optimizes for your own turnout.
-          </p>
-        </Subsection>
+        {plan.opponents.length > 0 ? (
+          <Subsection title="Opposition Research">
+            <ul className="space-y-6 text-sm">
+              {plan.opponents.map((opp) => (
+                <li key={opp.name} className="space-y-2">
+                  <p className="font-semibold text-foreground">{opp.name}</p>
+                  <ul className="space-y-1 pl-5 text-muted-foreground [list-style:disc]">
+                    <li>Party: {opp.party}</li>
+                    {opp.isIncumbent ? (
+                      <li>
+                        Incumbent — received {opp.lastVoteShare} of the vote
+                        last cycle
+                      </li>
+                    ) : null}
+                    <li>
+                      Positions on various issues:
+                      <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
+                        {opp.positions.map((p) => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                    </li>
+                    {opp.websites.length > 0 ? (
+                      <li>
+                        Websites:
+                        <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
+                          {opp.websites.map((w) => (
+                            <li key={w}>{w}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    ) : null}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          </Subsection>
+        ) : null}
       </Section>
 
       {/* 3. Electoral Goals & Key Metrics */}
@@ -263,11 +334,11 @@ const PlanSections = ({
         id="plan-section-3"
         number={3}
         title="Electoral Goals & Key Metrics"
+        transition="These projections come straight from public voter data and proprietary models. Once you confirm your platform issues in Campaign HQ, we can re-forecast against the audience you're actually targeting."
       >
         <p className="text-sm text-muted-foreground">
-          These are the numbers you will manage against. Each metric includes
-          its data source and the sensitivity we apply when re-forecasting
-          weekly.
+          The below numbers are projected from historical voter data and
+          proprietary models to get you the most accurate projections.
         </p>
         <PlanTable
           columns={['Metric', 'Target', 'Source / Formula']}
@@ -283,39 +354,52 @@ const PlanSections = ({
             </span>,
           ])}
         />
-        <Subsection title="Why 5x the Win Number?">
+        <Subsection title="Why 5× the Projected Votes to Win?">
           <p>
-            The industry convention to plan for roughly five voter-contact
-            attempts per vote needed comes from two realities. First, not every
-            attempt reaches the voter (text deliverability, unanswered calls,
-            wrong numbers). Second, voters typically need multiple exposures
-            before a name or message sticks. For a{' '}
-            {plan.winNumber.toLocaleString('en-US')}-vote target,{' '}
-            {plan.voterContactGoal.toLocaleString('en-US')} attempts yields
-            roughly two to three actual, memorable contacts per likely voter,
-            the minimum for reliable name recognition.
+            The industry standard convention that a campaign should plan for
+            roughly 5 voter contacts per likely voter comes from two realities:
+            (1) not every attempt reaches the voter (text deliverability,
+            unanswered calls, wrong numbers), and (2) voters typically need
+            multiple exposures before a name or message sticks. For{' '}
+            <span className="font-semibold text-foreground">
+              {plan.winNumber.toLocaleString('en-US')} projected votes to win
+            </span>
+            ,{' '}
+            <span className="font-semibold text-foreground">
+              {plan.voterContactGoal.toLocaleString('en-US')} voter contacts
+            </span>{' '}
+            yields roughly 5 actual contacts per likely voter, the minimum for
+            reliable name recognition in a nonpartisan race.
           </p>
         </Subsection>
         <Subsection title="Why a Volunteer-Hour Target?">
           <p>
-            Volunteer capacity, not money, is the binding constraint on most
-            small-precinct campaigns. The {plan.volunteerHourTarget}-hour floor
-            is a conservative estimate of what it will take for you to cover the
-            civic-event schedule, run a small door-knocking program, and monitor
+            Volunteer hours, not budget, is a binding constraint on most
+            campaigns. The{' '}
+            <span className="font-semibold text-foreground">
+              {plan.volunteerHourTarget.toLocaleString('en-US')} hour floor
+            </span>{' '}
+            is a conservative estimate of what it takes to personally cover
+            your event schedule, run a door-knocking campaign, and monitor
             Election Day operations.
           </p>
         </Subsection>
       </Section>
 
       {/* 4. Campaign Timeline */}
-      <Section id="plan-section-4" number={4} title="Campaign Timeline">
+      <Section
+        id="plan-section-4"
+        number={4}
+        title="Campaign Timeline"
+        transition="The key dates you need to know about your race have been established. What it doesn't yet reflect is your launch event, your fundraising rollout, and the issue moments you want to own. Share those with us on your Campaign HQ and we'll turn this into a working plan."
+      >
         <p className="text-sm text-muted-foreground">
-          Dates below are the hard gates you must hit. Each is followed by an
-          internal working deadline (one week earlier wherever possible) to
-          preserve a buffer.
+          Dates below are the hard gates the campaign must hit. Each is
+          followed by an internal working deadline (one week earlier wherever
+          possible) to preserve a buffer.
         </p>
         <PlanTable
-          columns={['Date', 'Milestone', 'Owner / Notes']}
+          columns={['Date', 'Milestone', 'Notes']}
           rows={plan.timeline.map((t) => [
             <span key="d" className="font-semibold whitespace-nowrap">
               {t.date}
@@ -323,24 +407,30 @@ const PlanSections = ({
             <span key="m" className="text-foreground">
               {t.milestone}
             </span>,
-            <span key="o" className="text-muted-foreground">
-              {t.owner}
+            <span key="n" className="text-muted-foreground">
+              {t.notes}
             </span>,
           ])}
         />
       </Section>
 
       {/* 5. Recommended Budget */}
-      <Section id="plan-section-5" number={5} title="Recommended Budget">
+      <Section
+        id="plan-section-5"
+        number={5}
+        title="Recommended Budget"
+        transition={`The $${plan.totalBudget.toLocaleString(
+          'en-US',
+        )} floor your minimum voter contact goal across digital and phone channels at a generic cost-per-vote benchmark. The real budget and how it gets spent depends on two things we don't yet know: what you can raise, and which voter you specifically should target. Go to your Campaign HQ to flesh out your budget and tailor it to achieve your goals.`}
+      >
         <p className="text-sm text-muted-foreground">
           The recommended total campaign budget is approximately{' '}
           <span className="font-semibold text-foreground">
             ${plan.totalBudget.toLocaleString('en-US')}
           </span>
-          , calculated from a cost-per-vote benchmark of roughly $3 to $4 per
-          targeted voter across all digital and phone channels, rounded for
-          planning clarity. Every dollar should be directed toward high-impact
-          outreach that drives name recognition and turnout.
+          , calculated from a cost-per-campaign benchmark across all channels.
+          Every dollar should be directed toward high-impact contact that
+          drives name recognition and turnout.
         </p>
         <Subsection title="Line-Item Breakdown">
           <PlanTable
@@ -358,8 +448,35 @@ const PlanSections = ({
             ])}
           />
         </Subsection>
-        <Subsection title="What This Budget Does Not Cover">
-          <DefinitionList items={plan.budgetNotCovered} />
+        <Subsection title="How to Raise This">
+          <p>
+            <span className="font-semibold text-foreground">
+              ${plan.totalBudget.toLocaleString('en-US')}
+            </span>{' '}
+            sounds like real money. For most candidates at this level, it comes
+            from a surprisingly small number of people, typically 20 to 40
+            donors giving $25 to $100 each. No extra cushion is needed on top
+            of that target; the budget already builds in a reserve for
+            unexpected costs.
+          </p>
+          <p>
+            The right fundraising mix is candidate-specific, but every source
+            compounds the others — an online donor becomes a house party host,
+            a family loan gets paid back by small-dollar supporters you never
+            expected. For a race like yours, the default starting mix looks
+            like this:
+          </p>
+          <PlanTable
+            columns={['Source', 'Share']}
+            rows={plan.fundraisingMix.map((f) => [
+              <span key="s" className="text-foreground">
+                {f.source}
+              </span>,
+              <span key="sh" className="font-semibold text-foreground">
+                {f.share}
+              </span>,
+            ])}
+          />
         </Subsection>
       </Section>
 
@@ -368,6 +485,7 @@ const PlanSections = ({
         id="plan-section-6"
         number={6}
         title="Community Engagement & Earned Media"
+        transition="These are your highest-value rooms and your best media targets. Once you tell us why you're running and what you stand for in Campaign HQ, we can turn this list into ready-to-use talking points for each event and a press pitch you can send this week."
       >
         <p className="text-sm text-muted-foreground">
           Earned media and in-person visibility are the highest-ROI channels in
@@ -375,12 +493,15 @@ const PlanSections = ({
           showing at a civic association meeting can move more voters than any
           paid channel at this budget.
         </p>
-        <Subsection title="Civic Events">
+        <Subsection title="Community Events">
           <PlanTable
-            columns={['Event', 'Date', 'Why It Matters']}
+            columns={['Event', 'Address', 'Date', 'Why It Matters']}
             rows={plan.civicEvents.map((e) => [
               <span key="e" className="text-foreground">
                 {e.event}
+              </span>,
+              <span key="a" className="text-muted-foreground">
+                {e.address}
               </span>,
               <span key="d" className="whitespace-nowrap text-foreground">
                 {e.date}
@@ -391,9 +512,22 @@ const PlanSections = ({
             ])}
           />
         </Subsection>
-        <Subsection title="Press / Media Outlets">
+        <Subsection title="Press & Media Outlets">
+          <p>
+            Target at least one earned-media placement per week between{' '}
+            <span className="font-semibold text-foreground">
+              {plan.contactWindowStart || '{12_weeks_before_election_date}'}
+            </span>{' '}
+            and{' '}
+            <span className="font-semibold text-foreground">
+              {plan.electionDate || '{election_date}'}
+            </span>
+            . We can help you prepare a single-page fact sheet and two short
+            op-ed drafts that can be tailored quickly to each outlet&apos;s
+            editorial voice.
+          </p>
           <PlanTable
-            columns={['Outlet', 'Type', 'Pitch Angle']}
+            columns={['Outlet', 'Type', 'Pitch Angle', 'Contact Info']}
             rows={plan.pressOutlets.map((o) => [
               <span key="o" className="text-foreground">
                 {o.outlet}
@@ -404,28 +538,33 @@ const PlanSections = ({
               <span key="a" className="text-muted-foreground">
                 {o.angle}
               </span>,
+              <span
+                key="c"
+                className="whitespace-pre-line text-muted-foreground"
+              >
+                {o.contact}
+              </span>,
             ])}
           />
-          <p className="text-sm text-foreground">
-            Aim for at least one earned-media placement per week during the
-            final month. Prepare a single-page fact sheet and two short op-ed
-            drafts (under 200 words) you can tailor quickly to each
-            outlet&apos;s editorial voice.
-          </p>
         </Subsection>
       </Section>
 
       {/* 7. Voter Contact Plan */}
-      <Section id="plan-section-7" number={7} title="Voter Contact Plan">
+      <Section
+        id="plan-section-7"
+        number={7}
+        title="Voter Contact Plan"
+        transition="This plan puts you in front of every likely voter at the right moment. But repeated exposure only converts to votes if the message is specific and credible. Once you share your issues and your story in Campaign HQ, we'll help you build the actual message for each campaign so all you need to do is schedule the campaign."
+      >
         <p className="text-sm text-muted-foreground">
-          The contact cadence below is designed so every likely voter receives
-          at least one introductory touch before mail ballots arrive, at least
-          one deadline reminder, and at least one Election-Day push.
-          Peer-to-peer texts are the primary workhorse. Robocalls layer on top
-          to catch landline-only voters.
+          The contact cadence below is designed so that every likely voter
+          receives at least 1 introductory voter contact, at least 1 persuasion
+          voter contact, at least 1 early vote reminder, and at least 1
+          Election Day push. Texts are the primary workhorse; robocalls layer
+          on top to catch landline-only voters.
         </p>
         <PlanTable
-          columns={['Date', 'Tactic', 'Audience', 'Purpose', 'Format']}
+          columns={['Date', 'Tactic', 'Purpose']}
           rows={plan.contactSchedule.map((s) => [
             <span key="d" className="whitespace-nowrap font-semibold">
               {s.date}
@@ -433,39 +572,30 @@ const PlanSections = ({
             <span key="t" className="font-semibold text-foreground">
               {s.tactic}
             </span>,
-            <span key="a" className="text-muted-foreground">
-              {s.audience}
-            </span>,
             <span key="p" className="text-muted-foreground">
               {s.purpose}
             </span>,
-            <span key="f" className="text-muted-foreground">
-              {s.format}
-            </span>,
           ])}
         />
-        <Subsection title="Expected Yield">
+        <Subsection title="Expected Outcome">
           <p>
-            Across these sends, the plan produces approximately{' '}
+            Across{' '}
             <span className="font-semibold text-foreground">
-              {plan.voterContactGoal.toLocaleString('en-US')} quality touches
-            </span>{' '}
-            against your voter universe, an average of roughly{' '}
-            <span className="font-semibold text-foreground">
-              {plan.averageTouchesPerVoter} contacts per likely voter
+              7 voter contact campaigns
             </span>
-            . Expected realized contact (accounting for deliverability and
-            answer rates) is 60 to 70 percent of attempts, which clears the
-            threshold for reliable name recognition.
-          </p>
-        </Subsection>
-        <Subsection title="Message Discipline">
-          <p>
-            Every send should carry the same three elements: your name in the
-            first line, one concrete local issue (the same issue every time),
-            and a single clear ask (register, request a ballot, vote on Election
-            Day). Variation across sends dilutes recognition. Consistency is the
-            point.
+            , this plan produces over{' '}
+            <span className="font-semibold text-foreground">
+              {plan.voterContactGoal.toLocaleString('en-US')} voter contacts
+            </span>{' '}
+            against the group of{' '}
+            <span className="font-semibold text-foreground">
+              {plan.winNumber.toLocaleString('en-US')} voters
+            </span>
+            , more than the 5 contacts per likely voter. Expected realized
+            contact (accounting for deliverability and answer rates) is{' '}
+            <span className="font-semibold text-foreground">~60–70%</span> of
+            voter contacts, which clears the threshold for reliable name
+            recognition in a nonpartisan race.
           </p>
         </Subsection>
       </Section>
@@ -475,27 +605,40 @@ const PlanSections = ({
         id="plan-section-8"
         number={8}
         title="Measurement & Accountability"
+        transition="The measurement system is live in Campaign HQ. What it's measuring right now is a default campaign. Once you personalize your plan with your goals, your capacity, and your timeline, the dashboard starts tracking the campaign you're actually running, and the gap between where you are and where you need to be becomes a lot easier to read."
       >
-        <p className="text-sm text-muted-foreground">
-          Your campaign manager should review the KPI dashboard every Monday and
-          report variances against target the same day. The goal is not to hit
-          every number exactly, but to catch trends early enough to reallocate
-          effort.
+        <p className="text-sm text-foreground">
+          Every week, log into your Campaign HQ to check your progress. We
+          estimate the number of likely votes you are on track to receive
+          based on the activity you complete. For every{' '}
+          <span className="font-semibold">5 voter contacts you make</span>, we
+          count that as{' '}
+          <span className="font-semibold">1 likely vote in your election</span>.
         </p>
-        <PlanTable
-          columns={['KPI', 'Target', 'Review Cadence']}
-          rows={plan.kpis.map((k) => [
-            <span key="k" className="text-foreground">
-              {k.kpi}
-            </span>,
-            <span key="t" className="font-semibold text-foreground">
-              {k.target}
-            </span>,
-            <span key="c" className="text-muted-foreground">
-              {k.cadence}
-            </span>,
-          ])}
-        />
+        <p className="text-sm text-foreground">
+          This number will grow as you work through your voter contact plan. It
+          will never reach 100% — that is by design. No campaign plan can
+          guarantee an outcome, and there is always another action that you can
+          take to increase your chances of winning. What this will do is show
+          you clearly whether you are on pace, ahead, or behind, and give you
+          time to adjust before it is too late.
+        </p>
+        <Subsection title="How to read your progress">
+          <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
+            <li>
+              If your likely votes are tracking toward your projected votes to
+              win, stay the course.
+            </li>
+            <li>
+              If you are falling behind, prioritize scheduling your next text or
+              robocall campaign and look for additional outreach opportunities.
+            </li>
+            <li>
+              Check in at least once a week — small gaps caught early are easy
+              to close; the same gap caught in the final week is not.
+            </li>
+          </ul>
+        </Subsection>
       </Section>
 
       {/* 9. Methodology & Data Sources */}
@@ -503,13 +646,15 @@ const PlanSections = ({
         id="plan-section-9"
         number={9}
         title="Methodology & Data Sources"
+        transition="This plan was prepared by GoodParty.org's automated campaign-intelligence system and is intended as a working starting point for the campaign. All estimates should be revisited weekly as new data arrives."
       >
         <p className="text-sm text-muted-foreground">
-          This plan was produced by GoodParty.org&apos;s automated
-          campaign-intelligence pipeline. Every metric in this document is an
-          estimate derived from the sources below. Where applicable, we include
-          a best-estimate confidence interval so you can understand how firm
-          each number is.
+          This plan was produced by GoodParty.org using public voter data,
+          historical election results, and our proprietary models. Every metric
+          in this document is an estimate derived from the sources below. Where
+          applicable, we include our best-estimate confidence interval so that
+          the candidate and campaign manager can understand how firm each
+          number is.
         </p>
         <Subsection title="Data Sources">
           <PlanTable
@@ -536,7 +681,7 @@ const PlanSections = ({
         </Subsection>
         <Subsection title="Confidence & Standard Error">
           <PlanTable
-            columns={['Estimate', 'Point Value', 'Estimated Range', 'Notes']}
+            columns={['Estimate', 'Point Value', 'Est. Range (95% CI)', 'Notes']}
             rows={plan.confidenceEstimates.map((c) => [
               <span key="e" className="text-foreground">
                 {c.estimate}
@@ -553,10 +698,11 @@ const PlanSections = ({
             ])}
           />
           <p className="text-sm text-muted-foreground">
-            Standard-error ranges reflect modeling uncertainty only. They do not
-            account for late-breaking external events (weather, news cycles,
-            last-minute challengers). Treat the point values as planning numbers
-            and revisit weekly as turnout signals harden.
+            Standard-error ranges above reflect modeling uncertainty only. They
+            do not account for late-breaking external events (weather, news
+            cycles, last-minute challengers). The campaign should treat the
+            point values as planning numbers and revisit them weekly as turnout
+            signals harden.
           </p>
         </Subsection>
         <Subsection title="What This Plan Does Not Do">
@@ -570,17 +716,17 @@ const PlanSections = ({
 
       {/* 10. Glossary */}
       <Section id="plan-section-10" number={10} title="Glossary">
-        <dl className="divide-y divide-base-border rounded-xl border border-base-border">
-          {plan.glossary.map((g) => (
-            <div
-              key={g.term}
-              className="grid grid-cols-1 gap-2 px-4 py-4 text-sm md:grid-cols-[200px_1fr] md:gap-6"
-            >
-              <dt className="font-semibold text-foreground">{g.term}</dt>
-              <dd className="text-muted-foreground">{g.definition}</dd>
-            </div>
-          ))}
-        </dl>
+        <PlanTable
+          columns={['Term', 'Definition']}
+          rows={plan.glossary.map((g) => [
+            <span key="t" className="font-semibold text-foreground">
+              {g.term}
+            </span>,
+            <span key="d" className="text-muted-foreground">
+              {g.definition}
+            </span>,
+          ])}
+        />
       </Section>
     </div>
   </div>

--- a/app/dashboard/strategy/components/PlanSections.tsx
+++ b/app/dashboard/strategy/components/PlanSections.tsx
@@ -1,0 +1,589 @@
+'use client'
+
+import PlanSectionNav, { type PlanSectionRef } from './PlanSectionNav'
+import type { PlanData } from './planContent'
+
+interface PlanSectionsProps {
+  plan: PlanData
+  onDownload?: () => void
+  onShare?: () => void
+  downloading?: boolean
+  onStuckChange?: (stuck: boolean) => void
+}
+
+interface SectionProps {
+  id: string
+  number: number
+  title: string
+  children: React.ReactNode
+}
+
+const Section = ({
+  id,
+  number,
+  title,
+  children,
+}: SectionProps): React.JSX.Element => (
+  <section
+    id={id}
+    className="scroll-mt-24 border-t border-base-border pt-12 first-of-type:border-t-0 first-of-type:pt-0"
+  >
+    <header className="mb-2 space-y-4">
+      <p className="text-xs font-semibold tracking-widest text-components-input-active uppercase">
+        Section {number}
+      </p>
+      <h2 className="text-2xl font-bold text-foreground sm:text-3xl">
+        {title}
+      </h2>
+    </header>
+    <div className="space-y-8 text-left">{children}</div>
+  </section>
+)
+
+const PLAN_SECTIONS: PlanSectionRef[] = [
+  { id: 'plan-section-1', label: '1. Executive Summary' },
+  { id: 'plan-section-2', label: '2. Strategic Landscape' },
+  { id: 'plan-section-3', label: '3. Electoral Goals & Key Metrics' },
+  { id: 'plan-section-4', label: '4. Campaign Timeline' },
+  { id: 'plan-section-5', label: '5. Recommended Budget' },
+  { id: 'plan-section-6', label: '6. Community Engagement & Earned Media' },
+  { id: 'plan-section-7', label: '7. Voter Contact Plan' },
+  { id: 'plan-section-8', label: '8. Measurement & Accountability' },
+  { id: 'plan-section-9', label: '9. Methodology & Data Sources' },
+  { id: 'plan-section-10', label: '10. Glossary' },
+]
+
+interface SubsectionProps {
+  title: string
+  children: React.ReactNode
+}
+
+const Subsection = ({
+  title,
+  children,
+}: SubsectionProps): React.JSX.Element => (
+  <div className="space-y-2">
+    <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+    <div className="space-y-3 text-sm text-foreground">{children}</div>
+  </div>
+)
+
+interface DefinitionListProps {
+  items: { title: string; body: string }[]
+}
+
+const DefinitionList = ({ items }: DefinitionListProps): React.JSX.Element => (
+  <ul className="space-y-1.5 text-sm">
+    {items.map((item) => (
+      <li key={item.title}>
+        <span className="font-semibold text-foreground">{item.title}</span>{' '}
+        <span className="text-muted-foreground">{item.body}</span>
+      </li>
+    ))}
+  </ul>
+)
+
+interface KeyValueTableProps {
+  rows: { label: string; value: string }[]
+}
+
+const KeyValueTable = ({ rows }: KeyValueTableProps): React.JSX.Element => (
+  <dl className="divide-y divide-base-border rounded-xl border border-base-border">
+    {rows.map((row) => (
+      <div
+        key={row.label}
+        className="grid grid-cols-1 gap-2 px-4 py-4 text-sm md:grid-cols-[200px_1fr] md:gap-6"
+      >
+        <dt className="text-muted-foreground">{row.label}</dt>
+        <dd className="font-semibold text-foreground">{row.value}</dd>
+      </div>
+    ))}
+  </dl>
+)
+
+interface PlanTableProps {
+  columns: string[]
+  rows: (string | React.ReactNode)[][]
+}
+
+const PlanTable = ({ columns, rows }: PlanTableProps): React.JSX.Element => (
+  <div className="overflow-x-auto rounded-xl border border-base-border">
+    <table className="w-full text-left text-sm">
+      <thead className="bg-muted">
+        <tr>
+          {columns.map((col) => (
+            <th key={col} className="px-4 py-3 font-semibold text-foreground">
+              {col}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-base-border">
+        {rows.map((row, rIdx) => (
+          <tr key={rIdx}>
+            {row.map((cell, cIdx) => (
+              <td key={cIdx} className="px-4 py-3 align-top text-foreground">
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
+const PlanSections = ({
+  plan,
+  onDownload,
+  onShare,
+  downloading,
+  onStuckChange,
+}: PlanSectionsProps): React.JSX.Element => (
+  <div className="text-left">
+    <PlanSectionNav
+      sections={PLAN_SECTIONS}
+      onDownload={onDownload}
+      onShare={onShare}
+      downloading={downloading}
+      onStuckChange={onStuckChange}
+    />
+
+    <div className="mt-8 space-y-16">
+      {/* 1. Executive Summary */}
+      <Section id="plan-section-1" number={1} title="Executive Summary">
+        <p className="text-sm text-muted-foreground">
+          This is the whole plan in one view. If you read nothing else, read
+          this.
+        </p>
+
+        <Subsection title="Your Race">
+          <p>
+            You are running for{' '}
+            <span className="font-semibold text-foreground">{plan.race}</span>
+            {plan.location ? ` in ${plan.location}` : ''}. The race is
+            nonpartisan with {plan.opponentCount} opponents. Election Day is{' '}
+            <span className="font-semibold text-foreground">
+              {plan.electionDate}
+            </span>
+            . Because the electorate is small and no party cue appears on the
+            ballot, the race is decided by name recognition and turnout, not
+            ideological persuasion.
+          </p>
+        </Subsection>
+
+        <Subsection title="Your Win Condition">
+          <p>
+            We project voter turnout of{' '}
+            <span className="font-semibold text-foreground">
+              {plan.projectedTurnout.toLocaleString('en-US')} (±10%)
+            </span>
+            , which puts your threshold for a guaranteed win at{' '}
+            <span className="font-semibold text-foreground">
+              {plan.winNumber.toLocaleString('en-US')} votes
+            </span>
+            , a conservative 50% + 1 target. Hitting that target requires{' '}
+            <span className="font-semibold text-foreground">
+              {plan.voterContactGoal.toLocaleString('en-US')} quality voter
+              touches
+            </span>{' '}
+            across the cycle, delivered through matched phone data plus
+            in-person visibility and earned media.
+          </p>
+        </Subsection>
+
+        <Subsection title="Strategy at a Glance">
+          <DefinitionList items={plan.strategyBullets} />
+        </Subsection>
+
+        <Subsection title="Key Numbers">
+          <KeyValueTable
+            rows={plan.keyNumbers.map((n) => ({
+              label: n.metric,
+              value: n.target,
+            }))}
+          />
+        </Subsection>
+
+        <Subsection title="Timeline Highlights">
+          <ul className="space-y-2 text-sm">
+            {plan.timelineHighlights.map((row) => (
+              <li key={row.date}>
+                <span className="font-semibold text-foreground">
+                  {row.date}.
+                </span>{' '}
+                <span className="text-muted-foreground">{row.description}</span>
+              </li>
+            ))}
+          </ul>
+        </Subsection>
+
+        <Subsection title="What You Must Commit Personally">
+          <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
+            {plan.candidateCommitments.map((c) => (
+              <li key={c}>{c}</li>
+            ))}
+          </ul>
+        </Subsection>
+
+        <Subsection title="Biggest Risks">
+          <DefinitionList items={plan.biggestRisks} />
+        </Subsection>
+      </Section>
+
+      {/* 2. Strategic Landscape */}
+      <Section id="plan-section-2" number={2} title="Strategic Landscape">
+        <p className="text-sm text-muted-foreground">
+          Your district is a small, often nonpartisan electorate where name
+          recognition and turnout, not ideological persuasion, decide most
+          races. The following opportunities and challenges are framed against
+          that reality.
+        </p>
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <Subsection title="Opportunities">
+            <DefinitionList items={plan.opportunities} />
+          </Subsection>
+          <Subsection title="Challenges">
+            <DefinitionList items={plan.challenges} />
+          </Subsection>
+        </div>
+        <Subsection title="Competitive Read">
+          <p>
+            This plan is deliberately opponent-agnostic. You should produce a
+            brief opponent memo covering each opponent&apos;s name-recognition
+            baseline, their top one or two public positions, and any obvious
+            coalitions they are courting. Until that memo exists, the plan
+            assumes a neutral split and optimizes for your own turnout.
+          </p>
+        </Subsection>
+      </Section>
+
+      {/* 3. Electoral Goals & Key Metrics */}
+      <Section
+        id="plan-section-3"
+        number={3}
+        title="Electoral Goals & Key Metrics"
+      >
+        <p className="text-sm text-muted-foreground">
+          These are the numbers you will manage against. Each metric includes
+          its data source and the sensitivity we apply when re-forecasting
+          weekly.
+        </p>
+        <PlanTable
+          columns={['Metric', 'Target', 'Source / Formula']}
+          rows={plan.metrics.map((m) => [
+            <span key="m" className="text-foreground">
+              {m.metric}
+            </span>,
+            <span key="t" className="font-semibold text-foreground">
+              {m.target}
+            </span>,
+            <span key="s" className="text-muted-foreground">
+              {m.source}
+            </span>,
+          ])}
+        />
+        <Subsection title="Why 5x the Win Number?">
+          <p>
+            The industry convention to plan for roughly five voter-contact
+            attempts per vote needed comes from two realities. First, not every
+            attempt reaches the voter (text deliverability, unanswered calls,
+            wrong numbers). Second, voters typically need multiple exposures
+            before a name or message sticks. For a{' '}
+            {plan.winNumber.toLocaleString('en-US')}-vote target,{' '}
+            {plan.voterContactGoal.toLocaleString('en-US')} attempts yields
+            roughly two to three actual, memorable contacts per likely voter,
+            the minimum for reliable name recognition.
+          </p>
+        </Subsection>
+        <Subsection title="Why a Volunteer-Hour Target?">
+          <p>
+            Volunteer capacity, not money, is the binding constraint on most
+            small-precinct campaigns. The {plan.volunteerHourTarget}-hour floor
+            is a conservative estimate of what it will take for you to cover the
+            civic-event schedule, run a small door-knocking program, and monitor
+            Election Day operations.
+          </p>
+        </Subsection>
+      </Section>
+
+      {/* 4. Campaign Timeline */}
+      <Section id="plan-section-4" number={4} title="Campaign Timeline">
+        <p className="text-sm text-muted-foreground">
+          Dates below are the hard gates you must hit. Each is followed by an
+          internal working deadline (one week earlier wherever possible) to
+          preserve a buffer.
+        </p>
+        <PlanTable
+          columns={['Date', 'Milestone', 'Owner / Notes']}
+          rows={plan.timeline.map((t) => [
+            <span key="d" className="font-semibold whitespace-nowrap">
+              {t.date}
+            </span>,
+            <span key="m" className="text-foreground">
+              {t.milestone}
+            </span>,
+            <span key="o" className="text-muted-foreground">
+              {t.owner}
+            </span>,
+          ])}
+        />
+      </Section>
+
+      {/* 5. Recommended Budget */}
+      <Section id="plan-section-5" number={5} title="Recommended Budget">
+        <p className="text-sm text-muted-foreground">
+          The recommended total campaign budget is approximately{' '}
+          <span className="font-semibold text-foreground">
+            ${plan.totalBudget.toLocaleString('en-US')}
+          </span>
+          , calculated from a cost-per-vote benchmark of roughly $3 to $4 per
+          targeted voter across all digital and phone channels, rounded for
+          planning clarity. Every dollar should be directed toward high-impact
+          outreach that drives name recognition and turnout.
+        </p>
+        <Subsection title="Line-Item Breakdown">
+          <PlanTable
+            columns={['Category', 'Amount', 'Rationale']}
+            rows={plan.budgetLineItems.map((b) => [
+              <span key="c" className="text-foreground">
+                {b.category}
+              </span>,
+              <span key="a" className="font-semibold text-foreground">
+                {b.amount}
+              </span>,
+              <span key="r" className="text-muted-foreground">
+                {b.rationale}
+              </span>,
+            ])}
+          />
+        </Subsection>
+        <Subsection title="What This Budget Does Not Cover">
+          <DefinitionList items={plan.budgetNotCovered} />
+        </Subsection>
+      </Section>
+
+      {/* 6. Community Engagement & Earned Media */}
+      <Section
+        id="plan-section-6"
+        number={6}
+        title="Community Engagement & Earned Media"
+      >
+        <p className="text-sm text-muted-foreground">
+          Earned media and in-person visibility are the highest-ROI channels in
+          a race this size. A single mention in a local outlet or a strong
+          showing at a civic association meeting can move more voters than any
+          paid channel at this budget.
+        </p>
+        <Subsection title="Civic Events">
+          <PlanTable
+            columns={['Event', 'Date', 'Why It Matters']}
+            rows={plan.civicEvents.map((e) => [
+              <span key="e" className="text-foreground">
+                {e.event}
+              </span>,
+              <span key="d" className="whitespace-nowrap text-foreground">
+                {e.date}
+              </span>,
+              <span key="w" className="text-muted-foreground">
+                {e.why}
+              </span>,
+            ])}
+          />
+        </Subsection>
+        <Subsection title="Press / Media Outlets">
+          <PlanTable
+            columns={['Outlet', 'Type', 'Pitch Angle']}
+            rows={plan.pressOutlets.map((o) => [
+              <span key="o" className="text-foreground">
+                {o.outlet}
+              </span>,
+              <span key="t" className="text-muted-foreground">
+                {o.type}
+              </span>,
+              <span key="a" className="text-muted-foreground">
+                {o.angle}
+              </span>,
+            ])}
+          />
+          <p className="text-sm text-foreground">
+            Aim for at least one earned-media placement per week during the
+            final month. Prepare a single-page fact sheet and two short op-ed
+            drafts (under 200 words) you can tailor quickly to each
+            outlet&apos;s editorial voice.
+          </p>
+        </Subsection>
+      </Section>
+
+      {/* 7. Voter Contact Plan */}
+      <Section id="plan-section-7" number={7} title="Voter Contact Plan">
+        <p className="text-sm text-muted-foreground">
+          The contact cadence below is designed so every likely voter receives
+          at least one introductory touch before mail ballots arrive, at least
+          one deadline reminder, and at least one Election-Day push.
+          Peer-to-peer texts are the primary workhorse. Robocalls layer on top
+          to catch landline-only voters.
+        </p>
+        <PlanTable
+          columns={['Date', 'Tactic', 'Audience', 'Purpose', 'Format']}
+          rows={plan.contactSchedule.map((s) => [
+            <span key="d" className="whitespace-nowrap font-semibold">
+              {s.date}
+            </span>,
+            <span key="t" className="font-semibold text-foreground">
+              {s.tactic}
+            </span>,
+            <span key="a" className="text-muted-foreground">
+              {s.audience}
+            </span>,
+            <span key="p" className="text-muted-foreground">
+              {s.purpose}
+            </span>,
+            <span key="f" className="text-muted-foreground">
+              {s.format}
+            </span>,
+          ])}
+        />
+        <Subsection title="Expected Yield">
+          <p>
+            Across these sends, the plan produces approximately{' '}
+            <span className="font-semibold text-foreground">
+              {plan.voterContactGoal.toLocaleString('en-US')} quality touches
+            </span>{' '}
+            against your voter universe, an average of roughly{' '}
+            <span className="font-semibold text-foreground">
+              {plan.averageTouchesPerVoter} contacts per likely voter
+            </span>
+            . Expected realized contact (accounting for deliverability and
+            answer rates) is 60 to 70 percent of attempts, which clears the
+            threshold for reliable name recognition.
+          </p>
+        </Subsection>
+        <Subsection title="Message Discipline">
+          <p>
+            Every send should carry the same three elements: your name in the
+            first line, one concrete local issue (the same issue every time),
+            and a single clear ask (register, request a ballot, vote on Election
+            Day). Variation across sends dilutes recognition. Consistency is the
+            point.
+          </p>
+        </Subsection>
+      </Section>
+
+      {/* 8. Measurement & Accountability */}
+      <Section
+        id="plan-section-8"
+        number={8}
+        title="Measurement & Accountability"
+      >
+        <p className="text-sm text-muted-foreground">
+          Your campaign manager should review the KPI dashboard every Monday and
+          report variances against target the same day. The goal is not to hit
+          every number exactly, but to catch trends early enough to reallocate
+          effort.
+        </p>
+        <PlanTable
+          columns={['KPI', 'Target', 'Review Cadence']}
+          rows={plan.kpis.map((k) => [
+            <span key="k" className="text-foreground">
+              {k.kpi}
+            </span>,
+            <span key="t" className="font-semibold text-foreground">
+              {k.target}
+            </span>,
+            <span key="c" className="text-muted-foreground">
+              {k.cadence}
+            </span>,
+          ])}
+        />
+      </Section>
+
+      {/* 9. Methodology & Data Sources */}
+      <Section
+        id="plan-section-9"
+        number={9}
+        title="Methodology & Data Sources"
+      >
+        <p className="text-sm text-muted-foreground">
+          This plan was produced by GoodParty.org&apos;s automated
+          campaign-intelligence pipeline. Every metric in this document is an
+          estimate derived from the sources below. Where applicable, we include
+          a best-estimate confidence interval so you can understand how firm
+          each number is.
+        </p>
+        <Subsection title="Data Sources">
+          <PlanTable
+            columns={['Metric', 'Source', 'Last Updated']}
+            rows={plan.dataSources.map((d) => [
+              <span key="m" className="text-foreground">
+                {d.metric}
+              </span>,
+              <span key="s" className="text-muted-foreground">
+                {d.source}
+              </span>,
+              <span key="u" className="whitespace-nowrap text-muted-foreground">
+                {d.lastUpdated}
+              </span>,
+            ])}
+          />
+        </Subsection>
+        <Subsection title="Key Assumptions">
+          <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
+            {plan.keyAssumptions.map((a) => (
+              <li key={a}>{a}</li>
+            ))}
+          </ul>
+        </Subsection>
+        <Subsection title="Confidence & Standard Error">
+          <PlanTable
+            columns={['Estimate', 'Point Value', 'Estimated Range', 'Notes']}
+            rows={plan.confidenceEstimates.map((c) => [
+              <span key="e" className="text-foreground">
+                {c.estimate}
+              </span>,
+              <span key="p" className="font-semibold whitespace-nowrap">
+                {c.pointValue}
+              </span>,
+              <span key="r" className="text-muted-foreground whitespace-nowrap">
+                {c.range}
+              </span>,
+              <span key="n" className="text-muted-foreground">
+                {c.notes}
+              </span>,
+            ])}
+          />
+          <p className="text-sm text-muted-foreground">
+            Standard-error ranges reflect modeling uncertainty only. They do not
+            account for late-breaking external events (weather, news cycles,
+            last-minute challengers). Treat the point values as planning numbers
+            and revisit weekly as turnout signals harden.
+          </p>
+        </Subsection>
+        <Subsection title="What This Plan Does Not Do">
+          <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
+            {plan.planDoesNotDo.map((p) => (
+              <li key={p}>{p}</li>
+            ))}
+          </ul>
+        </Subsection>
+      </Section>
+
+      {/* 10. Glossary */}
+      <Section id="plan-section-10" number={10} title="Glossary">
+        <dl className="divide-y divide-base-border rounded-xl border border-base-border">
+          {plan.glossary.map((g) => (
+            <div
+              key={g.term}
+              className="grid grid-cols-1 gap-2 px-4 py-4 text-sm md:grid-cols-[200px_1fr] md:gap-6"
+            >
+              <dt className="font-semibold text-foreground">{g.term}</dt>
+              <dd className="text-muted-foreground">{g.definition}</dd>
+            </div>
+          ))}
+        </dl>
+      </Section>
+    </div>
+  </div>
+)
+
+export default PlanSections

--- a/app/dashboard/strategy/components/SharePlanModal.tsx
+++ b/app/dashboard/strategy/components/SharePlanModal.tsx
@@ -1,15 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import {
-  Check,
-  Copy,
-  Facebook,
-  Instagram,
-  Link as LinkIcon,
-  Mail,
-  Twitter,
-} from 'lucide-react'
+import { Check, Copy, Facebook, Instagram, Mail, Twitter } from 'lucide-react'
 import {
   Button,
   Dialog,
@@ -17,7 +9,15 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
 } from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
 
 interface SharePlanModalProps {
   open: boolean
@@ -26,12 +26,59 @@ interface SharePlanModalProps {
   candidateName: string
 }
 
+interface ShareLink {
+  label: string
+  icon: React.ReactNode
+  href: string
+}
+
+interface ShareBodyProps {
+  copied: boolean
+  onCopy: () => void
+  links: ShareLink[]
+}
+
+const ShareBody = ({
+  copied,
+  onCopy,
+  links,
+}: ShareBodyProps): React.JSX.Element => (
+  <div className="space-y-2">
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full justify-start"
+      icon={copied ? <Check className="size-5" /> : <Copy className="size-5" />}
+      onClick={onCopy}
+    >
+      {copied ? 'Link copied' : 'Copy link'}
+    </Button>
+    <div className="grid grid-cols-2 gap-2">
+      {links.map((item) => (
+        <Button
+          key={item.label}
+          type="button"
+          variant="outline"
+          className="w-full justify-start"
+          icon={item.icon}
+          onClick={() =>
+            window.open(item.href, '_blank', 'noopener,noreferrer')
+          }
+        >
+          {item.label}
+        </Button>
+      ))}
+    </div>
+  </div>
+)
+
 const SharePlanModal = ({
   open,
   onClose,
   url,
   candidateName,
 }: SharePlanModalProps): React.JSX.Element => {
+  const isMobile = useIsMobile()
   const [copied, setCopied] = useState(false)
 
   const subject = candidateName
@@ -44,7 +91,7 @@ const SharePlanModal = ({
   const encodedUrl = encodeURIComponent(url)
   const encodedMessage = encodeURIComponent(message)
 
-  const links: { label: string; icon: React.ReactNode; href: string }[] = [
+  const links: ShareLink[] = [
     {
       label: 'Email',
       icon: <Mail className="size-5" />,
@@ -79,54 +126,41 @@ const SharePlanModal = ({
     }
   }
 
+  const title = 'Share your campaign plan'
+  const description =
+    'Send your plan to a teammate, family member, or supporter.'
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={(o) => !o && onClose()}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <div className="flex flex-col gap-4 p-4">
+            <ShareBody copied={copied} onCopy={handleCopy} links={links} />
+          </div>
+          <DrawerFooter>
+            <DrawerClose asChild>
+              <Button type="button" variant="outline">
+                Close
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Share your campaign plan</DialogTitle>
-          <DialogDescription>
-            Send your plan to a teammate, family member, or supporter.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
-
-        <div className="space-y-2">
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full justify-start"
-            icon={
-              copied ? (
-                <Check className="size-5" />
-              ) : (
-                <Copy className="size-5" />
-              )
-            }
-            onClick={handleCopy}
-          >
-            {copied ? 'Link copied' : 'Copy link'}
-          </Button>
-          <div className="grid grid-cols-2 gap-2">
-            {links.map((item) => (
-              <Button
-                key={item.label}
-                type="button"
-                variant="outline"
-                className="w-full justify-start"
-                icon={item.icon}
-                onClick={() =>
-                  window.open(item.href, '_blank', 'noopener,noreferrer')
-                }
-              >
-                {item.label}
-              </Button>
-            ))}
-          </div>
-        </div>
-
-        <p className="flex items-center gap-2 truncate rounded-md border border-base-border bg-muted px-3 py-2 text-xs text-muted-foreground">
-          <LinkIcon className="size-3 shrink-0" aria-hidden="true" />
-          <span className="truncate">{url}</span>
-        </p>
+        <ShareBody copied={copied} onCopy={handleCopy} links={links} />
       </DialogContent>
     </Dialog>
   )

--- a/app/dashboard/strategy/components/SharePlanModal.tsx
+++ b/app/dashboard/strategy/components/SharePlanModal.tsx
@@ -112,12 +112,12 @@ const SharePlanModal = ({
                 type="button"
                 variant="outline"
                 className="w-full justify-start"
-                asChild
+                icon={item.icon}
+                onClick={() =>
+                  window.open(item.href, '_blank', 'noopener,noreferrer')
+                }
               >
-                <a href={item.href} target="_blank" rel="noopener noreferrer">
-                  {item.icon}
-                  {item.label}
-                </a>
+                {item.label}
               </Button>
             ))}
           </div>

--- a/app/dashboard/strategy/components/SharePlanModal.tsx
+++ b/app/dashboard/strategy/components/SharePlanModal.tsx
@@ -112,10 +112,10 @@ const SharePlanModal = ({
                 type="button"
                 variant="outline"
                 className="w-full justify-start"
-                icon={item.icon}
                 asChild
               >
                 <a href={item.href} target="_blank" rel="noopener noreferrer">
+                  {item.icon}
                   {item.label}
                 </a>
               </Button>

--- a/app/dashboard/strategy/components/SharePlanModal.tsx
+++ b/app/dashboard/strategy/components/SharePlanModal.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Check,
+  Copy,
+  Facebook,
+  Instagram,
+  Link as LinkIcon,
+  Mail,
+  Twitter,
+} from 'lucide-react'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@styleguide'
+
+interface SharePlanModalProps {
+  open: boolean
+  onClose: () => void
+  url: string
+  candidateName: string
+}
+
+const SharePlanModal = ({
+  open,
+  onClose,
+  url,
+  candidateName,
+}: SharePlanModalProps): React.JSX.Element => {
+  const [copied, setCopied] = useState(false)
+
+  const subject = candidateName
+    ? `${candidateName}'s campaign plan`
+    : 'My campaign plan'
+  const message = candidateName
+    ? `${candidateName} just built a campaign plan with GoodParty.org. Take a look:`
+    : 'I just built a campaign plan with GoodParty.org. Take a look:'
+
+  const encodedUrl = encodeURIComponent(url)
+  const encodedMessage = encodeURIComponent(message)
+
+  const links: { label: string; icon: React.ReactNode; href: string }[] = [
+    {
+      label: 'Email',
+      icon: <Mail className="size-5" />,
+      href: `mailto:?subject=${encodeURIComponent(
+        subject,
+      )}&body=${encodedMessage}%0D%0A%0D%0A${encodedUrl}`,
+    },
+    {
+      label: 'Facebook',
+      icon: <Facebook className="size-5" />,
+      href: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+    },
+    {
+      label: 'X',
+      icon: <Twitter className="size-5" />,
+      href: `https://twitter.com/share?url=${encodedUrl}&text=${encodedMessage}`,
+    },
+    {
+      label: 'Instagram',
+      icon: <Instagram className="size-5" />,
+      href: 'https://www.instagram.com/',
+    },
+  ]
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable; do nothing.
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share your campaign plan</DialogTitle>
+          <DialogDescription>
+            Send your plan to a teammate, family member, or supporter.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full justify-start"
+            icon={
+              copied ? (
+                <Check className="size-5" />
+              ) : (
+                <Copy className="size-5" />
+              )
+            }
+            onClick={handleCopy}
+          >
+            {copied ? 'Link copied' : 'Copy link'}
+          </Button>
+          <div className="grid grid-cols-2 gap-2">
+            {links.map((item) => (
+              <Button
+                key={item.label}
+                type="button"
+                variant="outline"
+                className="w-full justify-start"
+                icon={item.icon}
+                asChild
+              >
+                <a href={item.href} target="_blank" rel="noopener noreferrer">
+                  {item.label}
+                </a>
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <p className="flex items-center gap-2 truncate rounded-md border border-base-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+          <LinkIcon className="size-3 shrink-0" aria-hidden="true" />
+          <span className="truncate">{url}</span>
+        </p>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default SharePlanModal

--- a/app/dashboard/strategy/components/StrategyPage.tsx
+++ b/app/dashboard/strategy/components/StrategyPage.tsx
@@ -114,7 +114,6 @@ const StrategyPage = ({ pathname }: StrategyPageProps): React.JSX.Element => {
               icon={<Download className="size-5" />}
               onClick={handleDownload}
               loading={downloading}
-              loadingText="Generating PDF"
               aria-label="Download campaign plan"
             >
               <span className="hidden sm:inline">Download</span>

--- a/app/dashboard/strategy/components/StrategyPage.tsx
+++ b/app/dashboard/strategy/components/StrategyPage.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Download, Share2 } from 'lucide-react'
+import { Button } from '@styleguide'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { useUser } from '@shared/hooks/useUser'
+import DashboardLayout from '../../shared/DashboardLayout'
+import PlanInputs from './PlanInputs'
+import PlanSections from './PlanSections'
+import SharePlanModal from './SharePlanModal'
+import { buildPlanData } from './planContent'
+
+interface StrategyPageProps {
+  pathname: string
+}
+
+const StrategyPage = ({ pathname }: StrategyPageProps): React.JSX.Element => {
+  const [campaign] = useCampaign()
+  const [user] = useUser()
+  const [shareOpen, setShareOpen] = useState(false)
+  const [downloading, setDownloading] = useState(false)
+
+  const firstName = user?.firstName ?? ''
+  const lastName = user?.lastName ?? ''
+  const candidateName = [firstName, lastName].filter(Boolean).join(' ').trim()
+  const race =
+    campaign?.positionName ||
+    campaign?.organization?.customPositionName ||
+    campaign?.office ||
+    'Your race'
+  const city = campaign?.details?.city ?? ''
+  const state = campaign?.details?.state ?? ''
+  const metrics = campaign?.raceTargetMetrics
+  const winNumber = metrics?.winNumber ?? 0
+  const projectedTurnout = metrics?.projectedTurnout ?? 0
+  const voterContactGoal = metrics?.voterContactGoal ?? winNumber * 5
+
+  const plan = useMemo(
+    () =>
+      buildPlanData({
+        candidateName,
+        race,
+        city,
+        state,
+        electionDateIso: campaign?.details?.electionDate ?? null,
+        winNumber,
+        projectedTurnout,
+        voterContactGoal,
+      }),
+    [
+      candidateName,
+      race,
+      city,
+      state,
+      campaign?.details?.electionDate,
+      winNumber,
+      projectedTurnout,
+      voterContactGoal,
+    ],
+  )
+
+  const handleDownload = async () => {
+    if (downloading) return
+    setDownloading(true)
+    try {
+      const [{ pdf }, { CampaignPlanPdf }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('./CampaignPlanPdf'),
+      ])
+      const blob = await pdf(<CampaignPlanPdf plan={plan} />).toBlob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      const safeName =
+        (candidateName || 'campaign-plan')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '') || 'campaign-plan'
+      a.download = `${safeName}-campaign-plan.pdf`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  const shareUrl = typeof window !== 'undefined' ? window.location.href : ''
+
+  return (
+    <DashboardLayout
+      pathname={pathname}
+      campaign={campaign}
+      wrapperClassName="!p-0"
+    >
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-8 sm:px-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
+              Your campaign plan
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The full plan for winning your race. Update your inputs to see the
+              gap.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="large"
+              icon={<Download className="size-5" />}
+              onClick={handleDownload}
+              loading={downloading}
+              loadingText="Generating PDF"
+              aria-label="Download campaign plan"
+            >
+              <span className="hidden sm:inline">Download</span>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="large"
+              icon={<Share2 className="size-5" />}
+              onClick={() => setShareOpen(true)}
+              aria-label="Share campaign plan"
+            >
+              <span className="hidden sm:inline">Share</span>
+            </Button>
+          </div>
+        </div>
+
+        <PlanInputs plan={plan} />
+
+        <PlanSections
+          plan={plan}
+          onDownload={handleDownload}
+          onShare={() => setShareOpen(true)}
+          downloading={downloading}
+        />
+      </div>
+
+      <SharePlanModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        url={shareUrl}
+        candidateName={candidateName}
+      />
+    </DashboardLayout>
+  )
+}
+
+export default StrategyPage

--- a/app/dashboard/strategy/components/planContent.ts
+++ b/app/dashboard/strategy/components/planContent.ts
@@ -782,12 +782,15 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   const CANDIDATE_HOURS_PER_WEEK = 14
   const VOLUNTEER_HOURS_PER_WEEK_EACH = 3
   const DOORS_PER_HOUR = 15
-  const FALLBACK_WEEKS_REMAINING = 12
-  let weeksRemaining = FALLBACK_WEEKS_REMAINING
+  const MAX_CAMPAIGN_WEEKS = 12
+  let weeksRemaining = MAX_CAMPAIGN_WEEKS
   if (electionDateValid) {
     const ms = electionDateValid.getTime() - Date.now()
     if (ms > 0) {
-      weeksRemaining = Math.ceil(ms / (7 * 24 * 60 * 60 * 1000))
+      weeksRemaining = Math.min(
+        Math.ceil(ms / (7 * 24 * 60 * 60 * 1000)),
+        MAX_CAMPAIGN_WEEKS,
+      )
     }
   }
   const totalDoors = Math.round(voterContactGoal * 0.2)

--- a/app/dashboard/strategy/components/planContent.ts
+++ b/app/dashboard/strategy/components/planContent.ts
@@ -18,15 +18,20 @@ export interface PlanInput {
   voterContactGoal: number
 }
 
-export interface KeyNumber {
+export interface KeyTarget {
   metric: string
   target: string
+}
+
+export interface KeyDate {
+  date: string
+  description: string
 }
 
 export interface TimelineRow {
   date: string
   milestone: string
-  owner: string
+  notes: string
 }
 
 export interface MetricRow {
@@ -41,8 +46,14 @@ export interface BudgetRow {
   rationale: string
 }
 
+export interface FundraisingRow {
+  source: string
+  share: string
+}
+
 export interface CivicEvent {
   event: string
+  address: string
   date: string
   why: string
 }
@@ -51,20 +62,13 @@ export interface PressOutlet {
   outlet: string
   type: string
   angle: string
+  contact: string
 }
 
 export interface ContactSend {
   date: string
   tactic: string
-  audience: string
   purpose: string
-  format: string
-}
-
-export interface KpiRow {
-  kpi: string
-  target: string
-  cadence: string
 }
 
 export interface DataSourceRow {
@@ -85,13 +89,26 @@ export interface GlossaryRow {
   definition: string
 }
 
+export interface Opponent {
+  name: string
+  party: string
+  isIncumbent: boolean
+  lastVoteShare: string
+  positions: string[]
+  websites: string[]
+}
+
 export interface PlanData {
   // Identity
   candidateName: string
   race: string
   location: string
+  districtName: string
   electionDate: string
   electionDateRaw: Date | null
+  planGenerationDate: string
+  // Approximate window when first voter contact should land — 12 weeks before E-Day.
+  contactWindowStart: string
 
   // Numbers
   winNumber: number
@@ -100,6 +117,7 @@ export interface PlanData {
   projectedTurnout: number
   projectedTurnoutLow: number
   projectedTurnoutHigh: number
+  registeredVoters: number
   voterContactGoal: number
 
   // Placeholder identity numbers
@@ -109,23 +127,24 @@ export interface PlanData {
   volunteerHourTarget: number
   totalBudget: number
   averageTouchesPerVoter: number
+  eventCount: number
+  mediaCount: number
 
-  // Weekly cadence targets (for plan-inputs gap analysis)
+  // Weekly cadence targets
   candidateHoursPerWeek: number
   volunteerHoursPerWeek: number
   weeksRemaining: number
   filingDeadline: string | null
 
   // Executive summary
-  strategyBullets: { title: string; body: string }[]
-  keyNumbers: KeyNumber[]
-  timelineHighlights: { date: string; description: string }[]
-  candidateCommitments: string[]
-  biggestRisks: { title: string; body: string }[]
+  planAtAGlance: { title: string; body: string }[]
+  keyCampaignTargets: KeyTarget[]
+  keyDates: KeyDate[]
 
   // Strategic landscape
   opportunities: { title: string; body: string }[]
   challenges: { title: string; body: string }[]
+  opponents: Opponent[]
 
   // Electoral goals
   metrics: MetricRow[]
@@ -135,7 +154,7 @@ export interface PlanData {
 
   // Budget
   budgetLineItems: BudgetRow[]
-  budgetNotCovered: { title: string; body: string }[]
+  fundraisingMix: FundraisingRow[]
 
   // Community engagement
   civicEvents: CivicEvent[]
@@ -143,9 +162,6 @@ export interface PlanData {
 
   // Voter contact
   contactSchedule: ContactSend[]
-
-  // KPIs
-  kpis: KpiRow[]
 
   // Methodology
   dataSources: DataSourceRow[]
@@ -169,13 +185,12 @@ const buildTimeline = (
   electionDate: Date | null,
 ): {
   timeline: TimelineRow[]
-  highlights: { date: string; description: string }[]
+  keyDates: KeyDate[]
 } => {
   if (!electionDate) {
-    return { timeline: [], highlights: [] }
+    return { timeline: [], keyDates: [] }
   }
   const filing = addDays(electionDate, -40)
-  const staffReady = addDays(electionDate, -34)
   const messagingLocked = addDays(electionDate, -27)
   const ballotsStart = addDays(electionDate, -25)
   const voterRegDeadline = addDays(electionDate, -10)
@@ -185,41 +200,39 @@ const buildTimeline = (
     {
       date: formatDate(filing),
       milestone: 'Nomination papers filed with Town Clerk',
-      owner: 'You. Bring two backup copies.',
-    },
-    {
-      date: formatDate(staffReady),
-      milestone: 'Staff and volunteer recruitment and training complete',
-      owner: 'Campaign Manager',
+      notes: 'Bring two backup copies.',
     },
     {
       date: formatDate(messagingLocked),
       milestone: 'Messaging, branding, and printed materials finalized',
-      owner: 'Comms Lead. Lock before first text send.',
+      notes: 'Lock down before first voter contact campaign.',
     },
     {
       date: formatDate(ballotsStart),
-      milestone: 'Absentee and mail-in ballot distribution begins',
-      owner: 'Plan first contact to land by this date.',
+      milestone:
+        'Absentee / mail-in ballot distribution begins (by Town Clerk)',
+      notes:
+        'Plan introduction text and robocall campaigns to be sent before this deadline.',
     },
     {
       date: formatDate(voterRegDeadline),
       milestone: 'Voter registration deadline',
-      owner: 'Push via first robocall and digital.',
+      notes: 'Push via robocall campaign.',
     },
     {
       date: formatDate(absenteeDeadline),
       milestone: 'Absentee ballot request deadline',
-      owner: 'Push via second P2P text.',
+      notes: 'Push via text campaign.',
     },
     {
       date: formatDate(electionDate),
-      milestone: 'Election Day. Polls open. Absentee ballots due.',
-      owner: 'All hands. See GOTV plan.',
+      milestone: 'Election Day, polls open; absentee ballots due',
+      notes:
+        'All hands on deck; push via GOTV text and robocall campaigns.',
     },
   ]
 
-  const highlights = [
+  const keyDates: KeyDate[] = [
     {
       date: formatDate(filing),
       description: 'Nomination papers filed with Town Clerk.',
@@ -227,7 +240,11 @@ const buildTimeline = (
     {
       date: formatDate(ballotsStart),
       description:
-        'Absentee and mail ballots begin distributing. First voter contact must land by this date.',
+        'Absentee / mail ballots begin distributing. First voter contact must land by this date.',
+    },
+    {
+      date: formatDate(addDays(electionDate, -20)),
+      description: '{N} community events that you should personally attend.',
     },
     {
       date: formatDate(voterRegDeadline),
@@ -239,78 +256,65 @@ const buildTimeline = (
     },
     {
       date: formatDate(electionDate),
-      description:
-        'Election Day. GOTV push via robocall and peer-to-peer text.',
+      description: 'Election Day.',
     },
   ]
 
-  return { timeline, highlights }
+  return { timeline, keyDates }
 }
 
 const buildContactSchedule = (electionDate: Date | null): ContactSend[] => {
   if (!electionDate) return []
   const sends: { offset: number; data: Omit<ContactSend, 'date'> }[] = [
     {
-      offset: -20,
+      offset: -56,
       data: {
-        tactic: 'P2P Text',
-        audience: 'All matched cells',
-        purpose: 'Introduce yourself and your top priorities.',
-        format: 'Personalized peer-to-peer text.',
+        tactic: 'Text',
+        purpose: 'Introduce yourself to voters with cellphones.',
       },
     },
     {
-      offset: -10,
+      offset: -49,
       data: {
         tactic: 'Robocall',
-        audience: 'All matched landlines',
-        purpose: 'Alert voters to registration deadline (today).',
-        format: 'Automated voice call.',
+        purpose: 'Introduce yourself to voters with landlines.',
       },
     },
     {
-      offset: -5,
+      offset: -35,
       data: {
-        tactic: 'P2P Text',
-        audience: 'All matched cells',
-        purpose: 'Remind voters of absentee and mail ballot deadlines.',
-        format: 'Peer-to-peer text.',
+        tactic: 'Text',
+        purpose:
+          'Build trust and persuade voters with cellphones to vote for you.',
       },
     },
     {
-      offset: -3,
+      offset: -28,
       data: {
         tactic: 'Robocall',
-        audience: 'All matched landlines',
-        purpose: 'Encourage early voting and ballot returns.',
-        format: 'Automated voice call.',
+        purpose:
+          'Build trust and persuade voters with landlines to vote for you.',
+      },
+    },
+    {
+      offset: -14,
+      data: {
+        tactic: 'Text',
+        purpose: 'Encourage voters with cellphones to vote early.',
       },
     },
     {
       offset: -1,
       data: {
-        tactic: 'P2P Text',
-        audience: 'All matched cells',
-        purpose: 'Day-before: polling location and reminder of candidacy.',
-        format: 'Peer-to-peer text.',
-      },
-    },
-    {
-      offset: 0,
-      data: {
         tactic: 'Robocall',
-        audience: 'All matched landlines',
-        purpose: 'GOTV push with poll hours.',
-        format: 'Automated voice call.',
+        purpose: 'Get out the vote on election day.',
       },
     },
     {
       offset: 0,
       data: {
-        tactic: 'P2P Text',
-        audience: 'All matched cells',
-        purpose: 'Final turnout push. Thank those who voted.',
-        format: 'Peer-to-peer text.',
+        tactic: 'Text',
+        purpose: 'Get out the vote on election day.',
       },
     },
   ]
@@ -333,18 +337,21 @@ const buildCivicEvents = (
   return [
     {
       event: `${cityLabel} Community Fall Festival`,
+      address: '{event_address}',
       date: formatDate(event1),
-      why: 'High family turnout. Strong opportunity for literature handoffs and name recognition.',
+      why: 'High family turnout; literature handoffs and name recognition.',
     },
     {
       event: `${cityLabel} Town Council Public Meeting`,
+      address: '{event_address}',
       date: formatDate(event2),
       why: "Demonstrate fluency with the council's actual agenda.",
     },
     {
       event: `${cityLabel} Civic Association Meeting`,
+      address: '{event_address}',
       date: formatDate(event3),
-      why: 'The single highest-density event inside your target precinct.',
+      why: 'The single highest-density event in the actual target precinct.',
     },
   ]
 }
@@ -356,36 +363,34 @@ const buildPressOutlets = (city: string, state: string): PressOutlet[] => {
     {
       outlet: `${cityLabel} Times`,
       type: 'Daily newspaper. Broad area reach.',
-      angle: 'Your profile or op-ed on a local policy priority.',
+      angle: 'Candidate profile or op-ed on local policy priority.',
+      contact: '{address}\n{phone_number}\n{email}',
     },
     {
       outlet: `The ${cityLabel} Weekly`,
       type: 'Weekly. Deep local government coverage.',
-      angle: 'Your Q&A. Respond quickly to any editorial coverage.',
+      angle: 'Candidate Q&A; respond quickly to any editorial coverage.',
+      contact: '{address}\n{phone_number}\n{email}',
     },
     {
       outlet: `${stateLabel} Local Radio`,
       type: 'Community radio.',
-      angle: 'Short interview segment. Aim for drive-time window.',
+      angle: 'Short interview segment; drive-time window.',
+      contact: '{address}\n{phone_number}\n{email}',
     },
   ]
 }
 
-// NOTE: budget math mirrors OutreachPlanStep. If you tweak the constants there,
-// match them here so the success-page plan stays consistent with what the
-// candidate saw in onboarding.
-const DOORS_PERCENT = 0.2
-const ROBOCALLS_PERCENT = 0.2
-const TEXTS_PERCENT = 0.6
-const ROBOCALL_COST = 0.045
+// Budget math mirrors OutreachPlanStep. Constants are placeholders; revisit with
+// strategy. Yard signs / palm cards are doc-exact dollar values (not formulas).
+const FILING_FEE = 100
+const YARD_SIGNS_COST = 385
+const PALM_CARDS_COST = 67
+const TEXT_CAMPAIGN_COUNT = 4
+const ROBOCALL_CAMPAIGN_COUNT = 3
 const TEXT_COST = 0.035
-const MAIL_UNIVERSE_RATE = 0.4
-const MAIL_COST_PER_PIECE = 0.55
-const DIGITAL_COST_PER_CONTACT = 0.06
-const SIGNS_PER_CONTACT_DENOMINATOR = 100
-const SIGN_COST = 5
-const DOOR_HANGER_COST = 0.2
-const COMPLIANCE_FLAT_COST = 400
+const ROBOCALL_COST = 0.045
+const CONTINGENCY_RATE = 0.05
 
 const formatDollars = (value: number): string =>
   `$${Math.round(value).toLocaleString('en-US')}`
@@ -395,70 +400,75 @@ interface BudgetBreakdown {
   lineItems: BudgetRow[]
 }
 
-const buildBudgetBreakdown = (voterContactGoal: number): BudgetBreakdown => {
-  const textCost = Math.round(voterContactGoal * TEXTS_PERCENT) * TEXT_COST
-  const robocallCost =
-    Math.round(voterContactGoal * ROBOCALLS_PERCENT) * ROBOCALL_COST
-  const digitalCost = voterContactGoal * DIGITAL_COST_PER_CONTACT
-  const mailCost =
-    Math.round(voterContactGoal * MAIL_UNIVERSE_RATE) * MAIL_COST_PER_PIECE
-  const totalDoors = Math.round(voterContactGoal * DOORS_PERCENT)
-  const signCount = Math.max(
-    0,
-    Math.ceil(voterContactGoal / SIGNS_PER_CONTACT_DENOMINATOR),
-  )
-  const yardLitCost = signCount * SIGN_COST + totalDoors * DOOR_HANGER_COST
-  const complianceCost = COMPLIANCE_FLAT_COST
-
-  const totalBudget = Math.round(
-    textCost +
-      robocallCost +
-      digitalCost +
-      mailCost +
-      yardLitCost +
-      complianceCost,
-  )
+const buildBudgetBreakdown = (
+  matchedCell: number,
+  matchedLandline: number,
+): BudgetBreakdown => {
+  const textCampaignsCost = TEXT_CAMPAIGN_COUNT * matchedCell * TEXT_COST
+  const robocallCampaignsCost =
+    ROBOCALL_CAMPAIGN_COUNT * matchedLandline * ROBOCALL_COST
+  const subtotal =
+    FILING_FEE +
+    YARD_SIGNS_COST +
+    PALM_CARDS_COST +
+    textCampaignsCost +
+    robocallCampaignsCost
+  const contingency = subtotal * CONTINGENCY_RATE
+  const totalBudget = Math.round(subtotal + contingency)
 
   const lineItems: BudgetRow[] = [
     {
-      category: 'Text messages',
-      amount: formatDollars(textCost),
-      rationale:
-        'Direct, scalable reach across your matched voter universe at the lowest cost per touch.',
+      category: 'Filing fees',
+      amount: formatDollars(FILING_FEE),
+      rationale: 'Nomination papers, any mandatory state/local filings.',
     },
     {
-      category: 'Robocalls',
-      amount: formatDollars(robocallCost),
+      category: 'Yard signs',
+      amount: formatDollars(YARD_SIGNS_COST),
       rationale:
-        "Catches landline-only voters that texts can't reach and reinforces your name on Election Day.",
+        'Core visibility in a small precinct; reusable between canvassers; estimated 50 yard signs for $385.',
     },
     {
-      category: 'Digital ads',
-      amount: formatDollars(digitalCost),
+      category: 'Palm cards',
+      amount: formatDollars(PALM_CARDS_COST),
       rationale:
-        'Geo-targeted reinforcement of name recognition across your district.',
+        'Handoffs at events and passive drops where canvassing allows; estimated 250 palm cards for $67.',
     },
     {
-      category: 'Direct mail',
-      amount: formatDollars(mailCost),
-      rationale:
-        'Tangible household touch that lands at home, often seen by the whole family.',
+      category: 'Text campaigns',
+      amount: formatDollars(textCampaignsCost),
+      rationale: `${TEXT_CAMPAIGN_COUNT} text campaigns to ${matchedCell.toLocaleString(
+        'en-US',
+      )} at $${TEXT_COST.toFixed(3)} per text.`,
     },
     {
-      category: 'Yard signs & literature',
-      amount: formatDollars(yardLitCost),
-      rationale:
-        'Local visibility multiplier. Every sign is a passive endorsement to every passerby.',
+      category: 'Robocall campaigns',
+      amount: formatDollars(robocallCampaignsCost),
+      rationale: `${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns to ${matchedLandline.toLocaleString(
+        'en-US',
+      )} at $${ROBOCALL_COST.toFixed(3)} per call.`,
     },
     {
-      category: 'Compliance & filing fees',
-      amount: formatDollars(complianceCost),
-      rationale: 'Mandatory state and local filings plus basic accounting.',
+      category: 'Contingency (5%)',
+      amount: formatDollars(contingency),
+      rationale: 'Reserve for last-week opportunities.',
+    },
+    {
+      category: 'Total',
+      amount: formatDollars(totalBudget),
+      rationale: 'Sum of all budget line-items.',
     },
   ]
 
   return { totalBudget, lineItems }
 }
+
+const FUNDRAISING_MIX: FundraisingRow[] = [
+  { source: 'Self-fund or loan', share: '30%' },
+  { source: 'Friends & family', share: '30%' },
+  { source: 'Small-dollar online', share: '25%' },
+  { source: 'Events, house parties, larger checks', share: '15%' },
+]
 
 const KEY_ASSUMPTIONS: string[] = [
   'Turnout behaves like recent comparable off-year municipal elections in your area, roughly 18 to 24 percent of registered voters.',
@@ -475,9 +485,9 @@ const PLAN_DOES_NOT_DO: string[] = [
 
 const GLOSSARY: GlossaryRow[] = [
   {
-    term: 'Projected Votes Needed to Win',
+    term: 'Projected Votes to Win',
     definition:
-      'The vote total needed to win the seat with certainty given the modeled voter turnout. Calculated as 50% plus one of projected voter turnout.',
+      'The vote total at which a candidate would win the seat with certainty given the modeled voter turnout. Calculated as 50% + 1 of the projected voter turnout.',
   },
   {
     term: 'Projected Voter Turnout',
@@ -485,17 +495,22 @@ const GLOSSARY: GlossaryRow[] = [
       'The estimated number of registered voters expected to cast a ballot in this specific election, derived from a turnout model applied to recent comparable cycles.',
   },
   {
-    term: 'Voter Contact Target',
+    term: 'Targeted Voter Contact Goal',
     definition:
-      'The total number of quality touches your campaign aims to deliver. Industry rule of thumb is 5x the win number.',
+      'The total number of contacts sent to voters that the campaign aims to deliver. Industry rule of thumb is 5× the projected votes to win.',
   },
   {
-    term: 'Quality Touch',
+    term: 'Voter Contact',
     definition:
-      'A contact attempt that reaches an intended voter via a channel capable of conveying the message (a delivered text, an answered call, an in-person conversation).',
+      'A contact attempt that reaches an intended voter via a channel capable of conveying the message (delivered text, answered call, in-person conversation).',
   },
   {
-    term: 'P2P Text (Peer-to-Peer Text)',
+    term: 'Likely Votes',
+    definition:
+      'The estimated number of votes you are on track to receive based on voter contacts completed to date. Calculated by counting 1 likely vote for every 5 voter contacts made.',
+  },
+  {
+    term: 'Text',
     definition:
       'A one-to-one SMS send from a volunteer-operated dashboard that complies with federal wireless regulations around automated dialing.',
   },
@@ -517,122 +532,111 @@ const GLOSSARY: GlossaryRow[] = [
   {
     term: 'GOTV',
     definition:
-      'Get Out The Vote. The concentrated push in the final 72 hours to convert identified supporters into cast ballots.',
+      '"Get Out The Vote", the concentrated push in the final 72 hours to convert identified supporters into cast ballots.',
   },
 ]
 
-const STRATEGY_BULLETS = [
+// "Campaign Plan at a Glance" — doc flags these as LLM-generated. Static
+// placeholders below render the doc's example copy with dynamic fields filled.
+const buildPlanAtAGlance = (
+  projectedTurnout: number,
+  contactWindowStart: string,
+  electionDate: string,
+  eventCount: number,
+): { title: string; body: string }[] => [
   {
-    title: "Mobilize, don't persuade.",
-    body: 'In a small electorate with no party cue, repeated name exposure and turnout are the decisive levers, not ideological persuasion.',
+    title: 'Voter turnout is the ball game.',
+    body: `In a ${projectedTurnout.toLocaleString(
+      'en-US',
+    )}-group of targeted voters with no party label to lean on, repeated name exposure and getting your people to the polls are the decisive levers.`,
   },
   {
     title: 'Stack the channels.',
-    body: 'Coordinated voter contact via peer-to-peer text and robocall covers your full voter universe across the campaign.',
+    body: `7 coordinated voter contacts (text + robocall) blanket your targeted voters between ${
+      contactWindowStart || '{12_weeks_before_election_date}'
+    } and ${electionDate || '{election_date}'}.`,
   },
   {
     title: 'Show up in person.',
-    body: 'High-density civic events carry more weight per hour than any paid channel at this budget.',
+    body: `${eventCount} high-density community events during your campaign carry more weight per hour than any paid channel.`,
   },
   {
-    title: 'Lock one message.',
-    body: 'Same name, same local issue, same ask on every send. Variation dilutes recognition.',
+    title: 'Message discipline.',
+    body: 'Define your core values and top issues that matter to you and your voters and stay consistent in how you communicate them.',
   },
 ]
 
-const CANDIDATE_COMMITMENTS = [
-  'Attend the three listed civic events in person.',
-  'Secure at least one earned-media placement per week during the final month.',
-  'Lock one concrete local issue as the consistent subject of every voter contact.',
-  'Clear calendar capacity for 10 to 15 hours per week of campaign activity through Election Day.',
-]
-
-const BIGGEST_RISKS = [
-  {
-    title: 'Vote-splitting.',
-    body: 'With multiple candidates on the ballot, a consolidated opposing base can win with as little as 35 to 40 percent of the vote. Your base must hold.',
-  },
-  {
-    title: 'Small-universe volatility.',
-    body: 'In a small voter universe, losing 30 committed supporters to weather, scheduling, or apathy moves the outcome by several percentage points. Contact redundancy is not optional.',
-  },
-  {
-    title: 'Compressed outreach window.',
-    body: 'Mail ballots begin distributing about three weeks before Election Day. Voters who return early cannot be persuaded late.',
-  },
-]
-
+// Opportunities and challenges — doc flags as LLM-generated. Doc example copy
+// preserved as static placeholders.
 const OPPORTUNITIES = [
   {
-    title: 'High reach potential.',
-    body: 'Matched phone data lets you realistically touch every likely voter multiple times across the cycle.',
-  },
-  {
-    title: 'Low absolute win number.',
-    body: 'A small win number is a mobilization target, not a persuasion target. A disciplined turnout operation is the decisive lever.',
+    title: 'Low absolute projected votes to win.',
+    body: 'A small win number is a target, not a ceiling. A disciplined turnout operation, not a media war, is the decisive lever (see Section 2).',
   },
   {
     title: 'Accessible earned media.',
-    body: 'Local outlets cover local races closely. A single op-ed or profile can move a meaningful share of your voter universe.',
+    body: 'Credible local outlets cover town-council races closely. A single op-ed or profile can move a meaningful share of the votes (see Section 5).',
   },
   {
     title: 'Strong civic calendar.',
-    body: 'Several high-value in-person events fall inside the final 30 days, listed in the Community Engagement section.',
+    body: 'High-value in-person opportunities fall inside the race window (see Section 5).',
   },
 ]
 
 const CHALLENGES = [
   {
     title: 'Vote-splitting risk.',
-    body: 'With multiple candidates on the ballot, your plan assumes the more conservative 50% + 1 target to absorb this risk.',
+    body: 'With multiple candidates on the ballot, a consolidated opposing base can win with as little as 35–40% of the votes. Our plan assumes the more conservative win-number target to absorb this risk.',
   },
   {
-    title: 'No party cue.',
-    body: 'A nonpartisan ballot means voters need repeated, standalone exposure to your name to recognize it when marking the ballot.',
+    title: 'No party ballot affiliation.',
+    body: 'Nonpartisan ballots mean voters need repeated, standalone exposure to your name to recognize it when marking the ballot. Name recognition has to be built one voter contact at a time.',
   },
   {
-    title: 'Compressed outreach window.',
-    body: 'Absentee and mail ballots begin distributing weeks before Election Day. Early contact is non-negotiable.',
+    title: 'Compressed contact window.',
+    body: 'Absentee, mail, or early ballots distribute weeks before Election Day. Voters who return early cannot be persuaded late — early contact is non-negotiable.',
   },
   {
-    title: 'Small-universe volatility.',
-    body: 'A small voter universe amplifies any swing. Redundancy in contact is the hedge against weather, schedule, or apathy.',
+    title: 'Small-district volatility.',
+    body: 'In a small voter universe, losing a few dozen committed supporters to weather, scheduling, or apathy moves the outcome by several percentage points. Redundancy in voter contact is not optional.',
+  },
+  {
+    title: 'No institutional endorsements at launch.',
+    body: 'Established organizations typically endorse candidates they already know. Endorsement outreach has to start in the first 30 days because most groups vote on endorsements months before Election Day.',
+  },
+  {
+    title: 'No prior donor list to inherit.',
+    body: 'Every dollar in your first 60 days has to be raised through cold asks to your personal network before extending out to contributors you do not already know.',
+  },
+  {
+    title: 'No existing volunteer base.',
+    body: 'The first 30 days should prioritize recruiting and training a core team of 5–10 volunteers, even if it slows other work.',
+  },
+  {
+    title: 'Debate and forum access is not automatic.',
+    body: "Candidate forums and debates are organized by civic groups, newspapers, or chambers of commerce, and inclusion depends on the organizer's discretion. Proactively contact every forum host in the district.",
+  },
+  {
+    title: 'Ballot access requirements have hard deadlines.',
+    body: 'Qualifying for the ballot requires meeting your jurisdiction-specific requirements by a fixed deadline. Work has to start early enough to absorb invalid signatures, paperwork errors, or timing risk.',
   },
 ]
 
-const KPIS = (
-  voterContactGoal: number,
-  volunteerHourTarget: number,
-): KpiRow[] => [
+// Opposition Research is rendered only when opponents.length >= 1. We don't yet
+// have opponent data from the campaign object, so this is a placeholder that
+// shows the doc's structure with {variable} slots.
+const OPPONENTS_PLACEHOLDER: Opponent[] = [
   {
-    kpi: 'Cumulative voter touches delivered',
-    target: `${voterContactGoal.toLocaleString('en-US')} by Election Day`,
-    cadence: 'Weekly Monday review',
-  },
-  {
-    kpi: 'Volunteer hours logged',
-    target: `${volunteerHourTarget}+ by Election Day`,
-    cadence: 'Weekly Monday review',
-  },
-  {
-    kpi: 'Earned-media placements',
-    target: 'At least 3 by Election Day',
-    cadence: 'Weekly Monday review',
-  },
-  {
-    kpi: 'Yard signs placed',
-    target: '40+ by 2 weeks before Election Day',
-    cadence: 'Bi-weekly walkthrough',
-  },
-  {
-    kpi: 'Absentee ballot requests among matched supporters',
-    target: '40%+ by absentee deadline',
-    cadence: 'Weekly after mail ballots open',
-  },
-  {
-    kpi: 'Event attendance (you in person)',
-    target: '3 of 3 civic events',
-    cadence: 'Tracked per event',
+    name: '{opponent_name_1}',
+    party: '{party}',
+    isIncumbent: false,
+    lastVoteShare: '{last_vote_share}',
+    positions: [
+      'Position on issue 1',
+      'Position on issue 2',
+      'Position on issue 3',
+    ],
+    websites: ['{website_1}'],
   },
 ]
 
@@ -645,7 +649,7 @@ const DATA_SOURCES: DataSourceRow[] = [
   {
     metric: 'Historical turnout',
     source:
-      'Certified results for the three most recent comparable municipal cycles.',
+      'Town Clerk certified results for the three most recent comparable municipal cycles.',
     lastUpdated: 'As of last certified election',
   },
   {
@@ -655,13 +659,14 @@ const DATA_SOURCES: DataSourceRow[] = [
     lastUpdated: 'Rolling 90-day refresh',
   },
   {
-    metric: 'Opponent-field data (opponents, seats)',
-    source: 'Local elections office candidate filings.',
+    metric: 'Candidate-field data (opponents, seats)',
+    source: 'Town Clerk candidate filings.',
     lastUpdated: 'As of filing deadline',
   },
   {
-    metric: 'Civic event calendar',
-    source: 'Public local calendars and civic association announcements.',
+    metric: 'Community event calendar',
+    source:
+      'Public local calendars and civic association announcements.',
     lastUpdated: 'Refreshed weekly',
   },
   {
@@ -679,53 +684,34 @@ const buildConfidenceEstimates = (
   winNumber: number,
   winNumberLow: number,
   winNumberHigh: number,
-  matchedCell: number,
-  matchedLandline: number,
 ): ConfidenceRow[] => [
   {
     estimate: 'Projected voter turnout',
     pointValue: projectedTurnout.toLocaleString('en-US'),
     range: `${projectedTurnoutLow.toLocaleString(
       'en-US',
-    )} to ${projectedTurnoutHigh.toLocaleString('en-US')}`,
-    notes:
-      'Based on 3-cycle turnout average plus or minus one standard deviation.',
+    )}–${projectedTurnoutHigh.toLocaleString('en-US')}`,
+    notes: 'Based on 3-cycle turnout average.',
   },
   {
-    estimate: 'Projected votes needed to win (50% + 1)',
+    estimate: 'Projected votes to win',
     pointValue: winNumber.toLocaleString('en-US'),
     range: `${winNumberLow.toLocaleString(
       'en-US',
-    )} to ${winNumberHigh.toLocaleString('en-US')}`,
-    notes: 'Moves with the voter universe.',
+    )}–${winNumberHigh.toLocaleString('en-US')}`,
+    notes: 'Moves with the targeted voters.',
   },
   {
-    estimate: 'Matched cell-phone records',
-    pointValue: matchedCell.toLocaleString('en-US'),
-    range: `${Math.round(matchedCell * 0.95).toLocaleString(
-      'en-US',
-    )} to ${Math.round(matchedCell * 1.05).toLocaleString('en-US')}`,
-    notes: 'Match-rate variance ±5%.',
-  },
-  {
-    estimate: 'Matched landline records',
-    pointValue: matchedLandline.toLocaleString('en-US'),
-    range: `${Math.round(matchedLandline * 0.95).toLocaleString(
-      'en-US',
-    )} to ${Math.round(matchedLandline * 1.05).toLocaleString('en-US')}`,
-    notes: 'Match-rate variance ±5%.',
-  },
-  {
-    estimate: 'Projected P2P text deliverability',
+    estimate: 'Projected text deliverability',
     pointValue: '~85%',
-    range: '80% to 90%',
-    notes: 'Industry benchmark (US wireless).',
+    range: '80–90%',
+    notes: 'Industry benchmark.',
   },
   {
-    estimate: 'Projected robocall answer rate',
+    estimate: 'Projected robocall listen rate',
     pointValue: '~30%',
-    range: '25% to 35%',
-    notes: 'Industry benchmark (landline).',
+    range: '25–35%',
+    notes: 'Industry benchmark.',
   },
 ]
 
@@ -733,6 +719,7 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   const candidateName = input.candidateName || 'Your campaign'
   const race = input.race || 'Your race'
   const location = [input.city, input.state].filter(Boolean).join(', ')
+  const districtName = location || '{district_name}'
 
   const electionDateRaw = input.electionDateIso
     ? new Date(input.electionDateIso)
@@ -745,6 +732,11 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     electionDateRaw && !Number.isNaN(electionDateRaw.getTime())
       ? electionDateRaw
       : null
+  const contactWindowStart = electionDateValid
+    ? formatDate(addDays(electionDateValid, -84))
+    : ''
+
+  const planGenerationDate = formatDate(new Date())
 
   const winNumber = input.winNumber
   const projectedTurnout = input.projectedTurnout
@@ -758,6 +750,10 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   const projectedTurnoutLow = Math.max(0, Math.round(projectedTurnout * 0.9))
   const projectedTurnoutHigh = Math.round(projectedTurnout * 1.1)
 
+  // Placeholder registered-voter count — derived from projected turnout
+  // assuming ~22% turnout. Replace once we have a real registered-voter source.
+  const registeredVoters =
+    projectedTurnout > 0 ? Math.round(projectedTurnout / 0.22) : 0
   const matchedCellRecords = Math.max(
     0,
     Math.round(projectedTurnout * PLACEHOLDER_MATCH_RATE_CELL * 4),
@@ -775,12 +771,12 @@ export const buildPlanData = (input: PlanInput): PlanData => {
       ? Number((voterContactGoal / projectedTurnout).toFixed(1))
       : 0
 
-  const { totalBudget, lineItems: budgetLineItems } =
-    buildBudgetBreakdown(voterContactGoal)
+  const { totalBudget, lineItems: budgetLineItems } = buildBudgetBreakdown(
+    matchedCellRecords,
+    matchedLandlineRecords,
+  )
 
-  // Weekly cadence targets (mirror OutreachPlanStep assumptions).
   const CANDIDATE_HOURS_PER_WEEK = 14
-  const VOLUNTEER_HOURS_PER_WEEK_EACH = 3
   const DOORS_PER_HOUR = 15
   const MAX_CAMPAIGN_WEEKS = 12
   let weeksRemaining = MAX_CAMPAIGN_WEEKS
@@ -800,18 +796,19 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     0,
     doorsPerWeek - candidateDoorsPerWeek,
   )
-  const volunteerHoursPerWeek =
-    Math.round(volunteerDoorsPerWeek / DOORS_PER_HOUR / 1) * 1
+  const volunteerHoursPerWeek = Math.round(
+    volunteerDoorsPerWeek / DOORS_PER_HOUR,
+  )
   const filingDeadline = electionDateValid
     ? formatDate(addDays(electionDateValid, -40))
     : null
-  void VOLUNTEER_HOURS_PER_WEEK_EACH
 
-  const { timeline, highlights } = buildTimeline(electionDateValid)
+  const { timeline, keyDates } = buildTimeline(electionDateValid)
   const contactSchedule = buildContactSchedule(electionDateValid)
   const civicEvents = buildCivicEvents(electionDateValid, input.city)
   const pressOutlets = buildPressOutlets(input.city, input.state)
-  const kpis = KPIS(voterContactGoal, volunteerHourTarget)
+  const eventCount = civicEvents.length
+  const mediaCount = pressOutlets.length
   const confidenceEstimates = buildConfidenceEstimates(
     projectedTurnout,
     projectedTurnoutLow,
@@ -819,81 +816,69 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     winNumber,
     winNumberLow,
     winNumberHigh,
-    matchedCellRecords,
-    matchedLandlineRecords,
+  )
+  const planAtAGlance = buildPlanAtAGlance(
+    projectedTurnout,
+    contactWindowStart,
+    electionDate,
+    eventCount,
   )
 
-  const keyNumbers: KeyNumber[] = [
+  const keyCampaignTargets: KeyTarget[] = [
     {
-      metric: 'Projected votes needed to win',
+      metric: 'Projected Votes to Win',
       target: winNumber.toLocaleString('en-US'),
     },
     {
-      metric: 'Projected voter turnout',
-      target: `${projectedTurnout.toLocaleString(
-        'en-US',
-      )} (range ${projectedTurnoutLow.toLocaleString(
-        'en-US',
-      )} to ${projectedTurnoutHigh.toLocaleString('en-US')})`,
+      metric: 'Projected Voter Turnout',
+      target: projectedTurnout.toLocaleString('en-US'),
     },
     {
-      metric: 'Voter contact target',
+      metric: 'Targeted Voter Contact Goal',
       target: voterContactGoal.toLocaleString('en-US'),
     },
     {
-      metric: 'Matched cell-phone records',
-      target: matchedCellRecords.toLocaleString('en-US'),
+      metric: 'Recommended Budget',
+      target: `$${totalBudget.toLocaleString('en-US')}`,
     },
     {
-      metric: 'Matched landline records',
-      target: matchedLandlineRecords.toLocaleString('en-US'),
-    },
-    {
-      metric: 'Volunteer-hour target',
-      target: `${volunteerHourTarget}+`,
-    },
-    {
-      metric: 'Total recommended budget',
-      target: `≈ $${totalBudget.toLocaleString('en-US')}`,
+      metric: 'Volunteer-Hour Goal',
+      target: `${volunteerHourTarget.toLocaleString('en-US')}+`,
     },
   ]
 
   const metrics: MetricRow[] = [
     {
-      metric: 'Projected votes needed to win',
-      target: winNumber.toLocaleString('en-US'),
-      source: '50% + 1 of projected voter turnout.',
-    },
-    {
-      metric: 'Projected voter turnout',
-      target: projectedTurnout.toLocaleString('en-US'),
+      metric: 'Registered Voters',
+      target: `${registeredVoters.toLocaleString('en-US')} registered voters`,
       source:
-        'Turnout model applied to active registered voters in your district.',
+        'The total pool of voters eligible to cast a ballot in your race, pulled from the latest voter file.',
     },
     {
-      metric: 'Voter contact target (quality touches)',
-      target: voterContactGoal.toLocaleString('en-US'),
-      source: '5x votes-to-win, industry rule of thumb for local races.',
+      metric: 'Projected Voter Turnout',
+      target: `${projectedTurnout.toLocaleString('en-US')} voters turnout`,
+      source:
+        'The projected number of voters we expect to cast a ballot in your race, based on past voter turnout and our proprietary models.',
     },
     {
-      metric: 'Matched cell-phone records',
-      target: matchedCellRecords.toLocaleString('en-US'),
-      source: 'Voter file append, commercial match.',
+      metric: 'Projected Votes to Win',
+      target: `${winNumber.toLocaleString('en-US')} votes needed to win`,
+      source: 'Projecting a simple majority (50% + 1) of projected voter turnout.',
     },
     {
-      metric: 'Matched landline records',
-      target: matchedLandlineRecords.toLocaleString('en-US'),
-      source: 'Voter file append, commercial match.',
+      metric: 'Contacts Per Likely Voter',
+      target: '5 contacts per likely voter',
+      source: 'Industry standard number of contacts for winning campaigns.',
     },
     {
-      metric: 'Average touches per likely voter',
-      target: `~${averageTouchesPerVoter}`,
-      source: 'Voter contact target divided by projected turnout.',
+      metric: 'Voter Contact Target',
+      target: `${voterContactGoal.toLocaleString('en-US')} total voter contacts`,
+      source: 'Voter Contacts × Votes-to-Win.',
     },
     {
-      metric: 'Volunteer-hour target',
-      target: `${volunteerHourTarget}+`,
-      source: 'Benchmark: about 1 volunteer hour per 3 votes needed.',
+      metric: 'Volunteer-Hour Target',
+      target: `${volunteerHourTarget.toLocaleString('en-US')} volunteer hours`,
+      source: 'Benchmark: 1 volunteer hour per ~3 votes needed.',
     },
   ]
 
@@ -901,14 +886,18 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     candidateName,
     race,
     location,
+    districtName,
     electionDate,
     electionDateRaw: electionDateValid,
+    planGenerationDate,
+    contactWindowStart,
     winNumber,
     winNumberLow,
     winNumberHigh,
     projectedTurnout,
     projectedTurnoutLow,
     projectedTurnoutHigh,
+    registeredVoters,
     voterContactGoal,
     opponentCount: FALLBACK_OPPONENT_COUNT,
     matchedCellRecords,
@@ -916,34 +905,25 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     volunteerHourTarget,
     totalBudget,
     averageTouchesPerVoter,
+    eventCount,
+    mediaCount,
     candidateHoursPerWeek: CANDIDATE_HOURS_PER_WEEK,
     volunteerHoursPerWeek,
     weeksRemaining,
     filingDeadline,
-    strategyBullets: STRATEGY_BULLETS,
-    keyNumbers,
-    timelineHighlights: highlights,
-    candidateCommitments: CANDIDATE_COMMITMENTS,
-    biggestRisks: BIGGEST_RISKS,
+    planAtAGlance,
+    keyCampaignTargets,
+    keyDates,
     opportunities: OPPORTUNITIES,
     challenges: CHALLENGES,
+    opponents: OPPONENTS_PLACEHOLDER,
     metrics,
     timeline,
     budgetLineItems,
-    budgetNotCovered: [
-      {
-        title: 'Paid staff.',
-        body: 'This plan assumes an all-volunteer operation.',
-      },
-      {
-        title: 'Polling.',
-        body: 'In a small voter universe, a statistically valid poll would cost more than the entire campaign.',
-      },
-    ],
+    fundraisingMix: FUNDRAISING_MIX,
     civicEvents,
     pressOutlets,
     contactSchedule,
-    kpis,
     dataSources: DATA_SOURCES,
     keyAssumptions: KEY_ASSUMPTIONS,
     confidenceEstimates,

--- a/app/dashboard/strategy/components/planContent.ts
+++ b/app/dashboard/strategy/components/planContent.ts
@@ -719,7 +719,11 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   const candidateName = input.candidateName || 'Your campaign'
   const race = input.race || 'Your race'
   const location = [input.city, input.state].filter(Boolean).join(', ')
-  const districtName = location || '{district_name}'
+  // Per the source doc, the hero line is the specific district label
+  // (e.g., "Precinct 6"), not city/state. The campaign object doesn't carry
+  // a real district_name today, so we surface the literal placeholder.
+  // Do not fall back to city/state.
+  const districtName = '{district_name}'
 
   const electionDateRaw = input.electionDateIso
     ? new Date(input.electionDateIso)

--- a/app/dashboard/strategy/components/planContent.ts
+++ b/app/dashboard/strategy/components/planContent.ts
@@ -1,0 +1,950 @@
+import { dateUsHelper } from 'helpers/dateHelper'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+const addDays = (date: Date, days: number): Date =>
+  new Date(date.getTime() + days * ONE_DAY_MS)
+
+const formatDate = (date: Date): string => dateUsHelper(date.toISOString())
+
+export interface PlanInput {
+  candidateName: string
+  race: string
+  city: string
+  state: string
+  electionDateIso: string | null | undefined
+  winNumber: number
+  projectedTurnout: number
+  voterContactGoal: number
+}
+
+export interface KeyNumber {
+  metric: string
+  target: string
+}
+
+export interface TimelineRow {
+  date: string
+  milestone: string
+  owner: string
+}
+
+export interface MetricRow {
+  metric: string
+  target: string
+  source: string
+}
+
+export interface BudgetRow {
+  category: string
+  amount: string
+  rationale: string
+}
+
+export interface CivicEvent {
+  event: string
+  date: string
+  why: string
+}
+
+export interface PressOutlet {
+  outlet: string
+  type: string
+  angle: string
+}
+
+export interface ContactSend {
+  date: string
+  tactic: string
+  audience: string
+  purpose: string
+  format: string
+}
+
+export interface KpiRow {
+  kpi: string
+  target: string
+  cadence: string
+}
+
+export interface DataSourceRow {
+  metric: string
+  source: string
+  lastUpdated: string
+}
+
+export interface ConfidenceRow {
+  estimate: string
+  pointValue: string
+  range: string
+  notes: string
+}
+
+export interface GlossaryRow {
+  term: string
+  definition: string
+}
+
+export interface PlanData {
+  // Identity
+  candidateName: string
+  race: string
+  location: string
+  electionDate: string
+  electionDateRaw: Date | null
+
+  // Numbers
+  winNumber: number
+  winNumberLow: number
+  winNumberHigh: number
+  projectedTurnout: number
+  projectedTurnoutLow: number
+  projectedTurnoutHigh: number
+  voterContactGoal: number
+
+  // Placeholder identity numbers
+  opponentCount: number
+  matchedCellRecords: number
+  matchedLandlineRecords: number
+  volunteerHourTarget: number
+  totalBudget: number
+  averageTouchesPerVoter: number
+
+  // Weekly cadence targets (for plan-inputs gap analysis)
+  candidateHoursPerWeek: number
+  volunteerHoursPerWeek: number
+  weeksRemaining: number
+  filingDeadline: string | null
+
+  // Executive summary
+  strategyBullets: { title: string; body: string }[]
+  keyNumbers: KeyNumber[]
+  timelineHighlights: { date: string; description: string }[]
+  candidateCommitments: string[]
+  biggestRisks: { title: string; body: string }[]
+
+  // Strategic landscape
+  opportunities: { title: string; body: string }[]
+  challenges: { title: string; body: string }[]
+
+  // Electoral goals
+  metrics: MetricRow[]
+
+  // Campaign timeline
+  timeline: TimelineRow[]
+
+  // Budget
+  budgetLineItems: BudgetRow[]
+  budgetNotCovered: { title: string; body: string }[]
+
+  // Community engagement
+  civicEvents: CivicEvent[]
+  pressOutlets: PressOutlet[]
+
+  // Voter contact
+  contactSchedule: ContactSend[]
+
+  // KPIs
+  kpis: KpiRow[]
+
+  // Methodology
+  dataSources: DataSourceRow[]
+  keyAssumptions: string[]
+  confidenceEstimates: ConfidenceRow[]
+  planDoesNotDo: string[]
+
+  // Glossary
+  glossary: GlossaryRow[]
+}
+
+const FALLBACK_OPPONENT_COUNT = 2
+
+const PLACEHOLDER_MATCH_RATE_CELL = 0.65
+const PLACEHOLDER_MATCH_RATE_LANDLINE = 0.35
+
+const placeholderCity = (city: string): string => city || 'your district'
+const placeholderState = (state: string): string => state || 'your state'
+
+const buildTimeline = (
+  electionDate: Date | null,
+): {
+  timeline: TimelineRow[]
+  highlights: { date: string; description: string }[]
+} => {
+  if (!electionDate) {
+    return { timeline: [], highlights: [] }
+  }
+  const filing = addDays(electionDate, -40)
+  const staffReady = addDays(electionDate, -34)
+  const messagingLocked = addDays(electionDate, -27)
+  const ballotsStart = addDays(electionDate, -25)
+  const voterRegDeadline = addDays(electionDate, -10)
+  const absenteeDeadline = addDays(electionDate, -7)
+
+  const timeline: TimelineRow[] = [
+    {
+      date: formatDate(filing),
+      milestone: 'Nomination papers filed with Town Clerk',
+      owner: 'You. Bring two backup copies.',
+    },
+    {
+      date: formatDate(staffReady),
+      milestone: 'Staff and volunteer recruitment and training complete',
+      owner: 'Campaign Manager',
+    },
+    {
+      date: formatDate(messagingLocked),
+      milestone: 'Messaging, branding, and printed materials finalized',
+      owner: 'Comms Lead. Lock before first text send.',
+    },
+    {
+      date: formatDate(ballotsStart),
+      milestone: 'Absentee and mail-in ballot distribution begins',
+      owner: 'Plan first contact to land by this date.',
+    },
+    {
+      date: formatDate(voterRegDeadline),
+      milestone: 'Voter registration deadline',
+      owner: 'Push via first robocall and digital.',
+    },
+    {
+      date: formatDate(absenteeDeadline),
+      milestone: 'Absentee ballot request deadline',
+      owner: 'Push via second P2P text.',
+    },
+    {
+      date: formatDate(electionDate),
+      milestone: 'Election Day. Polls open. Absentee ballots due.',
+      owner: 'All hands. See GOTV plan.',
+    },
+  ]
+
+  const highlights = [
+    {
+      date: formatDate(filing),
+      description: 'Nomination papers filed with Town Clerk.',
+    },
+    {
+      date: formatDate(ballotsStart),
+      description:
+        'Absentee and mail ballots begin distributing. First voter contact must land by this date.',
+    },
+    {
+      date: formatDate(voterRegDeadline),
+      description: 'Voter registration deadline.',
+    },
+    {
+      date: formatDate(absenteeDeadline),
+      description: 'Absentee ballot request deadline.',
+    },
+    {
+      date: formatDate(electionDate),
+      description:
+        'Election Day. GOTV push via robocall and peer-to-peer text.',
+    },
+  ]
+
+  return { timeline, highlights }
+}
+
+const buildContactSchedule = (electionDate: Date | null): ContactSend[] => {
+  if (!electionDate) return []
+  const sends: { offset: number; data: Omit<ContactSend, 'date'> }[] = [
+    {
+      offset: -20,
+      data: {
+        tactic: 'P2P Text',
+        audience: 'All matched cells',
+        purpose: 'Introduce yourself and your top priorities.',
+        format: 'Personalized peer-to-peer text.',
+      },
+    },
+    {
+      offset: -10,
+      data: {
+        tactic: 'Robocall',
+        audience: 'All matched landlines',
+        purpose: 'Alert voters to registration deadline (today).',
+        format: 'Automated voice call.',
+      },
+    },
+    {
+      offset: -5,
+      data: {
+        tactic: 'P2P Text',
+        audience: 'All matched cells',
+        purpose: 'Remind voters of absentee and mail ballot deadlines.',
+        format: 'Peer-to-peer text.',
+      },
+    },
+    {
+      offset: -3,
+      data: {
+        tactic: 'Robocall',
+        audience: 'All matched landlines',
+        purpose: 'Encourage early voting and ballot returns.',
+        format: 'Automated voice call.',
+      },
+    },
+    {
+      offset: -1,
+      data: {
+        tactic: 'P2P Text',
+        audience: 'All matched cells',
+        purpose: 'Day-before: polling location and reminder of candidacy.',
+        format: 'Peer-to-peer text.',
+      },
+    },
+    {
+      offset: 0,
+      data: {
+        tactic: 'Robocall',
+        audience: 'All matched landlines',
+        purpose: 'GOTV push with poll hours.',
+        format: 'Automated voice call.',
+      },
+    },
+    {
+      offset: 0,
+      data: {
+        tactic: 'P2P Text',
+        audience: 'All matched cells',
+        purpose: 'Final turnout push. Thank those who voted.',
+        format: 'Peer-to-peer text.',
+      },
+    },
+  ]
+
+  return sends.map(({ offset, data }) => ({
+    date: formatDate(addDays(electionDate, offset)),
+    ...data,
+  }))
+}
+
+const buildCivicEvents = (
+  electionDate: Date | null,
+  city: string,
+): CivicEvent[] => {
+  if (!electionDate) return []
+  const cityLabel = placeholderCity(city)
+  const event1 = addDays(electionDate, -23)
+  const event2 = addDays(electionDate, -15)
+  const event3 = addDays(electionDate, -13)
+  return [
+    {
+      event: `${cityLabel} Community Fall Festival`,
+      date: formatDate(event1),
+      why: 'High family turnout. Strong opportunity for literature handoffs and name recognition.',
+    },
+    {
+      event: `${cityLabel} Town Council Public Meeting`,
+      date: formatDate(event2),
+      why: "Demonstrate fluency with the council's actual agenda.",
+    },
+    {
+      event: `${cityLabel} Civic Association Meeting`,
+      date: formatDate(event3),
+      why: 'The single highest-density event inside your target precinct.',
+    },
+  ]
+}
+
+const buildPressOutlets = (city: string, state: string): PressOutlet[] => {
+  const cityLabel = placeholderCity(city)
+  const stateLabel = placeholderState(state)
+  return [
+    {
+      outlet: `${cityLabel} Times`,
+      type: 'Daily newspaper. Broad area reach.',
+      angle: 'Your profile or op-ed on a local policy priority.',
+    },
+    {
+      outlet: `The ${cityLabel} Weekly`,
+      type: 'Weekly. Deep local government coverage.',
+      angle: 'Your Q&A. Respond quickly to any editorial coverage.',
+    },
+    {
+      outlet: `${stateLabel} Local Radio`,
+      type: 'Community radio.',
+      angle: 'Short interview segment. Aim for drive-time window.',
+    },
+  ]
+}
+
+// NOTE: budget math mirrors OutreachPlanStep. If you tweak the constants there,
+// match them here so the success-page plan stays consistent with what the
+// candidate saw in onboarding.
+const DOORS_PERCENT = 0.2
+const ROBOCALLS_PERCENT = 0.2
+const TEXTS_PERCENT = 0.6
+const ROBOCALL_COST = 0.045
+const TEXT_COST = 0.035
+const MAIL_UNIVERSE_RATE = 0.4
+const MAIL_COST_PER_PIECE = 0.55
+const DIGITAL_COST_PER_CONTACT = 0.06
+const SIGNS_PER_CONTACT_DENOMINATOR = 100
+const SIGN_COST = 5
+const DOOR_HANGER_COST = 0.2
+const COMPLIANCE_FLAT_COST = 400
+
+const formatDollars = (value: number): string =>
+  `$${Math.round(value).toLocaleString('en-US')}`
+
+interface BudgetBreakdown {
+  totalBudget: number
+  lineItems: BudgetRow[]
+}
+
+const buildBudgetBreakdown = (voterContactGoal: number): BudgetBreakdown => {
+  const textCost = Math.round(voterContactGoal * TEXTS_PERCENT) * TEXT_COST
+  const robocallCost =
+    Math.round(voterContactGoal * ROBOCALLS_PERCENT) * ROBOCALL_COST
+  const digitalCost = voterContactGoal * DIGITAL_COST_PER_CONTACT
+  const mailCost =
+    Math.round(voterContactGoal * MAIL_UNIVERSE_RATE) * MAIL_COST_PER_PIECE
+  const totalDoors = Math.round(voterContactGoal * DOORS_PERCENT)
+  const signCount = Math.max(
+    0,
+    Math.ceil(voterContactGoal / SIGNS_PER_CONTACT_DENOMINATOR),
+  )
+  const yardLitCost = signCount * SIGN_COST + totalDoors * DOOR_HANGER_COST
+  const complianceCost = COMPLIANCE_FLAT_COST
+
+  const totalBudget = Math.round(
+    textCost +
+      robocallCost +
+      digitalCost +
+      mailCost +
+      yardLitCost +
+      complianceCost,
+  )
+
+  const lineItems: BudgetRow[] = [
+    {
+      category: 'Text messages',
+      amount: formatDollars(textCost),
+      rationale:
+        'Direct, scalable reach across your matched voter universe at the lowest cost per touch.',
+    },
+    {
+      category: 'Robocalls',
+      amount: formatDollars(robocallCost),
+      rationale:
+        "Catches landline-only voters that texts can't reach and reinforces your name on Election Day.",
+    },
+    {
+      category: 'Digital ads',
+      amount: formatDollars(digitalCost),
+      rationale:
+        'Geo-targeted reinforcement of name recognition across your district.',
+    },
+    {
+      category: 'Direct mail',
+      amount: formatDollars(mailCost),
+      rationale:
+        'Tangible household touch that lands at home, often seen by the whole family.',
+    },
+    {
+      category: 'Yard signs & literature',
+      amount: formatDollars(yardLitCost),
+      rationale:
+        'Local visibility multiplier. Every sign is a passive endorsement to every passerby.',
+    },
+    {
+      category: 'Compliance & filing fees',
+      amount: formatDollars(complianceCost),
+      rationale: 'Mandatory state and local filings plus basic accounting.',
+    },
+  ]
+
+  return { totalBudget, lineItems }
+}
+
+const KEY_ASSUMPTIONS: string[] = [
+  'Turnout behaves like recent comparable off-year municipal elections in your area, roughly 18 to 24 percent of registered voters.',
+  'Voter preferences distribute across the field without one opponent dominating. A plurality near 40 percent is often sufficient to win, but we plan to the more conservative 50% + 1 threshold.',
+  'Phone match and deliverability rates are consistent with recent cycles. We assume roughly 60% cell deliverability and 35% landline answer rate.',
+  'You will execute the contact cadence on schedule. Any slippage materially reduces the probability of hitting the contact goal.',
+]
+
+const PLAN_DOES_NOT_DO: string[] = [
+  'It does not include a persuasion model. We are not scoring individual voters for likelihood of supporting you specifically, which would require survey data we do not have.',
+  'It does not forecast a win probability. The race is close by design, and small shifts in turnout can flip the outcome.',
+  'It does not replace local political judgment. Your own read of the community should override any single number in this document.',
+]
+
+const GLOSSARY: GlossaryRow[] = [
+  {
+    term: 'Projected Votes Needed to Win',
+    definition:
+      'The vote total needed to win the seat with certainty given the modeled voter turnout. Calculated as 50% plus one of projected voter turnout.',
+  },
+  {
+    term: 'Projected Voter Turnout',
+    definition:
+      'The estimated number of registered voters expected to cast a ballot in this specific election, derived from a turnout model applied to recent comparable cycles.',
+  },
+  {
+    term: 'Voter Contact Target',
+    definition:
+      'The total number of quality touches your campaign aims to deliver. Industry rule of thumb is 5x the win number.',
+  },
+  {
+    term: 'Quality Touch',
+    definition:
+      'A contact attempt that reaches an intended voter via a channel capable of conveying the message (a delivered text, an answered call, an in-person conversation).',
+  },
+  {
+    term: 'P2P Text (Peer-to-Peer Text)',
+    definition:
+      'A one-to-one SMS send from a volunteer-operated dashboard that complies with federal wireless regulations around automated dialing.',
+  },
+  {
+    term: 'Robocall',
+    definition:
+      'An automated pre-recorded voice call, used here only to landlines to comply with applicable wireless rules.',
+  },
+  {
+    term: 'Match Rate',
+    definition:
+      'The share of records in a voter file that are successfully appended with a phone number from a commercial data vendor.',
+  },
+  {
+    term: 'Standard Error / 95% CI',
+    definition:
+      'A range around an estimate such that, under the modeling assumptions, the true value is expected to fall within the range 95% of the time.',
+  },
+  {
+    term: 'GOTV',
+    definition:
+      'Get Out The Vote. The concentrated push in the final 72 hours to convert identified supporters into cast ballots.',
+  },
+]
+
+const STRATEGY_BULLETS = [
+  {
+    title: "Mobilize, don't persuade.",
+    body: 'In a small electorate with no party cue, repeated name exposure and turnout are the decisive levers, not ideological persuasion.',
+  },
+  {
+    title: 'Stack the channels.',
+    body: 'Coordinated voter contact via peer-to-peer text and robocall covers your full voter universe across the campaign.',
+  },
+  {
+    title: 'Show up in person.',
+    body: 'High-density civic events carry more weight per hour than any paid channel at this budget.',
+  },
+  {
+    title: 'Lock one message.',
+    body: 'Same name, same local issue, same ask on every send. Variation dilutes recognition.',
+  },
+]
+
+const CANDIDATE_COMMITMENTS = [
+  'Attend the three listed civic events in person.',
+  'Secure at least one earned-media placement per week during the final month.',
+  'Lock one concrete local issue as the consistent subject of every voter contact.',
+  'Clear calendar capacity for 10 to 15 hours per week of campaign activity through Election Day.',
+]
+
+const BIGGEST_RISKS = [
+  {
+    title: 'Vote-splitting.',
+    body: 'With multiple candidates on the ballot, a consolidated opposing base can win with as little as 35 to 40 percent of the vote. Your base must hold.',
+  },
+  {
+    title: 'Small-universe volatility.',
+    body: 'In a small voter universe, losing 30 committed supporters to weather, scheduling, or apathy moves the outcome by several percentage points. Contact redundancy is not optional.',
+  },
+  {
+    title: 'Compressed outreach window.',
+    body: 'Mail ballots begin distributing about three weeks before Election Day. Voters who return early cannot be persuaded late.',
+  },
+]
+
+const OPPORTUNITIES = [
+  {
+    title: 'High reach potential.',
+    body: 'Matched phone data lets you realistically touch every likely voter multiple times across the cycle.',
+  },
+  {
+    title: 'Low absolute win number.',
+    body: 'A small win number is a mobilization target, not a persuasion target. A disciplined turnout operation is the decisive lever.',
+  },
+  {
+    title: 'Accessible earned media.',
+    body: 'Local outlets cover local races closely. A single op-ed or profile can move a meaningful share of your voter universe.',
+  },
+  {
+    title: 'Strong civic calendar.',
+    body: 'Several high-value in-person events fall inside the final 30 days, listed in the Community Engagement section.',
+  },
+]
+
+const CHALLENGES = [
+  {
+    title: 'Vote-splitting risk.',
+    body: 'With multiple candidates on the ballot, your plan assumes the more conservative 50% + 1 target to absorb this risk.',
+  },
+  {
+    title: 'No party cue.',
+    body: 'A nonpartisan ballot means voters need repeated, standalone exposure to your name to recognize it when marking the ballot.',
+  },
+  {
+    title: 'Compressed outreach window.',
+    body: 'Absentee and mail ballots begin distributing weeks before Election Day. Early contact is non-negotiable.',
+  },
+  {
+    title: 'Small-universe volatility.',
+    body: 'A small voter universe amplifies any swing. Redundancy in contact is the hedge against weather, schedule, or apathy.',
+  },
+]
+
+const KPIS = (
+  voterContactGoal: number,
+  volunteerHourTarget: number,
+): KpiRow[] => [
+  {
+    kpi: 'Cumulative voter touches delivered',
+    target: `${voterContactGoal.toLocaleString('en-US')} by Election Day`,
+    cadence: 'Weekly Monday review',
+  },
+  {
+    kpi: 'Volunteer hours logged',
+    target: `${volunteerHourTarget}+ by Election Day`,
+    cadence: 'Weekly Monday review',
+  },
+  {
+    kpi: 'Earned-media placements',
+    target: 'At least 3 by Election Day',
+    cadence: 'Weekly Monday review',
+  },
+  {
+    kpi: 'Yard signs placed',
+    target: '40+ by 2 weeks before Election Day',
+    cadence: 'Bi-weekly walkthrough',
+  },
+  {
+    kpi: 'Absentee ballot requests among matched supporters',
+    target: '40%+ by absentee deadline',
+    cadence: 'Weekly after mail ballots open',
+  },
+  {
+    kpi: 'Event attendance (you in person)',
+    target: '3 of 3 civic events',
+    cadence: 'Tracked per event',
+  },
+]
+
+const DATA_SOURCES: DataSourceRow[] = [
+  {
+    metric: 'Registered voters in your district',
+    source: 'Secretary of State voter file (public extract).',
+    lastUpdated: 'Refreshed monthly',
+  },
+  {
+    metric: 'Historical turnout',
+    source:
+      'Certified results for the three most recent comparable municipal cycles.',
+    lastUpdated: 'As of last certified election',
+  },
+  {
+    metric: 'Phone match rates',
+    source:
+      'Commercial voter-file append (industry-standard L2 / TargetSmart matching).',
+    lastUpdated: 'Rolling 90-day refresh',
+  },
+  {
+    metric: 'Opponent-field data (opponents, seats)',
+    source: 'Local elections office candidate filings.',
+    lastUpdated: 'As of filing deadline',
+  },
+  {
+    metric: 'Civic event calendar',
+    source: 'Public local calendars and civic association announcements.',
+    lastUpdated: 'Refreshed weekly',
+  },
+  {
+    metric: 'Press and media outlets',
+    source:
+      'GoodParty.org local-media directory, cross-checked against outlet websites.',
+    lastUpdated: 'Rolling',
+  },
+]
+
+const buildConfidenceEstimates = (
+  projectedTurnout: number,
+  projectedTurnoutLow: number,
+  projectedTurnoutHigh: number,
+  winNumber: number,
+  winNumberLow: number,
+  winNumberHigh: number,
+  matchedCell: number,
+  matchedLandline: number,
+): ConfidenceRow[] => [
+  {
+    estimate: 'Projected voter turnout',
+    pointValue: projectedTurnout.toLocaleString('en-US'),
+    range: `${projectedTurnoutLow.toLocaleString(
+      'en-US',
+    )} to ${projectedTurnoutHigh.toLocaleString('en-US')}`,
+    notes:
+      'Based on 3-cycle turnout average plus or minus one standard deviation.',
+  },
+  {
+    estimate: 'Projected votes needed to win (50% + 1)',
+    pointValue: winNumber.toLocaleString('en-US'),
+    range: `${winNumberLow.toLocaleString(
+      'en-US',
+    )} to ${winNumberHigh.toLocaleString('en-US')}`,
+    notes: 'Moves with the voter universe.',
+  },
+  {
+    estimate: 'Matched cell-phone records',
+    pointValue: matchedCell.toLocaleString('en-US'),
+    range: `${Math.round(matchedCell * 0.95).toLocaleString(
+      'en-US',
+    )} to ${Math.round(matchedCell * 1.05).toLocaleString('en-US')}`,
+    notes: 'Match-rate variance ±5%.',
+  },
+  {
+    estimate: 'Matched landline records',
+    pointValue: matchedLandline.toLocaleString('en-US'),
+    range: `${Math.round(matchedLandline * 0.95).toLocaleString(
+      'en-US',
+    )} to ${Math.round(matchedLandline * 1.05).toLocaleString('en-US')}`,
+    notes: 'Match-rate variance ±5%.',
+  },
+  {
+    estimate: 'Projected P2P text deliverability',
+    pointValue: '~85%',
+    range: '80% to 90%',
+    notes: 'Industry benchmark (US wireless).',
+  },
+  {
+    estimate: 'Projected robocall answer rate',
+    pointValue: '~30%',
+    range: '25% to 35%',
+    notes: 'Industry benchmark (landline).',
+  },
+]
+
+export const buildPlanData = (input: PlanInput): PlanData => {
+  const candidateName = input.candidateName || 'Your campaign'
+  const race = input.race || 'Your race'
+  const location = [input.city, input.state].filter(Boolean).join(', ')
+
+  const electionDateRaw = input.electionDateIso
+    ? new Date(input.electionDateIso)
+    : null
+  const electionDate =
+    electionDateRaw && !Number.isNaN(electionDateRaw.getTime())
+      ? formatDate(electionDateRaw)
+      : ''
+  const electionDateValid =
+    electionDateRaw && !Number.isNaN(electionDateRaw.getTime())
+      ? electionDateRaw
+      : null
+
+  const winNumber = input.winNumber
+  const projectedTurnout = input.projectedTurnout
+  const voterContactGoal =
+    input.voterContactGoal > 0
+      ? input.voterContactGoal
+      : Math.round(winNumber * 5)
+
+  const winNumberLow = Math.max(0, Math.round(winNumber * 0.9))
+  const winNumberHigh = Math.round(winNumber * 1.1)
+  const projectedTurnoutLow = Math.max(0, Math.round(projectedTurnout * 0.9))
+  const projectedTurnoutHigh = Math.round(projectedTurnout * 1.1)
+
+  const matchedCellRecords = Math.max(
+    0,
+    Math.round(projectedTurnout * PLACEHOLDER_MATCH_RATE_CELL * 4),
+  )
+  const matchedLandlineRecords = Math.max(
+    0,
+    Math.round(projectedTurnout * PLACEHOLDER_MATCH_RATE_LANDLINE * 2),
+  )
+  const volunteerHourTarget = Math.max(
+    100,
+    Math.round((winNumber || 0) / 3 / 10) * 10,
+  )
+  const averageTouchesPerVoter =
+    projectedTurnout > 0
+      ? Number((voterContactGoal / projectedTurnout).toFixed(1))
+      : 0
+
+  const { totalBudget, lineItems: budgetLineItems } =
+    buildBudgetBreakdown(voterContactGoal)
+
+  // Weekly cadence targets (mirror OutreachPlanStep assumptions).
+  const CANDIDATE_HOURS_PER_WEEK = 14
+  const VOLUNTEER_HOURS_PER_WEEK_EACH = 3
+  const DOORS_PER_HOUR = 15
+  const FALLBACK_WEEKS_REMAINING = 12
+  let weeksRemaining = FALLBACK_WEEKS_REMAINING
+  if (electionDateValid) {
+    const ms = electionDateValid.getTime() - Date.now()
+    if (ms > 0) {
+      weeksRemaining = Math.ceil(ms / (7 * 24 * 60 * 60 * 1000))
+    }
+  }
+  const totalDoors = Math.round(voterContactGoal * 0.2)
+  const doorsPerWeek = totalDoors / weeksRemaining
+  const candidateDoorsPerWeek = CANDIDATE_HOURS_PER_WEEK * DOORS_PER_HOUR
+  const volunteerDoorsPerWeek = Math.max(
+    0,
+    doorsPerWeek - candidateDoorsPerWeek,
+  )
+  const volunteerHoursPerWeek =
+    Math.round(volunteerDoorsPerWeek / DOORS_PER_HOUR / 1) * 1
+  const filingDeadline = electionDateValid
+    ? formatDate(addDays(electionDateValid, -40))
+    : null
+  void VOLUNTEER_HOURS_PER_WEEK_EACH
+
+  const { timeline, highlights } = buildTimeline(electionDateValid)
+  const contactSchedule = buildContactSchedule(electionDateValid)
+  const civicEvents = buildCivicEvents(electionDateValid, input.city)
+  const pressOutlets = buildPressOutlets(input.city, input.state)
+  const kpis = KPIS(voterContactGoal, volunteerHourTarget)
+  const confidenceEstimates = buildConfidenceEstimates(
+    projectedTurnout,
+    projectedTurnoutLow,
+    projectedTurnoutHigh,
+    winNumber,
+    winNumberLow,
+    winNumberHigh,
+    matchedCellRecords,
+    matchedLandlineRecords,
+  )
+
+  const keyNumbers: KeyNumber[] = [
+    {
+      metric: 'Projected votes needed to win',
+      target: winNumber.toLocaleString('en-US'),
+    },
+    {
+      metric: 'Projected voter turnout',
+      target: `${projectedTurnout.toLocaleString(
+        'en-US',
+      )} (range ${projectedTurnoutLow.toLocaleString(
+        'en-US',
+      )} to ${projectedTurnoutHigh.toLocaleString('en-US')})`,
+    },
+    {
+      metric: 'Voter contact target',
+      target: voterContactGoal.toLocaleString('en-US'),
+    },
+    {
+      metric: 'Matched cell-phone records',
+      target: matchedCellRecords.toLocaleString('en-US'),
+    },
+    {
+      metric: 'Matched landline records',
+      target: matchedLandlineRecords.toLocaleString('en-US'),
+    },
+    {
+      metric: 'Volunteer-hour target',
+      target: `${volunteerHourTarget}+`,
+    },
+    {
+      metric: 'Total recommended budget',
+      target: `≈ $${totalBudget.toLocaleString('en-US')}`,
+    },
+  ]
+
+  const metrics: MetricRow[] = [
+    {
+      metric: 'Projected votes needed to win',
+      target: winNumber.toLocaleString('en-US'),
+      source: '50% + 1 of projected voter turnout.',
+    },
+    {
+      metric: 'Projected voter turnout',
+      target: projectedTurnout.toLocaleString('en-US'),
+      source:
+        'Turnout model applied to active registered voters in your district.',
+    },
+    {
+      metric: 'Voter contact target (quality touches)',
+      target: voterContactGoal.toLocaleString('en-US'),
+      source: '5x votes-to-win, industry rule of thumb for local races.',
+    },
+    {
+      metric: 'Matched cell-phone records',
+      target: matchedCellRecords.toLocaleString('en-US'),
+      source: 'Voter file append, commercial match.',
+    },
+    {
+      metric: 'Matched landline records',
+      target: matchedLandlineRecords.toLocaleString('en-US'),
+      source: 'Voter file append, commercial match.',
+    },
+    {
+      metric: 'Average touches per likely voter',
+      target: `~${averageTouchesPerVoter}`,
+      source: 'Voter contact target divided by projected turnout.',
+    },
+    {
+      metric: 'Volunteer-hour target',
+      target: `${volunteerHourTarget}+`,
+      source: 'Benchmark: about 1 volunteer hour per 3 votes needed.',
+    },
+  ]
+
+  return {
+    candidateName,
+    race,
+    location,
+    electionDate,
+    electionDateRaw: electionDateValid,
+    winNumber,
+    winNumberLow,
+    winNumberHigh,
+    projectedTurnout,
+    projectedTurnoutLow,
+    projectedTurnoutHigh,
+    voterContactGoal,
+    opponentCount: FALLBACK_OPPONENT_COUNT,
+    matchedCellRecords,
+    matchedLandlineRecords,
+    volunteerHourTarget,
+    totalBudget,
+    averageTouchesPerVoter,
+    candidateHoursPerWeek: CANDIDATE_HOURS_PER_WEEK,
+    volunteerHoursPerWeek,
+    weeksRemaining,
+    filingDeadline,
+    strategyBullets: STRATEGY_BULLETS,
+    keyNumbers,
+    timelineHighlights: highlights,
+    candidateCommitments: CANDIDATE_COMMITMENTS,
+    biggestRisks: BIGGEST_RISKS,
+    opportunities: OPPORTUNITIES,
+    challenges: CHALLENGES,
+    metrics,
+    timeline,
+    budgetLineItems,
+    budgetNotCovered: [
+      {
+        title: 'Paid staff.',
+        body: 'This plan assumes an all-volunteer operation.',
+      },
+      {
+        title: 'Polling.',
+        body: 'In a small voter universe, a statistically valid poll would cost more than the entire campaign.',
+      },
+    ],
+    civicEvents,
+    pressOutlets,
+    contactSchedule,
+    kpis,
+    dataSources: DATA_SOURCES,
+    keyAssumptions: KEY_ASSUMPTIONS,
+    confidenceEstimates,
+    planDoesNotDo: PLAN_DOES_NOT_DO,
+    glossary: GLOSSARY,
+  }
+}

--- a/app/dashboard/strategy/page.tsx
+++ b/app/dashboard/strategy/page.tsx
@@ -1,0 +1,17 @@
+import pageMetaData from 'helpers/metadataHelper'
+import candidateAccess from '../shared/candidateAccess'
+import StrategyPage from './components/StrategyPage'
+
+const meta = pageMetaData({
+  title: 'Strategy | GoodParty.org',
+  description: 'Strategy',
+  slug: '/dashboard/strategy',
+})
+export const metadata = meta
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page(): Promise<React.JSX.Element> {
+  await candidateAccess()
+  return <StrategyPage pathname="/dashboard/strategy" />
+}

--- a/app/onboarding/components/LocalNewsSourcesSection.tsx
+++ b/app/onboarding/components/LocalNewsSourcesSection.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, queryOptions } from '@tanstack/react-query'
 import { Card, CardContent, Badge } from '@styleguide'
-import { Newspaper, RadioTower, Tv } from 'lucide-react'
 import { clientRequest } from 'gpApi/typed-request'
 import { reportErrorToSentry } from '@shared/sentry'
 
@@ -47,24 +46,6 @@ const localNewsQueryOptions = (params: {
   })
 
 export { localNewsQueryOptions }
-
-const typeIcon: Record<OutletType, React.JSX.Element> = {
-  [OUTLET_TYPE.PRINT]: (
-    <span className="flex size-11 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-components-input-active">
-      <Newspaper className="size-5" />
-    </span>
-  ),
-  [OUTLET_TYPE.TV]: (
-    <span className="flex size-11 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-500">
-      <Tv className="size-5" />
-    </span>
-  ),
-  [OUTLET_TYPE.RADIO]: (
-    <span className="flex size-11 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600">
-      <RadioTower className="size-5" />
-    </span>
-  ),
-}
 
 const typeLabel: Record<OutletType, string> = {
   [OUTLET_TYPE.TV]: 'Television',
@@ -133,7 +114,6 @@ const OutletRow = ({
         : 'flex items-start gap-4'
     }
   >
-    {typeIcon[outlet.type]}
     <div className="min-w-0 flex-1">
       <h3 className="text-base font-semibold text-foreground">{outlet.name}</h3>
       <p className="mt-1 text-sm leading-6 text-muted-foreground">

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -30,6 +30,7 @@ import { useUser } from '@shared/hooks/useUser'
 import { clientRequest } from 'gpApi/typed-request'
 import { clientFetch } from 'gpApi/clientFetch'
 import { apiRoutes } from 'gpApi/routes'
+import { numberFormatter } from 'helpers/numberHelper'
 import { setCookie } from 'helpers/cookieHelper'
 import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
@@ -40,7 +41,7 @@ import { ONBOARDING_STEPS, firstOnboardingStepId } from './onboardingConfig'
 import { getVisibleOnboardingSteps } from './onboardingHelpers'
 import { OfficeSelectionStep } from './OfficeSelectionStep'
 import { ManualOfficeEntryStep } from './ManualOfficeEntryStep'
-import { OutreachPlanStep } from './OutreachPlanStep'
+import { OutreachPlanStep, computeWeeksRemaining } from './OutreachPlanStep'
 import {
   PathToVictoryAside,
   PathToVictoryHeader,
@@ -965,7 +966,13 @@ export default function OnboardingFlow({
                     {activeStep.title}
                   </h1>
                   <p className="text-lg text-muted-foreground sm:text-base">
-                    {activeStep.description}
+                    {activeStep.id === 'outreach-plan'
+                      ? `You need ${numberFormatter(
+                          liveCampaign?.raceTargetMetrics?.winNumber ?? 0,
+                        )} projected voters to win with at least ${computeWeeksRemaining(
+                          liveCampaign?.details?.electionDate ?? null,
+                        )} weeks to campaign before Election Day.`
+                      : activeStep.description}
                   </p>
                 </div>
               )}

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -969,9 +969,7 @@ export default function OnboardingFlow({
                     {activeStep.id === 'outreach-plan'
                       ? `You need ${numberFormatter(
                           liveCampaign?.raceTargetMetrics?.winNumber ?? 0,
-                        )} projected voters to win with at least ${computeWeeksRemaining(
-                          liveCampaign?.details?.electionDate ?? null,
-                        )} weeks to campaign before Election Day.`
+                        )} projected voters to win. Here's the budget and time it'll take.`
                       : activeStep.description}
                   </p>
                 </div>

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -35,13 +35,17 @@ import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { identifyUser } from '@shared/utils/analytics'
 import { reportErrorToSentry } from '@shared/sentry'
-import { numberFormatter } from 'helpers/numberHelper'
 import type { Campaign } from 'helpers/types'
 import { ONBOARDING_STEPS, firstOnboardingStepId } from './onboardingConfig'
 import { getVisibleOnboardingSteps } from './onboardingHelpers'
 import { OfficeSelectionStep } from './OfficeSelectionStep'
 import { ManualOfficeEntryStep } from './ManualOfficeEntryStep'
-import { PathToVictoryStep } from './PathToVictoryStep'
+import { OutreachPlanStep } from './OutreachPlanStep'
+import {
+  PathToVictoryAside,
+  PathToVictoryHeader,
+  PathToVictoryStep,
+} from './PathToVictoryStep'
 import { PledgeStep } from './PledgeStep'
 import {
   VoterDemographicsStep,
@@ -340,6 +344,10 @@ const StepBody = ({
         office={answers.structuredOffice?.positionName}
       />
     )
+  }
+
+  if (activeStep.id === 'outreach-plan') {
+    return <OutreachPlanStep campaign={liveCampaign} />
   }
 
   if (activeStep.id === 'pledge') {
@@ -885,7 +893,7 @@ export default function OnboardingFlow({
       if (!effectiveCampaign) return
       const ok = await persistPledgeAndComplete()
       if (!ok) return
-      router.push('/dashboard')
+      router.push('/onboarding/success')
       return
     }
     if (nextStep) {
@@ -945,35 +953,19 @@ export default function OnboardingFlow({
                 activeStep.id === 'welcome' ? ' text-center' : ''
               }`}
             >
-              {isP2vBlocking ? null : (
+              {isP2vBlocking ? null : activeStep.id === 'path-to-victory' ? (
+                <PathToVictoryHeader
+                  title={activeStep.title}
+                  fallbackDescription={activeStep.description}
+                  officeName={p2vOfficeName}
+                />
+              ) : (
                 <div className="space-y-4">
                   <h1 className="text-4xl font-bold text-foreground sm:text-5xl">
                     {activeStep.title}
                   </h1>
                   <p className="text-lg text-muted-foreground sm:text-base">
-                    {activeStep.id === 'path-to-victory' && p2vOfficeName ? (
-                      <>
-                        We use historical voter data and proprietary models to
-                        get the most accurate projections for{' '}
-                        <span className="font-semibold text-foreground">
-                          {p2vOfficeName}
-                        </span>
-                        .
-                      </>
-                    ) : activeStep.id === 'voter-demographics' &&
-                      p2vOfficeName ? (
-                      <>
-                        We crunch the latest voter data, along with proprietary
-                        behavior models, and local news to prioritize the issues
-                        voters care about for{' '}
-                        <span className="font-semibold text-foreground">
-                          {p2vOfficeName}
-                        </span>
-                        .
-                      </>
-                    ) : (
-                      activeStep.description
-                    )}
+                    {activeStep.description}
                   </p>
                 </div>
               )}
@@ -1000,17 +992,9 @@ export default function OnboardingFlow({
                 }}
               >
                 {activeStep.id === 'path-to-victory' ? (
-                  <WhyWeAsk title="You can do this!">
-                    Most candidates think they need to convince{' '}
-                    <em>everyone</em>. You don&apos;t. You need to find{' '}
-                    {liveCampaign?.raceTargetMetrics?.winNumber
-                      ? `${numberFormatter(
-                          liveCampaign.raceTargetMetrics.winNumber,
-                        )} people`
-                      : 'your win number'}
-                    , talk to them, and make sure they vote. We&apos;ll show you
-                    exactly what that takes.
-                  </WhyWeAsk>
+                  <PathToVictoryAside
+                    winNumber={liveCampaign?.raceTargetMetrics?.winNumber}
+                  />
                 ) : (
                   <WhyWeAsk text={activeStep.whyWeAsk} />
                 )}
@@ -1038,11 +1022,7 @@ export default function OnboardingFlow({
             onClick={goNext}
             disabled={!canContinue}
           >
-            {nextStep
-              ? 'Continue'
-              : activeStep.id === 'pledge'
-              ? 'Agree & Create My Plan'
-              : 'Complete'}
+            {nextStep ? 'Continue' : activeStep.nextLabel ?? 'Complete'}
           </Button>
         </div>
       </div>

--- a/app/onboarding/components/OutreachPlanStep.tsx
+++ b/app/onboarding/components/OutreachPlanStep.tsx
@@ -6,8 +6,6 @@ import type { Campaign } from 'helpers/types'
 
 const VOTER_CONTACT_MULTIPLIER = 5
 const DOORS_PERCENT = 0.2
-const ROBOCALLS_PERCENT = 0.2
-const TEXTS_PERCENT = 0.6
 const ROBOCALL_COST = 0.045
 const TEXT_COST = 0.035
 const DOORS_PER_HOUR = 15
@@ -18,53 +16,20 @@ const CANDIDATE_HOURS_PER_WEEK = 14
 const MAX_CAMPAIGN_WEEKS = 12
 const FALLBACK_WEEKS_REMAINING = MAX_CAMPAIGN_WEEKS
 
-/**
- * Budget channel benchmarks — first-stab values for researcher review.
- * Each rate is a midpoint of public sources; tighten or tier these once
- * GoodParty.org strategy has a preferred number.
- *
- * Direct mail
- *   MAIL_UNIVERSE_RATE: real mail goes to a persuadable subset of the voter-
- *   contact universe, not all of it. 40% is a midpoint between high-prop
- *   targeting (~25%) and full-universe (~60%).
- *   MAIL_COST_PER_PIECE: $0.55 = midpoint of $0.50–$0.70 typical bulk political
- *   postcards (printing + postage). Drops to ~$0.32 at 50k+ pieces.
- *   https://suttonsmart.com/political-mailers/budgeting-cost-management/political-mailer-pricing-guide/
- *   https://www.thecampaignworkshop.com/blog/political-direct-mail/political-direct-mail
- *
- * Digital ads
- *   DIGITAL_COST_PER_CONTACT: $0.06 ≈ 5 impressions × ~$12 CPM. The $12 CPM is
- *   a "normal political year" midpoint for Meta political reach; election
- *   cycles can push this higher.
- *   DIGITAL_IMPRESSIONS_PER_CONTACT: used only for the hint string ("~N
- *   impressions"), not for cost. Keep in sync with the CPM assumption above.
- *   https://www.adamigo.ai/blog/meta-ads-cpm-cpc-benchmarks-by-country-2026
- *   https://www.brennancenter.org/our-work/analysis-opinion/online-ad-spending-2024-election-totaled-least-19-billion
- *
- * Yard signs & literature
- *   SIGNS_PER_CONTACT_DENOMINATOR: 1 sign per 100 voter contacts. Calibrated so
- *   a ~10k voter-contact race lands near 100 signs. May be too few for
- *   sprawling rural districts or too many for dense urban ones.
- *   SIGN_COST: $5 = mid-bulk price for an 18×24" coroplast sign (sign + stake).
- *   DOOR_HANGER_COST: $0.20/piece = bulk printing midpoint. Quantity reuses the
- *   already-computed `totalDoors` so it tracks the canvassing plan.
- *   https://www.thecampaignworkshop.com/yard-sign-calculator-learn-what-campaign-signs-cost
- *   https://www.doorhangerswork.com/door-hanger-distribution-cost/
- *
- * Compliance & filing fees
- *   COMPLIANCE_FLAT_COST: $400. Does not currently scale with race size; state
- *   races have higher filing fees but the difference is modest. Worth tiering
- *   later by `ballotLevel` if precision matters.
- *   https://ispolitical.com/compliance/
- */
-const MAIL_UNIVERSE_RATE = 0.4
-const MAIL_COST_PER_PIECE = 0.55
-const DIGITAL_COST_PER_CONTACT = 0.06
-const DIGITAL_IMPRESSIONS_PER_CONTACT = 5
-const SIGNS_PER_CONTACT_DENOMINATOR = 100
-const SIGN_COST = 5
-const DOOR_HANGER_COST = 0.2
-const COMPLIANCE_FLAT_COST = 400
+// Budget breakdown constants. Mirrors `buildBudgetBreakdown` in
+// planContent.ts (success-page plan). Tweak both in lockstep.
+const FILING_FEE = 100
+const YARD_SIGNS_COST = 385
+const PALM_CARDS_COST = 67
+const TEXT_CAMPAIGN_COUNT = 4
+const ROBOCALL_CAMPAIGN_COUNT = 3
+const CONTINGENCY_RATE = 0.05
+// Placeholder match rates used to derive registered-voter-with-phone counts
+// from projected turnout. Same formula as planContent.ts.
+const MATCH_RATE_CELL = 0.65
+const MATCH_RATE_LANDLINE = 0.35
+const CELL_REGISTRATION_MULTIPLIER = 4
+const LANDLINE_REGISTRATION_MULTIPLIER = 2
 
 interface OutreachPlanStepProps {
   campaign: Campaign | null
@@ -87,18 +52,14 @@ export const computeWeeksRemaining = (electionDate?: string | null): number => {
 }
 
 interface ResourcesComputation {
-  textCount: number
-  textCost: number
-  robocallCount: number
-  robocallCost: number
-  digitalImpressions: number
-  digitalCost: number
-  mailCount: number
-  mailCost: number
-  signCount: number
-  doorHangerCount: number
-  yardLitCost: number
-  complianceCost: number
+  filingCost: number
+  yardSignsCost: number
+  palmCardsCost: number
+  matchedCellRecords: number
+  matchedLandlineRecords: number
+  textCampaignsCost: number
+  robocallCampaignsCost: number
+  contingencyCost: number
   totalBudget: number
   candidateHoursPerWeek: number
   volunteersPerWeek: number
@@ -111,6 +72,7 @@ interface ResourcesComputation {
 const computeResources = (
   voterContactGoal: number,
   weeksRemaining: number,
+  projectedTurnout: number,
 ): ResourcesComputation => {
   // Volunteers needed each week:
   //   doors_to_knock = voterContactGoal × DOORS_PERCENT
@@ -125,48 +87,49 @@ const computeResources = (
       ? Math.ceil(totalDoors / doorsPerVolunteerOverCampaign)
       : 0
 
-  const textCount = Math.round(voterContactGoal * TEXTS_PERCENT)
-  const textCost = textCount * TEXT_COST
-  const robocallCount = Math.round(voterContactGoal * ROBOCALLS_PERCENT)
-  const robocallCost = robocallCount * ROBOCALL_COST
-
-  const digitalImpressions = voterContactGoal * DIGITAL_IMPRESSIONS_PER_CONTACT
-  const digitalCost = voterContactGoal * DIGITAL_COST_PER_CONTACT
-
-  const mailCount = Math.round(voterContactGoal * MAIL_UNIVERSE_RATE)
-  const mailCost = mailCount * MAIL_COST_PER_PIECE
-
-  const signCount = Math.max(
+  const matchedCellRecords = Math.max(
     0,
-    Math.ceil(voterContactGoal / SIGNS_PER_CONTACT_DENOMINATOR),
+    Math.round(
+      projectedTurnout * MATCH_RATE_CELL * CELL_REGISTRATION_MULTIPLIER,
+    ),
   )
-  const doorHangerCount = totalDoors
-  const yardLitCost = signCount * SIGN_COST + doorHangerCount * DOOR_HANGER_COST
+  const matchedLandlineRecords = Math.max(
+    0,
+    Math.round(
+      projectedTurnout *
+        MATCH_RATE_LANDLINE *
+        LANDLINE_REGISTRATION_MULTIPLIER,
+    ),
+  )
 
-  const complianceCost = COMPLIANCE_FLAT_COST
+  const filingCost = FILING_FEE
+  const yardSignsCost = YARD_SIGNS_COST
+  const palmCardsCost = PALM_CARDS_COST
+  const textCampaignsCost =
+    TEXT_CAMPAIGN_COUNT * matchedCellRecords * TEXT_COST
+  const robocallCampaignsCost =
+    ROBOCALL_CAMPAIGN_COUNT * matchedLandlineRecords * ROBOCALL_COST
+  const subtotal =
+    filingCost +
+    yardSignsCost +
+    palmCardsCost +
+    textCampaignsCost +
+    robocallCampaignsCost
+  const contingencyCost = subtotal * CONTINGENCY_RATE
+  const totalBudget = Math.round(subtotal + contingencyCost)
 
   const volunteerHoursPerWeek = volunteersPerWeek * VOLUNTEER_HOURS_PER_WEEK
 
   return {
-    textCount,
-    textCost,
-    robocallCount,
-    robocallCost,
-    digitalImpressions,
-    digitalCost,
-    mailCount,
-    mailCost,
-    signCount,
-    doorHangerCount,
-    yardLitCost,
-    complianceCost,
-    totalBudget:
-      textCost +
-      robocallCost +
-      digitalCost +
-      mailCost +
-      yardLitCost +
-      complianceCost,
+    filingCost,
+    yardSignsCost,
+    palmCardsCost,
+    matchedCellRecords,
+    matchedLandlineRecords,
+    textCampaignsCost,
+    robocallCampaignsCost,
+    contingencyCost,
+    totalBudget,
     candidateHoursPerWeek: CANDIDATE_HOURS_PER_WEEK,
     volunteersPerWeek,
     volunteerHoursPerWeek,
@@ -259,50 +222,38 @@ const BudgetAccordion = ({
     </p>
     <ul className="divide-y divide-base-border p-0 m-0">
       <BreakdownRow
-        label="Text messages"
-        value={formatCurrency(resources.textCost)}
-        hint={`${numberFormatter(resources.textCount)} messages × 3.5¢`}
+        label="Filing fees"
+        value={formatCurrency(resources.filingCost)}
+        hint="Nomination papers, any mandatory state/local filings."
       />
       <BreakdownRow
-        label="Robocalls"
-        value={formatCurrency(resources.robocallCost)}
-        hint={`${numberFormatter(resources.robocallCount)} calls × 4.5¢`}
+        label="Yard signs"
+        value={formatCurrency(resources.yardSignsCost)}
+        hint="Core visibility in a small precinct; estimated 50 yard signs for $385."
       />
       <BreakdownRow
-        label="Digital ads"
-        value={formatCurrency(resources.digitalCost)}
-        hint={`~${numberFormatter(
-          resources.digitalImpressions,
-        )} impressions, geo-targeted to your district`}
+        label="Palm cards"
+        value={formatCurrency(resources.palmCardsCost)}
+        hint="Handoffs at events and passive drops; estimated 250 palm cards for $67."
       />
       <BreakdownRow
-        label="Direct mail"
-        value={formatCurrency(resources.mailCost)}
-        hint={`${numberFormatter(
-          resources.mailCount,
-        )} pieces × $${MAIL_COST_PER_PIECE}`}
+        label="Text campaigns"
+        value={formatCurrency(resources.textCampaignsCost)}
+        hint={`${TEXT_CAMPAIGN_COUNT} text campaigns to ${numberFormatter(
+          resources.matchedCellRecords,
+        )} at $${TEXT_COST.toFixed(3)} per text.`}
       />
       <BreakdownRow
-        label="Yard signs & literature"
-        value={formatCurrency(resources.yardLitCost)}
-        hint={`${numberFormatter(
-          resources.signCount,
-        )} signs + ${numberFormatter(resources.doorHangerCount)} door hangers`}
+        label="Robocall campaigns"
+        value={formatCurrency(resources.robocallCampaignsCost)}
+        hint={`${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns to ${numberFormatter(
+          resources.matchedLandlineRecords,
+        )} at $${ROBOCALL_COST.toFixed(3)} per call.`}
       />
       <BreakdownRow
-        label="Compliance & filing fees"
-        value={formatCurrency(resources.complianceCost)}
-        hint={
-          <>
-            Compliance and filing fees come from BallotReady.{' '}
-            <a
-              href="mailto:customersupport@goodparty.org?subject=Issue%20with%20BallotReady%27s%20compliance%20and%20filing%20fees"
-              className="text-components-input-active hover:underline"
-            >
-              Report issue
-            </a>
-          </>
-        }
+        label="Contingency (5%)"
+        value={formatCurrency(resources.contingencyCost)}
+        hint="Reserve for last-week opportunities."
       />
     </ul>
   </ResourceAccordion>
@@ -363,6 +314,7 @@ export const OutreachPlanStep = ({
 }: OutreachPlanStepProps): React.JSX.Element => {
   const metrics = campaign?.raceTargetMetrics ?? null
   const winNumber = metrics?.winNumber ?? 0
+  const projectedTurnout = metrics?.projectedTurnout ?? 0
   const voterContactGoal =
     metrics?.voterContactGoal ?? winNumber * VOTER_CONTACT_MULTIPLIER
 
@@ -371,7 +323,11 @@ export const OutreachPlanStep = ({
   }
 
   const weeksRemaining = computeWeeksRemaining(campaign?.details?.electionDate)
-  const resources = computeResources(voterContactGoal, weeksRemaining)
+  const resources = computeResources(
+    voterContactGoal,
+    weeksRemaining,
+    projectedTurnout,
+  )
 
   return (
     <div className="flex w-full flex-col items-stretch gap-4 text-left">

--- a/app/onboarding/components/OutreachPlanStep.tsx
+++ b/app/onboarding/components/OutreachPlanStep.tsx
@@ -13,8 +13,10 @@ const TEXT_COST = 0.035
 const DOORS_PER_HOUR = 15
 const VOLUNTEER_HOURS_PER_WEEK = 3
 const CANDIDATE_HOURS_PER_WEEK = 14
-// Used only when electionDate is missing or in the past.
-const FALLBACK_WEEKS_REMAINING = 12
+// Cap the active campaign window at 12 weeks. Anything past this point counts
+// as "still in the prep window" — the plan assumes a final 12-week sprint.
+const MAX_CAMPAIGN_WEEKS = 12
+const FALLBACK_WEEKS_REMAINING = MAX_CAMPAIGN_WEEKS
 
 /**
  * Budget channel benchmarks — first-stab values for researcher review.
@@ -74,13 +76,14 @@ const formatCurrency = (value: number): string =>
 const formatHours = (value: number): string =>
   `${numberFormatter(Math.round(value))} hrs`
 
-const computeWeeksRemaining = (electionDate?: string | null): number => {
+export const computeWeeksRemaining = (electionDate?: string | null): number => {
   if (!electionDate) return FALLBACK_WEEKS_REMAINING
   const election = new Date(electionDate)
   if (Number.isNaN(election.getTime())) return FALLBACK_WEEKS_REMAINING
   const ms = election.getTime() - Date.now()
   if (ms <= 0) return FALLBACK_WEEKS_REMAINING
-  return Math.ceil(ms / (7 * 24 * 60 * 60 * 1000))
+  const weeks = Math.ceil(ms / (7 * 24 * 60 * 60 * 1000))
+  return Math.min(weeks, MAX_CAMPAIGN_WEEKS)
 }
 
 interface ResourcesComputation {
@@ -101,23 +104,25 @@ interface ResourcesComputation {
   volunteersPerWeek: number
   volunteerHoursPerWeek: number
   totalHoursPerWeek: number
+  weeksRemaining: number
+  totalHours: number
 }
 
 const computeResources = (
   voterContactGoal: number,
   weeksRemaining: number,
 ): ResourcesComputation => {
+  // Volunteers needed each week:
+  //   doors_to_knock = voterContactGoal × DOORS_PERCENT
+  //   volunteers/week = doors_to_knock / (doors_per_hr × vol_hrs_week × weeks)
+  // Each volunteer covers (doors_per_hr × vol_hrs_week × weeks) doors over
+  // the campaign; this many running concurrently each week clears the total.
   const totalDoors = Math.round(voterContactGoal * DOORS_PERCENT)
-  const doorsPerWeek = totalDoors / weeksRemaining
-  const candidateDoorsPerWeek = CANDIDATE_HOURS_PER_WEEK * DOORS_PER_HOUR
-  const volunteerDoorsPerWeek = Math.max(
-    0,
-    doorsPerWeek - candidateDoorsPerWeek,
-  )
-  const doorsPerVolunteerPerWeek = VOLUNTEER_HOURS_PER_WEEK * DOORS_PER_HOUR
+  const doorsPerVolunteerOverCampaign =
+    DOORS_PER_HOUR * VOLUNTEER_HOURS_PER_WEEK * weeksRemaining
   const volunteersPerWeek =
-    volunteerDoorsPerWeek > 0
-      ? Math.ceil(volunteerDoorsPerWeek / doorsPerVolunteerPerWeek)
+    doorsPerVolunteerOverCampaign > 0
+      ? Math.ceil(totalDoors / doorsPerVolunteerOverCampaign)
       : 0
 
   const textCount = Math.round(voterContactGoal * TEXTS_PERCENT)
@@ -166,11 +171,15 @@ const computeResources = (
     volunteersPerWeek,
     volunteerHoursPerWeek,
     totalHoursPerWeek: CANDIDATE_HOURS_PER_WEEK + volunteerHoursPerWeek,
+    weeksRemaining,
+    totalHours:
+      (CANDIDATE_HOURS_PER_WEEK + volunteerHoursPerWeek) * weeksRemaining,
   }
 }
 
 interface ResourceAccordionProps {
   label: string
+  sublabel?: string
   total: string
   icon: React.ReactNode
   children: React.ReactNode
@@ -178,6 +187,7 @@ interface ResourceAccordionProps {
 
 const ResourceAccordion = ({
   label,
+  sublabel,
   total,
   icon,
   children,
@@ -188,7 +198,14 @@ const ResourceAccordion = ({
         <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
           {icon}
         </span>
-        <span className="text-base font-semibold text-foreground">{label}</span>
+        <span className="flex flex-col">
+          <span className="text-base font-semibold text-foreground">
+            {label}
+          </span>
+          {sublabel ? (
+            <span className="text-xs text-muted-foreground">{sublabel}</span>
+          ) : null}
+        </span>
       </span>
       <span className="flex items-center gap-3">
         <span className="text-base font-semibold text-foreground">{total}</span>
@@ -205,7 +222,7 @@ const ResourceAccordion = ({
 interface BreakdownRowProps {
   label: string
   value: string
-  hint?: string
+  hint?: React.ReactNode
 }
 
 const BreakdownRow = ({
@@ -232,10 +249,14 @@ const BudgetAccordion = ({
   resources,
 }: BudgetAccordionProps): React.JSX.Element => (
   <ResourceAccordion
-    label="Budget"
+    label="Total budget"
+    sublabel="For voter outreach, compliance, and fees"
     total={formatCurrency(resources.totalBudget)}
     icon={<DollarSign className="size-5" aria-hidden="true" />}
   >
+    <p className="px-5 pt-4 text-xs text-muted-foreground">
+      Based on a {resources.weeksRemaining}-week campaign.
+    </p>
     <ul className="divide-y divide-base-border p-0 m-0">
       <BreakdownRow
         label="Text messages"
@@ -257,21 +278,31 @@ const BudgetAccordion = ({
       <BreakdownRow
         label="Direct mail"
         value={formatCurrency(resources.mailCost)}
-        hint={`${numberFormatter(resources.mailCount)} pieces × $${
-          MAIL_COST_PER_PIECE
-        }`}
+        hint={`${numberFormatter(
+          resources.mailCount,
+        )} pieces × $${MAIL_COST_PER_PIECE}`}
       />
       <BreakdownRow
         label="Yard signs & literature"
         value={formatCurrency(resources.yardLitCost)}
-        hint={`${numberFormatter(resources.signCount)} signs + ${numberFormatter(
-          resources.doorHangerCount,
-        )} door hangers`}
+        hint={`${numberFormatter(
+          resources.signCount,
+        )} signs + ${numberFormatter(resources.doorHangerCount)} door hangers`}
       />
       <BreakdownRow
         label="Compliance & filing fees"
         value={formatCurrency(resources.complianceCost)}
-        hint="FEC/state filings + accounting tool"
+        hint={
+          <>
+            Compliance and filing fees come from BallotReady.{' '}
+            <a
+              href="mailto:customersupport@goodparty.org?subject=Issue%20with%20BallotReady%27s%20compliance%20and%20filing%20fees"
+              className="text-components-input-active hover:underline"
+            >
+              Report issue
+            </a>
+          </>
+        }
       />
     </ul>
   </ResourceAccordion>
@@ -285,22 +316,34 @@ const TimeAccordion = ({
   resources,
 }: TimeAccordionProps): React.JSX.Element => (
   <ResourceAccordion
-    label="Time per week"
-    total={formatHours(resources.totalHoursPerWeek)}
+    label="Total time"
+    sublabel="For in-person campaigning, events, and volunteers"
+    total={formatHours(resources.totalHours)}
     icon={<Clock className="size-5" aria-hidden="true" />}
   >
+    <p className="px-5 pt-4 text-xs text-muted-foreground">
+      Based on a {resources.weeksRemaining}-week campaign.
+    </p>
     <ul className="divide-y divide-base-border p-0 m-0">
       <BreakdownRow
         label="Your time"
-        value={formatHours(resources.candidateHoursPerWeek)}
-        hint="Knocking doors and meeting voters in person."
+        value={formatHours(
+          resources.candidateHoursPerWeek * resources.weeksRemaining,
+        )}
+        hint={`${formatHours(
+          resources.candidateHoursPerWeek,
+        )} per week knocking doors and meeting voters in person.`}
       />
       <BreakdownRow
         label="Volunteers"
-        value={formatHours(resources.volunteerHoursPerWeek)}
+        value={formatHours(
+          resources.volunteerHoursPerWeek * resources.weeksRemaining,
+        )}
         hint={`${numberFormatter(resources.volunteersPerWeek)} ${
           resources.volunteersPerWeek === 1 ? 'volunteer' : 'volunteers'
-        } knocking doors for 3 hours per week.`}
+        } x ${VOLUNTEER_HOURS_PER_WEEK}hr ${
+          resources.volunteersPerWeek === 1 ? 'shift' : 'shifts'
+        } per week.`}
       />
     </ul>
   </ResourceAccordion>

--- a/app/onboarding/components/OutreachPlanStep.tsx
+++ b/app/onboarding/components/OutreachPlanStep.tsx
@@ -1,0 +1,339 @@
+'use client'
+
+import { ChevronDown, Clock, DollarSign } from 'lucide-react'
+import { numberFormatter } from 'helpers/numberHelper'
+import type { Campaign } from 'helpers/types'
+
+const VOTER_CONTACT_MULTIPLIER = 5
+const DOORS_PERCENT = 0.2
+const ROBOCALLS_PERCENT = 0.2
+const TEXTS_PERCENT = 0.6
+const ROBOCALL_COST = 0.045
+const TEXT_COST = 0.035
+const DOORS_PER_HOUR = 15
+const VOLUNTEER_HOURS_PER_WEEK = 3
+const CANDIDATE_HOURS_PER_WEEK = 14
+// Used only when electionDate is missing or in the past.
+const FALLBACK_WEEKS_REMAINING = 12
+
+/**
+ * Budget channel benchmarks — first-stab values for researcher review.
+ * Each rate is a midpoint of public sources; tighten or tier these once
+ * GoodParty.org strategy has a preferred number.
+ *
+ * Direct mail
+ *   MAIL_UNIVERSE_RATE: real mail goes to a persuadable subset of the voter-
+ *   contact universe, not all of it. 40% is a midpoint between high-prop
+ *   targeting (~25%) and full-universe (~60%).
+ *   MAIL_COST_PER_PIECE: $0.55 = midpoint of $0.50–$0.70 typical bulk political
+ *   postcards (printing + postage). Drops to ~$0.32 at 50k+ pieces.
+ *   https://suttonsmart.com/political-mailers/budgeting-cost-management/political-mailer-pricing-guide/
+ *   https://www.thecampaignworkshop.com/blog/political-direct-mail/political-direct-mail
+ *
+ * Digital ads
+ *   DIGITAL_COST_PER_CONTACT: $0.06 ≈ 5 impressions × ~$12 CPM. The $12 CPM is
+ *   a "normal political year" midpoint for Meta political reach; election
+ *   cycles can push this higher.
+ *   DIGITAL_IMPRESSIONS_PER_CONTACT: used only for the hint string ("~N
+ *   impressions"), not for cost. Keep in sync with the CPM assumption above.
+ *   https://www.adamigo.ai/blog/meta-ads-cpm-cpc-benchmarks-by-country-2026
+ *   https://www.brennancenter.org/our-work/analysis-opinion/online-ad-spending-2024-election-totaled-least-19-billion
+ *
+ * Yard signs & literature
+ *   SIGNS_PER_CONTACT_DENOMINATOR: 1 sign per 100 voter contacts. Calibrated so
+ *   a ~10k voter-contact race lands near 100 signs. May be too few for
+ *   sprawling rural districts or too many for dense urban ones.
+ *   SIGN_COST: $5 = mid-bulk price for an 18×24" coroplast sign (sign + stake).
+ *   DOOR_HANGER_COST: $0.20/piece = bulk printing midpoint. Quantity reuses the
+ *   already-computed `totalDoors` so it tracks the canvassing plan.
+ *   https://www.thecampaignworkshop.com/yard-sign-calculator-learn-what-campaign-signs-cost
+ *   https://www.doorhangerswork.com/door-hanger-distribution-cost/
+ *
+ * Compliance & filing fees
+ *   COMPLIANCE_FLAT_COST: $400. Does not currently scale with race size; state
+ *   races have higher filing fees but the difference is modest. Worth tiering
+ *   later by `ballotLevel` if precision matters.
+ *   https://ispolitical.com/compliance/
+ */
+const MAIL_UNIVERSE_RATE = 0.4
+const MAIL_COST_PER_PIECE = 0.55
+const DIGITAL_COST_PER_CONTACT = 0.06
+const DIGITAL_IMPRESSIONS_PER_CONTACT = 5
+const SIGNS_PER_CONTACT_DENOMINATOR = 100
+const SIGN_COST = 5
+const DOOR_HANGER_COST = 0.2
+const COMPLIANCE_FLAT_COST = 400
+
+interface OutreachPlanStepProps {
+  campaign: Campaign | null
+}
+
+const formatCurrency = (value: number): string =>
+  `$${numberFormatter(Math.round(value))}`
+
+const formatHours = (value: number): string =>
+  `${numberFormatter(Math.round(value))} hrs`
+
+const computeWeeksRemaining = (electionDate?: string | null): number => {
+  if (!electionDate) return FALLBACK_WEEKS_REMAINING
+  const election = new Date(electionDate)
+  if (Number.isNaN(election.getTime())) return FALLBACK_WEEKS_REMAINING
+  const ms = election.getTime() - Date.now()
+  if (ms <= 0) return FALLBACK_WEEKS_REMAINING
+  return Math.ceil(ms / (7 * 24 * 60 * 60 * 1000))
+}
+
+interface ResourcesComputation {
+  textCount: number
+  textCost: number
+  robocallCount: number
+  robocallCost: number
+  digitalImpressions: number
+  digitalCost: number
+  mailCount: number
+  mailCost: number
+  signCount: number
+  doorHangerCount: number
+  yardLitCost: number
+  complianceCost: number
+  totalBudget: number
+  candidateHoursPerWeek: number
+  volunteersPerWeek: number
+  volunteerHoursPerWeek: number
+  totalHoursPerWeek: number
+}
+
+const computeResources = (
+  voterContactGoal: number,
+  weeksRemaining: number,
+): ResourcesComputation => {
+  const totalDoors = Math.round(voterContactGoal * DOORS_PERCENT)
+  const doorsPerWeek = totalDoors / weeksRemaining
+  const candidateDoorsPerWeek = CANDIDATE_HOURS_PER_WEEK * DOORS_PER_HOUR
+  const volunteerDoorsPerWeek = Math.max(
+    0,
+    doorsPerWeek - candidateDoorsPerWeek,
+  )
+  const doorsPerVolunteerPerWeek = VOLUNTEER_HOURS_PER_WEEK * DOORS_PER_HOUR
+  const volunteersPerWeek =
+    volunteerDoorsPerWeek > 0
+      ? Math.ceil(volunteerDoorsPerWeek / doorsPerVolunteerPerWeek)
+      : 0
+
+  const textCount = Math.round(voterContactGoal * TEXTS_PERCENT)
+  const textCost = textCount * TEXT_COST
+  const robocallCount = Math.round(voterContactGoal * ROBOCALLS_PERCENT)
+  const robocallCost = robocallCount * ROBOCALL_COST
+
+  const digitalImpressions = voterContactGoal * DIGITAL_IMPRESSIONS_PER_CONTACT
+  const digitalCost = voterContactGoal * DIGITAL_COST_PER_CONTACT
+
+  const mailCount = Math.round(voterContactGoal * MAIL_UNIVERSE_RATE)
+  const mailCost = mailCount * MAIL_COST_PER_PIECE
+
+  const signCount = Math.max(
+    0,
+    Math.ceil(voterContactGoal / SIGNS_PER_CONTACT_DENOMINATOR),
+  )
+  const doorHangerCount = totalDoors
+  const yardLitCost = signCount * SIGN_COST + doorHangerCount * DOOR_HANGER_COST
+
+  const complianceCost = COMPLIANCE_FLAT_COST
+
+  const volunteerHoursPerWeek = volunteersPerWeek * VOLUNTEER_HOURS_PER_WEEK
+
+  return {
+    textCount,
+    textCost,
+    robocallCount,
+    robocallCost,
+    digitalImpressions,
+    digitalCost,
+    mailCount,
+    mailCost,
+    signCount,
+    doorHangerCount,
+    yardLitCost,
+    complianceCost,
+    totalBudget:
+      textCost +
+      robocallCost +
+      digitalCost +
+      mailCost +
+      yardLitCost +
+      complianceCost,
+    candidateHoursPerWeek: CANDIDATE_HOURS_PER_WEEK,
+    volunteersPerWeek,
+    volunteerHoursPerWeek,
+    totalHoursPerWeek: CANDIDATE_HOURS_PER_WEEK + volunteerHoursPerWeek,
+  }
+}
+
+interface ResourceAccordionProps {
+  label: string
+  total: string
+  icon: React.ReactNode
+  children: React.ReactNode
+}
+
+const ResourceAccordion = ({
+  label,
+  total,
+  icon,
+  children,
+}: ResourceAccordionProps): React.JSX.Element => (
+  <details className="group overflow-hidden rounded-xl border border-base-border bg-base-surface">
+    <summary className="flex cursor-pointer items-center justify-between gap-4 p-5 list-none transition-colors hover:bg-accent [&::-webkit-details-marker]:hidden">
+      <span className="flex items-center gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
+          {icon}
+        </span>
+        <span className="text-base font-semibold text-foreground">{label}</span>
+      </span>
+      <span className="flex items-center gap-3">
+        <span className="text-base font-semibold text-foreground">{total}</span>
+        <ChevronDown
+          className="size-4 text-muted-foreground transition-transform group-open:rotate-180"
+          aria-hidden="true"
+        />
+      </span>
+    </summary>
+    <div className="border-t border-base-border">{children}</div>
+  </details>
+)
+
+interface BreakdownRowProps {
+  label: string
+  value: string
+  hint?: string
+}
+
+const BreakdownRow = ({
+  label,
+  value,
+  hint,
+}: BreakdownRowProps): React.JSX.Element => (
+  <li className="flex w-full items-start justify-between gap-4 px-5 py-4 text-sm">
+    <div>
+      <p className="font-medium text-foreground">{label}</p>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+    <span className="font-semibold whitespace-nowrap text-foreground">
+      {value}
+    </span>
+  </li>
+)
+
+interface BudgetAccordionProps {
+  resources: ResourcesComputation
+}
+
+const BudgetAccordion = ({
+  resources,
+}: BudgetAccordionProps): React.JSX.Element => (
+  <ResourceAccordion
+    label="Budget"
+    total={formatCurrency(resources.totalBudget)}
+    icon={<DollarSign className="size-5" aria-hidden="true" />}
+  >
+    <ul className="divide-y divide-base-border p-0 m-0">
+      <BreakdownRow
+        label="Text messages"
+        value={formatCurrency(resources.textCost)}
+        hint={`${numberFormatter(resources.textCount)} messages × 3.5¢`}
+      />
+      <BreakdownRow
+        label="Robocalls"
+        value={formatCurrency(resources.robocallCost)}
+        hint={`${numberFormatter(resources.robocallCount)} calls × 4.5¢`}
+      />
+      <BreakdownRow
+        label="Digital ads"
+        value={formatCurrency(resources.digitalCost)}
+        hint={`~${numberFormatter(
+          resources.digitalImpressions,
+        )} impressions, geo-targeted to your district`}
+      />
+      <BreakdownRow
+        label="Direct mail"
+        value={formatCurrency(resources.mailCost)}
+        hint={`${numberFormatter(resources.mailCount)} pieces × $${
+          MAIL_COST_PER_PIECE
+        }`}
+      />
+      <BreakdownRow
+        label="Yard signs & literature"
+        value={formatCurrency(resources.yardLitCost)}
+        hint={`${numberFormatter(resources.signCount)} signs + ${numberFormatter(
+          resources.doorHangerCount,
+        )} door hangers`}
+      />
+      <BreakdownRow
+        label="Compliance & filing fees"
+        value={formatCurrency(resources.complianceCost)}
+        hint="FEC/state filings + accounting tool"
+      />
+    </ul>
+  </ResourceAccordion>
+)
+
+interface TimeAccordionProps {
+  resources: ResourcesComputation
+}
+
+const TimeAccordion = ({
+  resources,
+}: TimeAccordionProps): React.JSX.Element => (
+  <ResourceAccordion
+    label="Time per week"
+    total={formatHours(resources.totalHoursPerWeek)}
+    icon={<Clock className="size-5" aria-hidden="true" />}
+  >
+    <ul className="divide-y divide-base-border p-0 m-0">
+      <BreakdownRow
+        label="Your time"
+        value={formatHours(resources.candidateHoursPerWeek)}
+        hint="Knocking doors and meeting voters in person."
+      />
+      <BreakdownRow
+        label="Volunteers"
+        value={formatHours(resources.volunteerHoursPerWeek)}
+        hint={`${numberFormatter(resources.volunteersPerWeek)} ${
+          resources.volunteersPerWeek === 1 ? 'volunteer' : 'volunteers'
+        } knocking doors for 3 hours per week.`}
+      />
+    </ul>
+  </ResourceAccordion>
+)
+
+const ResourcesUnavailable = (): React.JSX.Element => (
+  <div className="rounded-lg border border-base-border bg-muted p-6 text-center">
+    <p className="text-sm leading-6 text-foreground">
+      We couldn&apos;t calculate your minimum resources yet. We&apos;ll keep
+      working on it in the background.
+    </p>
+  </div>
+)
+
+export const OutreachPlanStep = ({
+  campaign,
+}: OutreachPlanStepProps): React.JSX.Element => {
+  const metrics = campaign?.raceTargetMetrics ?? null
+  const winNumber = metrics?.winNumber ?? 0
+  const voterContactGoal =
+    metrics?.voterContactGoal ?? winNumber * VOTER_CONTACT_MULTIPLIER
+
+  if (voterContactGoal <= 0) {
+    return <ResourcesUnavailable />
+  }
+
+  const weeksRemaining = computeWeeksRemaining(campaign?.details?.electionDate)
+  const resources = computeResources(voterContactGoal, weeksRemaining)
+
+  return (
+    <div className="flex w-full flex-col items-stretch gap-4 text-left">
+      <BudgetAccordion resources={resources} />
+      <TimeAccordion resources={resources} />
+    </div>
+  )
+}

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -19,6 +19,55 @@ import type { Campaign } from 'helpers/types'
 
 const OFFICE_TEMPLATE_TOKEN = '{office}'
 const DEFAULT_OFFICE_NAME = 'your office'
+
+interface PathToVictoryHeaderProps {
+  title: string
+  fallbackDescription: string
+  officeName?: string | null
+}
+
+export const PathToVictoryHeader = ({
+  title,
+  fallbackDescription,
+  officeName,
+}: PathToVictoryHeaderProps): React.JSX.Element => (
+  <div className="space-y-4">
+    <h1 className="text-4xl font-bold text-foreground sm:text-5xl">{title}</h1>
+    <p className="text-lg text-muted-foreground sm:text-base">
+      {officeName ? (
+        <>
+          We use historical voter data and proprietary models to get the most
+          accurate projections for{' '}
+          <span className="font-semibold text-foreground">{officeName}</span>.
+        </>
+      ) : (
+        fallbackDescription
+      )}
+    </p>
+  </div>
+)
+
+interface PathToVictoryAsideProps {
+  winNumber?: number
+}
+
+export const PathToVictoryAside = ({
+  winNumber,
+}: PathToVictoryAsideProps): React.JSX.Element => (
+  <aside className="flex flex-col gap-2 rounded-xl border border-base-border p-5">
+    <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+      You can do this!
+    </span>
+    <p className="text-sm text-foreground">
+      Most candidates think they need to convince <em>everyone</em>. You
+      don&apos;t. You need to find{' '}
+      {winNumber ? `${numberFormatter(winNumber)} people` : 'your win number'},
+      talk to them, and make sure they vote. We&apos;ll show you exactly what
+      that takes.
+    </p>
+  </aside>
+)
+
 const CONTACTS_STATS_ROUTE = 'GET /v1/contacts/stats'
 const SENTRY_CONTEXT_FETCH_CONTACTS_STATS =
   'onboarding.pathToVictory.fetchContactsStats'
@@ -296,12 +345,12 @@ const ProjectionStep = ({
   description,
   value,
 }: ProjectionStepProps): React.JSX.Element => (
-  <li className="flex items-start gap-4 rounded-xl border border-base-border p-4">
-    <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+  <li className="flex items-start gap-4 p-4">
+    <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-grayscale-200 text-sm font-semibold text-foreground">
       {index}
     </span>
     <div className="flex-1">
-      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <p className="text-base font-medium text-foreground">{title}</p>
       <p className="text-xs text-muted-foreground">{description}</p>
     </div>
     <span className="text-base font-bold text-foreground">{value}</span>
@@ -370,7 +419,7 @@ const ProjectionExplanation = ({
           </DialogContent>
         </Dialog>
       </div>
-      <ol className="space-y-3">
+      <ol className="divide-y divide-base-border rounded-xl border border-base-border">
         {showRegisteredVoters ? (
           <ProjectionStep
             index={stepIndex++}

--- a/app/onboarding/components/PledgeStep.tsx
+++ b/app/onboarding/components/PledgeStep.tsx
@@ -24,8 +24,8 @@ const PLEDGE_ITEMS = [
 
 export const PledgeStep = (): React.JSX.Element => (
   <Card className="rounded-2xl border-base-border shadow-none">
-    <CardContent className="space-y-6 px-6 py-4 sm:px-8 sm:py-5">
-      <p className="text-xl font-bold leading-[1.08] text-foreground">
+    <CardContent className="space-y-6 px-6 py-2 sm:px-8 sm:py-3">
+      <p className="text-2xl font-semibold leading-[1.08] text-foreground">
         I pledge to be...
       </p>
 

--- a/app/onboarding/components/onboardingConfig.ts
+++ b/app/onboarding/components/onboardingConfig.ts
@@ -22,9 +22,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'party-affiliation',
-    title: 'Are you running with a major party?',
+    title: 'Are you running with a party designation?',
     description:
-      "GoodParty.org supports independent and nonpartisan candidates. Let's make sure you qualify.",
+      "Pick the party label voters will see on the ballot as an official designation for your race, not your personal voting history or party preference.",
     summary:
       'Eligible candidates continue; major-party candidates will be blocked by this step implementation.',
     whyWeAsk:
@@ -84,7 +84,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'path-to-victory',
-    title: "Here's how many votes you need to win",
+    title: "Projected votes needed to win",
     description:
       'We use historical voter data and proprietary models to get the most accurate projections for your race.',
     summary:
@@ -95,8 +95,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'voter-demographics',
-    title: "Here's what we know about the voters in your district",
-    description: 'Knowing who shows up to vote shapes who you reach and how.',
+    title: "Voter insights for your district",
+    description:
+      'We use survey and voter data along with your district demographics to project likely top issues for your race.',
     summary:
       'Voter demographic charts are rendered from the structured-office district stats.',
     whyWeAsk:
@@ -105,7 +106,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'outreach-plan',
-    title: 'Here are the minimum resources you need',
+    title: 'Projected minimum resources needed',
     description:
       'Commit at least this much money and time, and you’ll have a real shot at winning your race.',
     summary:

--- a/app/onboarding/components/onboardingConfig.ts
+++ b/app/onboarding/components/onboardingConfig.ts
@@ -3,19 +3,17 @@ import type { OnboardingStepConfig, NonEmptyArray } from './onboardingTypes'
 export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'welcome',
-    eyebrow: 'Campaign plan setup',
     title: "Let's build your winning campaign plan in 5 minutes",
     description:
-      "All we need to know is what office you're running for and where, and we'll take it from there",
+      "All we need to know is what office you're running for. We'll take it from there.",
     summary:
       'This step introduces the value of the flow before collecting candidate details.',
   },
   {
     id: 'ballot-status',
-    eyebrow: 'Candidate status',
     title: 'Are you already on the ballot?',
     description:
-      'We tailor your strategy to where you actually are in your campaign.',
+      "We'll tailor your strategy based on where you are in your campaign.",
     summary:
       'The answer is stored in onboarding state and can be submitted with the final payload.',
     whyWeAsk:
@@ -24,10 +22,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'party-affiliation',
-    eyebrow: 'Candidate eligibility',
-    title: 'Are you running with an official party designation?',
+    title: 'Are you running with a major party?',
     description:
-      'Party designation determines whether you can continue with GoodParty.org support.',
+      "GoodParty.org supports independent and nonpartisan candidates. Let's make sure you qualify.",
     summary:
       'Eligible candidates continue; major-party candidates will be blocked by this step implementation.',
     whyWeAsk:
@@ -38,10 +35,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'office-selection',
-    eyebrow: 'Office selection',
     title: 'What office are you running for?',
     description:
-      "We'll use this to analyze local voter data, trends, & news to create your campaign plan.",
+      "We'll use this to pull local voter data and shape your plan around your race.",
     summary:
       'Structured office selection feeds Path to Victory. Manual office entry follows a shorter path.',
     whyWeAsk:
@@ -51,10 +47,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'manual-office-entry',
-    eyebrow: 'Office details',
     title: 'Tell us about your office',
     description:
-      "We couldn't find a structured match. Enter your office details and our team will follow up.",
+      "We couldn't find your race in our database. Tell us a few details and our team will follow up.",
     summary:
       'The manualOffice and unmatchedOffice flags are stored in onboarding state.',
     whyWeAsk:
@@ -89,7 +84,6 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'path-to-victory',
-    eyebrow: 'Vote goal',
     title: "Here's how many votes you need to win",
     description:
       'We use historical voter data and proprietary models to get the most accurate projections for your race.',
@@ -101,10 +95,8 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'voter-demographics',
-    eyebrow: 'Voter demographics',
-    title: "Here's everything to know about your voters",
-    description:
-      'We crunch the latest voter data, along with proprietary behavior models, to give you a snapshot of who lives, votes, and pays attention in your community.',
+    title: "Here's what we know about the voters in your district",
+    description: 'Knowing who shows up to vote shapes who you reach and how.',
     summary:
       'Voter demographic charts are rendered from the structured-office district stats.',
     whyWeAsk:
@@ -112,13 +104,24 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
     shouldSkip: ({ answers }) => answers.officePath === 'manual',
   },
   {
-    id: 'pledge',
-    eyebrow: 'Final step',
-    title: 'Take our pledge to get your campaign plan',
+    id: 'outreach-plan',
+    title: 'Here are the minimum resources you need',
     description:
-      'We only work with candidates who are independent of both major parties, big-money influence, and are anti-corruption.',
+      'Commit at least this much money and time, and you’ll have a real shot at winning your race.',
+    summary:
+      'Translates the voter contact goal into a minimum budget and a minimum weekly time commitment.',
+    whyWeAsk:
+      'These two minimums are the foundation of your campaign plan. Everything else — your weekly tasks, volunteer asks, outreach mix — is sized against what you can commit here.',
+    shouldSkip: ({ answers }) => answers.officePath === 'manual',
+  },
+  {
+    id: 'pledge',
+    title: 'Almost there...',
+    description:
+      'Take the pledge below. Your campaign plan is waiting for you.',
     summary:
       'The final payload keeps collected answers available for future integrations.',
+    nextLabel: 'Agree & Create My Plan',
   },
 ]
 

--- a/app/onboarding/components/onboardingTypes.ts
+++ b/app/onboarding/components/onboardingTypes.ts
@@ -6,6 +6,7 @@ export type OnboardingStepId =
   | 'manual-office-entry'
   | 'path-to-victory'
   | 'voter-demographics'
+  | 'outreach-plan'
   | 'pledge'
 
 export type OnboardingOfficePath = 'structured' | 'manual'
@@ -74,11 +75,11 @@ export interface OnboardingStepContext {
 
 export interface OnboardingStepConfig {
   id: OnboardingStepId
-  eyebrow: string
   title: string
   description: string
   summary: string
   whyWeAsk?: string
+  nextLabel?: string
   shouldSkip?: (context: OnboardingStepContext) => boolean
   isValid?: (context: OnboardingStepContext) => boolean
 }

--- a/app/onboarding/success/components/ConfettiCanvas.tsx
+++ b/app/onboarding/success/components/ConfettiCanvas.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import { useRef, useEffect, useCallback } from 'react'
+
+interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  size: number
+  rotation: number
+  rotationSpeed: number
+  opacity: number
+  fadeRate: number
+  color: string
+  backColor: string
+  shapeIndex: number
+  wobbleAmplitude: number
+  wobblePhase: number
+  wobbleSpeed: number
+  gravity: number
+  drag: number
+  scaleX: number
+  flipSpeed: number
+  flipPhase: number
+}
+
+interface ConfettiCanvasProps {
+  play?: boolean
+  particleCount?: number
+  className?: string
+}
+
+// Shades of the brand primary (#2563eb). Update together if the brand changes.
+const COLORS = ['#082a92', '#0d3cb5', '#1351d8', '#2563eb', '#75affe']
+
+const SHAPES: [number, number][][] = [
+  [
+    [-0.5, -0.2],
+    [0.1, -0.35],
+    [0.5, -0.1],
+    [0.4, 0.2],
+    [-0.1, 0.35],
+    [-0.5, 0.15],
+  ],
+  [
+    [-0.3, -0.5],
+    [0.2, -0.4],
+    [0.5, 0.1],
+    [0.1, 0.5],
+    [-0.4, 0.3],
+  ],
+  [
+    [-0.1, -0.5],
+    [0.4, -0.15],
+    [0.1, 0.5],
+    [-0.4, 0.15],
+  ],
+  [
+    [-0.45, -0.25],
+    [0.3, -0.4],
+    [0.5, 0.2],
+    [-0.2, 0.4],
+  ],
+  [
+    [-0.5, -0.12],
+    [0.5, -0.18],
+    [0.45, 0.15],
+    [-0.5, 0.12],
+  ],
+  [
+    [-0.35, -0.3],
+    [0.15, -0.45],
+    [0.4, -0.05],
+    [0.2, 0.4],
+    [-0.25, 0.3],
+  ],
+  [
+    [-0.5, -0.15],
+    [0.0, -0.3],
+    [0.5, -0.1],
+    [0.3, 0.25],
+    [-0.3, 0.3],
+  ],
+]
+
+const createParticle = (width: number): Particle => {
+  const frontIndex = Math.floor(Math.random() * COLORS.length)
+  const backIndex = Math.max(0, frontIndex - 2)
+
+  return {
+    x: Math.random() * width,
+    y: -(Math.random() * 500 + 10),
+    vx: (Math.random() - 0.5) * 6,
+    vy: Math.random() * 4 + 8,
+    size: Math.random() * 10 + 5,
+    rotation: Math.random() * Math.PI * 2,
+    rotationSpeed: (Math.random() - 0.5) * 0.18,
+    opacity: 1,
+    fadeRate: Math.random() * 0.003 + 0.0012,
+    color: COLORS[frontIndex] ?? COLORS[0]!,
+    backColor: COLORS[backIndex] ?? COLORS[0]!,
+    shapeIndex: Math.floor(Math.random() * SHAPES.length),
+    wobbleAmplitude: Math.random() * 1.5 + 0.3,
+    wobblePhase: Math.random() * Math.PI * 2,
+    wobbleSpeed: Math.random() * 0.06 + 0.02,
+    gravity: Math.random() * 0.03 + 0.04,
+    drag: Math.random() * 0.001 + 0.0005,
+    scaleX: 1,
+    flipSpeed: Math.random() * 0.06 + 0.02,
+    flipPhase: Math.random() * Math.PI * 2,
+  }
+}
+
+const ConfettiCanvas = ({
+  play = false,
+  particleCount = 300,
+  className,
+}: ConfettiCanvasProps): React.JSX.Element => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const particlesRef = useRef<Particle[]>([])
+  const animFrameRef = useRef<number>(0)
+  const frameCountRef = useRef(0)
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const h = canvas.offsetHeight
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    frameCountRef.current++
+
+    const particles = particlesRef.current
+    let alive = 0
+    const frame = frameCountRef.current
+
+    for (const p of particles) {
+      if (p.opacity <= 0) continue
+      alive++
+
+      p.flipPhase += p.flipSpeed
+      p.scaleX = Math.cos(p.flipPhase)
+
+      // Face-on flutters slow, edge-on slices through and falls fast
+      const effectiveDrag = p.drag + Math.abs(p.scaleX) * 0.015
+
+      p.wobblePhase += p.wobbleSpeed
+      p.vx *= 1 - effectiveDrag
+      p.x += p.vx + Math.sin(p.wobblePhase) * p.wobbleAmplitude
+
+      p.vy += p.gravity
+      p.vy *= 1 - effectiveDrag
+      p.y += p.vy
+
+      p.rotation += p.rotationSpeed
+      p.rotationSpeed *= 0.999
+
+      const travel = Math.max(0, p.y / h)
+      if (travel > 0.3) {
+        p.opacity -= p.fadeRate * (1 + travel * 3)
+      }
+      if (frame > 120) {
+        p.opacity -= 0.012
+      }
+
+      const shape = SHAPES[p.shapeIndex]
+      if (!shape || shape.length === 0) continue
+      const first = shape[0]!
+
+      ctx.save()
+      ctx.translate(p.x, p.y)
+      ctx.rotate(p.rotation)
+      ctx.scale(p.scaleX, 1)
+      ctx.globalAlpha = Math.max(0, p.opacity)
+      ctx.fillStyle = p.scaleX < 0 ? p.backColor : p.color
+
+      ctx.beginPath()
+      ctx.moveTo(first[0] * p.size, first[1] * p.size)
+      for (let i = 1; i < shape.length; i++) {
+        const point = shape[i]!
+        ctx.lineTo(point[0] * p.size, point[1] * p.size)
+      }
+      ctx.closePath()
+      ctx.fill()
+
+      ctx.restore()
+    }
+
+    if (alive > 0) {
+      animFrameRef.current = requestAnimationFrame(draw)
+    }
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth * window.devicePixelRatio
+      canvas.height = canvas.offsetHeight * window.devicePixelRatio
+      const ctx = canvas.getContext('2d')
+      if (ctx) ctx.scale(window.devicePixelRatio, window.devicePixelRatio)
+    }
+
+    resize()
+    window.addEventListener('resize', resize)
+    return () => window.removeEventListener('resize', resize)
+  }, [])
+
+  useEffect(() => {
+    if (!play) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    frameCountRef.current = 0
+    const w = canvas.offsetWidth
+    particlesRef.current = Array.from({ length: particleCount }, () =>
+      createParticle(w),
+    )
+
+    cancelAnimationFrame(animFrameRef.current)
+    animFrameRef.current = requestAnimationFrame(draw)
+
+    return () => cancelAnimationFrame(animFrameRef.current)
+  }, [play, particleCount, draw])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={className}
+      style={{ width: '100%', height: '100%', pointerEvents: 'none' }}
+    />
+  )
+}
+
+export default ConfettiCanvas

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import { Download, Share2 } from 'lucide-react'
 import { Button, GoodPartyOrgLogo, IconButton } from '@styleguide'
 import { useCampaign } from '@shared/hooks/useCampaign'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 import { useUser } from '@shared/hooks/useUser'
 import type { User } from 'helpers/types'
 import ConfettiCanvas from './ConfettiCanvas'
@@ -18,12 +20,20 @@ interface SuccessPageProps {
 
 const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   const router = useRouter()
+  const queryClient = useQueryClient()
   const [clientUser] = useUser()
   const user = clientUser ?? initialUser
   const [campaign] = useCampaign()
   const [shareOpen, setShareOpen] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [mounted, setMounted] = useState(false)
+
+  // Campaign data is hydrated once when PageWrapper mounts. After onboarding
+  // updates the campaign server-side, the client cache is stale — re-fetch on
+  // mount so positionName, electionDate, etc. reflect the candidate's choices.
+  useEffect(() => {
+    void queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
+  }, [queryClient])
 
   useEffect(() => {
     const id = requestAnimationFrame(() => setMounted(true))
@@ -116,20 +126,9 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
       </div>
       <main className="mx-auto w-full max-w-4xl px-4 pt-8 pb-12 sm:px-8 sm:pt-16 sm:pb-20">
         <div
-          className={`relative flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 py-12 text-center sm:px-12 sm:py-16 ${cardEnter}`}
+          className={`relative flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 pt-12 pb-6 text-center sm:px-12 sm:py-16 ${cardEnter}`}
           style={{ transitionDelay: '0ms' }}
         >
-          <IconButton
-            type="button"
-            variant="outline"
-            size="medium"
-            onClick={() => setShareOpen(true)}
-            aria-label="Share campaign plan"
-            className="absolute top-3 right-3 sm:top-4 sm:right-4"
-          >
-            <Share2 className="size-5" />
-          </IconButton>
-
           <div className={enter} style={{ transitionDelay: '300ms' }}>
             <GoodPartyOrgLogo className="!h-12 !w-auto sm:!h-14" />
           </div>
@@ -138,49 +137,45 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
             className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
             style={{ transitionDelay: '500ms' }}
           >
-            Initial campaign plan
+            Your initial campaign plan
           </h1>
 
-          {plan.candidateName ? (
-            <div
-              className={`space-y-2 ${enter}`}
-              style={{ transitionDelay: '700ms' }}
-            >
-              <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase sm:text-sm">
-                Prepared for
-              </p>
-              <p className="text-xl font-bold text-foreground sm:text-2xl">
-                {plan.candidateName}
-              </p>
-            </div>
-          ) : null}
-
           <div
-            className={`space-y-1 ${enter}`}
-            style={{ transitionDelay: '900ms' }}
+            className={`flex flex-col items-center gap-1 ${enter}`}
+            style={{ transitionDelay: '700ms' }}
           >
-            {plan.race ? (
+            {plan.candidateName && plan.race ? (
+              <p className="text-xl font-bold text-foreground sm:text-2xl">
+                {plan.candidateName} for {plan.race}
+              </p>
+            ) : null}
+            {plan.districtName ? (
               <p className="text-base text-muted-foreground sm:text-lg">
-                {plan.race}
-                {plan.location ? ` • ${plan.location}` : ''}
+                {plan.districtName}
               </p>
             ) : null}
             {plan.electionDate ? (
-              <p className="text-sm text-muted-foreground sm:text-base">
+              <p className="text-sm italic text-muted-foreground sm:text-base">
                 Election Day: {plan.electionDate}
               </p>
             ) : null}
           </div>
 
           <div
-            className={`flex w-full flex-col items-center gap-1 border-t border-base-border pt-6 ${enter}`}
+            className={`w-full border-t border-base-border pt-6 ${enter}`}
             style={{ transitionDelay: '1100ms' }}
           >
-            <p className="text-xs text-muted-foreground sm:text-sm">
-              Prepared by GoodParty.org
-            </p>
-            <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-              Empowering people to run, win, and serve
+            <p className="text-xs italic text-muted-foreground sm:text-sm">
+              Campaign plan prepared for{' '}
+              <span className="font-semibold text-foreground">
+                {plan.candidateName}
+              </span>{' '}
+              on{' '}
+              <span className="font-semibold text-foreground">
+                {plan.planGenerationDate}
+              </span>{' '}
+              by GoodParty.org&apos;s Campaign Intelligence System using public
+              voter data and historical election results.
             </p>
           </div>
         </div>
@@ -195,16 +190,39 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
 
       <div className="fixed inset-x-0 bottom-0 border-t border-base-border bg-base-surface">
         <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between gap-3 px-4 sm:px-8">
-          <Button
-            type="button"
-            variant="ghost"
-            size="large"
-            icon={<Download className="size-5" />}
-            onClick={handleDownload}
-            loading={downloading}
-          >
-            Download
-          </Button>
+          <div className="flex items-center gap-2">
+            <IconButton
+              type="button"
+              variant="outline"
+              size="large"
+              onClick={handleDownload}
+              loading={downloading}
+              aria-label="Download campaign plan"
+              className="sm:hidden"
+            >
+              <Download className="size-5" />
+            </IconButton>
+            <Button
+              type="button"
+              variant="ghost"
+              size="large"
+              icon={<Download className="size-5" />}
+              onClick={handleDownload}
+              loading={downloading}
+              className="hidden sm:inline-flex"
+            >
+              Download
+            </Button>
+            <IconButton
+              type="button"
+              variant="outline"
+              size="large"
+              onClick={() => setShareOpen(true)}
+              aria-label="Share campaign plan"
+            >
+              <Share2 className="size-5" />
+            </IconButton>
+          </div>
           <Button
             type="button"
             variant="default"

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Download, Share2 } from 'lucide-react'
-import { Button, GoodPartyOrgLogo } from '@styleguide'
+import { Button, GoodPartyOrgLogo, IconButton } from '@styleguide'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { useUser } from '@shared/hooks/useUser'
 import type { User } from 'helpers/types'
@@ -116,71 +116,102 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
       </div>
       <main className="mx-auto w-full max-w-4xl px-4 pt-8 pb-12 sm:px-8 sm:pt-16 sm:pb-20">
         <div
-          className={`flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 py-12 text-center sm:px-12 sm:py-16 ${cardEnter}`}
+          className={`relative flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 py-12 text-center sm:px-12 sm:py-16 ${cardEnter}`}
           style={{ transitionDelay: '0ms' }}
         >
+          <IconButton
+            type="button"
+            variant="outline"
+            size="medium"
+            onClick={() => setShareOpen(true)}
+            aria-label="Share campaign plan"
+            className="absolute top-3 right-3 sm:top-4 sm:right-4"
+          >
+            <Share2 className="size-5" />
+          </IconButton>
+
           <div className={enter} style={{ transitionDelay: '300ms' }}>
             <GoodPartyOrgLogo className="!h-12 !w-auto sm:!h-14" />
           </div>
 
-          <div className="space-y-4">
-            <h1
-              className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
-              style={{ transitionDelay: '500ms' }}
-            >
-              Your campaign plan is ready!
-            </h1>
-            <p
-              className={`text-base text-muted-foreground sm:text-lg ${enter}`}
+          <h1
+            className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
+            style={{ transitionDelay: '500ms' }}
+          >
+            Initial campaign plan
+          </h1>
+
+          {plan.candidateName ? (
+            <div
+              className={`space-y-2 ${enter}`}
               style={{ transitionDelay: '700ms' }}
             >
-              Read it through, download a copy, or share it with your team. Find
-              it anytime on your Campaign plan page.
+              <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase sm:text-sm">
+                Prepared for
+              </p>
+              <p className="text-xl font-bold text-foreground sm:text-2xl">
+                {plan.candidateName}
+              </p>
+            </div>
+          ) : null}
+
+          <div
+            className={`space-y-1 ${enter}`}
+            style={{ transitionDelay: '900ms' }}
+          >
+            {plan.race ? (
+              <p className="text-base text-muted-foreground sm:text-lg">
+                {plan.race}
+                {plan.location ? ` • ${plan.location}` : ''}
+              </p>
+            ) : null}
+            {plan.electionDate ? (
+              <p className="text-sm text-muted-foreground sm:text-base">
+                Election Day: {plan.electionDate}
+              </p>
+            ) : null}
+          </div>
+
+          <div
+            className={`flex w-full flex-col items-center gap-1 border-t border-base-border pt-6 ${enter}`}
+            style={{ transitionDelay: '1100ms' }}
+          >
+            <p className="text-xs text-muted-foreground sm:text-sm">
+              Prepared by GoodParty.org
+            </p>
+            <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
+              Empowering people to run, win, and serve
             </p>
           </div>
         </div>
 
         <div
           className={`mt-8 sm:mt-16 ${enter}`}
-          style={{ transitionDelay: '1300ms' }}
+          style={{ transitionDelay: '1500ms' }}
         >
           <PlanSections plan={plan} />
         </div>
       </main>
 
       <div className="fixed inset-x-0 bottom-0 border-t border-base-border bg-base-surface">
-        <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between px-4 sm:px-8">
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="large"
-              icon={<Download className="size-5" />}
-              onClick={handleDownload}
-              loading={downloading}
-              loadingText="Generating PDF"
-              aria-label="Download campaign plan"
-            >
-              <span className="hidden sm:inline">Download</span>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="large"
-              icon={<Share2 className="size-5" />}
-              onClick={() => setShareOpen(true)}
-              aria-label="Share campaign plan"
-            >
-              <span className="hidden sm:inline">Share</span>
-            </Button>
-          </div>
+        <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between gap-3 px-4 sm:px-8">
+          <Button
+            type="button"
+            variant="ghost"
+            size="large"
+            icon={<Download className="size-5" />}
+            onClick={handleDownload}
+            loading={downloading}
+          >
+            Download
+          </Button>
           <Button
             type="button"
             variant="default"
             size="large"
             onClick={handleContinue}
           >
-            Continue
+            Campaign manager
           </Button>
         </div>
       </div>

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -124,48 +124,50 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
       <div className="pointer-events-none fixed inset-0 z-40">
         <ConfettiCanvas play />
       </div>
-      <main className="mx-auto w-full max-w-4xl px-4 pt-8 pb-12 sm:px-8 sm:pt-16 sm:pb-20">
+      <main className="mx-auto w-full max-w-4xl px-4 pt-4 pb-12 sm:px-8 sm:pt-16 sm:pb-20">
         <div
-          className={`relative flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 pt-12 pb-6 text-center sm:px-12 sm:py-16 ${cardEnter}`}
+          className={`relative flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 pt-12 pb-6 text-center sm:px-12 sm:pt-16 ${cardEnter}`}
           style={{ transitionDelay: '0ms' }}
         >
           <div className={enter} style={{ transitionDelay: '300ms' }}>
             <GoodPartyOrgLogo className="!h-12 !w-auto sm:!h-14" />
           </div>
 
-          <h1
-            className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
-            style={{ transitionDelay: '500ms' }}
-          >
-            Your initial campaign plan
-          </h1>
+          <div className="flex flex-col items-center gap-2">
+            <h1
+              className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
+              style={{ transitionDelay: '500ms' }}
+            >
+              Your initial campaign plan
+            </h1>
 
-          <div
-            className={`flex flex-col items-center gap-1 ${enter}`}
-            style={{ transitionDelay: '700ms' }}
-          >
-            {plan.candidateName && plan.race ? (
-              <p className="text-xl font-bold text-foreground sm:text-2xl">
-                {plan.candidateName} for {plan.race}
-              </p>
-            ) : null}
-            {plan.districtName ? (
-              <p className="text-base text-muted-foreground sm:text-lg">
-                {plan.districtName}
-              </p>
-            ) : null}
-            {plan.electionDate ? (
-              <p className="text-sm italic text-muted-foreground sm:text-base">
-                Election Day: {plan.electionDate}
-              </p>
-            ) : null}
+            <div
+              className={`flex flex-col items-center gap-1 ${enter}`}
+              style={{ transitionDelay: '700ms' }}
+            >
+              {plan.candidateName && plan.race ? (
+                <p className="text-xl font-bold text-foreground sm:text-2xl">
+                  {plan.candidateName} for {plan.race}
+                </p>
+              ) : null}
+              {plan.districtName ? (
+                <p className="text-base text-muted-foreground sm:text-lg">
+                  {plan.districtName}
+                </p>
+              ) : null}
+              {plan.electionDate ? (
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  Election Day: {plan.electionDate}
+                </p>
+              ) : null}
+            </div>
           </div>
 
           <div
             className={`w-full border-t border-base-border pt-6 ${enter}`}
             style={{ transitionDelay: '1100ms' }}
           >
-            <p className="text-xs italic text-muted-foreground sm:text-sm">
+            <p className="text-xs text-muted-foreground sm:text-sm">
               Campaign plan prepared for{' '}
               <span className="font-semibold text-foreground">
                 {plan.candidateName}
@@ -204,7 +206,7 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
             </IconButton>
             <Button
               type="button"
-              variant="ghost"
+              variant="outline"
               size="large"
               icon={<Download className="size-5" />}
               onClick={handleDownload}

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Download, Share2 } from 'lucide-react'
+import { Button, GoodPartyOrgLogo } from '@styleguide'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { useUser } from '@shared/hooks/useUser'
+import type { User } from 'helpers/types'
+import ConfettiCanvas from './ConfettiCanvas'
+import PlanSections from 'app/dashboard/strategy/components/PlanSections'
+import SharePlanModal from 'app/dashboard/strategy/components/SharePlanModal'
+import { buildPlanData } from 'app/dashboard/strategy/components/planContent'
+
+interface SuccessPageProps {
+  initialUser: User | null
+}
+
+const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
+  const router = useRouter()
+  const [clientUser] = useUser()
+  const user = clientUser ?? initialUser
+  const [campaign] = useCampaign()
+  const [shareOpen, setShareOpen] = useState(false)
+  const [downloading, setDownloading] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setMounted(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  const enterBase =
+    'transition-all duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)]'
+  const enterFrom = 'opacity-0 translate-y-3'
+  const enterTo = 'opacity-100 translate-y-0'
+  const enter = `${enterBase} ${mounted ? enterTo : enterFrom}`
+  const cardEnterFrom = 'opacity-0 scale-[0.98] translate-y-3'
+  const cardEnterTo = 'opacity-100 scale-100 translate-y-0'
+  const cardEnter = `${enterBase} ${mounted ? cardEnterTo : cardEnterFrom}`
+
+  const firstName = user?.firstName ?? ''
+  const lastName = user?.lastName ?? ''
+  const candidateName = [firstName, lastName].filter(Boolean).join(' ').trim()
+  const race =
+    campaign?.positionName ||
+    campaign?.organization?.customPositionName ||
+    campaign?.office ||
+    'Your race'
+  const city = campaign?.details?.city ?? ''
+  const state = campaign?.details?.state ?? ''
+  const metrics = campaign?.raceTargetMetrics
+  const winNumber = metrics?.winNumber ?? 0
+  const projectedTurnout = metrics?.projectedTurnout ?? 0
+  const voterContactGoal = metrics?.voterContactGoal ?? winNumber * 5
+
+  const plan = useMemo(
+    () =>
+      buildPlanData({
+        candidateName,
+        race,
+        city,
+        state,
+        electionDateIso: campaign?.details?.electionDate ?? null,
+        winNumber,
+        projectedTurnout,
+        voterContactGoal,
+      }),
+    [
+      candidateName,
+      race,
+      city,
+      state,
+      campaign?.details?.electionDate,
+      winNumber,
+      projectedTurnout,
+      voterContactGoal,
+    ],
+  )
+
+  const handleDownload = async () => {
+    if (downloading) return
+    setDownloading(true)
+    try {
+      const [{ pdf }, { CampaignPlanPdf }] = await Promise.all([
+        import('@react-pdf/renderer'),
+        import('app/dashboard/strategy/components/CampaignPlanPdf'),
+      ])
+      const blob = await pdf(<CampaignPlanPdf plan={plan} />).toBlob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      const safeName =
+        (candidateName || 'campaign-plan')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '') || 'campaign-plan'
+      a.download = `${safeName}-campaign-plan.pdf`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  const handleContinue = () => router.push('/dashboard')
+
+  const shareUrl = typeof window !== 'undefined' ? window.location.href : ''
+
+  return (
+    <div className="relative min-h-screen w-full bg-base-surface pb-28 text-foreground">
+      <div className="pointer-events-none fixed inset-0 z-40">
+        <ConfettiCanvas play />
+      </div>
+      <main className="mx-auto w-full max-w-4xl px-4 pt-8 pb-12 sm:px-8 sm:pt-16 sm:pb-20">
+        <div
+          className={`flex flex-col items-center gap-6 rounded-3xl border border-base-border bg-brand-cream px-6 py-12 text-center sm:px-12 sm:py-16 ${cardEnter}`}
+          style={{ transitionDelay: '0ms' }}
+        >
+          <div className={enter} style={{ transitionDelay: '300ms' }}>
+            <GoodPartyOrgLogo className="!h-12 !w-auto sm:!h-14" />
+          </div>
+
+          <div className="space-y-4">
+            <h1
+              className={`text-4xl font-bold text-foreground sm:text-5xl ${enter}`}
+              style={{ transitionDelay: '500ms' }}
+            >
+              Your campaign plan is ready!
+            </h1>
+            <p
+              className={`text-base text-muted-foreground sm:text-lg ${enter}`}
+              style={{ transitionDelay: '700ms' }}
+            >
+              Read it through, download a copy, or share it with your team. Find
+              it anytime on your Campaign plan page.
+            </p>
+          </div>
+        </div>
+
+        <div
+          className={`mt-8 sm:mt-16 ${enter}`}
+          style={{ transitionDelay: '1300ms' }}
+        >
+          <PlanSections plan={plan} />
+        </div>
+      </main>
+
+      <div className="fixed inset-x-0 bottom-0 border-t border-base-border bg-base-surface">
+        <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between px-4 sm:px-8">
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="large"
+              icon={<Download className="size-5" />}
+              onClick={handleDownload}
+              loading={downloading}
+              loadingText="Generating PDF"
+              aria-label="Download campaign plan"
+            >
+              <span className="hidden sm:inline">Download</span>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="large"
+              icon={<Share2 className="size-5" />}
+              onClick={() => setShareOpen(true)}
+              aria-label="Share campaign plan"
+            >
+              <span className="hidden sm:inline">Share</span>
+            </Button>
+          </div>
+          <Button
+            type="button"
+            variant="default"
+            size="large"
+            onClick={handleContinue}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+
+      <SharePlanModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        url={shareUrl}
+        candidateName={candidateName}
+      />
+    </div>
+  )
+}
+
+export default SuccessPage

--- a/app/onboarding/success/page.tsx
+++ b/app/onboarding/success/page.tsx
@@ -1,0 +1,20 @@
+import pageMetaData from 'helpers/metadataHelper'
+import candidateAccess from 'app/dashboard/shared/candidateAccess'
+import { getServerUser } from 'helpers/userServerHelper'
+import SuccessPage from './components/SuccessPage'
+
+const meta = pageMetaData({
+  title: 'Your Campaign Plan | GoodParty.org',
+  description: 'Your campaign plan is ready.',
+  slug: '/onboarding/success',
+})
+
+export const metadata = meta
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page(): Promise<React.JSX.Element> {
+  await candidateAccess()
+  const initialUser = await getServerUser()
+  return <SuccessPage initialUser={initialUser} />
+}

--- a/app/shared/layouts/PageWrapper.tsx
+++ b/app/shared/layouts/PageWrapper.tsx
@@ -53,7 +53,7 @@ const PageWrapper = async ({
                   <P2pUxEnabledProvider>
                     <NavigationProvider>
                       <SnackbarProvider>
-                        <div className="overflow-x-hidden">
+                        <div className="overflow-x-clip">
                           <JsonLdSchema />
                           <Nav />
                           {children}

--- a/app/shared/layouts/navigation/Nav.tsx
+++ b/app/shared/layouts/navigation/Nav.tsx
@@ -9,14 +9,14 @@ import { usePathname } from 'next/navigation'
 const Nav = (): React.JSX.Element => {
   const pathname = usePathname()
   const isDashboardPath = pathname?.startsWith('/dashboard')
+  const isOnboardingSuccessPath = pathname === '/onboarding/success'
+  const isHidden = isDashboardPath || isOnboardingSuccessPath
 
   return (
     <>
       <div
         id="top-nav"
-        className={`fixed w-screen h-14 z-50${
-          isDashboardPath ? ' hidden' : ''
-        }`}
+        className={`fixed w-screen h-14 z-50${isHidden ? ' hidden' : ''}`}
       >
         <div className="relative bg-indigo-50 lg:block border-solid border-b border-zinc-200 px-5 lg:px-8 z-50 h-14">
           <div
@@ -32,10 +32,10 @@ const Nav = (): React.JSX.Element => {
           </div>
         </div>
       </div>
-      {!isDashboardPath && <RightSideMobile />}
+      {!isHidden && <RightSideMobile />}
       <div
         id="top-nav-spacer"
-        className={`h-14 relative${isDashboardPath ? ' hidden' : ''}`}
+        className={`h-14 relative${isHidden ? ' hidden' : ''}`}
       >
         &nbsp;
       </div>

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -127,6 +127,7 @@ export const EVENTS = {
     },
     Dashboard: {
       ClickDashboard: 'Navigation - Dashboard: Click Dashboard',
+      ClickStrategy: 'Navigation - Dashboard: Click Strategy',
       ClickAIAssistant: 'Navigation - Dashboard: Click AI Assistant',
       ClickVoterData: 'Navigation - Dashboard: Click Voter Data',
       ClickDoorKnocking: 'Navigation - Dashboard: Click Door Knocking',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@react-google-maps/api": "^2.20.6",
+        "@react-pdf/renderer": "^4.5.1",
         "@segment/analytics-next": "^1.81.1",
         "@sentry/nextjs": "^10.39.0",
         "@sentry/profiling-node": "^10.39.0",
@@ -5655,6 +5656,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -8092,6 +8117,183 @@
       "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
       "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
       "license": "MIT"
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -12670,6 +12872,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -13428,6 +13636,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-image-compression": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
@@ -13435,6 +13652,15 @@
       "license": "MIT",
       "dependencies": {
         "uzip": "0.20201231.0"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -14002,6 +14228,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -15034,6 +15281,12 @@
         "typescript": "^5.4.4"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -15304,6 +15557,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -16500,7 +16759,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -16912,6 +17170,32 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/for-each": {
@@ -17488,6 +17772,21 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -17585,6 +17884,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/idb": {
       "version": "8.0.0",
@@ -18425,7 +18730,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-url-superb": {
@@ -18586,6 +18890,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -18654,6 +18967,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-sha256": {
       "version": "0.10.1",
@@ -19160,6 +19479,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -20062,6 +20400,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -21273,6 +21617,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
@@ -21709,6 +22062,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parchment": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
@@ -21778,6 +22137,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
       "license": "MIT"
     },
     "node_modules/parse5": {
@@ -22113,6 +22478,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/png-js/node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -22167,7 +22546,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/postcss-values-parser": {
@@ -22449,6 +22827,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -23562,6 +23949,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -25012,6 +25405,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -25265,6 +25664,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -25730,6 +26135,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
@@ -25738,6 +26153,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -26497,6 +26928,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vite-compatible-readable-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/vite-plugin-storybook-nextjs": {
@@ -27977,6 +28431,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zen-observable": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.6",
     "@react-google-maps/api": "^2.20.6",
+    "@react-pdf/renderer": "^4.5.1",
     "@segment/analytics-next": "^1.81.1",
     "@sentry/nextjs": "^10.39.0",
     "@sentry/profiling-node": "^10.39.0",

--- a/styleguide/components/ui/badge.tsx
+++ b/styleguide/components/ui/badge.tsx
@@ -13,7 +13,7 @@ const badgeVariants = cva(
           'border-transparent bg-primary text-white [a&]:hover:bg-primary/90',
         secondary:
           'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
-        soft: 'border-transparent bg-muted text-muted-foreground [a&]:hover:bg-muted/70',
+        soft: 'border-transparent bg-grayscale-200 text-foreground [a&]:hover:bg-grayscale-200/70',
         destructive:
           'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:

--- a/styleguide/components/ui/donut-chart.tsx
+++ b/styleguide/components/ui/donut-chart.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from 'recharts'
+import { Cell, Pie, PieChart, ResponsiveContainer } from 'recharts'
 import {
   CHART_COLORS,
   formatChartNumber,
@@ -21,69 +21,61 @@ interface DonutChartProps {
 const DonutChart = ({
   data = [],
   percentage = false,
-  height = 350,
+  height = 220,
 }: DonutChartProps): React.JSX.Element => {
-  const renderLegend = () => (
-    <div className="w-full px-2 text-foreground">
-      {data.map((item, index) => (
-        <div
-          key={`legend-row-${item.name}`}
-          className="flex w-full items-center justify-between py-1"
-        >
-          <div className="flex min-w-0 items-center">
-            <span
-              className="mr-2 inline-block rounded-full"
-              style={{
-                backgroundColor: CHART_COLORS[index % CHART_COLORS.length],
-                width: 8,
-                height: 8,
-              }}
-            />
-            <span className="truncate text-xs font-normal text-muted-foreground">
-              {item.name}
+  return (
+    <div className="w-full">
+      <ResponsiveContainer width="100%" height={height}>
+        <PieChart margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            labelLine={false}
+            label={false}
+            innerRadius={60}
+            outerRadius={100}
+            stroke="var(--color-base-muted)"
+            strokeWidth={4}
+            dataKey="value"
+          >
+            {data.map((entry, index) => (
+              <Cell
+                key={`cell-${entry.name}`}
+                fill={CHART_COLORS[index % CHART_COLORS.length]}
+              />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      <div className="w-full px-2 pt-2 text-foreground">
+        {data.map((item, index) => (
+          <div
+            key={`legend-row-${item.name}`}
+            className="flex w-full items-center justify-between py-1"
+          >
+            <div className="flex min-w-0 items-center">
+              <span
+                className="mr-2 inline-block rounded-full"
+                style={{
+                  backgroundColor: CHART_COLORS[index % CHART_COLORS.length],
+                  width: 8,
+                  height: 8,
+                }}
+              />
+              <span className="truncate text-xs font-normal text-muted-foreground">
+                {item.name}
+              </span>
+            </div>
+            <span className="ml-4 text-xs font-semibold">
+              {percentage
+                ? `${formatChartPercent(item.value)}%`
+                : formatChartNumber(item.value)}
             </span>
           </div>
-          <span className="ml-4 text-xs font-semibold">
-            {percentage
-              ? `${formatChartPercent(item.value)}%`
-              : formatChartNumber(item.value)}
-          </span>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
-  )
-
-  return (
-    <ResponsiveContainer width="100%" height={height}>
-      <PieChart margin={{ top: 0, right: 0, bottom: 24, left: 0 }}>
-        <Pie
-          data={data}
-          cx="50%"
-          cy="45%"
-          labelLine={false}
-          label={false}
-          innerRadius={60}
-          outerRadius={100}
-          stroke="var(--color-base-muted)"
-          strokeWidth={4}
-          dataKey="value"
-        >
-          {data.map((entry, index) => (
-            <Cell
-              key={`cell-${entry.name}`}
-              fill={CHART_COLORS[index % CHART_COLORS.length]}
-            />
-          ))}
-        </Pie>
-        <Legend
-          wrapperStyle={{ width: '100%' }}
-          verticalAlign="bottom"
-          align="center"
-          layout="vertical"
-          content={renderLegend}
-        />
-      </PieChart>
-    </ResponsiveContainer>
   )
 }
 

--- a/styleguide/components/ui/icon-button.tsx
+++ b/styleguide/components/ui/icon-button.tsx
@@ -1,31 +1,12 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
+import { LoaderCircle } from 'lucide-react'
 
 import { cn } from '@styleguide/lib/utils'
 
-// Loading spinner component for icon buttons
 const LoadingSpinner = ({ className }: { className?: string }) => (
-  <svg
-    className={cn('animate-spin', className)}
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <circle
-      className="opacity-25"
-      cx="12"
-      cy="12"
-      r="10"
-      stroke="currentColor"
-      strokeWidth="4"
-    ></circle>
-    <path
-      className="opacity-75"
-      fill="currentColor"
-      d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-    ></path>
-  </svg>
+  <LoaderCircle className={cn('animate-spin', className)} />
 )
 
 const iconButtonVariants = cva(


### PR DESCRIPTION
## Summary

Prototype branch exploring the new campaign-plan payoff experience. **Not for merge** — opening this PR to generate a Vercel preview link for review.

## What's in it

- **/onboarding/success**: payoff screen with confetti, cream hero card, staggered entrance animation, downloadable PDF, branded share modal, and the full 10-section campaign plan with a sticky "Jump to" nav.
- **/dashboard/strategy** ("Campaign plan"): rebuilt around the same plan content, with a **Plan Inputs** card (ballot status, budget raised, candidate canvassing hours, volunteer list with add/remove) doing gap analysis vs. plan targets.
- **Onboarding flow copy refresh**: titles and descriptions rewritten in candidate-voice ("you" not "the candidate"), pledge step retitled "Almost there...", outreach plan reduced to Budget + Time accordions, eyebrows dropped.
- **Dashboard "likely votes"**: replaces the voter-contact count, plain-language counts info modal, "Campaign plan" sidebar item points at the strategy page.
- **Shared plan code**: `planContent.ts`, PDF renderer, share modal, and sticky nav moved to `app/dashboard/strategy/components/` so both onboarding/success and the dashboard plan page share them.
- **`PageWrapper`**: swapped `overflow-x-hidden` → `overflow-x-clip` so `position: sticky` works for descendant elements (the "Jump to" nav).

## Test plan

- [ ] Run the onboarding flow end-to-end, hit `/onboarding/success`, confirm confetti + animation + sticky nav + PDF download + share modal
- [ ] Visit `/dashboard/strategy`, exercise the Plan Inputs card (ballot status radio, budget input, canvassing hours, add/remove volunteers)
- [ ] Confirm Continue / Download / Share buttons in success-page bottom bar
- [ ] Confirm copy reads naturally end-to-end (no "the candidate" third-person language)
- [ ] Mobile layout for hero card + bottom action bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)