### PR TITLE
fix(dashboard): show post-election state in AI Campaign Manager [ENG-7496]

### DIFF
--- a/app/dashboard/components/DashboardPage.tsx
+++ b/app/dashboard/components/DashboardPage.tsx
@@ -88,11 +88,11 @@ const DashboardPage = ({
                   <EmptyState />
                 )}
               </div>
-              {primaryElectionDate && (
+              {primaryElectionDate && electionDate && (
                 <PrimaryResultModal
                   open={primaryResultModalOpen}
                   onClose={closePrimaryResultModal}
-                  electionDate={electionDate!}
+                  electionDate={electionDate}
                   officeName={positionName}
                 />
               )}

--- a/app/dashboard/components/DashboardPage.tsx
+++ b/app/dashboard/components/DashboardPage.tsx
@@ -1,7 +1,6 @@
 'use client'
 import DashboardLayout from '../shared/DashboardLayout'
-import { weeksTill } from 'helpers/dateHelper'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { calculateContactGoalsFromCampaign } from './voterGoalsHelpers'
 import ElectionOver from './ElectionOver'
 import EmptyState from './EmptyState'
@@ -17,6 +16,7 @@ import type { Task } from './tasks/TaskItem'
 import type { TcrCompliance } from 'helpers/types'
 import { usePositionName } from '@shared/hooks/usePositionName'
 import { useCampaign } from '@shared/hooks/useCampaign'
+import { usePostElectionState } from './usePostElectionState'
 
 interface DashboardPageProps {
   pathname: string
@@ -31,21 +31,14 @@ const DashboardPage = ({
 }: DashboardPageProps): React.JSX.Element => {
   const [_, setUser] = useUser()
   const [campaign] = useCampaign()
-
-  const { goals, details } = campaign || {}
-  const { primaryElectionDate } = details || {}
-  type PrimaryResult = 'won' | 'lost'
-  type PrimaryResultState = {
-    modalOpen: boolean
-    modalDismissed: boolean
-    primaryResult: PrimaryResult | null | undefined
-  }
-  const [primaryResultState, setPrimaryResultState] =
-    useState<PrimaryResultState>({
-      modalOpen: false,
-      modalDismissed: false,
-      primaryResult: campaign?.details?.primaryResult,
-    })
+  const {
+    electionInPast,
+    primaryLost,
+    primaryResultModalOpen,
+    primaryElectionDate,
+    electionDate,
+    closePrimaryResultModal,
+  } = usePostElectionState()
 
   const positionName = usePositionName()
 
@@ -64,70 +57,13 @@ const DashboardPage = ({
     updateUserCookie()
   }, [])
 
-  const electionDate = details?.electionDate || goals?.electionDate
-  const now = new Date()
-  let resolvedDate = electionDate
-
-  if (primaryElectionDate) {
-    const primaryElectionDateObj = new Date(primaryElectionDate)
-    const { modalOpen, primaryResult, modalDismissed } = primaryResultState
-
-    if (primaryElectionDateObj > now) {
-      resolvedDate = primaryElectionDate
-    } else if (!primaryResult && !modalOpen && !modalDismissed) {
-      // Primary date has passed, open up results modal
-      setPrimaryResultState((state) => ({
-        ...state,
-        modalOpen: true,
-      }))
-    }
-  }
-
-  const weeksUntil = weeksTill(resolvedDate)
   const contactGoals = campaign
     ? calculateContactGoalsFromCampaign(campaign)
     : false
 
-  const primaryResultCloseCallback = useCallback(
-    (selectedResult?: PrimaryResult) => {
-      if (selectedResult) {
-        // user selected their primary election result
-        setPrimaryResultState((state) => ({
-          ...state,
-          modalOpen: false,
-          primaryResult: selectedResult,
-        }))
-      } else {
-        // user pressed Cancel to dismiss modal for now
-        setPrimaryResultState({
-          modalOpen: false,
-          modalDismissed: true,
-          primaryResult: undefined,
-        })
-      }
-    },
-    [],
-  )
-
   trackEvent(EVENTS.Dashboard.Viewed, {
     p2vCompleted: `${campaign?.raceTargetMetrics ? 'true' : 'false'}`,
   })
-
-  const weeksUntilValue =
-    typeof weeksUntil === 'object' && weeksUntil ? weeksUntil.weeks : NaN
-  const electionInPast =
-    weeksUntilValue < 0 && resolvedDate !== primaryElectionDate
-  const primaryLost = primaryResultState.primaryResult === 'lost'
-
-  if (electionInPast || primaryLost) {
-    console.log(
-      `displaying election over - electionInPast: ${electionInPast}, primaryLost: ${primaryLost}, resolvedDate: ${resolvedDate}, weeksUntil: ${JSON.stringify(
-        weeksUntil,
-      )}, primaryElectionDate: ${primaryElectionDate}, electionDate: ${electionDate}, primaryResult: ${
-        primaryResultState.primaryResult
-      }, now: ${now.toISOString()}`,
-    )
-  }
 
   return (
     <VoterContactsProvider>
@@ -154,8 +90,8 @@ const DashboardPage = ({
               </div>
               {primaryElectionDate && (
                 <PrimaryResultModal
-                  open={primaryResultState.modalOpen}
-                  onClose={primaryResultCloseCallback}
+                  open={primaryResultModalOpen}
+                  onClose={closePrimaryResultModal}
                   electionDate={electionDate!}
                   officeName={positionName}
                 />

--- a/app/dashboard/components/campaignManager/CampaignManager.test.tsx
+++ b/app/dashboard/components/campaignManager/CampaignManager.test.tsx
@@ -49,6 +49,18 @@ vi.mock('@shared/hooks/useCampaign', () => ({
   useCampaign: () => mockUseCampaign(),
 }))
 
+vi.mock('@shared/hooks/usePositionName', () => ({
+  usePositionName: () => 'Mayor',
+}))
+
+vi.mock('../ElectionOver', () => ({
+  default: () => <div>Election over</div>,
+}))
+
+vi.mock('../PrimaryResultModal', () => ({
+  default: () => null,
+}))
+
 vi.mock('gpApi/clientFetch', () => ({
   clientFetch: (...args: unknown[]) => mockClientFetch(...args),
 }))

--- a/app/dashboard/components/campaignManager/CampaignManager.test.tsx
+++ b/app/dashboard/components/campaignManager/CampaignManager.test.tsx
@@ -10,6 +10,8 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 const mockUseCampaign = vi.fn()
 const mockClientFetch = vi.fn()
 const mockUseTaskGenerationStream = vi.fn()
+const mockUsePostElectionState = vi.fn()
+const mockStartGeneration = vi.fn()
 
 vi.mock('app/dashboard/shared/DashboardLayout', () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -51,6 +53,10 @@ vi.mock('@shared/hooks/useCampaign', () => ({
 
 vi.mock('@shared/hooks/usePositionName', () => ({
   usePositionName: () => 'Mayor',
+}))
+
+vi.mock('../usePostElectionState', () => ({
+  usePostElectionState: () => mockUsePostElectionState(),
 }))
 
 vi.mock('../ElectionOver', () => ({
@@ -117,8 +123,16 @@ beforeEach(() => {
     isGenerating: true,
     progress: { message: 'Generating tasks', progress: 50 },
     error: null,
-    startGeneration: vi.fn(),
+    startGeneration: mockStartGeneration,
     cancelGeneration: vi.fn(),
+  })
+  mockUsePostElectionState.mockReturnValue({
+    electionInPast: false,
+    primaryLost: false,
+    primaryResultModalOpen: false,
+    primaryElectionDate: undefined,
+    electionDate: '2026-11-03',
+    closePrimaryResultModal: vi.fn(),
   })
 })
 
@@ -167,5 +181,70 @@ describe('CampaignManager generation tracking', () => {
     expect(mockTrackEvent).not.toHaveBeenCalledWith(
       EVENTS.Dashboard.CampaignPlan.GenerationCompleted,
     )
+  })
+})
+
+describe('CampaignManager election-over branch', () => {
+  it('renders ElectionOver and hides header/progress/tasks when the election is in the past', () => {
+    mockUsePostElectionState.mockReturnValue({
+      electionInPast: true,
+      primaryLost: false,
+      primaryResultModalOpen: false,
+      primaryElectionDate: undefined,
+      electionDate: '2026-01-01',
+      closePrimaryResultModal: vi.fn(),
+    })
+    mockUseTaskGenerationStream.mockReturnValue({
+      isGenerating: false,
+      progress: null,
+      error: null,
+      startGeneration: mockStartGeneration,
+      cancelGeneration: vi.fn(),
+    })
+    mockClientFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      data: [],
+    })
+
+    render(<CampaignManager pathname="/dashboard" tcrCompliance={null} />)
+
+    expect(screen.getByText('Election over')).toBeInTheDocument()
+    expect(screen.queryByText('Header')).not.toBeInTheDocument()
+    expect(screen.queryByText('Progress')).not.toBeInTheDocument()
+    expect(screen.queryByText('Tasks list')).not.toBeInTheDocument()
+  })
+
+  it('does not call startGeneration when the election is over even if there are no tasks', async () => {
+    mockUsePostElectionState.mockReturnValue({
+      electionInPast: true,
+      primaryLost: false,
+      primaryResultModalOpen: false,
+      primaryElectionDate: undefined,
+      electionDate: '2026-01-01',
+      closePrimaryResultModal: vi.fn(),
+    })
+    mockUseTaskGenerationStream.mockReturnValue({
+      isGenerating: false,
+      progress: null,
+      error: null,
+      startGeneration: mockStartGeneration,
+      cancelGeneration: vi.fn(),
+    })
+    mockClientFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      data: [],
+    })
+
+    render(<CampaignManager pathname="/dashboard" tcrCompliance={null} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Election over')).toBeInTheDocument()
+    })
+
+    expect(mockStartGeneration).not.toHaveBeenCalled()
   })
 })

--- a/app/dashboard/components/campaignManager/CampaignManager.tsx
+++ b/app/dashboard/components/campaignManager/CampaignManager.tsx
@@ -177,11 +177,11 @@ export default function CampaignManager({
               </>
             )}
           </div>
-          {primaryElectionDate && (
+          {primaryElectionDate && electionDate && (
             <PrimaryResultModal
               open={primaryResultModalOpen}
               onClose={closePrimaryResultModal}
-              electionDate={electionDate!}
+              electionDate={electionDate}
               officeName={positionName}
             />
           )}

--- a/app/dashboard/components/campaignManager/CampaignManager.tsx
+++ b/app/dashboard/components/campaignManager/CampaignManager.tsx
@@ -19,6 +19,10 @@ import { apiRoutes } from 'gpApi/routes'
 import { useTaskGenerationStream } from './useTaskGenerationStream'
 import { FailedToGenerate } from './FailedToGenerate'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import ElectionOver from '../ElectionOver'
+import PrimaryResultModal from '../PrimaryResultModal'
+import { usePostElectionState } from '../usePostElectionState'
+import { usePositionName } from '@shared/hooks/usePositionName'
 
 const TASKS_QUERY_KEY = ['campaignTasks']
 
@@ -35,6 +39,16 @@ export default function CampaignManager({
   const generatedInSessionRef = useRef(false)
   const trackedGenerationCompleteRef = useRef(false)
   const [showLoadingState, setShowLoadingState] = useState(false)
+  const positionName = usePositionName()
+  const {
+    electionInPast,
+    primaryLost,
+    primaryResultModalOpen,
+    primaryElectionDate,
+    electionDate,
+    closePrimaryResultModal,
+  } = usePostElectionState()
+  const electionOver = electionInPast || primaryLost
 
   const hideLoadingChecklist = useCallback(() => {
     setShowLoadingState(false)
@@ -75,7 +89,7 @@ export default function CampaignManager({
       generatingRef.current = false
       return
     }
-    if (!campaign || generatingRef.current) return
+    if (!campaign || generatingRef.current || electionOver) return
 
     generatingRef.current = true
     void startGeneration()
@@ -84,7 +98,14 @@ export default function CampaignManager({
       generatingRef.current = false
       cancelGeneration()
     }
-  }, [isLoadingTasks, tasks, campaign, startGeneration, cancelGeneration])
+  }, [
+    isLoadingTasks,
+    tasks,
+    campaign,
+    startGeneration,
+    cancelGeneration,
+    electionOver,
+  ])
 
   useEffect(() => {
     if (error) {
@@ -122,34 +143,48 @@ export default function CampaignManager({
       <VoterContactsProvider>
         <CampaignUpdateHistoryProvider>
           <div className="mx-auto w-full max-w-160 flex flex-col gap-6 px-4 py-8 md:px-0">
-            <HeaderSection />
-            <ProgressSection />
-            {showLoadingState && (
-              <LoadingState
-                isStreamComplete={isStreamComplete}
-                hideCallback={hideLoadingChecklist}
-              />
-            )}
-            {error && !isGenerating && !showLoadingState && (
-              <FailedToGenerate retryGeneration={startGeneration} />
-            )}
-            {!showLoadingState && (
+            {electionOver ? (
+              <ElectionOver />
+            ) : (
               <>
-                {tasks.length > 0 || contactGoals ? (
-                  <TasksList
-                    campaign={campaign}
-                    tasks={tasks}
-                    tcrCompliance={tcrCompliance}
-                    isLegacyList={false}
+                <HeaderSection />
+                <ProgressSection />
+                {showLoadingState && (
+                  <LoadingState
+                    isStreamComplete={isStreamComplete}
+                    hideCallback={hideLoadingChecklist}
                   />
-                ) : (
-                  <div className="mt-4">
-                    <EmptyState />
-                  </div>
+                )}
+                {error && !isGenerating && !showLoadingState && (
+                  <FailedToGenerate retryGeneration={startGeneration} />
+                )}
+                {!showLoadingState && (
+                  <>
+                    {tasks.length > 0 || contactGoals ? (
+                      <TasksList
+                        campaign={campaign}
+                        tasks={tasks}
+                        tcrCompliance={tcrCompliance}
+                        isLegacyList={false}
+                      />
+                    ) : (
+                      <div className="mt-4">
+                        <EmptyState />
+                      </div>
+                    )}
+                  </>
                 )}
               </>
             )}
           </div>
+          {primaryElectionDate && (
+            <PrimaryResultModal
+              open={primaryResultModalOpen}
+              onClose={closePrimaryResultModal}
+              electionDate={electionDate!}
+              officeName={positionName}
+            />
+          )}
         </CampaignUpdateHistoryProvider>
       </VoterContactsProvider>
     </DashboardLayout>

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePostElectionState } from './usePostElectionState'
+
+const mockUseCampaign = vi.fn()
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => mockUseCampaign(),
+}))
+
+const daysFromNow = (days: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+const setCampaign = (overrides: {
+  electionDate?: string
+  primaryElectionDate?: string
+  primaryResult?: 'won' | 'lost' | null
+  goalsElectionDate?: string
+}) => {
+  mockUseCampaign.mockReturnValue([
+    {
+      id: 'campaign-1',
+      details: {
+        electionDate: overrides.electionDate,
+        primaryElectionDate: overrides.primaryElectionDate,
+        primaryResult: overrides.primaryResult ?? null,
+      },
+      goals: overrides.goalsElectionDate
+        ? { electionDate: overrides.goalsElectionDate }
+        : undefined,
+    },
+  ])
+}
+
+describe('usePostElectionState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns electionInPast=false when the general election is in the future', () => {
+    setCampaign({ electionDate: daysFromNow(60) })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(false)
+    expect(result.current.primaryLost).toBe(false)
+    expect(result.current.primaryResultModalOpen).toBe(false)
+  })
+
+  it('returns electionInPast=true when the general election is in the past', () => {
+    setCampaign({ electionDate: daysFromNow(-30) })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(true)
+  })
+
+  it('falls back to goals.electionDate when details.electionDate is missing', () => {
+    setCampaign({ goalsElectionDate: daysFromNow(-30) })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(true)
+  })
+
+  it('opens the primary result modal when the primary date is past and no result is recorded', () => {
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.primaryResultModalOpen).toBe(true)
+    expect(result.current.electionInPast).toBe(false)
+  })
+
+  it('does not open the modal when the primary date is in the future', () => {
+    setCampaign({
+      electionDate: daysFromNow(120),
+      primaryElectionDate: daysFromNow(30),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+  })
+
+  it('does not open the modal when a primary result is already recorded', () => {
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+      primaryResult: 'won',
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+  })
+
+  it("closePrimaryResultModal('lost') sets primaryLost and closes the modal", () => {
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+    expect(result.current.primaryResultModalOpen).toBe(true)
+
+    act(() => {
+      result.current.closePrimaryResultModal('lost')
+    })
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+    expect(result.current.primaryLost).toBe(true)
+  })
+
+  it("closePrimaryResultModal('won') closes the modal without marking lost", () => {
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    act(() => {
+      result.current.closePrimaryResultModal('won')
+    })
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+    expect(result.current.primaryLost).toBe(false)
+  })
+
+  it('cancelling closePrimaryResultModal dismisses the modal without recording a result', () => {
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+    expect(result.current.primaryResultModalOpen).toBe(true)
+
+    act(() => {
+      result.current.closePrimaryResultModal()
+    })
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+    expect(result.current.primaryLost).toBe(false)
+  })
+
+  it('returns safe defaults when campaign is null', () => {
+    mockUseCampaign.mockReturnValue([null])
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(false)
+    expect(result.current.primaryLost).toBe(false)
+    expect(result.current.primaryResultModalOpen).toBe(false)
+    expect(result.current.electionDate).toBeUndefined()
+    expect(result.current.primaryElectionDate).toBeUndefined()
+  })
+})

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -154,6 +154,25 @@ describe('usePostElectionState', () => {
     expect(result.current.primaryLost).toBe(false)
   })
 
+  it('respects a persisted primaryResult that arrives after the hook mounts', () => {
+    // Simulate CampaignProvider returning [null] before the campaign loads
+    mockUseCampaign.mockReturnValue([null])
+
+    const { result, rerender } = renderHook(() => usePostElectionState())
+    expect(result.current.primaryResultModalOpen).toBe(false)
+
+    // Campaign resolves with a persisted result for a past primary
+    setCampaign({
+      electionDate: daysFromNow(60),
+      primaryElectionDate: daysFromNow(-10),
+      primaryResult: 'won',
+    })
+    rerender()
+
+    expect(result.current.primaryResultModalOpen).toBe(false)
+    expect(result.current.primaryLost).toBe(false)
+  })
+
   it('returns safe defaults when campaign is null', () => {
     mockUseCampaign.mockReturnValue([null])
 

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -92,6 +92,18 @@ describe('usePostElectionState', () => {
     expect(result.current.primaryResultModalOpen).toBe(false)
   })
 
+  it('marks electionInPast=true when general and primary dates are the same and both have passed', () => {
+    const sameDate = daysFromNow(-5)
+    setCampaign({
+      electionDate: sameDate,
+      primaryElectionDate: sameDate,
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(true)
+  })
+
   it('does not open the modal when the general election is also in the past', () => {
     setCampaign({
       electionDate: daysFromNow(-5),

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -92,6 +92,18 @@ describe('usePostElectionState', () => {
     expect(result.current.primaryResultModalOpen).toBe(false)
   })
 
+  it('does not open the modal when the general election is also in the past', () => {
+    setCampaign({
+      electionDate: daysFromNow(-5),
+      primaryElectionDate: daysFromNow(-30),
+    })
+
+    const { result } = renderHook(() => usePostElectionState())
+
+    expect(result.current.electionInPast).toBe(true)
+    expect(result.current.primaryResultModalOpen).toBe(false)
+  })
+
   it('does not open the modal when a primary result is already recorded', () => {
     setCampaign({
       electionDate: daysFromNow(60),

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -19,48 +19,43 @@ export function usePostElectionState(): PostElectionState {
   const { primaryElectionDate } = details || {}
 
   const [primaryResultState, setPrimaryResultState] = useState<{
-    modalOpen: boolean
     modalDismissed: boolean
     primaryResult: PrimaryResult | null | undefined
   }>({
-    modalOpen: false,
     modalDismissed: false,
     primaryResult: campaign?.details?.primaryResult,
   })
 
   const electionDate = details?.electionDate || goals?.electionDate
   const now = new Date()
-  let resolvedDate = electionDate
+  const primaryElectionDateObj = primaryElectionDate
+    ? new Date(primaryElectionDate)
+    : null
+  const primaryInFuture =
+    primaryElectionDateObj !== null && primaryElectionDateObj > now
+  const primaryInPast = primaryElectionDateObj !== null && !primaryInFuture
+  const resolvedDate = primaryInFuture ? primaryElectionDate : electionDate
 
-  if (primaryElectionDate) {
-    const primaryElectionDateObj = new Date(primaryElectionDate)
-    const { modalOpen, primaryResult, modalDismissed } = primaryResultState
-
-    if (primaryElectionDateObj > now) {
-      resolvedDate = primaryElectionDate
-    } else if (!primaryResult && !modalOpen && !modalDismissed) {
-      setPrimaryResultState((state) => ({ ...state, modalOpen: true }))
-    }
-  }
+  const { modalDismissed, primaryResult } = primaryResultState
+  const primaryResultModalOpen =
+    primaryInPast && !primaryResult && !modalDismissed
 
   const weeksUntil = weeksTill(resolvedDate)
   const weeksUntilValue =
     typeof weeksUntil === 'object' && weeksUntil ? weeksUntil.weeks : NaN
   const electionInPast =
     weeksUntilValue < 0 && resolvedDate !== primaryElectionDate
-  const primaryLost = primaryResultState.primaryResult === 'lost'
+  const primaryLost = primaryResult === 'lost'
 
   const closePrimaryResultModal = useCallback(
     (selectedResult?: PrimaryResult) => {
       if (selectedResult) {
-        setPrimaryResultState((state) => ({
-          ...state,
-          modalOpen: false,
+        setPrimaryResultState({
+          modalDismissed: false,
           primaryResult: selectedResult,
-        }))
+        })
       } else {
         setPrimaryResultState({
-          modalOpen: false,
           modalDismissed: true,
           primaryResult: undefined,
         })
@@ -72,7 +67,7 @@ export function usePostElectionState(): PostElectionState {
   return {
     electionInPast,
     primaryLost,
-    primaryResultModalOpen: primaryResultState.modalOpen,
+    primaryResultModalOpen,
     primaryElectionDate,
     electionDate,
     closePrimaryResultModal,

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react'
+import { weeksTill } from 'helpers/dateHelper'
+import { useCampaign } from '@shared/hooks/useCampaign'
+
+type PrimaryResult = 'won' | 'lost'
+
+export interface PostElectionState {
+  electionInPast: boolean
+  primaryLost: boolean
+  primaryResultModalOpen: boolean
+  primaryElectionDate: string | undefined
+  electionDate: string | undefined
+  closePrimaryResultModal: (result?: PrimaryResult) => void
+}
+
+export function usePostElectionState(): PostElectionState {
+  const [campaign] = useCampaign()
+  const { goals, details } = campaign || {}
+  const { primaryElectionDate } = details || {}
+
+  const [primaryResultState, setPrimaryResultState] = useState<{
+    modalOpen: boolean
+    modalDismissed: boolean
+    primaryResult: PrimaryResult | null | undefined
+  }>({
+    modalOpen: false,
+    modalDismissed: false,
+    primaryResult: campaign?.details?.primaryResult,
+  })
+
+  const electionDate = details?.electionDate || goals?.electionDate
+  const now = new Date()
+  let resolvedDate = electionDate
+
+  if (primaryElectionDate) {
+    const primaryElectionDateObj = new Date(primaryElectionDate)
+    const { modalOpen, primaryResult, modalDismissed } = primaryResultState
+
+    if (primaryElectionDateObj > now) {
+      resolvedDate = primaryElectionDate
+    } else if (!primaryResult && !modalOpen && !modalDismissed) {
+      setPrimaryResultState((state) => ({ ...state, modalOpen: true }))
+    }
+  }
+
+  const weeksUntil = weeksTill(resolvedDate)
+  const weeksUntilValue =
+    typeof weeksUntil === 'object' && weeksUntil ? weeksUntil.weeks : NaN
+  const electionInPast =
+    weeksUntilValue < 0 && resolvedDate !== primaryElectionDate
+  const primaryLost = primaryResultState.primaryResult === 'lost'
+
+  const closePrimaryResultModal = useCallback(
+    (selectedResult?: PrimaryResult) => {
+      if (selectedResult) {
+        setPrimaryResultState((state) => ({
+          ...state,
+          modalOpen: false,
+          primaryResult: selectedResult,
+        }))
+      } else {
+        setPrimaryResultState({
+          modalOpen: false,
+          modalDismissed: true,
+          primaryResult: undefined,
+        })
+      }
+    },
+    [],
+  )
+
+  return {
+    electionInPast,
+    primaryLost,
+    primaryResultModalOpen: primaryResultState.modalOpen,
+    primaryElectionDate,
+    electionDate,
+    closePrimaryResultModal,
+  }
+}

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -44,8 +44,6 @@ export function usePostElectionState(): PostElectionState {
     campaign?.details?.primaryResult ??
     null
   const { modalDismissed } = primaryResultState
-  const primaryResultModalOpen =
-    primaryInPast && !primaryResult && !modalDismissed
 
   const weeksUntil = weeksTill(resolvedDate)
   const weeksUntilValue =
@@ -53,6 +51,12 @@ export function usePostElectionState(): PostElectionState {
   const electionInPast =
     weeksUntilValue < 0 && resolvedDate !== primaryElectionDate
   const primaryLost = primaryResult === 'lost'
+
+  // Suppress the primary-result modal once the general election has also
+  // ended — at that point the race is over and we render ElectionOver
+  // (which is the screen the modal would otherwise cover non-dismissibly).
+  const primaryResultModalOpen =
+    primaryInPast && !primaryResult && !modalDismissed && !electionInPast
 
   const closePrimaryResultModal = useCallback(
     (selectedResult?: PrimaryResult) => {

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -48,8 +48,11 @@ export function usePostElectionState(): PostElectionState {
   const weeksUntil = weeksTill(resolvedDate)
   const weeksUntilValue =
     typeof weeksUntil === 'object' && weeksUntil ? weeksUntil.weeks : NaN
-  const electionInPast =
-    weeksUntilValue < 0 && resolvedDate !== primaryElectionDate
+  // resolvedDate represents the general election only when the primary
+  // is not still ahead of us — guarding on !primaryInFuture instead of
+  // string-comparing the dates avoids a false negative for campaigns
+  // whose primary and general dates are identical strings.
+  const electionInPast = weeksUntilValue < 0 && !primaryInFuture
   const primaryLost = primaryResult === 'lost'
 
   // Suppress the primary-result modal once the general election has also

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -20,10 +20,10 @@ export function usePostElectionState(): PostElectionState {
 
   const [primaryResultState, setPrimaryResultState] = useState<{
     modalDismissed: boolean
-    primaryResult: PrimaryResult | null | undefined
+    overrideResult: PrimaryResult | null
   }>({
     modalDismissed: false,
-    primaryResult: campaign?.details?.primaryResult,
+    overrideResult: null,
   })
 
   const electionDate = details?.electionDate || goals?.electionDate
@@ -36,7 +36,14 @@ export function usePostElectionState(): PostElectionState {
   const primaryInPast = primaryElectionDateObj !== null && !primaryInFuture
   const resolvedDate = primaryInFuture ? primaryElectionDate : electionDate
 
-  const { modalDismissed, primaryResult } = primaryResultState
+  // Derive primaryResult from the live campaign so persisted server values
+  // are always respected after they load — local state only tracks the
+  // current session's modal interaction.
+  const primaryResult =
+    primaryResultState.overrideResult ??
+    campaign?.details?.primaryResult ??
+    null
+  const { modalDismissed } = primaryResultState
   const primaryResultModalOpen =
     primaryInPast && !primaryResult && !modalDismissed
 
@@ -50,15 +57,15 @@ export function usePostElectionState(): PostElectionState {
   const closePrimaryResultModal = useCallback(
     (selectedResult?: PrimaryResult) => {
       if (selectedResult) {
-        setPrimaryResultState({
-          modalDismissed: false,
-          primaryResult: selectedResult,
-        })
+        setPrimaryResultState((state) => ({
+          ...state,
+          overrideResult: selectedResult,
+        }))
       } else {
-        setPrimaryResultState({
+        setPrimaryResultState((state) => ({
+          ...state,
           modalDismissed: true,
-          primaryResult: undefined,
-        })
+        }))
       }
     },
     [],


### PR DESCRIPTION
## Summary

- The AI Campaign Manager experiment branch (`CampaignManager.tsx`) never rendered `ElectionOver` or `PrimaryResultModal`, so candidates in that group got no signal that their race had ended. Fixes ENG-7496.
- Extracted the post-election state computation (resolved election date, `electionInPast`, `primaryLost`, primary modal open/close) into a shared `usePostElectionState` hook so both `DashboardPage` (control) and `CampaignManager` (experiment) stay in sync.
- Skips the AI task-generation effect when the election is over — no point streaming a campaign plan for a finished race.

`DashboardPage` behavior is preserved; the refactor lifts state into the hook without changing rendered output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dashboard post-election gating and introduces a shared hook that triggers modal-opening state based on date calculations; mistakes could hide tasks or incorrectly start/stop task generation for some users.
> 
> **Overview**
> Extracts the dashboard’s post-election/primary-result date logic into a shared `usePostElectionState` hook, and refactors `DashboardPage` to consume it (removing duplicated state, callbacks, and debug logging).
> 
> Updates the AI `CampaignManager` variant to **render `ElectionOver` and `PrimaryResultModal`** when appropriate, and to **skip task-generation streaming** when the election is already over.
> 
> Adjusts `CampaignManager` tests to mock the newly-rendered `ElectionOver`, `PrimaryResultModal`, and `usePositionName` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c9e97c61e1ffad1b8ad1ddcee4d848879011dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->