### PR TITLE
fix(briefings): drop "View briefing" CTA from Awaiting agenda dialog

### DIFF
--- a/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
+++ b/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from 'next/link'
 import { ChevronRight, MapPin } from 'lucide-react'
 import {
   Dialog,
@@ -9,7 +8,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@styleguide'
-import { buttonVariants } from '@styleguide'
 import {
   countdownLabel,
   formatDayTime,
@@ -27,7 +25,6 @@ export default function AwaitingAgendaRow({
   const shortDate = formatShortDate(summary.scheduledAt)
   const dayTime = formatDayTime(summary.scheduledAt)
   const countdown = countdownLabel(summary.scheduledAt)
-  const detailHref = `/dashboard/briefings/${summary.slug}`
 
   return (
     <Dialog>
@@ -90,12 +87,6 @@ export default function AwaitingAgendaRow({
         <p className="text-sm">
           <span className="font-medium">Status:</span> Agenda not posted yet
         </p>
-
-        <div className="pt-1">
-          <Link href={detailHref} className={buttonVariants()}>
-            View briefing
-          </Link>
-        </div>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Why

For a meeting whose agenda isn't posted yet, the briefing detail page has nothing to show. The "View briefing" CTA in the Awaiting agenda dialog invited a click that landed on an empty state. Removing it. The dialog still surfaces the meeting metadata and an explicit "Agenda not posted yet" status line so the user knows where they stand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a navigation link from the awaiting-agenda modal; no data or business-logic changes.
> 
> **Overview**
> Removes the "View briefing" link/CTA from the `AwaitingAgendaRow` dialog (and its related `next/link`/`buttonVariants` usage) so users aren’t navigated to an effectively empty briefing detail page when the agenda hasn’t been posted yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598b2c7aa486ed1ece134a5ab17b02ce18372997. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->