### PR TITLE
Update election filing API route and adjust form data handling

### DIFF
--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -40,7 +40,7 @@ export default function ElectionFiling(): React.JSX.Element {
     setHasSubmissionError(false)
     try {
       await submitTcrCompliance(
-        apiRoutes.campaign.tcrCompliance.create,
+        apiRoutes.campaign.tcrCompliance.createAgentic,
         toRegistrationFormData(formData),
         'Failed to submit election filing',
       )

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
@@ -311,6 +311,7 @@ const TextingComplianceRegistrationForm = ({
           value={phone}
           onChange={(e) => handleChange({ phone: e.target.value })}
         />
+        <div className="h-32"></div>
       </TextingComplianceForm>
       <TextingComplianceFooter>
         <TextingComplianceSubmitButton

--- a/app/dashboard/profile/texting-compliance/util/mapFormData.util.ts
+++ b/app/dashboard/profile/texting-compliance/util/mapFormData.util.ts
@@ -35,7 +35,7 @@ interface MappedFormData {
   placeId: string
   formattedAddress: string
   committeeName: string
-  websiteDomain: string
+  websiteDomain?: string
   filingUrl: string
   email: string
   phone: string
@@ -98,7 +98,7 @@ export const mapFormData = ({
   placeId: place_id,
   formattedAddress: formatted_address,
   committeeName: campaignCommitteeName,
-  websiteDomain: website,
+  websiteDomain: website || undefined,
   filingUrl: electionFilingLink,
   email,
   phone,

--- a/gpApi/routes.ts
+++ b/gpApi/routes.ts
@@ -284,6 +284,10 @@ export const apiRoutes = {
         path: '/campaigns/tcr-compliance',
         method: 'POST',
       },
+      createAgentic: {
+        path: '/campaigns/tcr-compliance/agentic',
+        method: 'POST',
+      },
       submitCvPin: {
         path: '/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
         method: 'POST',


### PR DESCRIPTION
- Changed the API route for election filing submission from `create` to `createAgentic`.
- Made the `websiteDomain` field optional in the mapped form data.
- Added spacing in the Texting Compliance Registration Form for improved layout.