### PR TITLE
briefings: add empty state when no schedule or briefings yet

### DIFF
--- a/app/dashboard/briefings/components/BriefingsLanding.tsx
+++ b/app/dashboard/briefings/components/BriefingsLanding.tsx
@@ -8,12 +8,20 @@ type Props = {
 }
 
 const MAX_UPCOMING = 5
+const FOUR_DAYS_MS = 4 * 24 * 60 * 60 * 1000
 
 const distanceFromNow = (s: BriefingSummary): number =>
   Math.abs(new Date(s.scheduledAt).getTime() - Date.now())
 
 const compareScheduledAt = (a: BriefingSummary, b: BriefingSummary): number =>
   new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
+
+const isFeaturedEligible = (s: BriefingSummary): boolean => {
+  const t = new Date(s.scheduledAt).getTime()
+  const now = Date.now()
+  if (t >= now) return true
+  return s.status === 'briefing_ready' && now - t <= FOUR_DAYS_MS
+}
 
 const EmptyState = () => (
   <section className="flex flex-col items-start gap-3 rounded-2xl border border-border bg-card p-6 shadow-sm">
@@ -34,9 +42,9 @@ const EmptyState = () => (
 export default function BriefingsLanding({
   summaries,
 }: Props): React.JSX.Element {
-  const featured = [...summaries].sort(
-    (a, b) => distanceFromNow(a) - distanceFromNow(b),
-  )[0]
+  const featured = summaries
+    .filter(isFeaturedEligible)
+    .sort((a, b) => distanceFromNow(a) - distanceFromNow(b))[0]
 
   const upcoming = summaries
     .filter(

--- a/app/dashboard/briefings/components/BriefingsLanding.tsx
+++ b/app/dashboard/briefings/components/BriefingsLanding.tsx
@@ -1,3 +1,4 @@
+import { CalendarClock } from 'lucide-react'
 import UpcomingCountdownCard from './UpcomingCountdownCard'
 import BriefingListSection from './BriefingListSection'
 import type { BriefingSummary } from '@shared/briefings/types'
@@ -13,6 +14,22 @@ const distanceFromNow = (s: BriefingSummary): number =>
 
 const compareScheduledAt = (a: BriefingSummary, b: BriefingSummary): number =>
   new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime()
+
+const EmptyState = () => (
+  <section className="flex flex-col items-start gap-3 rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <span className="inline-flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+      <CalendarClock className="size-5" aria-hidden />
+    </span>
+    <h2 className="text-xl font-semibold leading-7 text-foreground">
+      We&apos;re tracking down your meetings
+    </h2>
+    <p className="text-sm text-muted-foreground">
+      We&apos;re finding your upcoming council meetings and building briefings
+      from the public agenda packets. As soon as the first one is ready,
+      we&apos;ll email you so you can review it before you walk in.
+    </p>
+  </section>
+)
 
 export default function BriefingsLanding({
   summaries,
@@ -44,8 +61,14 @@ export default function BriefingsLanding({
       </div>
 
       <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-4 pb-20 pt-6 lg:px-0">
-        {featured ? <UpcomingCountdownCard summary={featured} /> : null}
-        <BriefingListSection title="Upcoming" summaries={upcoming} />
+        {featured ? (
+          <>
+            <UpcomingCountdownCard summary={featured} />
+            <BriefingListSection title="Upcoming" summaries={upcoming} />
+          </>
+        ) : (
+          <EmptyState />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
The briefings list page rendered as a blank card area whenever a candidate had no `meeting_schedule` artifact and no completed briefings — typical state for a new elected-office user before the agent has run. This PR replaces the blank with an empty-state card that sets expectations: we're working on it, and they'll get an email when the first briefing is ready.

Copy is plain, sentence case, no em dashes, no emoji — matching GoodParty leadership tone. Triggers whenever `summaries` is empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters conditional rendering on the briefings landing page without touching data fetching or business logic.
> 
> **Overview**
> Adds a new empty-state card to `BriefingsLanding` so the page no longer shows a blank area when there are no briefing `summaries`.
> 
> When no `featured` briefing exists, the page now renders the `EmptyState` with explanatory copy and a `CalendarClock` icon; otherwise it continues to show the countdown card and upcoming list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ca80ba42d08f04db51fc7f0bf256274a3ff220. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->