### PR TITLE
ci(update-snapshots): commit regenerated baselines even when other tests fail

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -129,6 +129,7 @@ jobs:
       # test failures (network, auth, flakes) should not block the commit of
       # updated baselines.
       - name: Run tests with --update-snapshots
+        id: run_tests
         working-directory: e2e-tests
         run: npx playwright test --update-snapshots
         continue-on-error: true
@@ -173,7 +174,7 @@ jobs:
             });
 
       - name: React when no snapshot changes were needed
-        if: steps.commit.outputs.committed == 'false'
+        if: steps.commit.outputs.committed == 'false' && steps.run_tests.outcome == 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -189,6 +190,25 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: 'ℹ️ No snapshot changes needed — visual baselines are already up to date.'
+            });
+
+      - name: React when tests failed but no snapshots changed
+        if: steps.commit.outputs.committed == 'false' && steps.run_tests.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'confused'
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⚠️ Tests failed and no snapshots were updated. [View logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})'
             });
 
       - name: React with failure

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -124,9 +124,14 @@ jobs:
         working-directory: e2e-tests
         run: npx playwright install --with-deps chromium
 
+      # Always proceed to the commit step, even if some tests fail. The
+      # purpose of this workflow is to regenerate visual snapshots — unrelated
+      # test failures (network, auth, flakes) should not block the commit of
+      # updated baselines.
       - name: Run tests with --update-snapshots
         working-directory: e2e-tests
         run: npx playwright test --update-snapshots
+        continue-on-error: true
         env:
           BASE_URL: ${{ steps.preview.outputs.url }}
           TEST_RUN_NAME: "Update Visual Snapshots"
@@ -134,19 +139,22 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
 
       - name: Commit updated baselines
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add e2e-tests/tests/__visual_snapshots__
           if git diff --cached --quiet; then
             echo "No snapshot changes to commit"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: update visual snapshots from CI"
             git push origin HEAD:${{ steps.pr.outputs.branch }}
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: React with success
-        if: success()
+      - name: React when snapshots were committed
+        if: steps.commit.outputs.committed == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -162,6 +170,25 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: '✅ Visual snapshots have been updated and pushed to this branch.'
+            });
+
+      - name: React when no snapshot changes were needed
+        if: steps.commit.outputs.committed == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'ℹ️ No snapshot changes needed — visual baselines are already up to date.'
             });
 
       - name: React with failure


### PR DESCRIPTION
## Summary

The \`/update-snapshots\` workflow regenerates visual snapshots by running Playwright with \`--update-snapshots\`. Previously, the workflow halted before the commit step if any test failed for *any* reason — including unrelated network timeouts, auth-token flakes, and persistently-broken tests. The regenerated baseline PNGs were stranded on the CI runner and not recoverable from the uploaded artifact (which only includes \`playwright-report/\` and \`test-results/\`, not \`tests/__visual_snapshots__/\`).

This came up on PR #1855 where the visual contacts-page baseline needs to be regenerated after switching the body font to Open Sans, but \`/update-snapshots\` keeps failing because the \`website.spec.ts\` test has a persistent environmental failure unrelated to the snapshot work.

## What changed

\`.github/workflows/update-snapshots.yml\`:

- **\`continue-on-error: true\` on the test step** so the workflow always reaches the commit step. The purpose of this workflow is to regenerate visual snapshots; unrelated test failures should not block the commit of updated baselines.
- **\`id: commit\` + \`committed=true|false\` output** on the commit step so downstream steps can tell whether anything was actually pushed.
- **Split the prior single success reaction into two states**:
  - \`committed=true\` → 🚀 + "Visual snapshots have been updated and pushed"
  - \`committed=false\` → 👍 + "No snapshot changes needed — visual baselines are already up to date"

  Previously the workflow posted "updated and pushed" in both cases, which was misleading when no commit actually happened.
- **Failure reaction is unchanged** (still fires via \`failure()\` for genuine infrastructure failures — no preview URL, npm install error, git push error).

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| All tests pass, snapshots updated | ✅ Committed + "updated" | ✅ Committed + "updated" (same) |
| All tests pass, no snapshots needed | ❌ "✅ updated and pushed" (lies — nothing pushed) | ℹ️ "No changes needed" (accurate) |
| Some test fails, snapshots updated | ❌ "Failed" (blocks PR — the bug) | ✅ Committed + "updated" |
| Some test fails, no snapshots needed | ❌ "Failed" | ℹ️ "No changes needed" |
| Infra failure (no preview, npm, git push) | ❌ "Failed" | ❌ "Failed" (same) |

## Test plan

- [x] YAML syntax valid
- [ ] After merge, comment \`/update-snapshots\` on PR #1855 → contacts visual baseline should commit + push back even though website-builder test fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change confined to the `update-snapshots` workflow, but it may now push snapshot updates even when the Playwright run had failures, so reviewers should confirm this is intended behavior.
> 
> **Overview**
> The `/update-snapshots` GitHub Actions workflow now runs Playwright with `continue-on-error: true` so regenerated visual snapshots can still be committed/pushed even if some tests fail.
> 
> It adds a `committed=true|false` output to the commit step and updates comment reactions to reflect three outcomes: snapshots pushed, no snapshot changes needed (with passing tests), or tests failed with no snapshot changes (linking to logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26669b66ee8708da2e4ed094f279356cd99ab0f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->