### PR TITLE
ENG-10229 Add hubspot attribution.

### DIFF
--- a/app/shared/utils/analytics.ts
+++ b/app/shared/utils/analytics.ts
@@ -70,10 +70,16 @@ export const identifyUser = async (
       return false
     }
 
+    const hutk = document.cookie
+      .split('; ')
+      .find((r) => r.startsWith('hubspotutk='))
+      ?.split('=')[1]
+    const enrichedTraits = hutk ? { ...traits, hutk } : traits
+
     if (userId) {
-      analyticsInstance.identify(String(userId), traits)
+      analyticsInstance.identify(String(userId), enrichedTraits)
     } else {
-      analyticsInstance.identify(traits)
+      analyticsInstance.identify(enrichedTraits)
     }
     return true
   } catch (error) {

--- a/app/shared/utils/analytics.ts
+++ b/app/shared/utils/analytics.ts
@@ -1,4 +1,5 @@
 import { AnalyticsBrowser, Analytics } from '@segment/analytics-next'
+import cookie from 'js-cookie'
 import { NEXT_PUBLIC_SEGMENT_WRITE_KEY } from 'appEnv'
 
 interface UserTraits {
@@ -70,10 +71,7 @@ export const identifyUser = async (
       return false
     }
 
-    const hutk = document.cookie
-      .split('; ')
-      .find((r) => r.startsWith('hubspotutk='))
-      ?.split('=')[1]
+    const hutk = cookie.get('hubspotutk')
     const enrichedTraits = hutk ? { ...traits, hutk } : traits
 
     if (userId) {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -572,10 +572,15 @@ export const trackRegistrationCompleted = async ({
       if (typeof analyticsInstance.ready === 'function') {
         await analyticsInstance.ready()
       }
+      const hutk = document.cookie
+        .split('; ')
+        .find((r) => r.startsWith('hubspotutk='))
+        ?.split('=')[1]
       analyticsInstance.identify(userId, {
         signUpDate,
         signUpMethod,
         ...(email ? { email } : {}),
+        ...(hutk ? { hutk } : {}),
       })
     }
   } catch (error) {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -572,10 +572,7 @@ export const trackRegistrationCompleted = async ({
       if (typeof analyticsInstance.ready === 'function') {
         await analyticsInstance.ready()
       }
-      const hutk = document.cookie
-        .split('; ')
-        .find((r) => r.startsWith('hubspotutk='))
-        ?.split('=')[1]
+      const hutk = cookie.get('hubspotutk')
       analyticsInstance.identify(userId, {
         signUpDate,
         signUpMethod,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only enriches existing `identify` payloads with a cookie-derived `hutk` value; main concern is inadvertent PII/consent implications and reliance on `document.cookie` being available client-side.
> 
> **Overview**
> Adds HubSpot attribution by extracting the `hubspotutk` cookie (`hutk`) and attaching it to Segment `identify` traits.
> 
> This is applied in both the shared `identifyUser` helper and the registration tracking flow (`trackRegistrationCompleted`), so user identification events now carry `hutk` when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbd9f1750824819ae9503b2f3f59644b7b15957. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->