### PR TITLE
briefings: scope Open Sans to briefings routes

### DIFF
--- a/app/dashboard/briefings/layout.tsx
+++ b/app/dashboard/briefings/layout.tsx
@@ -1,0 +1,19 @@
+import { Open_Sans } from 'next/font/google'
+
+const openSansBriefings = Open_Sans({
+  subsets: ['latin'],
+  variable: '--font-briefings',
+})
+
+const BriefingsSegmentLayout: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <div
+    className={openSansBriefings.variable}
+    style={{ fontFamily: 'var(--font-briefings)' }}
+  >
+    {children}
+  </div>
+)
+
+export default BriefingsSegmentLayout


### PR DESCRIPTION
The wider app uses Outfit as its global font (wired at the root layout). The briefings prototype was designed in Open Sans, and we want the briefings experience to keep that typographic identity without affecting the rest of the app. This adds a segment-level layout at `app/dashboard/briefings/` that loads Open Sans via `next/font/google`, exposes it as `--font-briefings`, and applies it to the briefings subtree only — leaving the global Outfit font untouched everywhere else.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a segment-level layout that changes typography only within the `app/dashboard/briefings` subtree; low risk aside from potential minor styling regressions in that section.
> 
> **Overview**
> Scopes Open Sans to the `app/dashboard/briefings` route segment by adding a new `layout.tsx` that loads `Open_Sans` via `next/font/google`, exposes it as `--font-briefings`, and applies it to the segment wrapper so the font change doesn’t leak to the rest of the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a81ceffe9b9e5b6ed2b80db2106c1587026db6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->