### PR TITLE
fix empty state text

### DIFF
--- a/app/dashboard/briefings/components/BriefingsLanding.tsx
+++ b/app/dashboard/briefings/components/BriefingsLanding.tsx
@@ -34,9 +34,9 @@ const EmptyState = () => (
       We&apos;re tracking down your meetings
     </h2>
     <p className="text-sm text-muted-foreground">
-      We&apos;re finding your upcoming council meetings and building briefings
-      from the public agenda packets. As soon as the first one is ready,
-      we&apos;ll email you so you can review it before you walk in.
+      We&apos;re finding your upcoming meetings and building briefings from the
+      public agendas. As soon as the first one is ready, we&apos;ll email you so
+      you can review it before you walk in.
     </p>
   </section>
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only copy change in the briefings empty state with no logic or data handling impact.
> 
> **Overview**
> Updates the `BriefingsLanding` empty-state message to remove “council”/“agenda packets” wording and use more generic “meetings” and “public agendas” phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdddbe8c7538f05fb069fb25b542e6604d7a6518. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->