### PR TITLE
fix(briefings): show awaiting-agenda modal/page instead of 404

### DIFF
--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import pageMetaData from 'helpers/metadataHelper'
-import { getBriefingBySlug } from '@shared/briefings/server'
+import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
 import AgendaItemCard from '../../components/detail/AgendaItemCard'
 
 type PageProps = {
@@ -9,7 +9,8 @@ type PageProps = {
 
 export async function generateMetadata({ params }: PageProps) {
   const { slug, itemId } = await params
-  const briefing = await getBriefingBySlug(slug)
+  const result = await getBriefingBySlug(slug)
+  const briefing = result && isFullBriefing(result) ? result : null
   const item = briefing?.items.find((i) => i.id === itemId)
   return pageMetaData({
     title:
@@ -31,8 +32,9 @@ export default async function Page({
   params,
 }: PageProps): Promise<React.JSX.Element> {
   const { slug, itemId } = await params
-  const briefing = await getBriefingBySlug(slug)
-  if (!briefing) notFound()
+  const result = await getBriefingBySlug(slug)
+  if (!result || !isFullBriefing(result)) notFound()
+  const briefing = result
   const index = briefing.items.findIndex((i) => i.id === itemId)
   const item = briefing.items[index]
   if (!item) notFound()

--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -9,6 +9,7 @@ import DetailHeader from '../components/detail/DetailHeader'
 import DetailToc from '../components/detail/DetailToc'
 import MobileBottomBar from '../components/detail/MobileBottomBar'
 import AnnotationsScope from '../components/annotations/AnnotationsScope'
+import BriefingAwaitingPage from '../components/BriefingAwaitingPage'
 
 type Props = {
   params: Promise<{ slug: string }>
@@ -32,6 +33,18 @@ export default async function BriefingChromeLayout({
   const { slug } = await params
   const briefing = await getBriefingBySlug(slug)
   if (!briefing) notFound()
+
+  if ('status' in briefing) {
+    return (
+      <DashboardLayout
+        pathname="/dashboard/briefings"
+        showAlert={false}
+        wrapperClassName="!p-0"
+      >
+        <BriefingAwaitingPage briefing={briefing} />
+      </DashboardLayout>
+    )
+  }
 
   return (
     <DashboardLayout

--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import pageMetaData from 'helpers/metadataHelper'
-import { getBriefingBySlug } from '@shared/briefings/server'
+import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
 import { renderBriefingForSpeech } from '@shared/briefings/renderForSpeech'
 import ExecutiveSummaryCard from '../components/detail/ExecutiveSummaryCard'
 import AgendaItemCard from '../components/detail/AgendaItemCard'
@@ -11,7 +11,8 @@ type PageProps = {
 
 export async function generateMetadata({ params }: PageProps) {
   const { slug } = await params
-  const briefing = await getBriefingBySlug(slug)
+  const result = await getBriefingBySlug(slug)
+  const briefing = result && isFullBriefing(result) ? result : null
   return pageMetaData({
     title: briefing
       ? `${briefing.title} | GoodParty.org`
@@ -37,8 +38,9 @@ export default async function Page({
   params,
 }: PageProps): Promise<React.JSX.Element> {
   const { slug } = await params
-  const briefing = await getBriefingBySlug(slug)
-  if (!briefing) notFound()
+  const result = await getBriefingBySlug(slug)
+  if (!result || !isFullBriefing(result)) notFound()
+  const briefing = result
 
   // Pre-render the briefing into a single plain-text blob for the speech
   // service. Doing this here (rather than in the button) keeps the speech

--- a/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
+++ b/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import Link from 'next/link'
+import { ChevronRight, MapPin } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@styleguide'
+import { buttonVariants } from '@styleguide'
+import {
+  countdownLabel,
+  formatDayTime,
+  formatShortDate,
+} from '@shared/briefings/dateHelpers'
+import type { BriefingSummary } from '@shared/briefings/types'
+
+type Props = {
+  summary: BriefingSummary
+}
+
+export default function AwaitingAgendaRow({
+  summary,
+}: Props): React.JSX.Element {
+  const shortDate = formatShortDate(summary.scheduledAt)
+  const dayTime = formatDayTime(summary.scheduledAt)
+  const countdown = countdownLabel(summary.scheduledAt)
+  const detailHref = `/dashboard/briefings/${summary.slug}`
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent focus:bg-accent focus:outline-none"
+        >
+          <span
+            aria-hidden
+            className="inline-block size-2.5 shrink-0 rounded-full border-2 border-current text-muted-foreground/60"
+          />
+
+          <span className="shrink-0 text-xs font-medium text-muted-foreground">
+            <span className="inline-block w-16 md:hidden">{shortDate}</span>
+            <span className="hidden w-52 md:inline-block">
+              {shortDate} · {dayTime}
+            </span>
+          </span>
+
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            {summary.meetingName}
+          </span>
+
+          <span className="inline-flex items-center whitespace-nowrap rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
+            Awaiting agenda
+          </span>
+
+          <ChevronRight
+            aria-hidden
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <div className="mb-1">
+            <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Upcoming{countdown ? ` · ${countdown}` : ''}
+            </span>
+          </div>
+          <DialogTitle className="text-xl font-bold leading-7">
+            {summary.meetingName}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
+          <p>
+            {shortDate} · {dayTime}
+          </p>
+          {summary.location ? (
+            <p className="flex items-center gap-1.5">
+              <MapPin className="size-3.5 shrink-0" aria-hidden />
+              {summary.location}
+            </p>
+          ) : null}
+        </div>
+
+        <p className="text-sm">
+          <span className="font-medium">Status:</span> Agenda not posted yet
+        </p>
+
+        <div className="pt-1">
+          <Link href={detailHref} className={buttonVariants()}>
+            View briefing
+          </Link>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/briefings/components/BriefingAwaitingPage.tsx
+++ b/app/dashboard/briefings/components/BriefingAwaitingPage.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { ArrowLeft, MapPin, Clock } from 'lucide-react'
+import { briefingsLandingHref } from '@shared/briefings/routes'
+import type { AwaitingBriefing } from '@shared/briefings/types'
+
+type Props = {
+  briefing: AwaitingBriefing
+}
+
+export default function BriefingAwaitingPage({
+  briefing,
+}: Props): React.JSX.Element {
+  return (
+    <div className="flex min-h-screen flex-col bg-muted">
+      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-4 pb-20 pt-6 lg:px-0">
+        <div>
+          <Link
+            href={briefingsLandingHref()}
+            className="inline-flex h-9 items-center gap-2 rounded-full pl-2 pr-3 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" aria-hidden />
+            Back to meetings
+          </Link>
+        </div>
+
+        <section className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6 shadow-sm">
+          <h1 className="text-xl font-semibold text-foreground">
+            {briefing.meetingName}
+          </h1>
+
+          <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
+            <p className="flex items-center gap-1.5">
+              <Clock className="size-3.5 shrink-0" aria-hidden />
+              {briefing.meetingDate}
+              {briefing.meetingTime ? ` · ${briefing.meetingTime}` : ''}
+            </p>
+            {briefing.location ? (
+              <p className="flex items-center gap-1.5">
+                <MapPin className="size-3.5 shrink-0" aria-hidden />
+                {briefing.location}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="rounded-lg border border-border bg-muted px-4 py-3">
+            <p className="text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">Status:</span>{' '}
+              Agenda not posted yet
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Your briefing will be generated automatically once the agenda is
+              published.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/briefings/components/BriefingListSection.tsx
+++ b/app/dashboard/briefings/components/BriefingListSection.tsx
@@ -1,4 +1,5 @@
 import BriefingListRow from './BriefingListRow'
+import AwaitingAgendaRow from './AwaitingAgendaRow'
 import type { BriefingSummary } from '@shared/briefings/types'
 
 type Props = {
@@ -24,9 +25,13 @@ export default function BriefingListSection({
         {title}
       </div>
       <div className="divide-y divide-border">
-        {summaries.map((s) => (
-          <BriefingListRow key={s.id} summary={s} />
-        ))}
+        {summaries.map((s) =>
+          s.status === 'awaiting_agenda' ? (
+            <AwaitingAgendaRow key={s.id} summary={s} />
+          ) : (
+            <BriefingListRow key={s.id} summary={s} />
+          ),
+        )}
       </div>
     </div>
   )

--- a/app/shared/briefings/server.ts
+++ b/app/shared/briefings/server.ts
@@ -13,6 +13,7 @@ import type {
   MeetingsListItemDto,
 } from 'gpApi/api-endpoints'
 import type {
+  AwaitingBriefing,
   Briefing,
   BriefingSummary,
   BudgetImpact,
@@ -152,14 +153,29 @@ const toBriefing = (
   }
 }
 
+export const isFullBriefing = (b: Briefing | AwaitingBriefing): b is Briefing =>
+  !('status' in b)
+
 export const getBriefingBySlug = async (
   slug: string,
-): Promise<Briefing | null> => {
+): Promise<Briefing | AwaitingBriefing | null> => {
   try {
     const { data } = await serverRequest('GET /v1/meetings/:date/briefing', {
       date: slug,
     })
-    return toBriefing(data, slug)
+    if ('status' in data && data.status === 'awaiting_agenda') {
+      return {
+        status: 'awaiting_agenda',
+        slug,
+        meetingName: data.meetingName,
+        meetingDate: format(parseISO(slug), 'MMMM d, yyyy'),
+        meetingTime: data.meetingTime,
+        meetingTimezone: data.meetingTimezone,
+        location: data.location,
+        durationMinutes: data.durationMinutes,
+      }
+    }
+    return toBriefing(data as MeetingBriefingResponseDto, slug)
   } catch (e) {
     if (e instanceof FetchError && e.status === 404) return null
     throw e

--- a/app/shared/briefings/types.ts
+++ b/app/shared/briefings/types.ts
@@ -146,6 +146,21 @@ export interface Briefing {
   title: string
 }
 
+/**
+ * Returned by getBriefingBySlug when the API signals no agenda yet.
+ * Meeting metadata is populated from the org's known schedule.
+ */
+export interface AwaitingBriefing {
+  status: 'awaiting_agenda'
+  slug: string
+  meetingName: string
+  meetingDate: string
+  meetingTime: string
+  meetingTimezone: string
+  location: string
+  durationMinutes: number
+}
+
 /** Slim shape for the landing list. Coming from `GET /v1/meetings`. */
 export interface BriefingSummary {
   id: string

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -144,6 +144,16 @@ export interface MeetingBriefingResponseDto {
   sources: MeetingBriefingSourceDto[]
 }
 
+export interface MeetingBriefingAwaitingDto {
+  status: 'awaiting_agenda'
+  meetingDate: string
+  meetingName: string
+  meetingTime: string
+  meetingTimezone: string
+  location: string
+  durationMinutes: number
+}
+
 export type APIEndpoints = {
   'GET /v1/users/me': {
     Request: {}
@@ -334,7 +344,7 @@ export type APIEndpoints = {
 
   'GET /v1/meetings/:date/briefing': {
     Request: { date: string }
-    Response: MeetingBriefingResponseDto
+    Response: MeetingBriefingResponseDto | MeetingBriefingAwaitingDto
   }
 
   'POST /v1/speech/synthesize': {


### PR DESCRIPTION
## Summary

- Clicking an "Awaiting agenda" row on the briefings list now opens a modal with meeting info (name, date/time, location) and "Status: Agenda not posted yet" — instead of navigating to a 404
- Navigating directly to `/dashboard/briefings/:date` for a meeting without an agenda renders a clean awaiting-state page instead of 404
- Depends on gp-api PR #1610 (`fix/briefing-awaiting-agenda`) which makes the API return `{ status: 'awaiting_agenda', ...meetingInfo }` instead of 404

## Changes

- `AwaitingAgendaRow` — new client component, wraps the list row in a Radix Dialog for awaiting meetings
- `BriefingAwaitingPage` — server component shown when navigating directly to an awaiting briefing URL
- `BriefingListSection` — routes awaiting rows to `AwaitingAgendaRow` instead of `BriefingListRow`
- `api-endpoints.ts` — added `MeetingBriefingAwaitingDto`, updated response union for `GET /v1/meetings/:date/briefing`
- `server.ts` — `getBriefingBySlug` returns `AwaitingBriefing | Briefing | null`; added `isFullBriefing` type guard
- `layout.tsx`, `page.tsx`, `[itemId]/page.tsx` — narrowed to `Briefing` via `isFullBriefing`

## Test plan

- [ ] On the briefings list, click a row labeled "Awaiting agenda" — modal appears with meeting name, date/time, location, and "Agenda not posted yet" status
- [ ] Modal "View briefing" link navigates to the detail page, which shows the awaiting-state page (not 404)
- [ ] Briefings with a ready artifact still open normally
- [ ] Type check passes (pre-existing `react-markdown` error unrelated)
- [ ] 46 existing briefings tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changing the `GET /v1/meetings/:date/briefing` contract to a union and updating several pages/layouts to handle a new non-briefing response shape; could surface runtime/type-narrowing issues if any call sites are missed.
> 
> **Overview**
> Fixes the briefing UX when a meeting’s agenda hasn’t been posted yet by rendering explicit *awaiting* states instead of falling through to `404`.
> 
> `getBriefingBySlug` now returns either a full `Briefing` or an `AwaitingBriefing` (new type + `isFullBriefing` guard) based on a new `awaiting_agenda` API response, and the briefing detail pages (`[slug]/page.tsx`, `[itemId]/page.tsx`) narrow to full briefings while the shared `[slug]/layout.tsx` renders a new `BriefingAwaitingPage` for awaiting meetings.
> 
> On the landing list, rows with `status === 'awaiting_agenda'` now open a new `AwaitingAgendaRow` modal showing meeting info and a “Agenda not posted yet” status, with an option to view the awaiting detail page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e861d79f978b41d3b550634ab83c788e055bdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->