### PR TITLE
briefings: QA pass — nav, back link, section label, feedback row

### DIFF
--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -43,6 +43,7 @@ export default async function Page({
       itemIndex={index}
       sources={briefing.sources}
       domId={`briefing-item-${item.id}`}
+      showFeedback={item.tier === 'featured'}
     />
   )
 }

--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -48,7 +48,7 @@ export default async function BriefingChromeLayout({
             />
 
             <div className="mx-auto w-full max-w-[1120px] px-4 py-6 lg:px-8">
-              <div className="hidden lg:mb-4 lg:block">
+              <div className="mb-4">
                 <Link
                   href={briefingsLandingHref()}
                   className="inline-flex h-9 items-center gap-2 rounded-full pl-2 pr-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
@@ -65,17 +65,7 @@ export default async function BriefingChromeLayout({
                   </div>
                 </aside>
 
-                <div className="flex flex-col gap-4">
-                  <Link
-                    href={briefingsLandingHref()}
-                    className="inline-flex h-9 items-center gap-2 self-start rounded-full pl-2 pr-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:hidden"
-                  >
-                    <ArrowLeft className="size-4" aria-hidden />
-                    Back to meetings
-                  </Link>
-
-                  {children}
-                </div>
+                <div className="flex flex-col gap-4">{children}</div>
               </div>
             </div>
           </div>

--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -66,6 +66,7 @@ export default async function Page({
           itemIndex={index}
           sources={briefing.sources}
           domId={`briefing-item-${item.id}`}
+          showFeedback
         />
       ))}
     </>

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -9,6 +9,7 @@ type Props = {
   itemIndex: number
   sources: Source[]
   domId: string
+  showFeedback: boolean
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -33,6 +34,7 @@ export default function AgendaItemCard({
   itemIndex,
   sources,
   domId,
+  showFeedback,
 }: Props): React.JSX.Element {
   const base = `/items/${itemIndex}`
   const display = item.display
@@ -65,7 +67,7 @@ export default function AgendaItemCard({
       </header>
 
       <section className="flex flex-col gap-2">
-        <SectionLabel>Summary</SectionLabel>
+        <SectionLabel>What to expect</SectionLabel>
         <p
           className="text-sm leading-6 text-foreground"
           data-briefing-json-path={`${base}/display/summary`}
@@ -127,7 +129,7 @@ export default function AgendaItemCard({
       ) : null}
 
       <SourcesCollapsible sources={itemSources} />
-      <FeedbackRow />
+      {showFeedback ? <FeedbackRow /> : null}
     </article>
   )
 }

--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -236,7 +236,7 @@ const getDashboardMenuItems = (
   if (isElectedOffice) {
     menuItems.splice(voterDataIndex, 0, POLLS_MENU_ITEM)
     if (briefingsEnabled) {
-      menuItems.splice(voterDataIndex, 0, BRIEFINGS_MENU_ITEM)
+      menuItems.unshift(BRIEFINGS_MENU_ITEM)
     }
   }
 


### PR DESCRIPTION
## Summary

Four small QA fixes against the briefings UI ahead of the next round of review.

- **Nav ordering.** Elected officials with the `serve-briefings` flag on now see "Meetings" at the top of the dashboard sidebar instead of next to Polls / Voter Data. Briefings is the daily entry point for this user, so it shouldn't be buried.
- **Back link dedupe.** The briefing detail layout was rendering two "Back to meetings" links — one intended for desktop, one for mobile — but the visibility classes weren't doing what they should, so both showed up at lg. Consolidated to a single always-visible link above the TOC + content split.
- **Section label.** "Summary" on agenda item cards is now "What to expect," which better matches how we're framing these items in the rest of the product.
- **Feedback row scoping.** `FeedbackRow` no longer renders unconditionally on every agenda item card. The card now takes a `showFeedback` prop; the overview page (which only renders featured items) passes `true`, and the per-item page passes through `item.tier === 'featured'`. Non-priority items don't need to be asking for feedback yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX-only changes; main risk is minor layout/menu ordering regressions for elected-office users behind feature flags.
> 
> **Overview**
> Improves the briefings UI QA polish: the dashboard sidebar now surfaces `Meetings` at the top for elected-office users when `serve-briefings` is enabled, and the briefing detail layout consolidates the "Back to meetings" link into a single consistently visible control.
> 
> Agenda item cards update the summary section label to "What to expect" and gate `FeedbackRow` rendering behind a new `showFeedback` prop, enabled only for featured items on both the overview and per-item pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59b98ef1e53494831e6d64cb7c25ed99f2eaa250. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->