### PR TITLE
Onboarding updates: top bar, copy, projection cards, styleguide cleanup

### DIFF
--- a/app/onboarding/[slug]/[step]/components/ballotOffices/RaceCard.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/RaceCard.tsx
@@ -1,5 +1,4 @@
-import { GrRadial, GrRadialSelected } from 'react-icons/gr'
-import { LoaderCircle } from 'lucide-react'
+import { Circle, CircleDot, LoaderCircle } from 'lucide-react'
 import Body2 from '@shared/typography/Body2'
 import { dateUsHelper } from 'helpers/dateHelper'
 import H5 from '@shared/typography/H5'
@@ -43,9 +42,9 @@ export default function RaceCard({
     >
       <div className="flex items-center">
         {selected ? (
-          <GrRadialSelected className="text-primary text-xl" />
+          <CircleDot className="text-primary size-5" />
         ) : (
-          <GrRadial className="text-xl text-indigo" />
+          <Circle className="text-indigo size-5" />
         )}
         {isHydrating ? (
           <LoaderCircle size={16} className="ml-2 animate-spin" />

--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -318,7 +318,7 @@ describe('OfficeSelectionStep', () => {
   it('shows an empty state until a search has been run', () => {
     renderStep()
     expect(
-      screen.getByText(/enter your zip code to see offices/i),
+      screen.getByText(/enter your zip code/i),
     ).toBeInTheDocument()
   })
 })

--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -317,8 +317,6 @@ describe('OfficeSelectionStep', () => {
 
   it('shows an empty state until a search has been run', () => {
     renderStep()
-    expect(
-      screen.getByText(/enter your zip code/i),
-    ).toBeInTheDocument()
+    expect(screen.getByText(/enter your zip code/i)).toBeInTheDocument()
   })
 })

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -190,9 +190,9 @@ const RaceListSkeleton = () => (
 )
 
 const EmptyState = ({ message }: { message: string }) => (
-  <div className="rounded-xl border border-dashed border-base-border px-4 py-8 text-center text-base text-foreground">
+  <p className="rounded-xl border border-base-border px-4 py-8 text-center text-sm text-muted-foreground">
     {message}
-  </div>
+  </p>
 )
 
 export const OfficeSelectionStep = ({
@@ -371,11 +371,11 @@ export const OfficeSelectionStep = ({
       <div className="space-y-6 text-left">
         <form noValidate onSubmit={handleSubmit}>
           <InputWithButton
-            label="Zip code"
+            label="ZIP code"
             inputMode="numeric"
             maxLength={5}
             pattern="[0-9]{5}"
-            placeholder="ZIP"
+            placeholder="Enter your ZIP code"
             value={zipInput}
             onChange={(event) =>
               setZipInput(event.target.value.replace(/\D/g, ''))
@@ -393,7 +393,7 @@ export const OfficeSelectionStep = ({
         </form>
 
         {!submittedZip && !query.isFetching ? (
-          <EmptyState message="Enter your zip code to see offices." />
+          <EmptyState message="Enter your ZIP code above to see available offices." />
         ) : null}
 
         {query.isFetching ? <RaceListSkeleton /> : null}
@@ -437,7 +437,7 @@ export const OfficeSelectionStep = ({
               <EmptyState
                 message={
                   totalOffices === 0
-                    ? "We couldn't find any offices for that ZIP. Try a different ZIP or enter your office manually below."
+                    ? "We couldn't find any offices for that ZIP code. Try a different ZIP code or enter your office manually below."
                     : activeFilter || nameFilter.trim()
                     ? 'No offices match that filter. Try clearing filters or another office type.'
                     : 'No offices available right now. Please try again or enter your office manually below.'

--- a/app/onboarding/components/OnboardingFlow.test.tsx
+++ b/app/onboarding/components/OnboardingFlow.test.tsx
@@ -91,7 +91,7 @@ describe('new onboarding flow shell', () => {
     expect(
       await screen.findByRole('heading', {
         level: 1,
-        name: /official party designation/i,
+        name: /party designation/i,
       }),
     ).toBeInTheDocument()
     expect(continueButton).toBeDisabled()

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -193,17 +193,17 @@ const welcomeCards = [
   },
 ]
 
-interface WhyWeAskProps {
+interface WhyThisMattersProps {
   text?: string
   title?: string
   children?: React.ReactNode
 }
 
-const WhyWeAsk = ({
+const WhyThisMatters = ({
   text,
   title = 'Why this matters',
   children,
-}: WhyWeAskProps): React.JSX.Element => (
+}: WhyThisMattersProps): React.JSX.Element => (
   <aside className="rounded-xl border border-base-border p-5 flex flex-col gap-2">
     <span className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
       {title}
@@ -238,7 +238,7 @@ const StepBody = ({
   onP2vMetricsResolved,
   p2vOfficeName,
   skipP2vReveal,
-}: StepBodyProps): React.JSX.Element => {
+}: StepBodyProps): React.JSX.Element | null => {
   if (activeStep.id === 'welcome') {
     return (
       <div className="space-y-8">
@@ -347,11 +347,7 @@ const StepBody = ({
     return <PledgeStep />
   }
 
-  return (
-    <div className="rounded-lg border border-base-border bg-muted p-5">
-      <p className="text-sm leading-6 text-foreground">{activeStep.summary}</p>
-    </div>
-  )
+  return null
 }
 
 export default function OnboardingFlow({
@@ -948,7 +944,7 @@ export default function OnboardingFlow({
         <div>
           <div
             className={`grid grid-cols-1 gap-8${
-              activeStep.whyWeAsk && !isP2vBlocking
+              activeStep.whyThisMatters && !isP2vBlocking
                 ? ' md:grid-cols-[minmax(0,1fr)_280px] md:items-start'
                 : ''
             }`}
@@ -994,7 +990,7 @@ export default function OnboardingFlow({
               />
             </section>
 
-            {activeStep.whyWeAsk && !isP2vBlocking ? (
+            {activeStep.whyThisMatters && !isP2vBlocking ? (
               <aside
                 className="md:fixed md:top-36 md:w-[280px]"
                 style={{
@@ -1002,7 +998,7 @@ export default function OnboardingFlow({
                 }}
               >
                 {activeStep.id === 'path-to-victory' ? (
-                  <WhyWeAsk title="You can do this!">
+                  <WhyThisMatters title="You can do this!">
                     Most candidates think they need to convince{' '}
                     <em>everyone</em>. You don&apos;t. You need to find{' '}
                     {liveCampaign?.raceTargetMetrics?.winNumber
@@ -1012,9 +1008,9 @@ export default function OnboardingFlow({
                       : 'your win number'}
                     , talk to them, and make sure they vote. We&apos;ll show you
                     exactly what that takes.
-                  </WhyWeAsk>
+                  </WhyThisMatters>
                 ) : (
-                  <WhyWeAsk text={activeStep.whyWeAsk} />
+                  <WhyThisMatters text={activeStep.whyThisMatters} />
                 )}
               </aside>
             ) : null}

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Card,
   CardContent,
-  Stepper,
 } from '@styleguide'
 import {
   CalendarCheck,
@@ -44,6 +43,7 @@ import { OfficeSelectionStep } from './OfficeSelectionStep'
 import { ManualOfficeEntryStep } from './ManualOfficeEntryStep'
 import { PathToVictoryStep } from './PathToVictoryStep'
 import { PledgeStep } from './PledgeStep'
+import OnboardingTopBar from '../shared/OnboardingTopBar'
 import {
   VoterDemographicsStep,
   onboardingDistrictStatsQueryOptions,
@@ -931,16 +931,11 @@ export default function OnboardingFlow({
 
   return (
     <div className="min-h-screen bg-base-surface pb-28 text-foreground">
-      <div className="fixed top-14 left-0 right-0 z-10 border-b border-slate-100 bg-base-surface">
-        <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-8">
-          <Stepper
-            variant="bar"
-            currentStep={activeStepNumber}
-            totalSteps={visibleSteps.length}
-          />
-        </div>
-      </div>
-      <main className="mx-auto w-full max-w-4xl px-4 pt-28 pb-6 sm:px-8 sm:pb-8">
+      <OnboardingTopBar
+        currentStep={activeStepNumber}
+        totalSteps={visibleSteps.length}
+      />
+      <main className="mx-auto w-full max-w-4xl px-4 pt-32 pb-6 sm:px-8 sm:pt-36 sm:pb-8">
         <div>
           <div
             className={`grid grid-cols-1 gap-8${

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -1,12 +1,6 @@
 'use client'
 
-import {
-  Alert,
-  AlertDescription,
-  Button,
-  Card,
-  CardContent,
-} from '@styleguide'
+import { Alert, AlertDescription, Button, Card, CardContent } from '@styleguide'
 import {
   CalendarCheck,
   CircleAlert,

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -973,17 +973,6 @@ export default function OnboardingFlow({
                         </span>
                         .
                       </>
-                    ) : activeStep.id === 'voter-demographics' &&
-                      p2vOfficeName ? (
-                      <>
-                        We crunch the latest voter data, along with proprietary
-                        behavior models, and local news to prioritize the issues
-                        voters care about for{' '}
-                        <span className="font-semibold text-foreground">
-                          {p2vOfficeName}
-                        </span>
-                        .
-                      </>
                     ) : (
                       activeStep.description
                     )}

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -935,7 +935,7 @@ export default function OnboardingFlow({
         currentStep={activeStepNumber}
         totalSteps={visibleSteps.length}
       />
-      <main className="mx-auto w-full max-w-4xl px-4 pt-32 pb-6 sm:px-8 sm:pt-36 sm:pb-8">
+      <main className="mx-auto w-full max-w-4xl px-4 pt-24 pb-6 sm:px-8 sm:pt-28 sm:pb-8">
         <div>
           <div
             className={`grid grid-cols-1 gap-8${
@@ -987,7 +987,7 @@ export default function OnboardingFlow({
 
             {activeStep.whyThisMatters && !isP2vBlocking ? (
               <aside
-                className="md:fixed md:top-36 md:w-[280px]"
+                className="md:fixed md:top-28 md:w-[280px]"
                 style={{
                   right: 'max(2rem, calc((100vw - 56rem) / 2 + 2rem))',
                 }}
@@ -1013,8 +1013,8 @@ export default function OnboardingFlow({
         </div>
       </main>
 
-      <div className="fixed inset-x-0 bottom-0 border-t border-base-border bg-base-surface">
-        <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between px-4 sm:px-8">
+      <div className="fixed inset-x-0 bottom-0 bg-base-surface">
+        <div className="mx-auto flex h-20 w-full max-w-4xl items-center justify-between px-4 sm:px-8 border-t border-base-border">
           <Button
             type="button"
             variant="ghost"

--- a/app/onboarding/components/PathToVictoryStep.tsx
+++ b/app/onboarding/components/PathToVictoryStep.tsx
@@ -273,7 +273,7 @@ const WinNumberHeroCard = ({
         <p className="text-base font-semibold text-foreground">{officeName}</p>
         <p className="pt-2 text-xs text-muted-foreground">
           Projected range:{' '}
-          <span className="font-semibold text-foreground">
+          <span className="font-semibold">
             {numberFormatter(lowEstimate)}–{numberFormatter(highEstimate)}
           </span>{' '}
           (~95% confidence)
@@ -297,14 +297,14 @@ const ProjectionStep = ({
   value,
 }: ProjectionStepProps): React.JSX.Element => (
   <li className="flex items-start gap-4 rounded-xl border border-base-border p-4">
-    <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+    <span className="flex size-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold bg-blue-50 text-components-input-active">
       {index}
     </span>
     <div className="flex-1">
-      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <p className="text-base font-semibold text-foreground">{title}</p>
       <p className="text-xs text-muted-foreground">{description}</p>
     </div>
-    <span className="text-base font-bold text-foreground">{value}</span>
+    <span className="text-base font-semibold text-foreground">{value}</span>
   </li>
 )
 

--- a/app/onboarding/components/PledgeStep.tsx
+++ b/app/onboarding/components/PledgeStep.tsx
@@ -25,7 +25,7 @@ const PLEDGE_ITEMS = [
 export const PledgeStep = (): React.JSX.Element => (
   <Card className="rounded-2xl border-base-border shadow-none">
     <CardContent className="space-y-6 px-6 py-4 sm:px-8 sm:py-5">
-      <p className="text-xl font-bold leading-[1.08] text-foreground">
+      <p className="text-2xl sm:text-3xl font-bold leading-[1.08] text-foreground">
         I pledge to be...
       </p>
 

--- a/app/onboarding/components/onboardingConfig.ts
+++ b/app/onboarding/components/onboardingConfig.ts
@@ -74,7 +74,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'path-to-victory',
-    title: "Projected votes needed to win",
+    title: 'Projected votes needed to win',
     description:
       'We use historical voter data and proprietary models to get the most accurate projections for your race.',
     whyThisMatters:
@@ -83,7 +83,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'voter-demographics',
-    title: "Voter insights for your district",
+    title: 'Voter insights for your district',
     description:
       'We use survey and voter data along with your district demographics to project likely top issues for your race.',
     whyThisMatters:
@@ -93,8 +93,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'pledge',
     title: 'Almost there...',
-    description:
-      'Take our pledge to get your campaign plan.',
+    description: 'Take our pledge to get your campaign plan.',
   },
 ]
 

--- a/app/onboarding/components/onboardingConfig.ts
+++ b/app/onboarding/components/onboardingConfig.ts
@@ -3,34 +3,25 @@ import type { OnboardingStepConfig, NonEmptyArray } from './onboardingTypes'
 export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'welcome',
-    eyebrow: 'Campaign plan setup',
     title: "Let's build your winning campaign plan in 5 minutes",
     description:
       "All we need to know is what office you're running for. We'll take it from there.",
-    summary:
-      'This step introduces the value of the flow before collecting candidate details.',
   },
   {
     id: 'ballot-status',
-    eyebrow: 'Candidate status',
     title: 'Are you already on the ballot?',
     description:
       'We tailor your strategy to where you actually are in your campaign.',
-    summary:
-      'The answer is stored in onboarding state and can be submitted with the final payload.',
-    whyWeAsk:
+    whyThisMatters:
       'Knowing whether you’re already on the ballot lets us tailor your timeline and the next steps in your campaign plan.',
     isValid: ({ answers }) => Boolean(answers.ballotStatus),
   },
   {
     id: 'party-affiliation',
-    eyebrow: 'Candidate eligibility',
     title: 'Are you running with a party designation?',
     description:
       'Pick the party label voters would see on their official ballots for you as a candidate, not your personal voting history or party preference.',
-    summary:
-      'Eligible candidates continue; major-party candidates will be blocked by this step implementation.',
-    whyWeAsk:
+    whyThisMatters:
       'GoodParty.org only works with non-partisan candidates or those who are independent of both major parties and big money, so they can run, win and serve empowered by our verifiably anti-corrupt platform.',
     isValid: ({ answers }) =>
       answers.partyAffiliation === 'nonpartisan' ||
@@ -38,26 +29,20 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'office-selection',
-    eyebrow: 'Office selection',
     title: 'What office are you running for?',
     description:
       "We'll use this to pull local voter data and shape your plan around your race.",
-    summary:
-      'Structured office selection feeds Path to Victory. Manual office entry follows a shorter path.',
-    whyWeAsk:
+    whyThisMatters:
       "We use this to find the district you're running in, pull registered voter data, historical voter turnout, partisan data, and local issues to build your campaign plan.",
     isValid: ({ answers }) =>
       Boolean(answers.structuredOffice) || answers.officePath === 'manual',
   },
   {
     id: 'manual-office-entry',
-    eyebrow: 'Office details',
     title: 'Tell us about your office',
     description:
       "We couldn't find a structured match. Enter your office details and our team will follow up.",
-    summary:
-      'The manualOffice and unmatchedOffice flags are stored in onboarding state.',
-    whyWeAsk:
+    whyThisMatters:
       'We capture your office details manually so we can still generate a tailored campaign plan, even without structured election data.',
     shouldSkip: ({ answers }) => answers.officePath !== 'manual',
     isValid: ({ answers }) => {
@@ -89,36 +74,27 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   },
   {
     id: 'path-to-victory',
-    eyebrow: 'Vote goal',
     title: "Projected votes needed to win",
     description:
       'We use historical voter data and proprietary models to get the most accurate projections for your race.',
-    summary:
-      'Manual-office users skip this step because the required structured election data is unavailable.',
-    whyWeAsk:
+    whyThisMatters:
       "Most candidates think they need to convince everyone. You don't. You need to find your win number, talk to them, and make sure they vote. We'll show you exactly what that takes.",
     shouldSkip: ({ answers }) => answers.officePath === 'manual',
   },
   {
     id: 'voter-demographics',
-    eyebrow: 'Voter demographics',
     title: "Voter insights for your district",
     description:
       'We use survey and voter data along with your district demographics to project likely top issues for your race.',
-    summary:
-      'Voter demographic charts are rendered from the structured-office district stats.',
-    whyWeAsk:
+    whyThisMatters:
       'We use this data to help you understand what voters care most about, and to customize your campaign plan.',
     shouldSkip: ({ answers }) => answers.officePath === 'manual',
   },
   {
     id: 'pledge',
-    eyebrow: 'Final step',
     title: 'Almost there...',
     description:
       'Take our pledge to get your campaign plan.',
-    summary:
-      'The final payload keeps collected answers available for future integrations.',
   },
 ]
 

--- a/app/onboarding/components/onboardingConfig.ts
+++ b/app/onboarding/components/onboardingConfig.ts
@@ -6,7 +6,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
     eyebrow: 'Campaign plan setup',
     title: "Let's build your winning campaign plan in 5 minutes",
     description:
-      "All we need to know is what office you're running for and where, and we'll take it from there",
+      "All we need to know is what office you're running for. We'll take it from there.",
     summary:
       'This step introduces the value of the flow before collecting candidate details.',
   },
@@ -25,9 +25,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'party-affiliation',
     eyebrow: 'Candidate eligibility',
-    title: 'Are you running with an official party designation?',
+    title: 'Are you running with a party designation?',
     description:
-      'Party designation determines whether you can continue with GoodParty.org support.',
+      'Pick the party label voters would see on their official ballots for you as a candidate, not your personal voting history or party preference.',
     summary:
       'Eligible candidates continue; major-party candidates will be blocked by this step implementation.',
     whyWeAsk:
@@ -41,7 +41,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
     eyebrow: 'Office selection',
     title: 'What office are you running for?',
     description:
-      "We'll use this to analyze local voter data, trends, & news to create your campaign plan.",
+      "We'll use this to pull local voter data and shape your plan around your race.",
     summary:
       'Structured office selection feeds Path to Victory. Manual office entry follows a shorter path.',
     whyWeAsk:
@@ -90,7 +90,7 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'path-to-victory',
     eyebrow: 'Vote goal',
-    title: "Here's how many votes you need to win",
+    title: "Projected votes needed to win",
     description:
       'We use historical voter data and proprietary models to get the most accurate projections for your race.',
     summary:
@@ -102,9 +102,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'voter-demographics',
     eyebrow: 'Voter demographics',
-    title: "Here's everything to know about your voters",
+    title: "Voter insights for your district",
     description:
-      'We crunch the latest voter data, along with proprietary behavior models, to give you a snapshot of who lives, votes, and pays attention in your community.',
+      'We use survey and voter data along with your district demographics to project likely top issues for your race.',
     summary:
       'Voter demographic charts are rendered from the structured-office district stats.',
     whyWeAsk:
@@ -114,9 +114,9 @@ export const ONBOARDING_STEPS: NonEmptyArray<OnboardingStepConfig> = [
   {
     id: 'pledge',
     eyebrow: 'Final step',
-    title: 'Take our pledge to get your campaign plan',
+    title: 'Almost there...',
     description:
-      'We only work with candidates who are independent of both major parties, big-money influence, and are anti-corruption.',
+      'Take our pledge to get your campaign plan.',
     summary:
       'The final payload keeps collected answers available for future integrations.',
   },

--- a/app/onboarding/components/onboardingTypes.ts
+++ b/app/onboarding/components/onboardingTypes.ts
@@ -74,11 +74,9 @@ export interface OnboardingStepContext {
 
 export interface OnboardingStepConfig {
   id: OnboardingStepId
-  eyebrow: string
   title: string
   description: string
-  summary: string
-  whyWeAsk?: string
+  whyThisMatters?: string
   shouldSkip?: (context: OnboardingStepContext) => boolean
   isValid?: (context: OnboardingStepContext) => boolean
 }

--- a/app/onboarding/shared/OnboardingTopBar.tsx
+++ b/app/onboarding/shared/OnboardingTopBar.tsx
@@ -1,0 +1,31 @@
+import { GoodPartyOrgLogo, Stepper } from '@styleguide'
+
+interface OnboardingTopBarProps {
+  currentStep: number
+  totalSteps: number
+}
+
+const OnboardingTopBar = ({
+  currentStep,
+  totalSteps,
+}: OnboardingTopBarProps): React.JSX.Element => (
+  <div className="fixed top-0 inset-x-0 z-10 border-b border-base-border bg-base-surface">
+    <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-8 sm:py-5">
+      <div className="flex items-center justify-between">
+        <GoodPartyOrgLogo />
+        <span className="text-sm font-medium text-muted-foreground">
+          Step {currentStep} of {totalSteps}
+        </span>
+      </div>
+      <Stepper
+        variant="bar"
+        showLabel={false}
+        currentStep={currentStep}
+        totalSteps={totalSteps}
+        className="mt-4"
+      />
+    </div>
+  </div>
+)
+
+export default OnboardingTopBar

--- a/app/onboarding/shared/OnboardingTopBar.tsx
+++ b/app/onboarding/shared/OnboardingTopBar.tsx
@@ -11,7 +11,7 @@ const OnboardingTopBar = ({
 }: OnboardingTopBarProps): React.JSX.Element => (
   <div className="fixed top-0 inset-x-0 z-10 border-b border-base-border bg-base-surface">
     <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-8 sm:py-5">
-      <div className="flex items-center justify-between">
+      <div className="flex items-end justify-between">
         <GoodPartyOrgLogo />
         <span className="text-sm font-medium text-muted-foreground">
           Step {currentStep} of {totalSteps}

--- a/app/onboarding/shared/OnboardingTopBar.tsx
+++ b/app/onboarding/shared/OnboardingTopBar.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useEffect, useState } from 'react'
 import { GoodPartyOrgLogo, Stepper } from '@styleguide'
 
 interface OnboardingTopBarProps {
@@ -8,24 +11,39 @@ interface OnboardingTopBarProps {
 const OnboardingTopBar = ({
   currentStep,
   totalSteps,
-}: OnboardingTopBarProps): React.JSX.Element => (
-  <div className="fixed top-0 inset-x-0 z-10 border-b border-base-border bg-base-surface">
-    <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-8 sm:py-5">
-      <div className="flex items-end justify-between">
-        <GoodPartyOrgLogo />
-        <span className="text-sm font-medium text-muted-foreground">
-          Step {currentStep} of {totalSteps}
-        </span>
+}: OnboardingTopBarProps): React.JSX.Element => {
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 0)
+    handleScroll()
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <div className="fixed top-0 inset-x-0 z-10 bg-base-surface">
+      <div
+        className={`mx-auto w-full max-w-4xl px-4 py-4 sm:px-8 sm:py-5 border-b transition-colors ${
+          scrolled ? 'border-base-border' : 'border-transparent'
+        }`}
+      >
+        <div className="flex items-end justify-between">
+          <GoodPartyOrgLogo />
+          <span className="text-sm font-medium text-muted-foreground">
+            Step {currentStep} of {totalSteps}
+          </span>
+        </div>
+        <Stepper
+          variant="bar"
+          showLabel={false}
+          currentStep={currentStep}
+          totalSteps={totalSteps}
+          className="mt-4"
+        />
       </div>
-      <Stepper
-        variant="bar"
-        showLabel={false}
-        currentStep={currentStep}
-        totalSteps={totalSteps}
-        className="mt-4"
-      />
     </div>
-  </div>
-)
+  )
+}
 
 export default OnboardingTopBar

--- a/app/polls/onboarding/components/NumberInsight.tsx
+++ b/app/polls/onboarding/components/NumberInsight.tsx
@@ -28,7 +28,7 @@ export const NumberInsight = ({
       <CardContent>
         <div className="flex items-center justify-between">
           <p>{title}</p>
-          <div className="text-lg text-slate-600 ">{icon}</div>
+          <div className="text-slate-600 [&_svg]:size-5">{icon}</div>
         </div>
         {showSkeleton && (
           <div className="mt-3 h-8 w-40 rounded bg-slate-100 animate-pulse" />

--- a/app/shared/layouts/navigation/Nav.tsx
+++ b/app/shared/layouts/navigation/Nav.tsx
@@ -8,15 +8,14 @@ import { usePathname } from 'next/navigation'
 
 const Nav = (): React.JSX.Element => {
   const pathname = usePathname()
-  const isDashboardPath = pathname?.startsWith('/dashboard')
+  const hideGlobalNav =
+    pathname?.startsWith('/dashboard') || pathname?.startsWith('/onboarding')
 
   return (
     <>
       <div
         id="top-nav"
-        className={`fixed w-screen h-14 z-50${
-          isDashboardPath ? ' hidden' : ''
-        }`}
+        className={`fixed w-screen h-14 z-50${hideGlobalNav ? ' hidden' : ''}`}
       >
         <div className="relative bg-indigo-50 lg:block border-solid border-b border-zinc-200 px-5 lg:px-8 z-50 h-14">
           <div
@@ -26,16 +25,16 @@ const Nav = (): React.JSX.Element => {
             <div className="flex items-center">
               <HeaderLogo />
 
-              {!isDashboardPath && <LeftSide />}
+              {!hideGlobalNav && <LeftSide />}
             </div>
-            {!isDashboardPath && <RightSide />}
+            {!hideGlobalNav && <RightSide />}
           </div>
         </div>
       </div>
-      {!isDashboardPath && <RightSideMobile />}
+      {!hideGlobalNav && <RightSideMobile />}
       <div
         id="top-nav-spacer"
-        className={`h-14 relative${isDashboardPath ? ' hidden' : ''}`}
+        className={`h-14 relative${hideGlobalNav ? ' hidden' : ''}`}
       >
         &nbsp;
       </div>

--- a/e2e-tests/tests/core/auth/custom-office.spec.ts
+++ b/e2e-tests/tests/core/auth/custom-office.spec.ts
@@ -69,9 +69,10 @@ test.describe('Custom office flow', () => {
     await expect(continueButton).toBeEnabled()
     await continueButton.click()
 
-    // Manual flow skips P2V/voter-demographics; lands on the pledge step.
+    // Manual flow skips P2V/voter-demographics; lands on the pledge step
+    // (H1 reads "Almost there..." since the renamed copy).
     await expect(
-      page.getByRole('heading', { level: 1, name: /pledge/i }),
+      page.getByRole('heading', { level: 1, name: /almost there/i }),
     ).toBeVisible({ timeout: 15000 })
 
     type OrganizationsResponse = {

--- a/e2e-tests/tests/core/auth/onboarding.spec.ts
+++ b/e2e-tests/tests/core/auth/onboarding.spec.ts
@@ -113,7 +113,7 @@ async function completeOfficeSelectionStep(page: Page): Promise<void> {
 async function completePathToVictoryStep(page: Page): Promise<void> {
   console.log('Step: Path to victory')
   await expect(
-    page.getByRole('heading', { level: 1, name: /votes you need/i }),
+    page.getByRole('heading', { level: 1, name: /votes needed to win/i }),
   ).toBeVisible({ timeout: 30000 })
   // Wait for the metrics card to render before continuing.
   await expect(page.getByText(/votes needed to win/i).first()).toBeVisible({

--- a/e2e-tests/tests/core/auth/onboarding.spec.ts
+++ b/e2e-tests/tests/core/auth/onboarding.spec.ts
@@ -80,7 +80,7 @@ async function completePartyAffiliationStep(page: Page): Promise<void> {
   await expect(
     page.getByRole('heading', {
       level: 1,
-      name: /official party designation/i,
+      name: /party designation/i,
     }),
   ).toBeVisible()
   await page.getByRole('radio').first().click({ force: true })

--- a/e2e-tests/tests/core/auth/onboarding.spec.ts
+++ b/e2e-tests/tests/core/auth/onboarding.spec.ts
@@ -125,7 +125,7 @@ async function completePathToVictoryStep(page: Page): Promise<void> {
 async function completeVoterDemographicsStep(page: Page): Promise<void> {
   console.log('Step: Voter demographics')
   await expect(
-    page.getByRole('heading', { level: 1, name: /your voters/i }),
+    page.getByRole('heading', { level: 1, name: /voter insights/i }),
   ).toBeVisible({ timeout: 15000 })
   await clickContinue(page)
 }
@@ -133,7 +133,7 @@ async function completeVoterDemographicsStep(page: Page): Promise<void> {
 async function completePledgeStep(page: Page): Promise<void> {
   console.log('Step: Pledge')
   await expect(
-    page.getByRole('heading', { level: 1, name: /pledge/i }),
+    page.getByRole('heading', { level: 1, name: /almost there/i }),
   ).toBeVisible()
   const submit = page
     .getByRole('button', { name: /agree.*create my plan/i })

--- a/styleguide/components/ui/badge.tsx
+++ b/styleguide/components/ui/badge.tsx
@@ -13,7 +13,7 @@ const badgeVariants = cva(
           'border-transparent bg-primary text-white [a&]:hover:bg-primary/90',
         secondary:
           'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
-        soft: 'border-transparent bg-muted text-muted-foreground [a&]:hover:bg-muted/70',
+        soft: 'border-transparent bg-grayscale-200 text-foreground [a&]:hover:bg-grayscale-200/70',
         destructive:
           'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:

--- a/styleguide/components/ui/good-party-org-logo-wordmark.tsx
+++ b/styleguide/components/ui/good-party-org-logo-wordmark.tsx
@@ -1,9 +1,11 @@
+import { cn } from '@styleguide/lib/utils'
+
 interface GoodPartyOrgLogoWordmarkProps {
   className?: string
   /**
    * Visual size of the word-mark (applies Tailwind width/height utilities).
    * – small  : 149 × 20
-   * – default: 208 × 28 (base)
+   * – default: 208 × 28
    * – large  : 313 × 42
    * – xl     : 500 × 67
    */
@@ -14,6 +16,13 @@ interface GoodPartyOrgLogoWordmarkProps {
   textVariant?: 'light' | 'dark'
 }
 
+const sizeClasses = {
+  small: 'w-[149px] h-[20px]',
+  default: 'w-[208px] h-[28px]',
+  large: 'w-[313px] h-[42px]',
+  xl: 'w-[500px] h-[67px]',
+} as const
+
 export const GoodPartyOrgLogoWordmark = ({
   className = '',
   size = 'default',
@@ -21,17 +30,10 @@ export const GoodPartyOrgLogoWordmark = ({
 }: GoodPartyOrgLogoWordmarkProps) => {
   const textFill = textVariant === 'dark' ? '#000000' : '#FFFFFF'
 
-  const sizeClasses = {
-    small: 'w-[149px] h-[20px]',
-    default: 'w-[208px] h-[28px] lg:w-[313px] lg:h-[42px]',
-    large: 'w-[313px] h-[42px]',
-    xl: 'w-[500px] h-[67px]',
-  } as const
-
   return (
     <svg
       data-slot="good-party-org-logo-wordmark"
-      className={`${sizeClasses[size]} ${className}`}
+      className={cn(sizeClasses[size], className)}
       viewBox="0 0 967 130"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/styleguide/components/ui/good-party-org-logo.tsx
+++ b/styleguide/components/ui/good-party-org-logo.tsx
@@ -1,11 +1,31 @@
+import { cn } from '@styleguide/lib/utils'
+
 interface GoodPartyOrgLogoProps {
   className?: string
+  /**
+   * Visual size of the logo (applies Tailwind width/height utilities).
+   * – small  : 24 × 20
+   * – default: 34 × 28
+   * – large  : 50 × 42
+   * – xl     : 80 × 67
+   */
+  size?: 'small' | 'default' | 'large' | 'xl'
 }
 
-export const GoodPartyOrgLogo = ({ className = '' }: GoodPartyOrgLogoProps) => (
+const sizeClasses = {
+  small: 'w-6 h-5',
+  default: 'w-[34px] h-[28px]',
+  large: 'w-[50px] h-[42px]',
+  xl: 'w-20 h-[67px]',
+} as const
+
+export const GoodPartyOrgLogo = ({
+  className = '',
+  size = 'default',
+}: GoodPartyOrgLogoProps) => (
   <svg
     data-slot="good-party-org-logo"
-    className={`w-[34px] h-[28px] lg:w-[50px] lg:h-[42px] ${className}`}
+    className={cn(sizeClasses[size], className)}
     viewBox="0 0 160 130"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/styleguide/stories/GoodPartyOrgLogo.stories.tsx
+++ b/styleguide/stories/GoodPartyOrgLogo.stories.tsx
@@ -28,19 +28,19 @@ export const DifferentSizes: Story = {
     <div className="flex flex-col gap-6 items-center">
       <div className="flex flex-col items-center gap-2">
         <h3 className="text-sm font-medium">Small (24px)</h3>
-        <GoodPartyOrgLogo className="w-6 h-5" />
+        <GoodPartyOrgLogo size="small" />
       </div>
       <div className="flex flex-col items-center gap-2">
         <h3 className="text-sm font-medium">Default (34px × 28px)</h3>
-        <GoodPartyOrgLogo />
+        <GoodPartyOrgLogo size="default" />
       </div>
       <div className="flex flex-col items-center gap-2">
         <h3 className="text-sm font-medium">Large (50px × 42px)</h3>
-        <GoodPartyOrgLogo className="w-[50px] h-[42px]" />
+        <GoodPartyOrgLogo size="large" />
       </div>
       <div className="flex flex-col items-center gap-2">
         <h3 className="text-sm font-medium">Extra Large (80px × 67px)</h3>
-        <GoodPartyOrgLogo className="w-20 h-[67px]" />
+        <GoodPartyOrgLogo size="xl" />
       </div>
     </div>
   ),


### PR DESCRIPTION
## Summary

- Replace the two stacked fixed bars (global Nav + stepper-only bar) with a single `OnboardingTopBar` component: heart logo on the left, "Step N of M" on the right, progress pills underneath. Hide the global Nav on `/onboarding/*` the same way it's already hidden on `/dashboard/*`.
- Reveal the top bar's bottom divider only after scroll, and constrain both top + bottom fixed-nav dividers to the `max-w-4xl` content column instead of spanning the viewport.
- Rework onboarding step titles/subtitles to plan-style framing ("Projected votes needed to win", "Voter insights for your district", "Almost there..." for pledge), tighten the welcome / office-selection / party-affiliation copy, and add a ballot-facing clarification to the party-affiliation subtitle.
- Drop unused step fields (`eyebrow`, `summary`) from `OnboardingStepConfig` + every step. Rename `whyWeAsk` → `whyThisMatters` (field, component, interface). Remove the unreachable fallback render path in `OnboardingFlow.StepBody`.
- Restyle the path-to-victory projection-step cards: branded blue numeric badge instead of muted chip, bigger title hierarchy, refined projected-range copy.
- `OfficeSelectionStep`: defuse `EmptyState` styling — solid border + muted text + smaller type so empty states stop reading as drop-zones / click areas.
- `PledgeStep`: bump "I pledge to be..." intro to `text-2xl sm:text-3xl` so it sits visually above the per-item headings.

## Styleguide changes

- `GoodPartyOrgLogo`: add `size` prop (`small | default | large | xl`) mirroring the wordmark API; switch className composition to `cn()` so consumer overrides actually win.
- `GoodPartyOrgLogo` + `GoodPartyOrgLogoWordmark`: drop the responsive `default` size that silently scaled to `large` dimensions at `lg+`. Named sizes are now flat.
- `Badge` `soft` variant: swap `bg-muted/text-muted-foreground` for `bg-grayscale-200/text-foreground` so the chip reads against the page surface instead of dissolving into it.
- `RaceCard` + `NumberInsight`: lucide-only inside `app/onboarding/*` (drop `react-icons/gr` usage in RaceCard; size the NumberInsight icon slot internally so consumers don't need to remember to size lucide icons).

## Test plan

- [x] `npm run test` — 522/522 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: walk through onboarding flow end-to-end on desktop and mobile widths, verify the new top bar, scroll-aware divider, step copy, pledge intro, and projection-step card styling
- [ ] Manual: confirm global Nav stays hidden on `/onboarding/*` and visible on `/login`, `/sign-up`, etc.
- [ ] Manual: verify `OfficeSelectionStep` empty states (no-zip, no-results, error) render the new solid-border + muted-text style and no longer feel clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures the onboarding shell (new fixed top bar, step config schema changes) and updates navigation visibility, which could regress step rendering/progression and layout across routes.
> 
> **Overview**
> **Onboarding flow UI is refactored** by replacing the fixed stepper bar with a new `OnboardingTopBar` (logo + "Step N of M" + progress bar) and hiding the global `Nav` on `/onboarding/*` routes.
> 
> **Step configuration is simplified and renamed** by removing `eyebrow`/`summary`, renaming `whyWeAsk` to `whyThisMatters`, and updating step titles/descriptions; `OnboardingFlow` is updated accordingly (including dropping the fallback step body render) and tests are adjusted for the new copy.
> 
> **Visual polish updates**: restyles `OfficeSelectionStep` empty states and ZIP input copy, tweaks `PathToVictoryStep` projection cards/typography, bumps `PledgeStep` heading size, and swaps onboarding `RaceCard` selection icons to `lucide-react`.
> 
> **Styleguide tweaks**: adds a `size` prop to `GoodPartyOrgLogo` (and flattens sizing behavior for logo/wordmark via `cn()` class merging), updates `Badge` `soft` colors, and standardizes icon sizing in `NumberInsight`; Storybook stories are updated to use the new logo sizing API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a12bf247173f92acb3dfa52d147f04094cd46c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->