### PR TITLE
styleguide(sidebar): drop the page-title header from the story

### DIFF
--- a/styleguide/stories/Sidebar.stories.tsx
+++ b/styleguide/stories/Sidebar.stories.tsx
@@ -30,7 +30,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
-  SidebarTrigger,
 } from '../components/ui/sidebar'
 
 const meta: Meta<typeof Sidebar> = {
@@ -171,10 +170,6 @@ function SidebarDemo({
         </SidebarFooter>
       </Sidebar>
       <SidebarInset>
-        <header className="flex h-14 items-center gap-2 border-b px-4">
-          <SidebarTrigger />
-          <span className="font-medium">Page title</span>
-        </header>
         <main className="text-muted-foreground p-6 text-sm">
           Page content. The sidebar renders alongside it via{' '}
           <code>SidebarInset</code>.


### PR DESCRIPTION
## Summary
The Sidebar Storybook story rendered a placeholder header inside `SidebarInset` (SidebarTrigger + 'Page title'). The trigger is not how production uses the sidebar, and the bare header read as fake chrome. Remove it and let `SidebarInset` host just the page-content placeholder.

## Test plan
- [ ] `npm run storybook` → Components / Sidebar → Default + Playground should now show the sidebar alongside a clean main content area, no top header bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook-only change that removes a demo header/trigger; no production logic or data flow is affected.
> 
> **Overview**
> Removes the placeholder top header from the `Components/Sidebar` Storybook demo by dropping the `SidebarTrigger` import/usage and the `'Page title'` bar inside `SidebarInset`, leaving only the main content area in the story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f0878d112b702411c8a418fe1ed9d3e687c9aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->