### PR TITLE
briefings: add dev-only manual agent dispatch buttons

### DIFF
--- a/app/dashboard/briefings/components/BriefingsLanding.tsx
+++ b/app/dashboard/briefings/components/BriefingsLanding.tsx
@@ -1,10 +1,12 @@
 import { CalendarClock } from 'lucide-react'
 import UpcomingCountdownCard from './UpcomingCountdownCard'
 import BriefingListSection from './BriefingListSection'
+import DevAgentTriggerBar from './DevAgentTriggerBar'
 import type { BriefingSummary } from '@shared/briefings/types'
 
 type Props = {
   summaries: BriefingSummary[]
+  devElectedOfficeId?: string | null
 }
 
 const MAX_UPCOMING = 5
@@ -41,6 +43,7 @@ const EmptyState = () => (
 
 export default function BriefingsLanding({
   summaries,
+  devElectedOfficeId,
 }: Props): React.JSX.Element {
   const featured = summaries
     .filter(isFeaturedEligible)
@@ -69,6 +72,9 @@ export default function BriefingsLanding({
       </div>
 
       <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-4 pb-20 pt-6 lg:px-0">
+        {devElectedOfficeId && (
+          <DevAgentTriggerBar electedOfficeId={devElectedOfficeId} />
+        )}
         {featured ? (
           <>
             <UpcomingCountdownCard summary={featured} />

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
@@ -85,7 +85,7 @@ describe('DevAgentTriggerBar', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/^Failed to dispatch schedule: /),
+        screen.getByText('Failed to dispatch schedule: boom'),
       ).toBeInTheDocument()
     })
   })

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
@@ -38,11 +38,12 @@ describe('DevAgentTriggerBar', () => {
 
   it('disables both buttons while a dispatch is in flight', async () => {
     const user = userEvent.setup()
-    let resolveDispatch: (() => void) | null = null
+    let resolveDispatch: () => void = () => undefined
+    const dispatchGate = new Promise<void>((resolve) => {
+      resolveDispatch = resolve
+    })
     api.mock('POST /v1/meetings/briefings/dispatch', async () => {
-      await new Promise<void>((resolve) => {
-        resolveDispatch = resolve
-      })
+      await dispatchGate
       return { status: 200, data: { dispatched: true, kind: 'schedule' } }
     })
 
@@ -63,7 +64,7 @@ describe('DevAgentTriggerBar', () => {
     })
     expect(briefingBtn).toBeDisabled()
 
-    resolveDispatch?.()
+    resolveDispatch()
 
     await waitFor(() => {
       expect(scheduleBtn).not.toBeDisabled()

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import DevAgentTriggerBar from './DevAgentTriggerBar'
+import BriefingsLanding from './BriefingsLanding'
+
+describe('DevAgentTriggerBar', () => {
+  it('renders both trigger buttons', () => {
+    render(<DevAgentTriggerBar electedOfficeId="eo-1" />)
+    expect(
+      screen.getByRole('button', { name: 'Trigger meeting_schedule' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Trigger meeting_briefing' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows success message after a successful dispatch', async () => {
+    const user = userEvent.setup()
+    api.mock('POST /v1/meetings/briefings/dispatch', {
+      status: 200,
+      data: { dispatched: true, kind: 'briefing' },
+    })
+
+    render(<DevAgentTriggerBar electedOfficeId="eo-1" />)
+    await user.click(
+      screen.getByRole('button', { name: 'Trigger meeting_briefing' }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Dispatched briefing agent run'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('disables both buttons while a dispatch is in flight', async () => {
+    const user = userEvent.setup()
+    let resolveDispatch: (() => void) | null = null
+    api.mock('POST /v1/meetings/briefings/dispatch', async () => {
+      await new Promise<void>((resolve) => {
+        resolveDispatch = resolve
+      })
+      return { status: 200, data: { dispatched: true, kind: 'schedule' } }
+    })
+
+    render(<DevAgentTriggerBar electedOfficeId="eo-1" />)
+    const scheduleBtn = screen.getByRole('button', {
+      name: 'Trigger meeting_schedule',
+    })
+    const briefingBtn = screen.getByRole('button', {
+      name: 'Trigger meeting_briefing',
+    })
+
+    await user.click(scheduleBtn)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Dispatching…' }),
+      ).toBeDisabled()
+    })
+    expect(briefingBtn).toBeDisabled()
+
+    resolveDispatch?.()
+
+    await waitFor(() => {
+      expect(scheduleBtn).not.toBeDisabled()
+      expect(briefingBtn).not.toBeDisabled()
+    })
+  })
+
+  it('surfaces the error message when dispatch fails', async () => {
+    const user = userEvent.setup()
+    api.mock('POST /v1/meetings/briefings/dispatch', {
+      status: 500,
+      data: { message: 'boom' },
+    })
+
+    render(<DevAgentTriggerBar electedOfficeId="eo-1" />)
+    await user.click(
+      screen.getByRole('button', { name: 'Trigger meeting_schedule' }),
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/^Failed to dispatch schedule: /),
+      ).toBeInTheDocument()
+    })
+  })
+})
+
+describe('BriefingsLanding dev bar gating', () => {
+  it('does not render DevAgentTriggerBar when devElectedOfficeId is absent', () => {
+    render(<BriefingsLanding summaries={[]} devElectedOfficeId={null} />)
+    expect(
+      screen.queryByText('Dev tools — manual agent dispatch'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders DevAgentTriggerBar when devElectedOfficeId is provided', () => {
+    render(<BriefingsLanding summaries={[]} devElectedOfficeId="eo-current" />)
+    expect(
+      screen.getByText('Dev tools — manual agent dispatch'),
+    ).toBeInTheDocument()
+  })
+})

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
@@ -31,7 +31,11 @@ export default function DevAgentTriggerBar({
       })
       setMessage(`Dispatched ${kind} agent run`)
     } catch (err) {
-      const detail = err instanceof Error ? err.message : 'unknown error'
+      const detail =
+        err instanceof Error
+          ? ((err as { data?: { message?: string } }).data?.message ??
+            err.message)
+          : 'unknown error'
       setMessage(`Failed to dispatch ${kind}: ${detail}`)
     } finally {
       setPending(null)

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@styleguide'
+import { clientRequest } from 'gpApi/typed-request'
+
+type Props = {
+  electedOfficeId: string
+}
+
+type Kind = 'schedule' | 'briefing'
+
+const labels: Record<Kind, string> = {
+  schedule: 'Trigger meeting_schedule',
+  briefing: 'Trigger meeting_briefing',
+}
+
+export default function DevAgentTriggerBar({
+  electedOfficeId,
+}: Props): React.JSX.Element {
+  const [pending, setPending] = useState<Kind | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const trigger = async (kind: Kind) => {
+    setPending(kind)
+    setMessage(null)
+    try {
+      await clientRequest('POST /v1/meetings/briefings/dispatch', {
+        electedOfficeId,
+        kind,
+      })
+      setMessage(`Dispatched ${kind} agent run`)
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : 'unknown error'
+      setMessage(`Failed to dispatch ${kind}: ${detail}`)
+    } finally {
+      setPending(null)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-dashed border-amber-500 bg-amber-50 p-3 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-semibold text-amber-900">
+          Dev tools — manual agent dispatch
+        </span>
+        <div className="flex gap-2">
+          <Button
+            size="small"
+            variant="outline"
+            disabled={pending !== null}
+            onClick={() => trigger('schedule')}
+          >
+            {pending === 'schedule' ? 'Dispatching…' : labels.schedule}
+          </Button>
+          <Button
+            size="small"
+            variant="outline"
+            disabled={pending !== null}
+            onClick={() => trigger('briefing')}
+          >
+            {pending === 'briefing' ? 'Dispatching…' : labels.briefing}
+          </Button>
+        </div>
+      </div>
+      {message && <div className="text-xs text-amber-900">{message}</div>}
+    </div>
+  )
+}

--- a/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
+++ b/app/dashboard/briefings/components/DevAgentTriggerBar.tsx
@@ -33,8 +33,8 @@ export default function DevAgentTriggerBar({
     } catch (err) {
       const detail =
         err instanceof Error
-          ? ((err as { data?: { message?: string } }).data?.message ??
-            err.message)
+          ? (err as { data?: { message?: string } }).data?.message ??
+            err.message
           : 'unknown error'
       setMessage(`Failed to dispatch ${kind}: ${detail}`)
     } finally {

--- a/app/dashboard/briefings/page.tsx
+++ b/app/dashboard/briefings/page.tsx
@@ -1,5 +1,7 @@
 import pageMetaData from 'helpers/metadataHelper'
 import { getBriefingsList } from '@shared/briefings/server'
+import { serverRequest } from 'gpApi/server-request'
+import { IS_PROD } from 'appEnv'
 import serveAccess from '../shared/serveAccess'
 import DashboardLayout from '../shared/DashboardLayout'
 import BriefingsLanding from './components/BriefingsLanding'
@@ -12,13 +14,29 @@ const meta = pageMetaData({
 export const metadata = meta
 export const dynamic = 'force-dynamic'
 
+const loadElectedOfficeId = async (): Promise<string | null> => {
+  if (IS_PROD) return null
+  try {
+    const { data } = await serverRequest('GET /v1/elected-office/current', {})
+    return data.id ?? null
+  } catch {
+    return null
+  }
+}
+
 export default async function Page(): Promise<React.JSX.Element> {
   await serveAccess()
 
-  const summaries = await getBriefingsList()
+  const [summaries, devElectedOfficeId] = await Promise.all([
+    getBriefingsList(),
+    loadElectedOfficeId(),
+  ])
   return (
     <DashboardLayout pathname="/dashboard/briefings" showAlert={false}>
-      <BriefingsLanding summaries={summaries} />
+      <BriefingsLanding
+        summaries={summaries}
+        devElectedOfficeId={devElectedOfficeId}
+      />
     </DashboardLayout>
   )
 }

--- a/app/dashboard/briefings/page.tsx
+++ b/app/dashboard/briefings/page.tsx
@@ -1,7 +1,7 @@
 import pageMetaData from 'helpers/metadataHelper'
 import { getBriefingsList } from '@shared/briefings/server'
 import { serverRequest } from 'gpApi/server-request'
-import { IS_PROD } from 'appEnv'
+import { IS_DEV, IS_LOCAL } from 'appEnv'
 import serveAccess from '../shared/serveAccess'
 import DashboardLayout from '../shared/DashboardLayout'
 import BriefingsLanding from './components/BriefingsLanding'
@@ -15,7 +15,7 @@ export const metadata = meta
 export const dynamic = 'force-dynamic'
 
 const loadElectedOfficeId = async (): Promise<string | null> => {
-  if (IS_PROD) return null
+  if (!IS_LOCAL && !IS_DEV) return null
   try {
     const { data } = await serverRequest('GET /v1/elected-office/current', {})
     return data.id ?? null

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -211,6 +211,14 @@ export type APIEndpoints = {
     Response: ElectedOffice
   }
 
+  'POST /v1/meetings/briefings/dispatch': {
+    Request: {
+      electedOfficeId: string
+      kind: 'schedule' | 'briefing'
+    }
+    Response: { dispatched: true; kind: 'schedule' | 'briefing' }
+  }
+
   'GET /v1/contacts/stats': {
     Request: {}
     Response: ContactsStats


### PR DESCRIPTION
## Why

Companion to gp-api PR thegoodparty/gp-api#1616, which gates the daily briefing cron and the elected-office-create auto-dispatch behind `MEETINGS_AUTOMATION_ENABLED`. With automation off in dev, we still need a way to fire `meeting_schedule` and `meeting_briefing` agents on demand for QA.

Surface a Dev Tools bar on the briefings landing page with "Trigger meeting_schedule" and "Trigger meeting_briefing" buttons. The bar is rendered only when `!IS_PROD` and the user has a current elected office. Calls the new admin-only `POST /v1/meetings/briefings/dispatch` endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new client-side UI that can trigger server-side agent dispatch via a new API route; while gated from prod, misuse or mis-gating could cause unintended backend runs in non-prod environments.
> 
> **Overview**
> Adds a **dev-only “Dev tools” bar** to the briefings landing page that lets QA manually dispatch `meeting_schedule` and `meeting_briefing` agent runs.
> 
> The briefings page now (when `!IS_PROD`) fetches the current `electedOfficeId` and conditionally renders `DevAgentTriggerBar`, which calls the new typed endpoint `POST /v1/meetings/briefings/dispatch` and shows basic pending/success/failure status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75ab6ada3bf01c5f54defa99be241f26eb61688e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->