### PR TITLE
briefings: lovable polish — Vaul drawer, panel dock, simplified read-aloud

### DIFF
--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation'
 import pageMetaData from 'helpers/metadataHelper'
 import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
+import { renderItemForSpeech } from '@shared/briefings/renderForSpeech'
 import AgendaItemCard from '../../components/detail/AgendaItemCard'
 
 type PageProps = {
@@ -48,6 +49,8 @@ export default async function Page({
       meetingDate={slug}
       showFeedback={item.tier === 'featured'}
       variant={item.tier === 'featured' ? 'full' : 'whatToExpectOnly'}
+      speechText={renderItemForSpeech(item)}
+      analyticsLabel={`briefing-item-${item.id}`}
     />
   )
 }

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -3,14 +3,16 @@
 import { useEffect, useState } from 'react'
 import {
   Button,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
   Textarea,
 } from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
 import type { SheetState } from './AnnotationsScope'
+import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
 
 type Props = {
   sheet: SheetState
@@ -53,6 +55,8 @@ export default function AddNoteSheet({
   onDelete,
 }: Props): React.JSX.Element {
   const open = isAddNoteState(sheet)
+  const isDesktop = !useIsMobile()
+  const direction = isDesktop ? 'right' : 'bottom'
 
   const initialBody =
     sheet.kind === 'add_note_edit' ? sheet.annotation.note?.body ?? '' : ''
@@ -67,6 +71,10 @@ export default function AddNoteSheet({
       setBody('')
     }
   }, [sheet])
+
+  // Clear the user's text selection once the drawer opens — leaving a live
+  // selection blocks Vaul's drag-to-dismiss.
+  useClearSelectionOnOpen(open)
 
   const quote = quoteFor(sheet)
   const isEdit = sheet.kind === 'add_note_edit'
@@ -100,23 +108,25 @@ export default function AddNoteSheet({
   const canSave = body.trim().length > 0 && !saving
 
   return (
-    <Sheet open={open} onOpenChange={(v) => (v ? null : onClose())}>
-      <SheetContent
-        side="right"
-        onPointerDownOutside={() => onClose()}
-        onEscapeKeyDown={() => onClose()}
-        className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]"
-      >
-        <SheetHeader className="px-6 pb-4 pr-12 pt-6">
-          <SheetTitle className="text-2xl font-semibold tracking-tight text-foreground">
+    <Drawer
+      open={open}
+      onOpenChange={(v) => (v ? null : onClose())}
+      direction={direction}
+    >
+      <DrawerContent className="flex flex-col gap-0 p-0 lg:max-w-[480px]">
+        <DrawerHeader className="px-6 pb-4 pr-12 pt-6">
+          <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             {isEdit ? 'Edit note' : 'Add a Note'}
-          </SheetTitle>
-        </SheetHeader>
+          </DrawerTitle>
+        </DrawerHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4">
+        <div
+          data-vaul-no-drag
+          className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4"
+        >
           {quote ? (
-            <blockquote className="rounded-md bg-muted px-3 py-2 text-sm italic text-foreground">
-              &ldquo;{quote}&rdquo;
+            <blockquote className="border-l-2 border-border pl-3 text-sm italic leading-6 text-muted-foreground">
+              {quote}
             </blockquote>
           ) : !isEdit ? (
             <p className="rounded-md bg-muted px-3 py-2 text-sm italic text-muted-foreground">
@@ -133,7 +143,10 @@ export default function AddNoteSheet({
           />
         </div>
 
-        <div className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3 lg:border-t-0">
+        <div
+          data-vaul-no-drag
+          className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3 lg:border-t-0"
+        >
           <Button
             type="button"
             disabled={!canSave}
@@ -154,7 +167,7 @@ export default function AddNoteSheet({
             </Button>
           ) : null}
         </div>
-      </SheetContent>
-    </Sheet>
+      </DrawerContent>
+    </Drawer>
   )
 }

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -113,7 +113,7 @@ export default function AddNoteSheet({
       onOpenChange={(v) => (v ? null : onClose())}
       direction={direction}
     >
-      <DrawerContent className="flex flex-col gap-0 p-0 lg:max-w-[480px]">
+      <DrawerContent className="flex flex-col gap-0 p-0 data-[vaul-drawer-direction=right]:sm:max-w-[480px]">
         <DrawerHeader className="px-6 pb-4 pr-12 pt-6">
           <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             {isEdit ? 'Edit note' : 'Add a Note'}

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -323,8 +323,7 @@ export default function AnnotationsScope({
   }, [annotations])
 
   const topLevelChatAnnotationId = useMemo(
-    () =>
-      annotations.find((a) => a.kind === 'chat' && a.jsonPath === null)?.id,
+    () => annotations.find((a) => a.kind === 'chat' && a.jsonPath === null)?.id,
     [annotations],
   )
 

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -105,6 +105,13 @@ export type SheetState = OverlayState
 
 type Ctx = {
   meetingDate: string
+  /**
+   * Id of the user's existing top-level chat annotation on this briefing,
+   * if any. Passed to AskAiPopover so reopens skip `createBriefingChat`
+   * and load prior messages directly. Undefined when no top-level chat
+   * exists yet — first open will mint one.
+   */
+  topLevelChatAnnotationId?: string
   openAddNoteFromSelection: () => void
   openAddNoteTopLevel: () => void
   openReportErrorFromSelection: () => void
@@ -315,9 +322,16 @@ export default function AnnotationsScope({
     return () => document.removeEventListener('click', onClick)
   }, [annotations])
 
+  const topLevelChatAnnotationId = useMemo(
+    () =>
+      annotations.find((a) => a.kind === 'chat' && a.jsonPath === null)?.id,
+    [annotations],
+  )
+
   const ctxValue: Ctx = useMemo(
     () => ({
       meetingDate,
+      topLevelChatAnnotationId,
       openAddNoteFromSelection,
       openAddNoteTopLevel,
       openReportErrorFromSelection,
@@ -331,6 +345,7 @@ export default function AnnotationsScope({
     }),
     [
       meetingDate,
+      topLevelChatAnnotationId,
       openAddNoteFromSelection,
       openAddNoteTopLevel,
       openReportErrorFromSelection,

--- a/app/dashboard/briefings/components/annotations/AskAiPopover.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiPopover.tsx
@@ -118,7 +118,7 @@ export default function AskAiPopover({
       <PopoverContent
         align={align}
         side={side}
-        className="flex w-[400px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-2xl p-0 shadow-xl"
+        className="font-opensans flex w-[400px] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-2xl p-0 shadow-xl"
         onEscapeKeyDown={() => setOpen(false)}
       >
         <div className="flex items-center gap-3 border-b border-base-border px-4 py-3">

--- a/app/dashboard/briefings/components/annotations/AskAiSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiSheet.test.tsx
@@ -245,6 +245,20 @@ describe('<AskAiSheet>', () => {
     expect(screen.getByText(/hello/)).toBeInTheDocument()
   })
 
+  it('renders the anchor quote inside a blockquote without surrounding quote characters', async () => {
+    setupEmptyHistory()
+    render(
+      <AskAiSheet
+        sheet={anchoredSheet()}
+        meetingDate="briefing_x"
+        onClose={vi.fn()}
+      />,
+    )
+    const quote = await screen.findByText('hello')
+    expect(quote.tagName).toBe('BLOCKQUOTE')
+    expect(quote.textContent).toBe('hello')
+  })
+
   it('skips create and loads existing messages for an existing-chat overlay', async () => {
     const messages: ChatMessage[] = [
       {

--- a/app/dashboard/briefings/components/annotations/AskAiSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiSheet.tsx
@@ -1,12 +1,7 @@
 'use client'
 
 import { useCallback, useMemo } from 'react'
-import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-} from '@styleguide'
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@styleguide'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import type { AnnotationAnchor } from '@shared/briefings/types'
 import type { OverlayState } from './AnnotationsScope'
@@ -101,7 +96,7 @@ export default function AskAiSheet({
       onOpenChange={(v) => (v ? null : onClose())}
       direction={direction}
     >
-      <DrawerContent className="font-opensans flex flex-col gap-0 p-0 lg:max-w-[480px]">
+      <DrawerContent className="font-opensans flex flex-col gap-0 p-0 data-[vaul-drawer-direction=right]:sm:max-w-[480px]">
         <DrawerHeader className="gap-2 px-6 pb-4 pr-12 pt-6">
           <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             Ask AI

--- a/app/dashboard/briefings/components/annotations/AskAiSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiSheet.tsx
@@ -1,10 +1,17 @@
 'use client'
 
 import { useCallback, useMemo } from 'react'
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@styleguide'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import type { AnnotationAnchor } from '@shared/briefings/types'
 import type { OverlayState } from './AnnotationsScope'
 import AskAiChatBody from './AskAiChatBody'
+import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
 
 type Props = {
   sheet: OverlayState
@@ -51,7 +58,8 @@ function annotationIdOverrideFor(state: OverlayState): string | undefined {
 }
 
 /**
- * Right-side Sheet for the Ask AI chat surface.
+ * Ask AI chat surface. Renders as a right-side drawer at lg+ and as a
+ * bottom drawer with drag-to-dismiss + drag handle on mobile.
  *
  * Two open states:
  *  - `ask_ai_anchored`: selection-spawned chat; renders the anchor quote and
@@ -60,7 +68,7 @@ function annotationIdOverrideFor(state: OverlayState): string | undefined {
  *    and loads prior messages directly.
  *
  * Top-of-page Ask AI uses `AskAiPopover` anchored to its button — not this
- * Sheet.
+ * drawer.
  */
 export default function AskAiSheet({
   sheet,
@@ -72,6 +80,13 @@ export default function AskAiSheet({
   const quote = quoteFor(sheet)
   const anchor = useMemo(() => anchorFor(sheet), [sheet])
   const annotationIdOverride = annotationIdOverrideFor(sheet)
+  const isDesktop = !useIsMobile()
+  const direction = isDesktop ? 'right' : 'bottom'
+
+  // Clear the user's text selection once the drawer opens. The anchor is
+  // already captured in state; leaving the selection live blocks Vaul's
+  // drag-to-dismiss (vaul refuses to drag while text is selected).
+  useClearSelectionOnOpen(open)
 
   const handleChatCreated = useCallback(
     (info: { annotationId: string; conversationId: string }) => {
@@ -81,25 +96,27 @@ export default function AskAiSheet({
   )
 
   return (
-    <Sheet open={open} onOpenChange={(v) => (v ? null : onClose())}>
-      <SheetContent
-        side="right"
-        onPointerDownOutside={() => onClose()}
-        onEscapeKeyDown={() => onClose()}
-        className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]"
-      >
-        <SheetHeader className="gap-2 px-6 pb-4 pr-12 pt-6">
-          <SheetTitle className="text-2xl font-semibold tracking-tight text-foreground">
+    <Drawer
+      open={open}
+      onOpenChange={(v) => (v ? null : onClose())}
+      direction={direction}
+    >
+      <DrawerContent className="font-opensans flex flex-col gap-0 p-0 lg:max-w-[480px]">
+        <DrawerHeader className="gap-2 px-6 pb-4 pr-12 pt-6">
+          <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             Ask AI
-          </SheetTitle>
+          </DrawerTitle>
           {quote ? (
-            <p className="text-sm italic text-muted-foreground">
-              &ldquo;{quote}&rdquo;
-            </p>
+            <blockquote className="border-l-2 border-border pl-3 text-sm italic leading-6 text-muted-foreground">
+              {quote}
+            </blockquote>
           ) : null}
-        </SheetHeader>
+        </DrawerHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-0 px-0 pb-0">
+        <div
+          data-vaul-no-drag
+          className="flex min-h-0 flex-1 flex-col gap-0 px-0 pb-0"
+        >
           <AskAiChatBody
             meetingDate={meetingDate}
             anchor={anchor}
@@ -111,7 +128,7 @@ export default function AskAiSheet({
             onChatCreated={onChatCreated ? handleChatCreated : undefined}
           />
         </div>
-      </SheetContent>
-    </Sheet>
+      </DrawerContent>
+    </Drawer>
   )
 }

--- a/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
@@ -3,14 +3,16 @@
 import { useEffect, useState } from 'react'
 import {
   Button,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
   Textarea,
 } from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
 import type { SheetState } from './AnnotationsScope'
+import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
 
 type Props = {
   sheet: SheetState
@@ -45,6 +47,9 @@ export default function ReportErrorSheet({
   onDelete,
 }: Props): React.JSX.Element {
   const open = isReportState(sheet)
+  const isDesktop = !useIsMobile()
+  const direction = isDesktop ? 'right' : 'bottom'
+
   const initialDescription =
     sheet.kind === 'report_error_view'
       ? sheet.annotation.bugReport?.description ?? ''
@@ -59,6 +64,10 @@ export default function ReportErrorSheet({
       setDescription('')
     }
   }, [sheet])
+
+  // Clear the user's text selection once the drawer opens — leaving a live
+  // selection blocks Vaul's drag-to-dismiss.
+  useClearSelectionOnOpen(open)
 
   const quote = quoteFor(sheet)
   const isView = sheet.kind === 'report_error_view'
@@ -88,23 +97,25 @@ export default function ReportErrorSheet({
   const canSubmit = description.trim().length > 0 && !saving
 
   return (
-    <Sheet open={open} onOpenChange={(v) => (v ? null : onClose())}>
-      <SheetContent
-        side="right"
-        onPointerDownOutside={() => onClose()}
-        onEscapeKeyDown={() => onClose()}
-        className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]"
-      >
-        <SheetHeader className="px-6 pb-4 pr-12 pt-6">
-          <SheetTitle className="text-2xl font-semibold tracking-tight text-foreground">
+    <Drawer
+      open={open}
+      onOpenChange={(v) => (v ? null : onClose())}
+      direction={direction}
+    >
+      <DrawerContent className="flex flex-col gap-0 p-0 lg:max-w-[480px]">
+        <DrawerHeader className="px-6 pb-4 pr-12 pt-6">
+          <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             Report or Correct an Error
-          </SheetTitle>
-        </SheetHeader>
+          </DrawerTitle>
+        </DrawerHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4">
+        <div
+          data-vaul-no-drag
+          className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4"
+        >
           {quote ? (
-            <blockquote className="rounded-md border-l-2 border-destructive/40 bg-muted/40 px-3 py-2 text-sm italic text-foreground">
-              &ldquo;{quote}&rdquo;
+            <blockquote className="border-l-2 border-destructive/40 pl-3 text-sm italic leading-6 text-foreground">
+              {quote}
             </blockquote>
           ) : null}
 
@@ -130,7 +141,10 @@ export default function ReportErrorSheet({
           ) : null}
         </div>
 
-        <div className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3 lg:border-t-0">
+        <div
+          data-vaul-no-drag
+          className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3 lg:border-t-0"
+        >
           {isView ? (
             <Button
               type="button"
@@ -152,7 +166,7 @@ export default function ReportErrorSheet({
             </Button>
           )}
         </div>
-      </SheetContent>
-    </Sheet>
+      </DrawerContent>
+    </Drawer>
   )
 }

--- a/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
@@ -102,7 +102,7 @@ export default function ReportErrorSheet({
       onOpenChange={(v) => (v ? null : onClose())}
       direction={direction}
     >
-      <DrawerContent className="flex flex-col gap-0 p-0 lg:max-w-[480px]">
+      <DrawerContent className="flex flex-col gap-0 p-0 data-[vaul-drawer-direction=right]:sm:max-w-[480px]">
         <DrawerHeader className="px-6 pb-4 pr-12 pt-6">
           <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
             Report or Correct an Error

--- a/app/dashboard/briefings/components/annotations/useClearSelectionOnOpen.test.tsx
+++ b/app/dashboard/briefings/components/annotations/useClearSelectionOnOpen.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
+
+function Probe({ open }: { open: boolean }): null {
+  useClearSelectionOnOpen(open)
+  return null
+}
+
+function selectFirstTextNode(): { rangeCount: () => number } {
+  const host = document.createElement('p')
+  host.textContent = 'select me'
+  document.body.appendChild(host)
+
+  const range = document.createRange()
+  const textNode = host.firstChild as Text
+  range.setStart(textNode, 0)
+  range.setEnd(textNode, textNode.length)
+
+  const selection = window.getSelection()
+  if (!selection) throw new Error('window.getSelection() returned null')
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  return {
+    rangeCount: () => window.getSelection()?.rangeCount ?? 0,
+  }
+}
+
+describe('useClearSelectionOnOpen', () => {
+  it('leaves an active selection alone when open is false', () => {
+    const sel = selectFirstTextNode()
+    expect(sel.rangeCount()).toBe(1)
+
+    render(<Probe open={false} />)
+
+    expect(sel.rangeCount()).toBe(1)
+  })
+
+  it('clears the active selection when open transitions to true', () => {
+    const sel = selectFirstTextNode()
+    expect(sel.rangeCount()).toBe(1)
+
+    const { rerender } = render(<Probe open={false} />)
+    expect(sel.rangeCount()).toBe(1)
+
+    rerender(<Probe open={true} />)
+
+    expect(sel.rangeCount()).toBe(0)
+  })
+
+  it('clears the selection on mount when open is initially true', () => {
+    const sel = selectFirstTextNode()
+    expect(sel.rangeCount()).toBe(1)
+
+    render(<Probe open={true} />)
+
+    expect(sel.rangeCount()).toBe(0)
+  })
+})

--- a/app/dashboard/briefings/components/annotations/useClearSelectionOnOpen.ts
+++ b/app/dashboard/briefings/components/annotations/useClearSelectionOnOpen.ts
@@ -1,0 +1,9 @@
+'use client'
+import { useEffect } from 'react'
+
+export const useClearSelectionOnOpen = (open: boolean): void => {
+  useEffect(() => {
+    if (!open || typeof window === 'undefined') return
+    window.getSelection()?.removeAllRanges()
+  }, [open])
+}

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import AgendaItemCard from './AgendaItemCard'
+import type { Item, Source } from '@shared/briefings/types'
+
+vi.mock('../../shared/useReadAloud', () => ({
+  useReadAloud: () => ({
+    status: 'idle',
+    error: null,
+    play: vi.fn(),
+    stop: vi.fn(),
+  }),
+}))
+
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'item_1',
+    itemNumber: '1',
+    title: 'Call to order',
+    tier: 'standard',
+    voteRequired: false,
+    tierReason: [],
+    display: {
+      summary: 'The mayor or chair opens the meeting.',
+    },
+    ...overrides,
+  }
+}
+
+const noSources: Source[] = []
+
+describe('<AgendaItemCard>', () => {
+  it('renders a read-aloud button when speechText is provided', () => {
+    render(
+      <AgendaItemCard
+        item={makeItem()}
+        itemIndex={0}
+        sources={noSources}
+        domId="briefing-item-item_1"
+        meetingDate="2026-05-18"
+        showFeedback={false}
+        speechText="The mayor or chair opens the meeting."
+      />,
+    )
+
+    expect(
+      screen.getByRole('button', { name: /read aloud/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render a read-aloud button when speechText is omitted', () => {
+    render(
+      <AgendaItemCard
+        item={makeItem()}
+        itemIndex={0}
+        sources={noSources}
+        domId="briefing-item-item_1"
+        meetingDate="2026-05-18"
+        showFeedback={false}
+      />,
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /read aloud/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the read-aloud button as an icon-only control (no visible "Read aloud" text label)', () => {
+    render(
+      <AgendaItemCard
+        item={makeItem()}
+        itemIndex={0}
+        sources={noSources}
+        domId="briefing-item-item_1"
+        meetingDate="2026-05-18"
+        showFeedback={false}
+        speechText="The mayor or chair opens the meeting."
+      />,
+    )
+
+    const btn = screen.getByRole('button', { name: /read aloud/i })
+    expect(btn.textContent?.trim()).toBe('')
+  })
+})

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -12,6 +12,7 @@ import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
 import SourcesCollapsible from './SourcesCollapsible'
 import FeedbackRow from './FeedbackRow'
+import ReadAloudButton from './ReadAloudButton'
 
 type Variant = 'full' | 'whatToExpectOnly'
 
@@ -23,6 +24,15 @@ type Props = {
   meetingDate: string
   showFeedback: boolean
   variant?: Variant
+  /**
+   * Pre-rendered plain-text for the speech service. When provided, the
+   * card header renders a compact read-aloud control. Non-priority item
+   * pages pass this; the featured-items overview omits it (the page-level
+   * Executive Summary card already exposes read-aloud for the briefing).
+   */
+  speechText?: string
+  /** Optional label forwarded to analytics so usage can be sliced by surface. */
+  analyticsLabel?: string
 }
 
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
@@ -173,6 +183,8 @@ const AgendaItemCard = ({
   meetingDate,
   showFeedback,
   variant = 'full',
+  speechText,
+  analyticsLabel,
 }: Props): React.JSX.Element => {
   const base = `/items/${itemIndex}`
   const display = item.display
@@ -200,16 +212,25 @@ const AgendaItemCard = ({
       id={domId}
       className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6"
     >
-      <header className="flex flex-col gap-1">
-        <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">
-          Agenda item
-        </span>
-        <h3
-          className="text-lg font-semibold text-foreground"
-          data-briefing-json-path={`${base}/title`}
-        >
-          {item.title}
-        </h3>
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">
+            Agenda item
+          </span>
+          <h3
+            className="text-lg font-semibold text-foreground"
+            data-briefing-json-path={`${base}/title`}
+          >
+            {item.title}
+          </h3>
+        </div>
+        {speechText ? (
+          <ReadAloudButton
+            text={speechText}
+            analyticsLabel={analyticsLabel}
+            compact
+          />
+        ) : null}
       </header>
 
       <section className="flex flex-col gap-2">

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -28,8 +28,12 @@ export default function DetailHeaderActions({
   meetingMetaLine,
   liveBriefingUrl,
 }: Props): React.JSX.Element {
-  const { meetingDate, openAddNoteTopLevel, onChatCreated } =
-    useAnnotationsCtx()
+  const {
+    meetingDate,
+    openAddNoteTopLevel,
+    onChatCreated,
+    topLevelChatAnnotationId,
+  } = useAnnotationsCtx()
   const [downloading, setDownloading] = useState(false)
 
   const onDownload = async () => {
@@ -66,6 +70,7 @@ export default function DetailHeaderActions({
         anchor={null}
         align="end"
         side="bottom"
+        existingAnnotationId={topLevelChatAnnotationId}
         onChatCreated={onChatCreated}
         trigger={
           <Button>

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -39,7 +39,9 @@ describe('<MobileBottomBar>', () => {
 
     const selector = screen.getByRole('button', { name: /executive summary/i })
     const download = screen.getByRole('button', { name: /download pdf/i })
-    const askAi = screen.getByRole('button', { name: /open briefing assistant/i })
+    const askAi = screen.getByRole('button', {
+      name: /open briefing assistant/i,
+    })
 
     // All three controls share a common ancestor (the dock row) so they
     // render as a single horizontal group instead of being scattered.

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import MobileBottomBar from './MobileBottomBar'
+import type { Item } from '@shared/briefings/types'
+
+vi.mock('../annotations/AnnotationsScope', () => ({
+  useAnnotationsCtx: () => ({
+    meetingDate: 'briefing_x',
+    onChatCreated: vi.fn(),
+    topLevelChatAnnotationId: undefined,
+    openAddNoteTopLevel: vi.fn(),
+  }),
+}))
+
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<object>('next/navigation')
+  return {
+    ...actual,
+    usePathname: () => '/dashboard/briefings/town-hall',
+  }
+})
+
+function makeItems(n: number): Item[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `item_${i + 1}`,
+    itemNumber: String(i + 1),
+    title: `Item ${i + 1}`,
+    tier: 'standard',
+    voteRequired: false,
+    tierReason: [],
+    display: { summary: '' },
+  }))
+}
+
+describe('<MobileBottomBar>', () => {
+  it('renders the page-selector pill, Download, and Ask AI as siblings in one row on a solid panel', () => {
+    render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(2)} />)
+
+    const selector = screen.getByRole('button', { name: /executive summary/i })
+    const download = screen.getByRole('button', { name: /download pdf/i })
+    const askAi = screen.getByRole('button', { name: /open briefing assistant/i })
+
+    // All three controls share a common ancestor (the dock row) so they
+    // render as a single horizontal group instead of being scattered.
+    const row = selector.parentElement
+    expect(row).not.toBeNull()
+    expect(row).toContainElement(download)
+    expect(row).toContainElement(askAi)
+
+    // The dock itself must be a solid panel with a top border — not a
+    // pointer-events-none overlay of floating FABs.
+    const dock = row?.parentElement
+    expect(dock?.className ?? '').toMatch(/border-t/)
+    expect(dock?.className ?? '').not.toMatch(/pointer-events-none/)
+  })
+})

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -54,85 +54,83 @@ export default function MobileBottomBar({
   }, [items, briefingSlug, overviewHref, pathname])
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 flex items-end justify-between gap-2 px-4 pb-4 lg:hidden">
-      <Sheet open={open} onOpenChange={setOpen}>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => setOpen(true)}
-          className="pointer-events-auto max-w-[70%] shadow-md"
-        >
-          <List className="size-4 shrink-0 text-primary" aria-hidden />
-          <span className="truncate">{currentLabel}</span>
-          <ChevronUp
-            className="size-4 shrink-0 text-muted-foreground"
-            aria-hidden
-          />
-        </Button>
-        <SheetContent
-          side="bottom"
-          className="max-h-[70vh] rounded-t-2xl px-4 pb-6 pt-4"
-        >
-          <SheetHeader className="px-0">
-            <SheetTitle>Jump to section</SheetTitle>
-          </SheetHeader>
-          <ul className="mt-3 flex list-none flex-col gap-0.5 overflow-y-auto">
-            <li>
-              <Link
-                href={overviewHref}
-                onClick={() => setOpen(false)}
-                className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
-                  pathname === overviewHref
-                    ? 'bg-muted font-semibold text-foreground'
-                    : 'text-foreground hover:bg-muted/60'
-                }`}
-              >
-                Executive Summary
-              </Link>
-            </li>
-            {items.map((a) => {
-              const href = briefingItemHref(briefingSlug, a.id)
-              const isActive = pathname === href
-              return (
-                <li key={a.id}>
-                  <Link
-                    href={href}
-                    onClick={() => setOpen(false)}
-                    className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
-                      isActive
-                        ? 'bg-muted font-semibold text-foreground'
-                        : 'text-foreground hover:bg-muted/60'
-                    }`}
-                  >
-                    {a.title}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
-        </SheetContent>
-      </Sheet>
+    <div className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-sidebar/95 backdrop-blur supports-[backdrop-filter]:bg-sidebar/80 lg:hidden">
+      <div className="mx-auto flex w-full max-w-[800px] items-center gap-2 px-4 py-3">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(true)}
+            className="min-w-0 flex-1 justify-between"
+          >
+            <List className="size-4 shrink-0 text-primary" aria-hidden />
+            <span className="truncate">{currentLabel}</span>
+            <ChevronUp
+              className="size-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          </Button>
+          <SheetContent
+            side="bottom"
+            className="max-h-[70vh] rounded-t-2xl px-4 pb-6 pt-4"
+          >
+            <SheetHeader className="px-0">
+              <SheetTitle>Jump to section</SheetTitle>
+            </SheetHeader>
+            <ul className="mt-3 flex list-none flex-col gap-0.5 overflow-y-auto">
+              <li>
+                <Link
+                  href={overviewHref}
+                  onClick={() => setOpen(false)}
+                  className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
+                    pathname === overviewHref
+                      ? 'bg-muted font-semibold text-foreground'
+                      : 'text-foreground hover:bg-muted/60'
+                  }`}
+                >
+                  Executive Summary
+                </Link>
+              </li>
+              {items.map((a) => {
+                const href = briefingItemHref(briefingSlug, a.id)
+                const isActive = pathname === href
+                return (
+                  <li key={a.id}>
+                    <Link
+                      href={href}
+                      onClick={() => setOpen(false)}
+                      className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
+                        isActive
+                          ? 'bg-muted font-semibold text-foreground'
+                          : 'text-foreground hover:bg-muted/60'
+                      }`}
+                    >
+                      {a.title}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </SheetContent>
+        </Sheet>
 
-      <div className="pointer-events-auto flex flex-col gap-2">
         <IconButton
           type="button"
-          size="large"
+          size="medium"
           variant="outline"
           aria-label="Download PDF"
           onClick={() => {
             // TODO: trigger PDF download via Swain's briefing API.
           }}
-          className="shadow-md"
         >
           <Download className="size-5" aria-hidden />
         </IconButton>
         <IconButton
           type="button"
-          size="large"
+          size="medium"
           variant="outline"
           aria-label="Add notes"
           onClick={openAddNoteTopLevel}
-          className="shadow-md"
         >
           <NotebookPen className="size-5" aria-hidden />
         </IconButton>
@@ -145,9 +143,8 @@ export default function MobileBottomBar({
           trigger={
             <IconButton
               type="button"
-              size="large"
+              size="medium"
               aria-label="Open briefing assistant"
-              className="shadow-md"
             >
               <Sparkles className="size-5" aria-hidden />
             </IconButton>

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -40,8 +40,12 @@ export default function MobileBottomBar({
 }: Props): React.JSX.Element {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
-  const { meetingDate, openAddNoteTopLevel, onChatCreated } =
-    useAnnotationsCtx()
+  const {
+    meetingDate,
+    openAddNoteTopLevel,
+    onChatCreated,
+    topLevelChatAnnotationId,
+  } = useAnnotationsCtx()
 
   const overviewHref = briefingOverviewHref(briefingSlug)
 
@@ -139,6 +143,7 @@ export default function MobileBottomBar({
           anchor={null}
           align="end"
           side="top"
+          existingAnnotationId={topLevelChatAnnotationId}
           onChatCreated={onChatCreated}
           trigger={
             <IconButton

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import ReadAloudButton from './ReadAloudButton'
+import type { ReadAloudStatus } from '../../shared/useReadAloud'
+
+type HookState = {
+  status: ReadAloudStatus
+  error: string | null
+}
+
+const hookState: HookState = { status: 'idle', error: null }
+const playMock = vi.fn()
+const stopMock = vi.fn()
+
+vi.mock('../../shared/useReadAloud', () => ({
+  useReadAloud: () => ({
+    status: hookState.status,
+    error: hookState.error,
+    play: playMock,
+    stop: stopMock,
+  }),
+}))
+
+function setHook(state: HookState): void {
+  hookState.status = state.status
+  hookState.error = state.error
+}
+
+describe('<ReadAloudButton>', () => {
+  describe('compact variant', () => {
+    it('renders a spinner and is busy + disabled while loading', () => {
+      setHook({ status: 'loading', error: null })
+
+      render(<ReadAloudButton text="hello" compact />)
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('aria-busy', 'true')
+      expect(button).toBeDisabled()
+      // IconButton's built-in LoadingSpinner has the `animate-spin` class.
+      const spinner = button.querySelector('.animate-spin')
+      expect(spinner).not.toBeNull()
+    })
+
+    it('shows a destructive-tinted warning indicator on error', () => {
+      setHook({ status: 'error', error: 'boom' })
+
+      render(<ReadAloudButton text="hello" compact />)
+
+      const button = screen.getByRole('button', { name: /read aloud failed/i })
+      // The warning glyph should be tinted destructive so sighted users see
+      // that the previous attempt failed.
+      const destructive = button.querySelector('.text-destructive')
+      expect(destructive).not.toBeNull()
+    })
+
+    it('shows the play icon when idle and is enabled', () => {
+      setHook({ status: 'idle', error: null })
+
+      render(<ReadAloudButton text="hello" compact />)
+
+      const button = screen.getByRole('button', { name: /^read aloud$/i })
+      expect(button).not.toBeDisabled()
+      expect(button).toHaveAttribute('aria-busy', 'false')
+      expect(button.querySelector('.animate-spin')).toBeNull()
+    })
+
+    it('shows a stop icon and is enabled while playing', () => {
+      setHook({ status: 'playing', error: null })
+
+      render(<ReadAloudButton text="hello" compact />)
+
+      const button = screen.getByRole('button', { name: /stop reading/i })
+      expect(button).not.toBeDisabled()
+      // Not in the spinner state — content is the stop icon, not LoadingSpinner.
+      expect(button.querySelector('.animate-spin')).toBeNull()
+    })
+  })
+
+  describe('labeled variant', () => {
+    it('renders "Try again" text on error', () => {
+      setHook({ status: 'error', error: 'boom' })
+
+      render(<ReadAloudButton text="hello" />)
+
+      const button = screen.getByRole('button', { name: /read aloud failed/i })
+      expect(button).toHaveTextContent(/try again/i)
+      expect(button).not.toHaveTextContent(/^read aloud$/i)
+    })
+
+    it('renders "Loading…" while loading', () => {
+      setHook({ status: 'loading', error: null })
+
+      render(<ReadAloudButton text="hello" />)
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveTextContent(/loading/i)
+      expect(button).toBeDisabled()
+    })
+
+    it('renders "Read aloud" when idle', () => {
+      setHook({ status: 'idle', error: null })
+
+      render(<ReadAloudButton text="hello" />)
+
+      const button = screen.getByRole('button', { name: /^read aloud$/i })
+      expect(button).toHaveTextContent(/read aloud/i)
+      expect(button).not.toBeDisabled()
+    })
+
+    it('renders "Stop" while playing', () => {
+      setHook({ status: 'playing', error: null })
+
+      render(<ReadAloudButton text="hello" />)
+
+      const button = screen.getByRole('button', { name: /stop reading/i })
+      expect(button).toHaveTextContent(/stop/i)
+    })
+  })
+})

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { Volume2, Square } from 'lucide-react'
-import { Button } from '@styleguide'
+import { Volume2, Square, TriangleAlert } from 'lucide-react'
+import { Button, IconButton } from '@styleguide'
 import { useReadAloud } from '../../shared/useReadAloud'
 
 type Props = {
@@ -13,6 +13,12 @@ type Props = {
   text: string
   /** Optional label forwarded to analytics so usage can be sliced by surface. */
   analyticsLabel?: string
+  /**
+   * When true, render as an icon-only round outline button. Used in card
+   * headers for non-priority items where the labeled variant takes too
+   * much space.
+   */
+  compact?: boolean
 }
 
 /**
@@ -24,6 +30,7 @@ type Props = {
 export default function ReadAloudButton({
   text,
   analyticsLabel,
+  compact = false,
 }: Props): React.JSX.Element {
   const { status, error, play, stop } = useReadAloud({ text, analyticsLabel })
 
@@ -35,21 +42,51 @@ export default function ReadAloudButton({
       ? 'Stop reading'
       : 'Read aloud'
 
+  const onClick = () => {
+    if (isBusy) {
+      stop()
+    } else {
+      void play()
+    }
+  }
+
+  if (compact) {
+    return (
+      <IconButton
+        type="button"
+        variant="outline"
+        size="medium"
+        aria-label={ariaLabel}
+        aria-busy={status === 'loading'}
+        disabled={status === 'loading'}
+        loading={status === 'loading'}
+        onClick={onClick}
+      >
+        {status === 'error' ? (
+          <TriangleAlert className="size-4 text-destructive" aria-hidden />
+        ) : status === 'playing' ? (
+          <Square className="size-4" aria-hidden />
+        ) : (
+          <Volume2 className="size-4" aria-hidden />
+        )}
+      </IconButton>
+    )
+  }
+
   return (
     <Button
       variant="outline"
       aria-label={ariaLabel}
       aria-busy={status === 'loading'}
       disabled={status === 'loading'}
-      onClick={() => {
-        if (isBusy) {
-          stop()
-        } else {
-          void play()
-        }
-      }}
+      onClick={onClick}
     >
-      {isBusy ? (
+      {status === 'error' ? (
+        <>
+          <TriangleAlert className="size-4 text-destructive" aria-hidden />
+          Try again
+        </>
+      ) : isBusy ? (
         <>
           <Square className="size-4" aria-hidden />
           {status === 'loading' ? 'Loading\u2026' : 'Stop'}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,11 @@ import RouteTracker from '@shared/scripts/RouteTrackerScript'
 import AnalyticsSessionReplayMiddleware from '@shared/AnalyticsSessionReplayMiddleware'
 
 const outfit = Outfit({ subsets: ['latin'], variable: '--outfit-font' })
-const openSans = Open_Sans({ subsets: ['latin'], variable: '--open-sans-font' })
+const openSans = Open_Sans({
+  subsets: ['latin'],
+  variable: '--open-sans-font',
+  adjustFontFallback: false,
+})
 
 const sfPro = localFont({
   // @ts-expect-error - localFont types are not correct

--- a/app/shared/briefings/renderForSpeech.test.ts
+++ b/app/shared/briefings/renderForSpeech.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { renderBriefingForSpeech } from './renderForSpeech'
+import { renderBriefingForSpeech, renderItemForSpeech } from './renderForSpeech'
 import type { Briefing, Item } from './types'
 
 const baseBriefing = (overrides: Partial<Briefing> = {}): Briefing => ({
@@ -127,6 +127,113 @@ describe('renderBriefingForSpeech', () => {
     )
     expect(text).toBe(
       'City Council meeting briefing for June 1, 2026\n\nAgenda item: Quiet item.',
+    )
+  })
+})
+
+const itemWithDisplay = (overrides: Partial<Item['display']> = {}): Item => ({
+  id: 'i-1',
+  itemNumber: '1',
+  title: 'Untitled',
+  tier: 'featured',
+  voteRequired: false,
+  tierReason: [],
+  display: {
+    summary: '',
+    constituentSentiment: null,
+    recentNews: null,
+    budgetImpact: null,
+    talkingPoints: null,
+    sourceIds: [],
+    ...overrides,
+  },
+})
+
+describe('renderItemForSpeech', () => {
+  it('joins title, summary, sentiment, budget, and talking points with single spaces', () => {
+    const item: Item = {
+      id: 'i-2',
+      itemNumber: '3',
+      title: 'Approve new park funding',
+      tier: 'featured',
+      voteRequired: true,
+      tierReason: [],
+      display: {
+        summary: 'Council will vote on a 2 million dollar park proposal.',
+        constituentSentiment: {
+          summary: 'Strong support across the district.',
+          detail: null,
+          districtNote: null,
+          haystaqColumn: 'parks',
+          meanScore: 0.7,
+          scoreDirection: 'positive',
+          voterCount: 800,
+          haystaqStatus: 'ok',
+          haystaqSource: 'curated',
+          sourceIds: [],
+        },
+        recentNews: null,
+        budgetImpact: {
+          summary: 'Adds 2 million to the capital budget.',
+          figures: [],
+          sourceIds: [],
+        },
+        talkingPoints: [
+          'Parks improve public health.',
+          'Funding comes from reserves.',
+        ],
+        sourceIds: [],
+      },
+    }
+
+    expect(renderItemForSpeech(item)).toBe(
+      'Agenda item: Approve new park funding. Council will vote on a 2 million dollar park proposal. Constituent sentiment: Strong support across the district. Budget impact: Adds 2 million to the capital budget. Talking points. Parks improve public health. Funding comes from reserves.',
+    )
+  })
+
+  it('strips markdown markers from the rendered output', () => {
+    const item = itemWithDisplay({
+      summary: '*bold* _italic_ `code` # heading > quote ~strike~',
+    })
+    item.title = 'Ordinance review'
+
+    const output = renderItemForSpeech(item)
+
+    expect(output).not.toMatch(/[*_`#>~]/)
+    expect(output).toBe(
+      'Agenda item: Ordinance review. bold italic code heading quote strike',
+    )
+  })
+
+  it('collapses internal whitespace (newlines, tabs, repeated spaces) to single spaces', () => {
+    const item = itemWithDisplay({
+      summary: 'First line.\n\nSecond\tline.   Third    line.',
+    })
+    item.title = 'Zoning update'
+
+    const output = renderItemForSpeech(item)
+
+    expect(output).not.toMatch(/\n/)
+    expect(output).not.toMatch(/\t/)
+    expect(output).not.toMatch(/ {2,}/)
+    expect(output).toBe(
+      'Agenda item: Zoning update. First line. Second line. Third line.',
+    )
+  })
+
+  it('omits optional section labels when sentiment, budget, and talking points are missing', () => {
+    const item = itemWithDisplay({
+      summary: 'Procedural items only.',
+    })
+    item.title = 'Routine consent agenda'
+
+    const output = renderItemForSpeech(item)
+
+    expect(output).not.toContain('Constituent sentiment:')
+    expect(output).not.toContain('Budget impact:')
+    expect(output).not.toContain('Talking points.')
+    expect(output).toBe(
+      'Agenda item: Routine consent agenda. Procedural items only.',
     )
   })
 })

--- a/app/shared/briefings/renderForSpeech.ts
+++ b/app/shared/briefings/renderForSpeech.ts
@@ -29,6 +29,9 @@ export const renderBriefingForSpeech = (briefing: Briefing): string => {
     .join('\n\n')
 }
 
+export const renderItemForSpeech = (item: Item): string =>
+  normalize(renderItem(item))
+
 const renderItem = (item: Item): string => {
   const parts: string[] = []
   parts.push(`Agenda item: ${item.title}.`)

--- a/app/shared/ui/ModalOrDrawer.test.tsx
+++ b/app/shared/ui/ModalOrDrawer.test.tsx
@@ -38,6 +38,7 @@ vi.mock('@styleguide/components/ui/drawer', () => ({
     className?: string
   }) => (
     <div className={className} data-slot="drawer-content">
+      <button aria-label="Close" data-slot="drawer-auto-close" />
       {children}
     </div>
   ),
@@ -48,23 +49,6 @@ vi.mock('@styleguide/components/ui/drawer', () => ({
     children: React.ReactNode
     className?: string
   }) => <h2 className={className}>{children}</h2>,
-  DrawerClose: ({
-    children,
-    onClick,
-    ...rest
-  }: {
-    children: React.ReactNode
-    onClick?: () => void
-    className?: string
-  }) => (
-    <button {...rest} onClick={onClick}>
-      {children}
-    </button>
-  ),
-}))
-
-vi.mock('@styleguide/components/ui/icons', () => ({
-  XMarkIcon: () => <span>×</span>,
 }))
 
 vi.mock('@shared/hooks/useTailwindBreakpoints', () => ({
@@ -111,7 +95,8 @@ describe('ModalOrDrawer', () => {
       )
       expect(screen.getByText('Test Title')).toBeInTheDocument()
       expect(screen.getByText('Drawer content')).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument()
+      const closeButtons = screen.getAllByRole('button', { name: /close/i })
+      expect(closeButtons).toHaveLength(1)
     },
   )
 
@@ -165,7 +150,7 @@ describe('ModalOrDrawer', () => {
         <p>Content</p>
       </ModalOrDrawer>,
     )
-    const closeButton = screen.getByRole('button', { name: /close/i })
-    expect(closeButton).toBeInTheDocument()
+    const closeButtons = screen.getAllByRole('button', { name: /close/i })
+    expect(closeButtons).toHaveLength(1)
   })
 })

--- a/app/shared/ui/ModalOrDrawer.tsx
+++ b/app/shared/ui/ModalOrDrawer.tsx
@@ -12,9 +12,7 @@ import {
   DrawerContent,
   DrawerDescription,
   DrawerTitle,
-  DrawerClose,
 } from '@styleguide/components/ui/drawer'
-import { XMarkIcon } from '@styleguide/components/ui/icons'
 
 interface ModalOrDrawerProps {
   open: boolean
@@ -51,10 +49,6 @@ export function ModalOrDrawer({
               {description}
             </DrawerDescription>
           ) : null}
-          <DrawerClose className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden">
-            <XMarkIcon />
-            <span className="sr-only">Close</span>
-          </DrawerClose>
           {children}
         </DrawerContent>
       </Drawer>

--- a/styleguide/components/ui/drawer.tsx
+++ b/styleguide/components/ui/drawer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Drawer as DrawerPrimitive } from 'vaul'
 
 import { cn } from '@styleguide/lib/utils'
+import { XMarkIcon } from './icons'
 
 function Drawer({
   ...props
@@ -63,7 +64,17 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div
+          aria-hidden
+          className="mx-auto mt-3 hidden h-1.5 w-12 shrink-0 rounded-full bg-muted-foreground/30 group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
+        />
+        <DrawerPrimitive.Close
+          className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none z-10"
+          aria-label="Close"
+        >
+          <XMarkIcon className="size-6" />
+          <span className="sr-only">Close</span>
+        </DrawerPrimitive.Close>
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/styleguide/tailwind-theme.css
+++ b/styleguide/tailwind-theme.css
@@ -26,7 +26,7 @@
   /* Font families */
   --font-outfit: var(--outfit-font);
   --font-sfpro: var(--sfpro-font);
-  --font-opensans: var(--open-sans-font);
+  --font-opensans: var(--open-sans-font), sans-serif;
   --font-geist: 'Geist', ui-sans-serif, system-ui, sans-serif;
   --font-geist-mono: 'Geist Mono', ui-monospace, monospace;
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,6 +3,12 @@ import { testQueryClient } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { beforeEach, vi } from 'vitest'
 
+if (typeof Element !== 'undefined' && !Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+  Element.prototype.releasePointerCapture = () => {}
+  Element.prototype.hasPointerCapture = () => false
+}
+
 beforeEach(() => {
   testQueryClient.clear()
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,8 +4,9 @@ import { router } from 'helpers/test-utils/router-mocking'
 import { beforeEach, vi } from 'vitest'
 
 if (typeof Element !== 'undefined' && !Element.prototype.setPointerCapture) {
-  Element.prototype.setPointerCapture = () => {}
-  Element.prototype.releasePointerCapture = () => {}
+  const noop = (): void => undefined
+  Element.prototype.setPointerCapture = noop
+  Element.prototype.releasePointerCapture = noop
   Element.prototype.hasPointerCapture = () => false
 }
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -10,6 +10,23 @@ if (typeof Element !== 'undefined' && !Element.prototype.setPointerCapture) {
   Element.prototype.hasPointerCapture = () => false
 }
 
+// jsdom's CSSStyleDeclaration returns `""` for `transform` and
+// `undefined` for the webkit/moz variants. vaul reads them via
+// `(transform || webkitTransform || mozTransform).match(...)` in drag
+// handlers, which short-circuits to `undefined` and throws. Coerce all
+// three to a real "none" string so vaul's regex match returns null
+// instead of crashing.
+if (typeof CSSStyleDeclaration !== 'undefined') {
+  for (const prop of ['transform', 'webkitTransform', 'mozTransform']) {
+    Object.defineProperty(CSSStyleDeclaration.prototype, prop, {
+      configurable: true,
+      get(): string {
+        return 'none'
+      },
+    })
+  }
+}
+
 beforeEach(() => {
   testQueryClient.clear()
 })


### PR DESCRIPTION
## Summary

Match lovable's design for the briefings UX:

- **AI chat / Add Note / Report Error → Vaul drawer.** Right-side on lg+, bottom drawer on mobile with a drag handle pill and drag-to-dismiss. Chat/footer carry `data-vaul-no-drag` so only the header area drags. Selection is cleared on open via a shared `useClearSelectionOnOpen` hook (vaul refuses to drag while text is selected).
- **Markdown-style anchored quote** in the chat header — left border, italic, no smart-quote chars wrapping the text.
- **Open Sans on chat surfaces** — disabled `next/font`'s auto-fallback so the computed family is `"Open Sans", sans-serif`, not `"Open Sans Fallback"`.
- **Mobile bottom dock rebuilt as a solid panel** — `border-t bg-sidebar/95 backdrop-blur`, single horizontal row of selector + Download + Add notes + Ask AI. No more `pointer-events-none` floating FABs.
- **Simplified read-aloud on non-priority agenda items** — `ReadAloudButton` gains a `compact` (icon-only round outline) variant with IconButton's `loading` prop for the spinner and a destructive-tinted "Try again" state on error.
- **Styleguide `DrawerContent`** now auto-injects a top-right Close button. `ModalOrDrawer` dropped its now-duplicate manual `DrawerClose`.
- **`vitest.setup.ts`** polyfills `Element.setPointerCapture` / `releasePointerCapture` / `hasPointerCapture` for jsdom + Vaul compatibility.

## Tests

124 passing across 15 files (briefings + shared/briefings + ModalOrDrawer). New red/green TDD coverage:

- `useClearSelectionOnOpen` — hook clears the live selection when `open` flips true
- `AgendaItemCard` — compact read-aloud renders only when `speechText` is provided
- `MobileBottomBar` — dock is a single solid panel containing all three controls in one row
- `ReadAloudButton` — compact + labeled variants across idle / loading / playing / error states
- `renderItemForSpeech` — exact-string join, markdown stripping, whitespace collapse, optional-section omission
- `AskAiSheet` — tightened anchored-quote assertion (`tagName === 'BLOCKQUOTE'`, exact textContent)
- `ModalOrDrawer` — `getAllByRole('button', {name:/close/i}).toHaveLength(1)` regression guard

## Test plan

- [ ] Pull, `npm run test`, expect 124 green in the affected areas
- [ ] On desktop, briefing detail page: highlight text → toolbar Ask AI → right-side drawer slides in with markdown blockquote + Open Sans font
- [ ] On mobile width, same flow: bottom drawer slides up with drag handle pill, drag down to close
- [ ] On a non-priority agenda item page, header shows the compact (round, icon-only) read-aloud control
- [ ] On mobile, bottom dock is a solid panel with selector + Download + Add notes + Ask AI in one row
- [ ] On mobile drawers, the chat body / textarea / save button are not draggable; only the header is

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI behavior changes across briefings overlays and the shared `DrawerContent` component could affect dismissal/drag interactions and close-button accessibility across the app.
> 
> **Overview**
> Aligns briefing annotation overlays with Vaul drawers: `AskAiSheet`, `AddNoteSheet`, and `ReportErrorSheet` now render as responsive drawers (right on desktop, bottom on mobile), add non-draggable body/footer regions via `data-vaul-no-drag`, and clear live text selection on open via new `useClearSelectionOnOpen`.
> 
> Improves briefing detail UX by rebuilding the mobile bottom dock into a solid panel row, adding a compact, icon-only read-aloud control to `AgendaItemCard` (wired from item pages via new `renderItemForSpeech`), and updating `ReadAloudButton` with compact + error/loading states and analytics labeling.
> 
> Updates typography and UI infrastructure: Ask AI popover/sheet opt into `font-opensans`, Open Sans fallback behavior is adjusted in `app/layout.tsx` + Tailwind theme, `DrawerContent` now auto-injects a top-right close button (removing duplicate close logic from `ModalOrDrawer`), and Vitest adds pointer-capture polyfills for Vaul compatibility; extensive new/updated tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff03bc015c364b307ac2eae2062a80fd96bdd94. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->