### PR TITLE
briefings: closest-to-today featured, cap upcoming at 5, recolor Briefing ready pill

### DIFF
--- a/app/dashboard/briefings/components/BriefingListRow.tsx
+++ b/app/dashboard/briefings/components/BriefingListRow.tsx
@@ -16,7 +16,7 @@ function pillFor(status: BriefingStatus): PillVariant | null {
   if (status === 'briefing_ready') {
     return {
       label: 'Briefing ready',
-      className: 'bg-accent text-accent-foreground',
+      className: 'bg-success-100 text-success-700',
     }
   }
   if (status === 'awaiting_agenda') {

--- a/app/dashboard/briefings/components/BriefingsLanding.tsx
+++ b/app/dashboard/briefings/components/BriefingsLanding.tsx
@@ -6,25 +6,29 @@ type Props = {
   summaries: BriefingSummary[]
 }
 
-function compareScheduledAt(a: BriefingSummary, b: BriefingSummary): number {
-  return new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
-}
+const MAX_UPCOMING = 5
 
-/**
- * Briefings landing page.
- *
- * Top: full-width page header with title and subtitle.
- * Middle: UPCOMING countdown callout for the nearest upcoming briefing.
- * Bottom: list of remaining upcoming briefings.
- *
- * Past briefings are intentionally not rendered in v1.
- */
+const distanceFromNow = (s: BriefingSummary): number =>
+  Math.abs(new Date(s.scheduledAt).getTime() - Date.now())
+
+const compareScheduledAt = (a: BriefingSummary, b: BriefingSummary): number =>
+  new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
+
 export default function BriefingsLanding({
   summaries,
 }: Props): React.JSX.Element {
-  const sorted = [...summaries].sort(compareScheduledAt)
-  const featured = sorted[0]
-  const rest = sorted.slice(1)
+  const featured = [...summaries].sort(
+    (a, b) => distanceFromNow(a) - distanceFromNow(b),
+  )[0]
+
+  const upcoming = summaries
+    .filter(
+      (s) =>
+        s.id !== featured?.id &&
+        new Date(s.scheduledAt).getTime() >= Date.now(),
+    )
+    .sort(compareScheduledAt)
+    .slice(0, MAX_UPCOMING)
 
   return (
     <div className="flex min-h-screen flex-col bg-muted">
@@ -41,7 +45,7 @@ export default function BriefingsLanding({
 
       <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-4 pb-20 pt-6 lg:px-0">
         {featured ? <UpcomingCountdownCard summary={featured} /> : null}
-        <BriefingListSection title="Upcoming" summaries={rest} />
+        <BriefingListSection title="Upcoming" summaries={upcoming} />
       </div>
     </div>
   )


### PR DESCRIPTION
The list was showing months of past projected dates as "Awaiting agenda" because the featured-card logic picked the earliest projected date instead of the one closest to today, and the upcoming list was unbounded. Pairs with gp-api PR on the server side that drops past projected dates without briefings.

- Featured: closest meeting in time to today (past or future). When the closest is past, it will be a real briefing (server-enforced via the companion PR), so the existing "View briefing" CTA + suppressed countdown pill work correctly.
- Upcoming list: filtered to dates >= today, excluding the featured one, capped at 5.
- Briefing ready pill: switched from `bg-accent` to `bg-success-100 text-success-700` so it reads as a clearly positive state distinct from the muted Awaiting agenda pill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust client-side sorting/filtering and a status pill color; main risk is off-by-one/timezone/date parsing differences affecting which briefing is featured/shown.
> 
> **Overview**
> Updates the briefings landing page so the featured card selects the meeting *closest to now* (by absolute time distance) instead of the earliest scheduled date.
> 
> Tightens the “Upcoming” list to exclude the featured item, filter out past meetings, and cap results to `MAX_UPCOMING` (5). Also changes the `briefing_ready` status pill styling to a success color (`bg-success-100 text-success-700`) to better distinguish it from “Awaiting agenda”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f1902713c9e63b8a15a9604212e4eacd6375ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->