### PR TITLE
Add generative to SpeechSynthesisEngine type

### DIFF
--- a/app/dashboard/briefings/shared/speech-types.ts
+++ b/app/dashboard/briefings/shared/speech-types.ts
@@ -1,4 +1,4 @@
-export type SpeechSynthesisEngine = 'neural' | 'standard'
+export type SpeechSynthesisEngine = 'neural' | 'standard' | 'generative'
 
 /**
  * Speech is a domain-agnostic pure pipe. Callers render their own text


### PR DESCRIPTION
## Summary

- Adds `'generative'` to the local `SpeechSynthesisEngine` union type to match the updated gp-api contracts

Pairs with: thegoodparty/gp-api#1603

## Test plan

- [ ] All 31 briefings/speech tests pass
- [ ] Lint passes clean
- [ ] Verify read-aloud works end-to-end with the new Amy/generative voice from gp-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only change that expands an existing union; main risk is downstream callers needing to handle the new `engine` value when passed through to APIs.
> 
> **Overview**
> Updates the `SpeechSynthesisEngine` union type to include the new `'generative'` option, allowing `SynthesizeSpeechRequest`/read-aloud callers to specify the generative engine in a type-safe way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e6ed9f34c6913340185fd0c58493c9456cf957. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->