### PR TITLE
briefings: render per-section source pills

### DIFF
--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -20,6 +20,57 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
   )
 }
 
+const initialFor = (name: string): string =>
+  name.trim().charAt(0).toUpperCase() || '?'
+
+const SectionSourcePills = ({
+  sourceIds,
+  sourceById,
+}: {
+  sourceIds: string[]
+  sourceById: Map<string, Source>
+}): React.JSX.Element | null => {
+  const resolved = sourceIds
+    .map((id) => sourceById.get(id))
+    .filter((s): s is Source => Boolean(s))
+  if (resolved.length === 0) return null
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+      <span className="italic text-muted-foreground">source:</span>
+      {resolved.map((s) => {
+        const pillClass =
+          'inline-flex max-w-[200px] items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-foreground'
+        const inner = (
+          <>
+            <span
+              aria-hidden
+              className="inline-flex size-4 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary"
+            >
+              {initialFor(s.name)}
+            </span>
+            <span className="truncate font-medium">{s.name}</span>
+          </>
+        )
+        return s.url ? (
+          <a
+            key={s.id}
+            href={s.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${pillClass} hover:bg-muted`}
+          >
+            {inner}
+          </a>
+        ) : (
+          <span key={s.id} className={pillClass}>
+            {inner}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
 /**
  * One item card on the briefing detail page. Sections rendered, in order:
  * Summary, Constituent Sentiment, Recent News, Budget Impact, Talking Points,
@@ -93,6 +144,12 @@ export default function AgendaItemCard({
               {sentiment.detail}
             </p>
           ) : null}
+          {sentiment.sourceIds.length > 0 ? (
+            <SectionSourcePills
+              sourceIds={sentiment.sourceIds}
+              sourceById={sourceById}
+            />
+          ) : null}
         </section>
       ) : null}
 
@@ -115,6 +172,12 @@ export default function AgendaItemCard({
           >
             {budget.summary}
           </p>
+          {budget.sourceIds.length > 0 ? (
+            <SectionSourcePills
+              sourceIds={budget.sourceIds}
+              sourceById={sourceById}
+            />
+          ) : null}
         </section>
       ) : null}
 

--- a/app/shared/briefings/renderForSpeech.test.ts
+++ b/app/shared/briefings/renderForSpeech.test.ts
@@ -53,11 +53,13 @@ describe('renderBriefingForSpeech', () => {
                 voterCount: 1200,
                 haystaqStatus: 'ok',
                 haystaqSource: 'curated',
+                sourceIds: [],
               },
               recentNews: null,
               budgetImpact: {
                 summary: '+$2M to capital reserves.',
                 figures: [],
+                sourceIds: [],
               },
               talkingPoints: ['Lock in school funding.', 'Defer the new park.'],
               sourceIds: [],

--- a/app/shared/briefings/server.ts
+++ b/app/shared/briefings/server.ts
@@ -67,6 +67,7 @@ const toSentiment = (
   voterCount: dto.voter_count,
   haystaqStatus: dto.haystaq_status,
   haystaqSource: dto.haystaq_source,
+  sourceIds: (dto as { source_ids?: string[] }).source_ids ?? [],
 })
 
 const toRecentNews = (
@@ -86,6 +87,7 @@ const toBudgetImpact = (dto: MeetingBriefingBudgetImpactDto): BudgetImpact => ({
     value: f.value,
     sourceId: f.source_id,
   })),
+  sourceIds: (dto as { source_ids?: string[] }).source_ids ?? [],
 })
 
 const toDisplay = (dto: MeetingBriefingItemDisplayDto): ItemDisplay => ({

--- a/app/shared/briefings/types.ts
+++ b/app/shared/briefings/types.ts
@@ -61,6 +61,7 @@ export interface ConstituentSentiment {
   voterCount: number
   haystaqStatus: HaystaqStatus
   haystaqSource: HaystaqSource
+  sourceIds: string[]
 }
 
 export interface RecentNewsEntry {
@@ -80,6 +81,7 @@ export interface BudgetImpactFigure {
 export interface BudgetImpact {
   summary: string
   figures: BudgetImpactFigure[]
+  sourceIds: string[]
 }
 
 export interface ItemDisplay {


### PR DESCRIPTION
## Why

The agenda item card already has a bottom-of-card Sources collapsible that lists every source for the item, but candidates can't tell which source backs which on-card section. The Lovable prototype solves this with inline source pills below each section that has them — surfacing per-section attribution that the runbook artifact is being updated to carry on `display.constituent_sentiment` and `display.budget_impact`.

This PR renders those pills. The companion runbook PR adds `source_ids` to the artifact schema and instruction; until that lands the field is optimistically read off the DTO with a `[]` fallback, so this is safe to ship ahead of artifact regeneration — sections without `source_ids` simply render no pill row.

Companion: thegoodparty/runbooks#27.

## Notes

- Pills are additive: the existing `<SourcesCollapsible />` at the bottom of each card stays in place.
- Per the brief, `gpApi/api-endpoints.ts` is a cross-repo contract and was not touched — the `source_ids` fields are read with `(dto as { source_ids?: string[] }).source_ids ?? []` in `app/shared/briefings/server.ts`. Worth a follow-up to formalize the DTO once the runbook schema is merged and gp-api regenerates its contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI and type/mapping additions; main risk is schema/contract drift since `source_ids` is read via a permissive cast and could be missing or malformed from the API.
> 
> **Overview**
> Adds inline **per-section source attribution** on the briefing agenda item card by rendering “source” pills under `Constituent sentiment` and `Budget impact` when those sections provide `sourceIds`.
> 
> Extends briefing display types (`ConstituentSentiment`, `BudgetImpact`) and server DTO mapping to populate `sourceIds` from optional `source_ids` fields with a safe `[]` fallback, and updates the speech-rendering test fixtures accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77565fce24b162dede8d31435196c2dda28b2e35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->