### PR TITLE
styleguide(input): add Default story alongside Playground

### DIFF
--- a/styleguide/stories/Input.stories.tsx
+++ b/styleguide/stories/Input.stories.tsx
@@ -49,6 +49,12 @@ export const Playground: StoryObj<PlaygroundArgs> = {
   ),
 }
 
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter your text here',
+  },
+}
+
 export const WithLabel: Story = {
   render: () => (
     <div className="grid w-full max-w-sm items-center gap-1.5">


### PR DESCRIPTION
## Summary

Follow-up to #1863. Cursor flagged on that review that `Input.stories.tsx` was the only one of the 26 components touched in PR 1863 that didn't keep its `Default` named variant after adding `Playground`. Every other component story has both. This PR restores the symmetric pattern.

## Test plan

- [x] `npm run lint` — clean
- [ ] `npm run storybook` — confirm Input docs page now shows both Playground and Default stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates Storybook stories and does not affect runtime component behavior or production code paths.
> 
> **Overview**
> Adds a `Default` Storybook story back to `Input.stories.tsx`, providing a simple args-based baseline (`placeholder`) alongside the existing `Playground` story for consistency across the styleguide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411646e1beb0b209f067f84cb614a838fd1bf955. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->