### PR TITLE
fix(briefings): QA pass on meeting briefings detail

### DIFF
--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -47,6 +47,7 @@ export default async function Page({
       domId={`briefing-item-${item.id}`}
       meetingDate={slug}
       showFeedback={item.tier === 'featured'}
+      variant={item.tier === 'featured' ? 'full' : 'whatToExpectOnly'}
     />
   )
 }

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { render, testQueryClient } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { annotationsQueryKey } from '@shared/briefings/use-annotations'
+import type { StagedDraft } from '../notes-intake/AddNotesDialog'
 import AnnotationsScope, { useAnnotationsCtx } from './AnnotationsScope'
 
 vi.mock('next/navigation', () => ({
@@ -27,6 +28,24 @@ vi.mock('@shared/briefings/annotations-api', () => ({
     updateNote: (id: string, body: string) =>
       mockAnnotationsApi.updateNote(id, body),
     delete: (id: string) => mockAnnotationsApi.delete(id),
+  },
+}))
+
+const mockUploadAttachment = vi.fn()
+vi.mock('@shared/briefings/attachments-api', () => ({
+  uploadAttachment: (...args: unknown[]) => mockUploadAttachment(...args),
+}))
+
+let capturedOnSubmit: ((drafts: StagedDraft[]) => Promise<void> | void) | null =
+  null
+vi.mock('../notes-intake/AddNotesDialog', () => ({
+  default: ({
+    onSubmit,
+  }: {
+    onSubmit: (drafts: StagedDraft[]) => Promise<void> | void
+  }) => {
+    capturedOnSubmit = onSubmit
+    return null
   },
 }))
 
@@ -63,7 +82,9 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.create.mockReset()
     mockAnnotationsApi.updateNote.mockReset()
     mockAnnotationsApi.delete.mockReset()
+    mockUploadAttachment.mockReset()
     mockAnnotationsApi.list.mockResolvedValue([])
+    capturedOnSubmit = null
     testQueryClient.clear()
   })
 
@@ -87,6 +108,97 @@ describe('<AnnotationsScope>', () => {
     )
 
     await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: annotationsQueryKey('briefing_x'),
+      })
+    })
+  })
+
+  describe('AddNotesDialog onSubmit', () => {
+    const mountAndCaptureOnSubmit = async () => {
+      testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [])
+      render(<AnnotationsScope meetingDate="briefing_x" />)
+      await waitFor(() => {
+        expect(capturedOnSubmit).not.toBeNull()
+      })
+      return capturedOnSubmit!
+    }
+
+    it('commits a typed draft via annotationsApi.create and invalidates the query', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_typed',
+        kind: 'note',
+      })
+      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
+      const onSubmit = await mountAndCaptureOnSubmit()
+
+      await onSubmit([{ id: 't1', kind: 'typed', body: 'hello world' }])
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
+        kind: 'note',
+        anchor: { jsonPath: null, start: null, end: null },
+        payload: { body: 'hello world' },
+      })
+      expect(mockUploadAttachment).not.toHaveBeenCalled()
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: annotationsQueryKey('briefing_x'),
+      })
+    })
+
+    it('commits a file draft via create → uploadAttachment → waitForOcr and invalidates the query', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_file',
+        kind: 'note',
+      })
+      mockUploadAttachment.mockResolvedValue({ attachmentId: 'att_1' })
+      mockAnnotationsApi.list.mockResolvedValue([
+        {
+          id: 'ann_file',
+          kind: 'note',
+          note: {
+            attachments: [{ id: 'att_1', ocrStatus: 'completed' }],
+          },
+        },
+      ])
+      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
+      const onSubmit = await mountAndCaptureOnSubmit()
+
+      const file = new File(['contents'], 'note.txt', { type: 'text/plain' })
+      await onSubmit([{ id: 'f1', kind: 'file', file, from: 'upload' }])
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
+        kind: 'note',
+        anchor: { jsonPath: null, start: null, end: null },
+        payload: {},
+      })
+      expect(mockUploadAttachment).toHaveBeenCalledWith({
+        annotationId: 'ann_file',
+        file,
+      })
+      expect(mockAnnotationsApi.list).toHaveBeenCalledWith('briefing_x')
+      expect(mockAnnotationsApi.delete).not.toHaveBeenCalled()
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: annotationsQueryKey('briefing_x'),
+      })
+    })
+
+    it('rolls back the created annotation when uploadAttachment fails, and re-throws', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_rollback',
+        kind: 'note',
+      })
+      mockAnnotationsApi.delete.mockResolvedValue(undefined)
+      mockUploadAttachment.mockRejectedValue(new Error('s3_upload_failed:500'))
+      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
+      const onSubmit = await mountAndCaptureOnSubmit()
+
+      const file = new File(['contents'], 'note.txt', { type: 'text/plain' })
+      await expect(
+        onSubmit([{ id: 'f1', kind: 'file', file, from: 'upload' }]),
+      ).rejects.toThrow('s3_upload_failed:500')
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalled()
+      expect(mockAnnotationsApi.delete).toHaveBeenCalledWith('ann_rollback')
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: annotationsQueryKey('briefing_x'),
       })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -117,7 +117,11 @@ describe('<AnnotationsScope>', () => {
   describe('AddNotesDialog onSubmit', () => {
     const mountAndCaptureOnSubmit = async () => {
       testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [])
-      render(<AnnotationsScope meetingDate="briefing_x" />)
+      render(
+        <AnnotationsScope meetingDate="briefing_x">
+          <div />
+        </AnnotationsScope>,
+      )
       await waitFor(() => {
         expect(capturedOnSubmit).not.toBeNull()
       })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -450,16 +450,13 @@ export default function AnnotationsScope({
                 anchor: { jsonPath: null, start: null, end: null },
                 payload: {},
               })
+              let attachmentId: string
               try {
-                const { attachmentId } = await uploadAttachment({
+                const result = await uploadAttachment({
                   annotationId: created.id,
                   file: draft.file,
                 })
-                // Block until OCR has a terminal status so the recap/assistant
-                // can see extracted text. Caps at 60s; if we time out we
-                // proceed silently and the polled annotations query will
-                // catch up.
-                await waitForOcr(meetingDate, attachmentId)
+                attachmentId = result.attachmentId
               } catch (uploadErr) {
                 // Best-effort rollback of the empty annotation. We swallow
                 // the rollback error specifically so the original upload
@@ -471,6 +468,15 @@ export default function AnnotationsScope({
                      useful than masking it with a rollback failure */
                 }
                 throw uploadErr
+              }
+              // Block until OCR has a terminal status so the recap/assistant
+              // can see extracted text. Caps at 60s; poll errors are
+              // non-fatal — the upload already succeeded, the polled
+              // annotations query will catch up.
+              try {
+                await waitForOcr(meetingDate, attachmentId)
+              } catch {
+                /* poll failure must not roll back a successful upload */
               }
             }
           } finally {

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -28,6 +28,26 @@ import AnnotationsHighlightLayer from './AnnotationsHighlightLayer'
 import AskAiSheet from './AskAiSheet'
 import AddNotesDialog from '../notes-intake/AddNotesDialog'
 import { uploadAttachment } from '@shared/briefings/attachments-api'
+import { annotationsApi } from '@shared/briefings/annotations-api'
+
+const OCR_TERMINAL_STATUSES = new Set(['completed', 'failed', 'skipped'])
+const OCR_POLL_INTERVAL_MS = 2_000
+const OCR_POLL_TIMEOUT_MS = 60_000
+
+const waitForOcr = async (
+  meetingDate: string,
+  attachmentId: string,
+): Promise<void> => {
+  const started = Date.now()
+  while (Date.now() - started < OCR_POLL_TIMEOUT_MS) {
+    const list = await annotationsApi.list(meetingDate)
+    for (const ann of list) {
+      const att = ann.note?.attachments?.find((a) => a.id === attachmentId)
+      if (att && OCR_TERMINAL_STATUSES.has(att.ocrStatus)) return
+    }
+    await new Promise((r) => setTimeout(r, OCR_POLL_INTERVAL_MS))
+  }
+}
 
 /**
  * Either an in-progress selection-driven anchor, or null for a top-level
@@ -431,10 +451,15 @@ export default function AnnotationsScope({
                 payload: {},
               })
               try {
-                await uploadAttachment({
+                const { attachmentId } = await uploadAttachment({
                   annotationId: created.id,
                   file: draft.file,
                 })
+                // Block until OCR has a terminal status so the recap/assistant
+                // can see extracted text. Caps at 60s; if we time out we
+                // proceed silently and the polled annotations query will
+                // catch up.
+                await waitForOcr(meetingDate, attachmentId)
               } catch (uploadErr) {
                 // Best-effort rollback of the empty annotation. We swallow
                 // the rollback error specifically so the original upload

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -1,5 +1,6 @@
 import type { Item, Source } from '@shared/briefings/types'
 import { Popover, PopoverContent, PopoverTrigger } from '@styleguide'
+import { ExternalLink } from 'lucide-react'
 import { toDisplaySource } from '@shared/briefings/displaySource'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
@@ -37,57 +38,71 @@ const SectionSourcePills = ({
     .map(toDisplaySource)
   if (resolved.length === 0) return null
   const pillClass =
-    'inline-flex max-w-[200px] items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-foreground'
+    'inline-flex max-w-[180px] items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground'
   return (
     <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
       <span className="italic text-muted-foreground">source:</span>
-      {resolved.map((s) => {
-        const inner = (
-          <>
+      {resolved.map((s) => (
+        <Popover key={s.id}>
+          <PopoverTrigger className={pillClass} title={s.displayLabel}>
             <span
               aria-hidden
-              className="inline-flex size-4 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary"
+              className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[9px] font-bold text-primary"
             >
               {s.initial}
             </span>
-            <span className="truncate font-medium">{s.displayName}</span>
-          </>
-        )
-        if (s.isProprietary) {
-          return (
-            <Popover key={s.id}>
-              <PopoverTrigger
-                className={`${pillClass} hover:bg-muted`}
-                title={s.displayName}
-              >
-                {inner}
-              </PopoverTrigger>
-              <PopoverContent className="w-72 text-sm">
-                <p className="font-medium text-foreground">{s.displayName}</p>
-                {s.displayBlurb ? (
-                  <p className="mt-1 text-muted-foreground">{s.displayBlurb}</p>
+            <span className="truncate">{s.displayLabel}</span>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80 rounded-xl p-3 text-sm">
+            <div className="flex flex-col gap-3 text-left">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>Source</span>
+                <span>1 source</span>
+              </div>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    aria-hidden
+                    className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
+                  >
+                    {s.initial}
+                  </span>
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {s.publisher}
+                  </span>
+                </div>
+                {s.isProprietary ? (
+                  <span className="text-sm font-semibold text-foreground">
+                    {s.displayName}
+                  </span>
+                ) : s.url ? (
+                  <a
+                    href={s.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-start gap-1 text-sm font-semibold leading-5 text-info-600 hover:underline"
+                  >
+                    <span>{s.displayName}</span>
+                    <ExternalLink
+                      aria-hidden
+                      className="mt-1 size-3 shrink-0"
+                    />
+                  </a>
+                ) : (
+                  <span className="text-sm font-semibold text-foreground">
+                    {s.displayName}
+                  </span>
+                )}
+                {s.description ? (
+                  <p className="text-xs leading-5 text-muted-foreground">
+                    {s.description}
+                  </p>
                 ) : null}
-              </PopoverContent>
-            </Popover>
-          )
-        }
-        return s.url ? (
-          <a
-            key={s.id}
-            href={s.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${pillClass} hover:bg-muted`}
-            title={s.displayName}
-          >
-            {inner}
-          </a>
-        ) : (
-          <span key={s.id} className={pillClass} title={s.displayName}>
-            {inner}
-          </span>
-        )
-      })}
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      ))}
     </div>
   )
 }
@@ -143,7 +158,7 @@ const AgendaItemCard = ({
       className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6"
     >
       <header className="flex flex-col gap-1">
-        <span className="text-[12px] font-bold uppercase tracking-wide text-primary">
+        <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">
           Agenda item
         </span>
         <h3

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -1,8 +1,12 @@
 import type { Item, Source } from '@shared/briefings/types'
+import { Popover, PopoverContent, PopoverTrigger } from '@styleguide'
+import { toDisplaySource } from '@shared/briefings/displaySource'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
 import SourcesCollapsible from './SourcesCollapsible'
 import FeedbackRow from './FeedbackRow'
+
+type Variant = 'full' | 'whatToExpectOnly'
 
 type Props = {
   item: Item
@@ -11,18 +15,14 @@ type Props = {
   domId: string
   meetingDate: string
   showFeedback: boolean
+  variant?: Variant
 }
 
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="text-[12px] font-bold uppercase tracking-wide text-foreground">
-      {children}
-    </span>
-  )
-}
-
-const initialFor = (name: string): string =>
-  name.trim().charAt(0).toUpperCase() || '?'
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <span className="text-[12px] font-bold uppercase tracking-wide text-foreground">
+    {children}
+  </span>
+)
 
 const SectionSourcePills = ({
   sourceIds,
@@ -34,24 +34,43 @@ const SectionSourcePills = ({
   const resolved = sourceIds
     .map((id) => sourceById.get(id))
     .filter((s): s is Source => Boolean(s))
+    .map(toDisplaySource)
   if (resolved.length === 0) return null
+  const pillClass =
+    'inline-flex max-w-[200px] items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-foreground'
   return (
     <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
       <span className="italic text-muted-foreground">source:</span>
       {resolved.map((s) => {
-        const pillClass =
-          'inline-flex max-w-[200px] items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-foreground'
         const inner = (
           <>
             <span
               aria-hidden
               className="inline-flex size-4 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary"
             >
-              {initialFor(s.name)}
+              {s.initial}
             </span>
-            <span className="truncate font-medium">{s.name}</span>
+            <span className="truncate font-medium">{s.displayName}</span>
           </>
         )
+        if (s.isProprietary) {
+          return (
+            <Popover key={s.id}>
+              <PopoverTrigger
+                className={`${pillClass} hover:bg-muted`}
+                title={s.displayName}
+              >
+                {inner}
+              </PopoverTrigger>
+              <PopoverContent className="w-72 text-sm">
+                <p className="font-medium text-foreground">{s.displayName}</p>
+                {s.displayBlurb ? (
+                  <p className="mt-1 text-muted-foreground">{s.displayBlurb}</p>
+                ) : null}
+              </PopoverContent>
+            </Popover>
+          )
+        }
         return s.url ? (
           <a
             key={s.id}
@@ -59,17 +78,24 @@ const SectionSourcePills = ({
             target="_blank"
             rel="noopener noreferrer"
             className={`${pillClass} hover:bg-muted`}
+            title={s.displayName}
           >
             {inner}
           </a>
         ) : (
-          <span key={s.id} className={pillClass}>
+          <span key={s.id} className={pillClass} title={s.displayName}>
             {inner}
           </span>
         )
       })}
     </div>
   )
+}
+
+const formatSentimentLine = (meanScore: number): string => {
+  const support = Math.round(meanScore)
+  const oppose = Math.round(100 - meanScore)
+  return `${support}% support · ${oppose}% oppose`
 }
 
 /**
@@ -81,26 +107,35 @@ const SectionSourcePills = ({
  * attribute so phase 4's selection toolbar can build an anchor that maps to
  * the v2 artifact shape.
  */
-export default function AgendaItemCard({
+const AgendaItemCard = ({
   item,
   itemIndex,
   sources,
   domId,
   meetingDate,
   showFeedback,
-}: Props): React.JSX.Element {
+  variant = 'full',
+}: Props): React.JSX.Element => {
   const base = `/items/${itemIndex}`
   const display = item.display
   const sentiment = display.constituentSentiment
   const budget = display.budgetImpact
   const news = display.recentNews ?? []
   const talkingPoints = display.talkingPoints ?? []
-  const sourceIds = display.sourceIds ?? []
 
   const sourceById = new Map(sources.map((s) => [s.id, s]))
-  const itemSources = sourceIds
+
+  const aggregatedSourceIds = [
+    ...(display.sourceIds ?? []),
+    ...(sentiment?.sourceIds ?? []),
+    ...(budget?.sourceIds ?? []),
+  ]
+  const uniqueIds = Array.from(new Set(aggregatedSourceIds))
+  const itemSources = uniqueIds
     .map((id) => sourceById.get(id))
     .filter((s): s is Source => Boolean(s))
+
+  const isWhatToExpectOnly = variant === 'whatToExpectOnly'
 
   return (
     <article
@@ -129,74 +164,90 @@ export default function AgendaItemCard({
         </p>
       </section>
 
-      {sentiment ? (
-        <section className="flex flex-col gap-2">
-          <SectionLabel>Constituent sentiment</SectionLabel>
-          <p
-            className="text-sm leading-6 text-foreground"
-            data-briefing-json-path={`${base}/display/constituent_sentiment/summary`}
-          >
-            {sentiment.summary}
-          </p>
-          {sentiment.detail ? (
-            <p
-              className="text-sm leading-6 text-foreground"
-              data-briefing-json-path={`${base}/display/constituent_sentiment/detail`}
-            >
-              {sentiment.detail}
-            </p>
+      {isWhatToExpectOnly ? null : (
+        <>
+          {sentiment ? (
+            <section className="flex flex-col gap-2">
+              <SectionLabel>Constituent sentiment</SectionLabel>
+              {sentiment.haystaqStatus === 'ok' &&
+              typeof sentiment.meanScore === 'number' ? (
+                <p className="text-sm font-semibold text-foreground">
+                  {formatSentimentLine(sentiment.meanScore)}
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No sentiment data yet for {item.title}.
+                </p>
+              )}
+              <p
+                className="text-sm leading-6 text-foreground"
+                data-briefing-json-path={`${base}/display/constituent_sentiment/summary`}
+              >
+                {sentiment.summary}
+              </p>
+              {sentiment.detail ? (
+                <p
+                  className="text-sm leading-6 text-foreground"
+                  data-briefing-json-path={`${base}/display/constituent_sentiment/detail`}
+                >
+                  {sentiment.detail}
+                </p>
+              ) : null}
+              {sentiment.sourceIds.length > 0 ? (
+                <SectionSourcePills
+                  sourceIds={sentiment.sourceIds}
+                  sourceById={sourceById}
+                />
+              ) : null}
+            </section>
           ) : null}
-          {sentiment.sourceIds.length > 0 ? (
-            <SectionSourcePills
-              sourceIds={sentiment.sourceIds}
-              sourceById={sourceById}
-            />
+
+          {news.length > 0 ? (
+            <section className="flex flex-col gap-2">
+              <SectionLabel>Recent news</SectionLabel>
+              <RecentNewsList
+                items={news}
+                pathPrefix={`${base}/display/recent_news`}
+              />
+            </section>
           ) : null}
-        </section>
-      ) : null}
 
-      {news.length > 0 ? (
-        <section className="flex flex-col gap-2">
-          <SectionLabel>Recent news</SectionLabel>
-          <RecentNewsList
-            items={news}
-            pathPrefix={`${base}/display/recent_news`}
-          />
-        </section>
-      ) : null}
-
-      {budget ? (
-        <section className="flex flex-col gap-2">
-          <SectionLabel>Budget impact</SectionLabel>
-          <p
-            className="text-sm leading-6 text-foreground"
-            data-briefing-json-path={`${base}/display/budget_impact/summary`}
-          >
-            {budget.summary}
-          </p>
-          {budget.sourceIds.length > 0 ? (
-            <SectionSourcePills
-              sourceIds={budget.sourceIds}
-              sourceById={sourceById}
-            />
+          {budget ? (
+            <section className="flex flex-col gap-2">
+              <SectionLabel>Budget impact</SectionLabel>
+              <p
+                className="text-sm leading-6 text-foreground"
+                data-briefing-json-path={`${base}/display/budget_impact/summary`}
+              >
+                {budget.summary}
+              </p>
+              {budget.sourceIds.length > 0 ? (
+                <SectionSourcePills
+                  sourceIds={budget.sourceIds}
+                  sourceById={sourceById}
+                />
+              ) : null}
+            </section>
           ) : null}
-        </section>
-      ) : null}
 
-      {talkingPoints.length > 0 ? (
-        <section className="flex flex-col gap-2">
-          <SectionLabel>Talking points</SectionLabel>
-          <TalkingPointsList
-            points={talkingPoints}
-            pathPrefix={`${base}/display/talking_points`}
-          />
-        </section>
-      ) : null}
+          {talkingPoints.length > 0 ? (
+            <section className="flex flex-col gap-2">
+              <SectionLabel>Talking points</SectionLabel>
+              <TalkingPointsList
+                points={talkingPoints}
+                pathPrefix={`${base}/display/talking_points`}
+              />
+            </section>
+          ) : null}
 
-      <SourcesCollapsible sources={itemSources} />
-      {showFeedback ? (
-        <FeedbackRow meetingDate={meetingDate} itemId={item.id} />
-      ) : null}
+          <SourcesCollapsible sources={itemSources} />
+          {showFeedback ? (
+            <FeedbackRow meetingDate={meetingDate} itemId={item.id} />
+          ) : null}
+        </>
+      )}
     </article>
   )
 }
+
+export default AgendaItemCard

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -198,7 +198,7 @@ const AgendaItemCard = ({
   return (
     <article
       id={domId}
-      className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6"
+      className="flex flex-col gap-4 divide-y divide-border rounded-2xl border border-border bg-card p-6"
     >
       <header className="flex flex-col gap-1">
         <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -152,7 +152,7 @@ const SectionSourcePills = ({
 
 const formatSentimentLine = (meanScore: number): string => {
   const support = Math.round(meanScore)
-  const oppose = Math.round(100 - meanScore)
+  const oppose = 100 - support
   return `${support}% support · ${oppose}% oppose`
 }
 

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -1,7 +1,13 @@
+'use client'
+
+import { useRef, useState } from 'react'
 import type { Item, Source } from '@shared/briefings/types'
 import { Popover, PopoverContent, PopoverTrigger } from '@styleguide'
 import { ExternalLink } from 'lucide-react'
-import { toDisplaySource } from '@shared/briefings/displaySource'
+import {
+  toDisplaySource,
+  type DisplaySource,
+} from '@shared/briefings/displaySource'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
 import SourcesCollapsible from './SourcesCollapsible'
@@ -25,6 +31,103 @@ const SectionLabel = ({ children }: { children: React.ReactNode }) => (
   </span>
 )
 
+const PILL_CLASS =
+  'inline-flex max-w-[180px] items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground'
+
+const SourcePill = ({ source }: { source: DisplaySource }) => {
+  const [open, setOpen] = useState(false)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelClose = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+  const scheduleClose = () => {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setOpen(false), 120)
+  }
+  const handleEnter = () => {
+    cancelClose()
+    setOpen(true)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        className={PILL_CLASS}
+        title={source.displayLabel}
+        onMouseEnter={handleEnter}
+        onMouseLeave={scheduleClose}
+        onFocus={handleEnter}
+        onBlur={scheduleClose}
+      >
+        <span
+          aria-hidden
+          className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[9px] font-bold text-primary"
+        >
+          {source.initial}
+        </span>
+        <span className="truncate">{source.displayLabel}</span>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={6}
+        className="w-80 rounded-xl p-3 text-sm"
+        onMouseEnter={handleEnter}
+        onMouseLeave={scheduleClose}
+      >
+        <div className="flex flex-col gap-3 text-left">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Source</span>
+            <span>1 source</span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-1.5">
+              <span
+                aria-hidden
+                className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
+              >
+                {source.initial}
+              </span>
+              <span className="truncate text-[11px] text-muted-foreground">
+                {source.publisher}
+              </span>
+            </div>
+            {source.isProprietary ? (
+              <span className="text-sm font-semibold text-foreground">
+                {source.displayName}
+              </span>
+            ) : source.url ? (
+              <a
+                href={source.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-start gap-1 text-sm font-semibold leading-5 text-info-600 hover:underline"
+              >
+                <span>{source.displayName}</span>
+                <ExternalLink aria-hidden className="mt-1 size-3 shrink-0" />
+              </a>
+            ) : (
+              <span className="text-sm font-semibold text-foreground">
+                {source.displayName}
+              </span>
+            )}
+            {source.description ? (
+              <p className="text-xs leading-5 text-muted-foreground">
+                {source.description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 const SectionSourcePills = ({
   sourceIds,
   sourceById,
@@ -37,71 +140,11 @@ const SectionSourcePills = ({
     .filter((s): s is Source => Boolean(s))
     .map(toDisplaySource)
   if (resolved.length === 0) return null
-  const pillClass =
-    'inline-flex max-w-[180px] items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground'
   return (
     <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs">
       <span className="italic text-muted-foreground">source:</span>
       {resolved.map((s) => (
-        <Popover key={s.id}>
-          <PopoverTrigger className={pillClass} title={s.displayLabel}>
-            <span
-              aria-hidden
-              className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[9px] font-bold text-primary"
-            >
-              {s.initial}
-            </span>
-            <span className="truncate">{s.displayLabel}</span>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-80 rounded-xl p-3 text-sm">
-            <div className="flex flex-col gap-3 text-left">
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>Source</span>
-                <span>1 source</span>
-              </div>
-              <div className="flex flex-col gap-1">
-                <div className="flex items-center gap-1.5">
-                  <span
-                    aria-hidden
-                    className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
-                  >
-                    {s.initial}
-                  </span>
-                  <span className="truncate text-[11px] text-muted-foreground">
-                    {s.publisher}
-                  </span>
-                </div>
-                {s.isProprietary ? (
-                  <span className="text-sm font-semibold text-foreground">
-                    {s.displayName}
-                  </span>
-                ) : s.url ? (
-                  <a
-                    href={s.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-start gap-1 text-sm font-semibold leading-5 text-info-600 hover:underline"
-                  >
-                    <span>{s.displayName}</span>
-                    <ExternalLink
-                      aria-hidden
-                      className="mt-1 size-3 shrink-0"
-                    />
-                  </a>
-                ) : (
-                  <span className="text-sm font-semibold text-foreground">
-                    {s.displayName}
-                  </span>
-                )}
-                {s.description ? (
-                  <p className="text-xs leading-5 text-muted-foreground">
-                    {s.description}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
+        <SourcePill key={s.id} source={s} />
       ))}
     </div>
   )

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -61,8 +61,6 @@ const SourcePill = ({ source }: { source: DisplaySource }) => {
         title={source.displayLabel}
         onMouseEnter={handleEnter}
         onMouseLeave={scheduleClose}
-        onFocus={handleEnter}
-        onBlur={scheduleClose}
       >
         <span
           aria-hidden
@@ -79,6 +77,8 @@ const SourcePill = ({ source }: { source: DisplaySource }) => {
         className="w-80 rounded-xl p-3 text-sm"
         onMouseEnter={handleEnter}
         onMouseLeave={scheduleClose}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <div className="flex flex-col gap-3 text-left">
           <div className="flex items-center justify-between text-xs text-muted-foreground">

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -198,7 +198,7 @@ const AgendaItemCard = ({
   return (
     <article
       id={domId}
-      className="flex flex-col gap-4 divide-y divide-border rounded-2xl border border-border bg-card p-6"
+      className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6"
     >
       <header className="flex flex-col gap-1">
         <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">
@@ -298,7 +298,11 @@ const AgendaItemCard = ({
             </section>
           ) : null}
 
-          <SourcesCollapsible sources={itemSources} />
+          {itemSources.length > 0 ? (
+            <div className="border-y border-border py-4">
+              <SourcesCollapsible sources={itemSources} />
+            </div>
+          ) : null}
           {showFeedback ? (
             <FeedbackRow meetingDate={meetingDate} itemId={item.id} />
           ) : null}

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -299,7 +299,7 @@ const AgendaItemCard = ({
           ) : null}
 
           {itemSources.length > 0 ? (
-            <div className="border-y border-border py-4">
+            <div className="border-y border-border py-2">
               <SourcesCollapsible sources={itemSources} />
             </div>
           ) : null}

--- a/app/dashboard/briefings/components/detail/FeedbackRow.tsx
+++ b/app/dashboard/briefings/components/detail/FeedbackRow.tsx
@@ -40,8 +40,8 @@ export default function FeedbackRow({
         onClick={() => vote('positive')}
         className={
           current === 'positive'
-            ? 'bg-muted text-foreground'
-            : 'text-muted-foreground'
+            ? 'text-success-600 hover:text-success-600'
+            : 'text-muted-foreground hover:text-foreground'
         }
       >
         <ThumbsUp className="size-4" aria-hidden />
@@ -55,8 +55,8 @@ export default function FeedbackRow({
         onClick={() => vote('negative')}
         className={
           current === 'negative'
-            ? 'bg-muted text-foreground'
-            : 'text-muted-foreground'
+            ? 'text-destructive hover:text-destructive'
+            : 'text-muted-foreground hover:text-foreground'
         }
       >
         <ThumbsDown className="size-4" aria-hidden />

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -6,15 +6,16 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from '@styleguide'
 import type { Source, SourceType } from '@shared/briefings/types'
+import { toDisplaySource } from '@shared/briefings/displaySource'
 
 type Props = {
   sources: Source[]
 }
-
-const initialFor = (name: string): string =>
-  name.trim().charAt(0).toUpperCase() || '?'
 
 const SOURCE_TYPE_LABEL: Record<SourceType, string> = {
   agenda_packet: 'Agenda packet',
@@ -28,9 +29,7 @@ const SOURCE_TYPE_LABEL: Record<SourceType, string> = {
  * "Sources (N)" inline expander at the bottom of each agenda item card.
  * Uses the new Collapsible primitive added to the styleguide.
  */
-export default function SourcesCollapsible({
-  sources,
-}: Props): React.JSX.Element | null {
+const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
   const [open, setOpen] = useState(false)
   if (sources.length === 0) return null
 
@@ -46,38 +45,66 @@ export default function SourcesCollapsible({
       </CollapsibleTrigger>
       <CollapsibleContent>
         <ul className="mt-2 flex flex-col gap-2">
-          {sources.map((s) => (
-            <li
-              key={s.id}
-              className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm"
-            >
+          {sources.map((raw) => {
+            const s = toDisplaySource(raw)
+            const avatar = (
               <span
                 aria-hidden
-                className="inline-flex items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
-                style={{ width: 16, height: 16 }}
+                className="inline-flex size-5 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary"
               >
-                {initialFor(s.name)}
+                {s.initial}
               </span>
-              {s.url ? (
-                <a
-                  href={s.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 font-medium text-info hover:underline"
-                >
-                  <span>{s.name}</span>
-                  <ExternalLink aria-hidden className="size-3" />
-                </a>
-              ) : (
-                <span className="font-medium text-foreground">{s.name}</span>
-              )}
+            )
+            const typeLabel = (
               <span className="ml-auto text-xs uppercase tracking-wide text-muted-foreground">
-                {SOURCE_TYPE_LABEL[s.sourceType]}
+                {SOURCE_TYPE_LABEL[raw.sourceType]}
               </span>
-            </li>
-          ))}
+            )
+            return (
+              <li
+                key={s.id}
+                className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm"
+              >
+                {avatar}
+                {s.isProprietary ? (
+                  <Popover>
+                    <PopoverTrigger className="inline-flex items-center gap-1 font-medium text-info hover:underline">
+                      <span>{s.displayName}</span>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-72 text-sm">
+                      <p className="font-medium text-foreground">
+                        {s.displayName}
+                      </p>
+                      {s.displayBlurb ? (
+                        <p className="mt-1 text-muted-foreground">
+                          {s.displayBlurb}
+                        </p>
+                      ) : null}
+                    </PopoverContent>
+                  </Popover>
+                ) : s.url ? (
+                  <a
+                    href={s.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 font-medium text-info hover:underline"
+                  >
+                    <span>{s.displayName}</span>
+                    <ExternalLink aria-hidden className="size-3" />
+                  </a>
+                ) : (
+                  <span className="font-medium text-foreground">
+                    {s.displayName}
+                  </span>
+                )}
+                {typeLabel}
+              </li>
+            )
+          })}
         </ul>
       </CollapsibleContent>
     </Collapsible>
   )
 }
+
+export default SourcesCollapsible

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -30,59 +30,54 @@ const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
           className="size-4 shrink-0 text-muted-foreground transition-transform duration-[250ms] ease-out"
         />
       </CollapsibleTrigger>
-      <CollapsibleContent
-        forceMount
-        className="grid overflow-hidden transition-[grid-template-rows] duration-[250ms] ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
-      >
-        <div className="overflow-hidden">
-          <ul className="mt-1 flex flex-col gap-3">
-            {sources.map((raw) => {
-              const s = toDisplaySource(raw)
-              return (
-                <li key={s.id} className="flex items-start gap-2">
-                  <span
-                    aria-hidden
-                    className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
-                  >
-                    {s.initial}
+      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+        <ul className="mt-1 flex flex-col divide-y divide-border border-y border-border">
+          {sources.map((raw) => {
+            const s = toDisplaySource(raw)
+            return (
+              <li key={s.id} className="flex items-start gap-2 py-3">
+                <span
+                  aria-hidden
+                  className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
+                >
+                  {s.initial}
+                </span>
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {s.publisher}
                   </span>
-                  <div className="flex min-w-0 flex-col gap-0.5">
-                    <span className="truncate text-[11px] text-muted-foreground">
-                      {s.publisher}
+                  {s.isProprietary ? (
+                    <span className="text-sm font-semibold text-foreground">
+                      {s.displayName}
                     </span>
-                    {s.isProprietary ? (
-                      <span className="text-sm font-semibold text-foreground">
-                        {s.displayName}
-                      </span>
-                    ) : s.url ? (
-                      <a
-                        href={s.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-start gap-1 text-sm font-semibold text-info-600 hover:underline"
-                      >
-                        <span>{s.displayName}</span>
-                        <ExternalLink
-                          aria-hidden
-                          className="mt-1 size-3 shrink-0"
-                        />
-                      </a>
-                    ) : (
-                      <span className="text-sm font-semibold text-foreground">
-                        {s.displayName}
-                      </span>
-                    )}
-                    {s.description ? (
-                      <span className="text-xs leading-5 text-muted-foreground">
-                        {s.description}
-                      </span>
-                    ) : null}
-                  </div>
-                </li>
-              )
-            })}
-          </ul>
-        </div>
+                  ) : s.url ? (
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-start gap-1 text-sm font-semibold text-info-600 hover:underline"
+                    >
+                      <span>{s.displayName}</span>
+                      <ExternalLink
+                        aria-hidden
+                        className="mt-1 size-3 shrink-0"
+                      />
+                    </a>
+                  ) : (
+                    <span className="text-sm font-semibold text-foreground">
+                      {s.displayName}
+                    </span>
+                  )}
+                  {s.description ? (
+                    <span className="text-xs leading-5 text-muted-foreground">
+                      {s.description}
+                    </span>
+                  ) : null}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
       </CollapsibleContent>
     </Collapsible>
   )

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -31,11 +31,11 @@ const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
         />
       </CollapsibleTrigger>
       <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-        <ul className="mt-1 flex flex-col divide-y divide-border border-y border-border">
+        <ul className="mt-1 flex flex-col gap-3">
           {sources.map((raw) => {
             const s = toDisplaySource(raw)
             return (
-              <li key={s.id} className="flex items-start gap-2 py-3">
+              <li key={s.id} className="flex items-start gap-2">
                 <span
                   aria-hidden
                   className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -27,57 +27,62 @@ const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
         <span>Sources ({sources.length})</span>
         <Plus
           aria-hidden
-          className="size-4 shrink-0 text-muted-foreground transition-transform duration-200"
+          className="size-4 shrink-0 text-muted-foreground transition-transform duration-[250ms] ease-out"
         />
       </CollapsibleTrigger>
-      <CollapsibleContent>
-        <ul className="mt-1 flex flex-col gap-3">
-          {sources.map((raw) => {
-            const s = toDisplaySource(raw)
-            return (
-              <li key={s.id} className="flex items-start gap-2">
-                <span
-                  aria-hidden
-                  className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
-                >
-                  {s.initial}
-                </span>
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="truncate text-[11px] text-muted-foreground">
-                    {s.publisher}
+      <CollapsibleContent
+        forceMount
+        className="grid overflow-hidden transition-[grid-template-rows] duration-[250ms] ease-out data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]"
+      >
+        <div className="overflow-hidden">
+          <ul className="mt-1 flex flex-col gap-3">
+            {sources.map((raw) => {
+              const s = toDisplaySource(raw)
+              return (
+                <li key={s.id} className="flex items-start gap-2">
+                  <span
+                    aria-hidden
+                    className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
+                  >
+                    {s.initial}
                   </span>
-                  {s.isProprietary ? (
-                    <span className="text-sm font-semibold text-foreground">
-                      {s.displayName}
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span className="truncate text-[11px] text-muted-foreground">
+                      {s.publisher}
                     </span>
-                  ) : s.url ? (
-                    <a
-                      href={s.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-start gap-1 text-sm font-semibold text-info-600 hover:underline"
-                    >
-                      <span>{s.displayName}</span>
-                      <ExternalLink
-                        aria-hidden
-                        className="mt-1 size-3 shrink-0"
-                      />
-                    </a>
-                  ) : (
-                    <span className="text-sm font-semibold text-foreground">
-                      {s.displayName}
-                    </span>
-                  )}
-                  {s.description ? (
-                    <span className="text-xs leading-5 text-muted-foreground">
-                      {s.description}
-                    </span>
-                  ) : null}
-                </div>
-              </li>
-            )
-          })}
-        </ul>
+                    {s.isProprietary ? (
+                      <span className="text-sm font-semibold text-foreground">
+                        {s.displayName}
+                      </span>
+                    ) : s.url ? (
+                      <a
+                        href={s.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-start gap-1 text-sm font-semibold text-info-600 hover:underline"
+                      >
+                        <span>{s.displayName}</span>
+                        <ExternalLink
+                          aria-hidden
+                          className="mt-1 size-3 shrink-0"
+                        />
+                      </a>
+                    ) : (
+                      <span className="text-sm font-semibold text-foreground">
+                        {s.displayName}
+                      </span>
+                    )}
+                    {s.description ? (
+                      <span className="text-xs leading-5 text-muted-foreground">
+                        {s.description}
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
       </CollapsibleContent>
     </Collapsible>
   )

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -22,7 +22,7 @@ const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger
         data-state={open ? 'open' : 'closed'}
-        className="flex w-full items-center justify-between rounded-md py-2 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted/60 [&[data-state=open]>svg]:rotate-45"
+        className="flex w-full items-center justify-between rounded-md py-2 text-left text-sm font-semibold text-foreground transition-colors [&[data-state=open]>svg]:rotate-45"
       >
         <span>Sources ({sources.length})</span>
         <Plus

--- a/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
+++ b/app/dashboard/briefings/components/detail/SourcesCollapsible.tsx
@@ -1,103 +1,79 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, Minus, ExternalLink } from 'lucide-react'
+import { Plus, ExternalLink } from 'lucide-react'
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
 } from '@styleguide'
-import type { Source, SourceType } from '@shared/briefings/types'
+import type { Source } from '@shared/briefings/types'
 import { toDisplaySource } from '@shared/briefings/displaySource'
 
 type Props = {
   sources: Source[]
 }
 
-const SOURCE_TYPE_LABEL: Record<SourceType, string> = {
-  agenda_packet: 'Agenda packet',
-  news: 'News',
-  government_website: 'Government',
-  campaign: 'Campaign',
-  haystaq: 'Voter data',
-}
-
-/**
- * "Sources (N)" inline expander at the bottom of each agenda item card.
- * Uses the new Collapsible primitive added to the styleguide.
- */
 const SourcesCollapsible = ({ sources }: Props): React.JSX.Element | null => {
   const [open, setOpen] = useState(false)
   if (sources.length === 0) return null
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md py-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted/60">
+      <CollapsibleTrigger
+        data-state={open ? 'open' : 'closed'}
+        className="flex w-full items-center justify-between rounded-md py-2 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted/60 [&[data-state=open]>svg]:rotate-45"
+      >
         <span>Sources ({sources.length})</span>
-        {open ? (
-          <Minus aria-hidden className="size-4 text-muted-foreground" />
-        ) : (
-          <Plus aria-hidden className="size-4 text-muted-foreground" />
-        )}
+        <Plus
+          aria-hidden
+          className="size-4 shrink-0 text-muted-foreground transition-transform duration-200"
+        />
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <ul className="mt-2 flex flex-col gap-2">
+        <ul className="mt-1 flex flex-col gap-3">
           {sources.map((raw) => {
             const s = toDisplaySource(raw)
-            const avatar = (
-              <span
-                aria-hidden
-                className="inline-flex size-5 items-center justify-center rounded-full bg-primary/15 text-[10px] font-bold text-primary"
-              >
-                {s.initial}
-              </span>
-            )
-            const typeLabel = (
-              <span className="ml-auto text-xs uppercase tracking-wide text-muted-foreground">
-                {SOURCE_TYPE_LABEL[raw.sourceType]}
-              </span>
-            )
             return (
-              <li
-                key={s.id}
-                className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-sm"
-              >
-                {avatar}
-                {s.isProprietary ? (
-                  <Popover>
-                    <PopoverTrigger className="inline-flex items-center gap-1 font-medium text-info hover:underline">
-                      <span>{s.displayName}</span>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-72 text-sm">
-                      <p className="font-medium text-foreground">
-                        {s.displayName}
-                      </p>
-                      {s.displayBlurb ? (
-                        <p className="mt-1 text-muted-foreground">
-                          {s.displayBlurb}
-                        </p>
-                      ) : null}
-                    </PopoverContent>
-                  </Popover>
-                ) : s.url ? (
-                  <a
-                    href={s.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 font-medium text-info hover:underline"
-                  >
-                    <span>{s.displayName}</span>
-                    <ExternalLink aria-hidden className="size-3" />
-                  </a>
-                ) : (
-                  <span className="font-medium text-foreground">
-                    {s.displayName}
+              <li key={s.id} className="flex items-start gap-2">
+                <span
+                  aria-hidden
+                  className="mt-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-bold text-primary"
+                >
+                  {s.initial}
+                </span>
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {s.publisher}
                   </span>
-                )}
-                {typeLabel}
+                  {s.isProprietary ? (
+                    <span className="text-sm font-semibold text-foreground">
+                      {s.displayName}
+                    </span>
+                  ) : s.url ? (
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-start gap-1 text-sm font-semibold text-info-600 hover:underline"
+                    >
+                      <span>{s.displayName}</span>
+                      <ExternalLink
+                        aria-hidden
+                        className="mt-1 size-3 shrink-0"
+                      />
+                    </a>
+                  ) : (
+                    <span className="text-sm font-semibold text-foreground">
+                      {s.displayName}
+                    </span>
+                  )}
+                  {s.description ? (
+                    <span className="text-xs leading-5 text-muted-foreground">
+                      {s.description}
+                    </span>
+                  ) : null}
+                </div>
               </li>
             )
           })}

--- a/app/dashboard/briefings/components/notes-intake/AddNotesDialog.tsx
+++ b/app/dashboard/briefings/components/notes-intake/AddNotesDialog.tsx
@@ -177,7 +177,7 @@ export default function AddNotesDialog({
       const att = ann.note?.attachments?.[0]
       const kind: NotePillKind =
         section === 'typed' ? 'typed' : section === 'camera' ? 'image' : 'file'
-      const text = att ? att.fileName : ann.note?.body ?? '(empty note)'
+      const text = att ? att.fileName : (ann.note?.body ?? '(empty note)')
       out[section].push({
         id: ann.id,
         kind,
@@ -305,7 +305,7 @@ export default function AddNotesDialog({
         type="button"
         onClick={args.onClick}
         disabled={submitting}
-        className="-m-2 flex items-start gap-3 rounded-xl p-2 text-left transition-colors hover:bg-accent/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+        className="-m-2 flex items-start gap-3 rounded-xl p-2 text-left transition-colors hover:bg-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
       >
         <span
           aria-hidden
@@ -351,7 +351,7 @@ export default function AddNotesDialog({
         type="button"
         onClick={() => setTypeExpanded(true)}
         disabled={submitting || typeExpanded}
-        className="-m-2 flex items-start gap-3 rounded-xl p-2 text-left transition-colors hover:bg-accent/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:hover:bg-transparent"
+        className="-m-2 flex items-start gap-3 rounded-xl p-2 text-left transition-colors hover:bg-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:hover:bg-transparent"
       >
         <span
           aria-hidden

--- a/app/dashboard/briefings/components/notes-intake/AddNotesDialog.tsx
+++ b/app/dashboard/briefings/components/notes-intake/AddNotesDialog.tsx
@@ -177,7 +177,7 @@ export default function AddNotesDialog({
       const att = ann.note?.attachments?.[0]
       const kind: NotePillKind =
         section === 'typed' ? 'typed' : section === 'camera' ? 'image' : 'file'
-      const text = att ? att.fileName : (ann.note?.body ?? '(empty note)')
+      const text = att ? att.fileName : ann.note?.body ?? '(empty note)'
       out[section].push({
         id: ann.id,
         kind,

--- a/app/shared/briefings/displaySource.ts
+++ b/app/shared/briefings/displaySource.ts
@@ -58,9 +58,10 @@ const formatDate = (iso?: string | null): string | null => {
 
 const buildDescription = (s: Source): string | null => {
   const parts: string[] = []
-  if (s.articleType && ARTICLE_TYPE_LABEL[s.articleType]) {
-    parts.push(ARTICLE_TYPE_LABEL[s.articleType])
-  }
+  const articleLabel = s.articleType
+    ? ARTICLE_TYPE_LABEL[s.articleType]
+    : undefined
+  if (articleLabel) parts.push(articleLabel)
   if (s.sectionHeading) parts.push(s.sectionHeading)
   if (typeof s.pageNumber === 'number') parts.push(`p. ${s.pageNumber}`)
   const date = formatDate(s.publicationDate)

--- a/app/shared/briefings/displaySource.ts
+++ b/app/shared/briefings/displaySource.ts
@@ -2,36 +2,101 @@ import type { Source } from '@shared/briefings/types'
 
 export type DisplaySource = {
   id: string
+  /** Long form name (used in popover/sources panel title fallback). */
   displayName: string
+  /** Short label for inline pills (publisher or hostname). */
+  displayLabel: string
+  /** Publisher line shown above the title in popover and sources panel. */
+  publisher: string
+  /** Description line shown under the title. */
+  description: string | null
+  /**
+   * Proprietary-source descriptive blurb (no link on title). Kept separate
+   * from `description` so callers can decide rendering.
+   */
   displayBlurb: string | null
   url?: string | null
   isProprietary: boolean
   initial: string
 }
 
-// TODO(product): refine the proprietary-source copy with product/design.
 const PROPRIETARY_NAME = 'GoodParty.org constituent sentiment'
+const PROPRIETARY_LABEL = 'GoodParty.org'
+const PROPRIETARY_PUBLISHER = 'GoodParty.org'
 const PROPRIETARY_BLURB =
   'Modeled estimate from GoodParty.org’s proprietary constituent ' +
   'sentiment data. Methodology details available on request.'
+
+const ARTICLE_TYPE_LABEL: Record<string, string> = {
+  reporting: 'Reporting',
+  opinion: 'Opinion',
+  editorial: 'Editorial',
+  press_release: 'Press release',
+  government_communication: 'Government communication',
+}
+
+const hostnameFromUrl = (url?: string | null): string | null => {
+  if (!url) return null
+  try {
+    const u = new URL(url)
+    return u.hostname.replace(/^www\./, '')
+  } catch {
+    return null
+  }
+}
+
+const formatDate = (iso?: string | null): string | null => {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+const buildDescription = (s: Source): string | null => {
+  const parts: string[] = []
+  if (s.articleType && ARTICLE_TYPE_LABEL[s.articleType]) {
+    parts.push(ARTICLE_TYPE_LABEL[s.articleType])
+  }
+  if (s.sectionHeading) parts.push(s.sectionHeading)
+  if (typeof s.pageNumber === 'number') parts.push(`p. ${s.pageNumber}`)
+  const date = formatDate(s.publicationDate)
+  if (date) parts.push(date)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+const truncate = (text: string, max: number): string =>
+  text.length <= max ? text : `${text.slice(0, max - 1).trimEnd()}…`
 
 export const toDisplaySource = (s: Source): DisplaySource => {
   if (s.sourceType === 'haystaq') {
     return {
       id: s.id,
       displayName: PROPRIETARY_NAME,
+      displayLabel: PROPRIETARY_LABEL,
+      publisher: PROPRIETARY_PUBLISHER,
+      description: PROPRIETARY_BLURB,
       displayBlurb: PROPRIETARY_BLURB,
       url: null,
       isProprietary: true,
       initial: 'G',
     }
   }
+  const host = hostnameFromUrl(s.url)
+  const publisher = s.publisher ?? host ?? s.name
+  const label = s.publisher ?? host ?? truncate(s.name, 28)
   return {
     id: s.id,
     displayName: s.name,
+    displayLabel: label,
+    publisher,
+    description: buildDescription(s),
     displayBlurb: null,
     url: s.url ?? null,
     isProprietary: false,
-    initial: (s.name.trim().charAt(0) || '?').toUpperCase(),
+    initial: (publisher.trim().charAt(0) || '?').toUpperCase(),
   }
 }

--- a/app/shared/briefings/displaySource.ts
+++ b/app/shared/briefings/displaySource.ts
@@ -1,0 +1,37 @@
+import type { Source } from '@shared/briefings/types'
+
+export type DisplaySource = {
+  id: string
+  displayName: string
+  displayBlurb: string | null
+  url?: string | null
+  isProprietary: boolean
+  initial: string
+}
+
+// TODO(product): refine the proprietary-source copy with product/design.
+const PROPRIETARY_NAME = 'GoodParty.org constituent sentiment'
+const PROPRIETARY_BLURB =
+  'Modeled estimate from GoodParty.org’s proprietary constituent ' +
+  'sentiment data. Methodology details available on request.'
+
+export const toDisplaySource = (s: Source): DisplaySource => {
+  if (s.sourceType === 'haystaq') {
+    return {
+      id: s.id,
+      displayName: PROPRIETARY_NAME,
+      displayBlurb: PROPRIETARY_BLURB,
+      url: null,
+      isProprietary: true,
+      initial: 'G',
+    }
+  }
+  return {
+    id: s.id,
+    displayName: s.name,
+    displayBlurb: null,
+    url: s.url ?? null,
+    isProprietary: false,
+    initial: (s.name.trim().charAt(0) || '?').toUpperCase(),
+  }
+}

--- a/styleguide/tailwind-theme.css
+++ b/styleguide/tailwind-theme.css
@@ -456,4 +456,31 @@
   --color-components-input-focus: rgba(37, 99, 235, 0.3);
   --color-components-tooltip-base: #262626;
   --color-components-tooltip-foreground: #ffffff;
+
+  /* ==========================================================================
+   * RADIX COLLAPSIBLE ANIMATIONS
+   * Use: data-[state=open]:animate-collapsible-down,
+   *      data-[state=closed]:animate-collapsible-up
+   * Reads --radix-collapsible-content-height set by Radix on the content node.
+   * ========================================================================== */
+  --animate-collapsible-down: collapsible-down 250ms ease-out;
+  --animate-collapsible-up: collapsible-up 250ms ease-out;
+}
+
+@keyframes collapsible-down {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+  }
+}
+
+@keyframes collapsible-up {
+  from {
+    height: var(--radix-collapsible-content-height);
+  }
+  to {
+    height: 0;
+  }
 }


### PR DESCRIPTION
## Why

Seven bugs surfaced from a QA pass on the new meeting briefings feature against the Lovable target design.

**Bug 1 — green hover on Add Notes dialog tiles.** The three method tiles inside the Add Notes modal used `hover:bg-accent/40`, and our `--accent` token resolves to GoodParty green. Lovable's hover is neutral gray. Swapped to `hover:bg-muted/60` to match.

**Bug 2 — missing support/oppose subheader.** Local rendered only the 0-100 modeled-lean narrative; Lovable shows a bold `X% support · Y% oppose` stat above the prose. The data was already in the artifact (`meanScore`); we just weren't rendering it. Added an empty-state fallback ("No sentiment data yet for …") when `haystaqStatus !== 'ok'`.

**Bug 3 — non-priority items showed too much.** Every non-featured agenda item rendered Constituent sentiment + Budget impact + Talking points. Lovable strips non-priority items to "What to expect" only. `AgendaItemCard` now takes a `variant` prop; the per-item page passes `whatToExpectOnly` when `tier !== 'featured'`.

**Bug 4 — expandable Sources(N) section dropped.** The collapsible was being rendered but always early-returning, because `itemSources` was built only from `display.sourceIds` — which is empty. Sources live on per-section IDs. Aggregated across `display + sentiment + budget`, deduped.

**Bug 5 — source pill styling drift.** Avatar in the expanded panel was `rounded-sm`; matched Lovable with `rounded-full size-5`. Added `title` for hover-revealed full names on truncated inline pills.

**Bug 6 — internal data sources exposed to the user.** Source labels like `Haystaq L2 Modeled Constituent Sentiment` leaked vendor and voter-file infrastructure names. Added a small `displaySource.ts` helper that masks `sourceType === 'haystaq'` as `GoodParty.org constituent sentiment` and renders a clickable Popover with a proprietary-data blurb instead of a URL. Other sources are untouched. The copy is a placeholder with a `TODO(product)` marker — needs design/product final.

**Bug 8 — note uploads advanced before OCR finished.** Submit was enabled the moment a file pill appeared, even though OCR hadn't run yet — so the note text was unusable to the AI assistant (see companion gp-api PR). Now polls the annotations endpoint after `uploadAttachment` returns, holds the dialog open until the attachment's `ocrStatus` is terminal, with a 60s safety cap.

## Companion

Backend fix so the assistant can actually consume file-attachment note text: thegoodparty/gp-api#1620

## Out of scope

QA also surfaced (a) console errors/warnings on briefing detail and (b) stray "Open bug report" buttons embedded inline in body text. Tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes alter briefing-detail rendering logic and add client-side polling after uploads, which could impact UX/performance and relies on annotations API behavior/timeouts.
> 
> **Overview**
> Improves meeting briefing detail UX to better match design: non-featured agenda items now render a reduced `AgendaItemCard` (*What to expect only*) via a new `variant` prop, while featured items keep the full sections.
> 
> Enhances constituent sentiment display by adding a bold support/oppose line derived from `meanScore` and showing a user-facing empty state when sentiment data isn’t available.
> 
> Fixes source rendering across the card by aggregating/deduping source IDs from multiple sections, adds consistent source “pills”/avatars, and introduces `toDisplaySource` to mask proprietary `haystaq` sources behind a popover blurb instead of exposing internal/vendor names.
> 
> Updates note intake/upload flow to wait for attachment OCR to reach a terminal status (polling up to 60s) before proceeding, and tweaks Add Notes dialog hover styling and a small pill text fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1811895db56adfad2d5db197f678bd3a35181e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
