### PR TITLE
briefings: drop green accent hover on list rows

### DIFF
--- a/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
+++ b/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
@@ -34,7 +34,7 @@ export default function AwaitingAgendaRow({
       <DialogTrigger asChild>
         <button
           type="button"
-          className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent focus:bg-accent focus:outline-none"
+          className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus:bg-muted/60 focus:outline-none"
         >
           <span
             aria-hidden

--- a/app/dashboard/briefings/components/BriefingListRow.tsx
+++ b/app/dashboard/briefings/components/BriefingListRow.tsx
@@ -44,7 +44,7 @@ export default function BriefingListRow({ summary }: Props): React.JSX.Element {
   return (
     <Link
       href={`/dashboard/briefings/${summary.slug}`}
-      className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-accent focus:bg-accent focus:outline-none"
+      className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus:bg-muted/60 focus:outline-none"
     >
       {/* Indicator dot - open circle for upcoming */}
       <span


### PR DESCRIPTION
The Upcoming list rows were highlighting bright brand green on hover/focus (`bg-accent` = `#63D1A0`) — too loud for a list of mostly neutral, awaiting-agenda rows. Switched to `hover:bg-muted/60 focus:bg-muted/60` to match every other hover surface inside the briefings feature (DetailToc, MobileBottomBar, SourcesCollapsible).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that updates hover/focus background classes on two briefing list row components; no behavior, routing, or data handling is modified.
> 
> **Overview**
> Reduces the hover/focus emphasis in the briefings Upcoming list by switching row highlight styles from `bg-accent` to a subtler `bg-muted/60`.
> 
> Applies this styling change consistently to both `BriefingListRow` and `AwaitingAgendaRow` row interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f681c26072a51ef24700347b82f8a5cebda2a919. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->