### PR TITLE
Feature/briefing single page layout

### DIFF
--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -1,56 +1,24 @@
-import { notFound } from 'next/navigation'
-import pageMetaData from 'helpers/metadataHelper'
-import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
-import { renderItemForSpeech } from '@shared/briefings/renderForSpeech'
-import AgendaItemCard from '../../components/detail/AgendaItemCard'
+import { redirect } from 'next/navigation'
+import {
+  briefingItemDomId,
+  briefingOverviewHref,
+} from '@shared/briefings/routes'
 
 type PageProps = {
   params: Promise<{ slug: string; itemId: string }>
 }
 
-export async function generateMetadata({ params }: PageProps) {
-  const { slug, itemId } = await params
-  const result = await getBriefingBySlug(slug)
-  const briefing = result && isFullBriefing(result) ? result : null
-  const item = briefing?.items.find((i) => i.id === itemId)
-  return pageMetaData({
-    title:
-      briefing && item
-        ? `${item.title} · ${briefing.title} | GoodParty.org`
-        : 'Briefing | GoodParty.org',
-    description: item?.display.summary ?? 'Meeting briefing',
-    slug: `/dashboard/briefings/${slug}/${itemId}`,
-  })
-}
-
 export const dynamic = 'force-dynamic'
 
 /**
- * Per-item briefing page. Every item has its own route so the TOC
- * navigates rather than scrolls.
+ * Legacy per-item route. All agenda items now render inline on the
+ * briefing overview page; this route redirects deep links to the matching
+ * hash anchor so existing bookmarks and PDF cross-references keep
+ * working.
  */
 export default async function Page({
   params,
-}: PageProps): Promise<React.JSX.Element> {
+}: PageProps): Promise<never> {
   const { slug, itemId } = await params
-  const result = await getBriefingBySlug(slug)
-  if (!result || !isFullBriefing(result)) notFound()
-  const briefing = result
-  const index = briefing.items.findIndex((i) => i.id === itemId)
-  const item = briefing.items[index]
-  if (!item) notFound()
-
-  return (
-    <AgendaItemCard
-      item={item}
-      itemIndex={index}
-      sources={briefing.sources}
-      domId={`briefing-item-${item.id}`}
-      meetingDate={slug}
-      showFeedback={item.tier === 'featured'}
-      variant={item.tier === 'featured' ? 'full' : 'whatToExpectOnly'}
-      speechText={renderItemForSpeech(item)}
-      analyticsLabel={`briefing-item-${item.id}`}
-    />
-  )
+  redirect(`${briefingOverviewHref(slug)}#${briefingItemDomId(itemId)}`)
 }

--- a/app/dashboard/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/briefings/[slug]/[itemId]/page.tsx
@@ -16,9 +16,7 @@ export const dynamic = 'force-dynamic'
  * hash anchor so existing bookmarks and PDF cross-references keep
  * working.
  */
-export default async function Page({
-  params,
-}: PageProps): Promise<never> {
+export default async function Page({ params }: PageProps): Promise<never> {
   const { slug, itemId } = await params
   redirect(`${briefingOverviewHref(slug)}#${briefingItemDomId(itemId)}`)
 }

--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -55,14 +55,19 @@ export default async function BriefingChromeLayout({
     >
       <AnnotationsScope meetingDate={slug}>
         <div className="relative">
-          <div className="flex min-h-full flex-col bg-muted pb-20 lg:pb-12">
+          {/* lg+: constrain the whole briefing area to viewport height and
+              disable document-level scroll. The sidebar pane stays
+              visually fixed because it doesn't scroll; only the content
+              pane scrolls. Mobile keeps the original document-scroll
+              model so the bottom bar / page chrome behave as before. */}
+          <div className="flex min-h-full flex-col bg-muted pb-20 lg:h-svh lg:min-h-0 lg:overflow-hidden lg:pb-0">
             <DetailHeader
               briefing={briefing}
               preparedForLine={briefing.officialName}
               liveBriefingUrl={`${APP_BASE}/dashboard/briefings/${slug}`}
             />
 
-            <div className="mx-auto w-full max-w-[1120px] px-4 py-6 lg:px-8">
+            <div className="mx-auto w-full max-w-[1120px] px-4 py-6 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden lg:px-8">
               <div className="mb-4">
                 <Link
                   href={briefingsLandingHref()}
@@ -73,14 +78,18 @@ export default async function BriefingChromeLayout({
                 </Link>
               </div>
 
-              <div className="lg:grid lg:grid-cols-[260px_1fr] lg:gap-8">
-                <aside className="hidden lg:block">
-                  <div className="sticky top-[88px] max-h-[calc(100vh-104px)] overflow-y-auto rounded-2xl border border-border bg-card p-3">
-                    <DetailToc briefingSlug={slug} items={briefing.items} />
-                  </div>
+              <div className="lg:flex lg:min-h-0 lg:flex-1 lg:items-stretch lg:gap-8 lg:overflow-hidden">
+                <aside className="hidden rounded-2xl border border-border bg-card p-3 lg:block lg:w-[260px] lg:shrink-0 lg:overflow-y-auto">
+                  <DetailToc briefingSlug={slug} items={briefing.items} />
                 </aside>
 
-                <div className="flex flex-col gap-4">{children}</div>
+                <div
+                  id="briefing-detail-pane"
+                  data-briefing-scroll-container
+                  className="flex flex-col gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto"
+                >
+                  {children}
+                </div>
               </div>
             </div>
           </div>

--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -1,7 +1,14 @@
 import { notFound } from 'next/navigation'
 import pageMetaData from 'helpers/metadataHelper'
 import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
-import { renderBriefingForSpeech } from '@shared/briefings/renderForSpeech'
+import {
+  renderBriefingForSpeech,
+  renderItemForSpeech,
+} from '@shared/briefings/renderForSpeech'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemDomId,
+} from '@shared/briefings/routes'
 import ExecutiveSummaryCard from '../components/detail/ExecutiveSummaryCard'
 import AgendaItemCard from '../components/detail/AgendaItemCard'
 
@@ -24,15 +31,14 @@ export async function generateMetadata({ params }: PageProps) {
 
 export const dynamic = 'force-dynamic'
 
-const EXECUTIVE_SUMMARY_DOM_ID = 'briefing-executive-summary'
-
 /**
- * Briefing overview page.
+ * Briefing detail page.
  *
- * Renders the Executive Summary plus the top issues (action items) inline
- * so the user can scan the priorities at a glance. Non-action items (Call
- * to order, Public comment period, etc.) have their own per-item pages
- * reached via the sidebar TOC.
+ * Renders the Executive Summary followed by every agenda item inline.
+ * Featured items show the full card (talking points, recent news, budget,
+ * sentiment, feedback); non-featured items render in the lightweight
+ * "What to expect" variant. The sidebar TOC and mobile jump-to-section
+ * sheet scroll within this page via hash anchors — no sub-routes.
  */
 export default async function Page({
   params,
@@ -48,30 +54,32 @@ export default async function Page({
   // briefing-schema knowledge.
   const speechText = renderBriefingForSpeech(briefing)
 
-  const featuredItems = briefing.items
-    .map((item, index) => ({ item, index }))
-    .filter(({ item }) => item.tier === 'featured')
-
   return (
     <>
       <ExecutiveSummaryCard
         summary={briefing.executiveSummary}
-        domId={EXECUTIVE_SUMMARY_DOM_ID}
+        domId={BRIEFING_EXECUTIVE_SUMMARY_DOM_ID}
         speechText={speechText}
         analyticsLabel="briefing"
       />
 
-      {featuredItems.map(({ item, index }) => (
-        <AgendaItemCard
-          key={item.id}
-          item={item}
-          itemIndex={index}
-          sources={briefing.sources}
-          domId={`briefing-item-${item.id}`}
-          meetingDate={slug}
-          showFeedback
-        />
-      ))}
+      {briefing.items.map((item, index) => {
+        const isFeatured = item.tier === 'featured'
+        return (
+          <AgendaItemCard
+            key={item.id}
+            item={item}
+            itemIndex={index}
+            sources={briefing.sources}
+            domId={briefingItemDomId(item.id)}
+            meetingDate={slug}
+            showFeedback={isFeatured}
+            variant={isFeatured ? 'full' : 'whatToExpectOnly'}
+            speechText={isFeatured ? renderItemForSpeech(item) : undefined}
+            analyticsLabel={`briefing-item-${item.id}`}
+          />
+        )
+      })}
     </>
   )
 }

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -213,9 +213,6 @@ const AgendaItemCard = ({
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
-          <span className="text-[12px] font-bold uppercase tracking-wide text-info-600">
-            Agenda item
-          </span>
           <h3
             className="text-lg font-semibold text-foreground"
             data-briefing-json-path={`${base}/title`}

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -209,7 +209,7 @@ const AgendaItemCard = ({
   return (
     <article
       id={domId}
-      className="flex scroll-mt-[104px] flex-col gap-4 rounded-2xl border border-border bg-card p-6"
+      className="flex scroll-mt-[104px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 lg:scroll-mt-3"
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -26,9 +26,8 @@ type Props = {
   variant?: Variant
   /**
    * Pre-rendered plain-text for the speech service. When provided, the
-   * card header renders a compact read-aloud control. Non-priority item
-   * pages pass this; the featured-items overview omits it (the page-level
-   * Executive Summary card already exposes read-aloud for the briefing).
+   * card header renders a compact read-aloud control. Featured items on
+   * the overview pass this; non-featured items omit it.
    */
   speechText?: string
   /** Optional label forwarded to analytics so usage can be sliced by surface. */
@@ -210,7 +209,7 @@ const AgendaItemCard = ({
   return (
     <article
       id={domId}
-      className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-6"
+      className="flex scroll-mt-[104px] flex-col gap-4 rounded-2xl border border-border bg-card p-6"
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -85,12 +85,19 @@ export default function DetailToc({
       if (raf === 0) raf = requestAnimationFrame(pickActive)
     }
 
+    // Listen on both window (mobile, where the document scrolls) and the
+    // briefing content pane (desktop, where the right column scrolls
+    // independently). Element scroll events don't bubble, so we have to
+    // attach directly to the pane.
+    const pane = document.getElementById('briefing-detail-pane')
     pickActive()
     window.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
+    pane?.addEventListener('scroll', onScroll, { passive: true })
     return () => {
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)
+      pane?.removeEventListener('scroll', onScroll)
       if (raf !== 0) cancelAnimationFrame(raf)
     }
   }, [entries, briefingSlug])

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -83,9 +83,7 @@ export default function DetailToc({
       // lg breakpoint switches modes without a remount.
       const paneScrolls =
         !!pane && window.matchMedia('(min-width: 1024px)').matches
-      const containerTop = paneScrolls
-        ? pane.getBoundingClientRect().top
-        : 0
+      const containerTop = paneScrolls ? pane.getBoundingClientRect().top : 0
       const offset = paneScrolls ? DESKTOP_PANE_OFFSET : MOBILE_HEADER_OFFSET
 
       let bestKey = entries[0]?.key ?? ''
@@ -141,10 +139,7 @@ export default function DetailToc({
     }
   }, [entries, briefingSlug])
 
-  function onJump(
-    e: React.MouseEvent<HTMLAnchorElement>,
-    entry: Entry,
-  ) {
+  function onJump(e: React.MouseEvent<HTMLAnchorElement>, entry: Entry) {
     if (typeof window === 'undefined') return
     const target = document.getElementById(entry.domId)
     if (!target) return

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -18,20 +18,25 @@ type Entry = {
   domId: string
 }
 
-// Distance below the top of the viewport where we draw the "current section"
-// line. Matches the sticky header height + the `scroll-mt-[104px]` applied to
-// each card root, so scroll target alignment and active-state detection use
-// the same offset.
-const HEADER_OFFSET = 104
+// Distance below the top of the scroll container where the "current section"
+// line is drawn. Mobile uses the document scroll and sits below the sticky
+// DetailHeader (~88px + breathing room). Desktop scrolls inside the content
+// pane, which has no internal sticky header, so the line is just below the
+// pane's top edge. Both values track the corresponding `scroll-mt-*` on the
+// card roots so scroll target alignment and active-state detection agree.
+const MOBILE_HEADER_OFFSET = 104
+const DESKTOP_PANE_OFFSET = 12
 
 /**
  * Sidebar TOC. All agenda items render inline on the briefing detail
  * page, so the TOC scrolls within the page rather than navigating.
  *
  * Active state is a rAF-throttled scroll-spy: on every scroll frame we
- * pick the section whose top sits closest to (but above) HEADER_OFFSET.
- * One section is "active" per frame, so the highlight never flickers
- * during smooth scrolls.
+ * pick the section whose top sits closest to (but above) the active-line
+ * offset, measured relative to the active scroll container — `window` on
+ * mobile, the `#briefing-detail-pane` element at lg+ where the pane owns
+ * the scroll. One section is "active" per frame, so the highlight never
+ * flickers during smooth scrolls.
  */
 export default function DetailToc({
   briefingSlug,
@@ -56,24 +61,43 @@ export default function DetailToc({
   }, [items])
 
   const [activeKey, setActiveKey] = useState<string>(entries[0]?.key ?? '')
+  // When a user clicks a TOC entry, pin that entry as active until they
+  // perform a real manual scroll (wheel/touch/key). The smooth scroll
+  // animation fires `scroll` events too, but doesn't fire wheel/touch/key
+  // — so this lets the clicked entry stay highlighted even when the
+  // scroll container can't bring its section all the way to the active
+  // line (e.g. clicking one of the last entries when there isn't enough
+  // remaining scroll room below it).
+  const [pinnedKey, setPinnedKey] = useState<string | null>(null)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (entries.length === 0) return
 
     let raf = 0
+    const pane = document.getElementById('briefing-detail-pane')
 
     function pickActive() {
       raf = 0
+      // Pick the scroll container live each frame so a resize across the
+      // lg breakpoint switches modes without a remount.
+      const paneScrolls =
+        !!pane && window.matchMedia('(min-width: 1024px)').matches
+      const containerTop = paneScrolls
+        ? pane.getBoundingClientRect().top
+        : 0
+      const offset = paneScrolls ? DESKTOP_PANE_OFFSET : MOBILE_HEADER_OFFSET
+
       let bestKey = entries[0]?.key ?? ''
       let bestTop = -Infinity
       for (const e of entries) {
         const el = document.getElementById(e.domId)
         if (!el) continue
-        const top = el.getBoundingClientRect().top
+        // Section's top relative to the scroll container's top edge.
+        const top = el.getBoundingClientRect().top - containerTop
         // Sections at or above the offset line are candidates. The one
         // closest to the line (largest top that's still <= offset) wins.
-        if (top - HEADER_OFFSET <= 1 && top > bestTop) {
+        if (top - offset <= 1 && top > bestTop) {
           bestTop = top
           bestKey = e.key
         }
@@ -85,43 +109,64 @@ export default function DetailToc({
       if (raf === 0) raf = requestAnimationFrame(pickActive)
     }
 
+    function onUserInput() {
+      setPinnedKey(null)
+    }
+
     // Listen on both window (mobile, where the document scrolls) and the
     // briefing content pane (desktop, where the right column scrolls
     // independently). Element scroll events don't bubble, so we have to
-    // attach directly to the pane.
-    const pane = document.getElementById('briefing-detail-pane')
+    // attach directly to the pane. Wheel/touch/key events clear any
+    // click-pinned highlight — the smooth-scroll animation doesn't fire
+    // them, so the pin survives the animation.
     pickActive()
     window.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
+    window.addEventListener('wheel', onUserInput, { passive: true })
+    window.addEventListener('touchstart', onUserInput, { passive: true })
+    window.addEventListener('keydown', onUserInput)
     pane?.addEventListener('scroll', onScroll, { passive: true })
+    pane?.addEventListener('wheel', onUserInput, { passive: true })
+    pane?.addEventListener('touchstart', onUserInput, { passive: true })
     return () => {
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)
+      window.removeEventListener('wheel', onUserInput)
+      window.removeEventListener('touchstart', onUserInput)
+      window.removeEventListener('keydown', onUserInput)
       pane?.removeEventListener('scroll', onScroll)
+      pane?.removeEventListener('wheel', onUserInput)
+      pane?.removeEventListener('touchstart', onUserInput)
       if (raf !== 0) cancelAnimationFrame(raf)
     }
   }, [entries, briefingSlug])
 
-  function onJump(e: React.MouseEvent<HTMLAnchorElement>, domId: string) {
+  function onJump(
+    e: React.MouseEvent<HTMLAnchorElement>,
+    entry: Entry,
+  ) {
     if (typeof window === 'undefined') return
-    const target = document.getElementById(domId)
+    const target = document.getElementById(entry.domId)
     if (!target) return
     e.preventDefault()
+    setPinnedKey(entry.key)
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
     if (window.history && window.history.replaceState) {
-      window.history.replaceState(null, '', `#${domId}`)
+      window.history.replaceState(null, '', `#${entry.domId}`)
     }
   }
+
+  const displayedKey = pinnedKey ?? activeKey
 
   return (
     <ul className="flex list-none flex-col gap-0.5">
       {entries.map((e) => {
-        const isActive = activeKey === e.key
+        const isActive = displayedKey === e.key
         return (
           <li key={e.key}>
             <a
               href={`#${e.domId}`}
-              onClick={(ev) => onJump(ev, e.domId)}
+              onClick={(ev) => onJump(ev, e)}
               className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
                 isActive
                   ? 'bg-muted font-semibold text-foreground'

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { useMemo } from 'react'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
 import {
-  briefingItemHref,
-  briefingOverviewHref,
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemDomId,
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
 
@@ -17,48 +15,106 @@ type Props = {
 type Entry = {
   key: string
   label: string
-  href: string
+  domId: string
 }
 
+// Distance below the top of the viewport where we draw the "current section"
+// line. Matches the sticky header height + the `scroll-mt-[104px]` applied to
+// each card root, so scroll target alignment and active-state detection use
+// the same offset.
+const HEADER_OFFSET = 104
+
 /**
- * Sidebar TOC for the briefing detail layout. Every agenda item is its
- * own page; the TOC navigates rather than scrolling.
+ * Sidebar TOC. All agenda items render inline on the briefing detail
+ * page, so the TOC scrolls within the page rather than navigating.
  *
- * Active state is derived from the current pathname.
+ * Active state is a rAF-throttled scroll-spy: on every scroll frame we
+ * pick the section whose top sits closest to (but above) HEADER_OFFSET.
+ * One section is "active" per frame, so the highlight never flickers
+ * during smooth scrolls.
  */
 export default function DetailToc({
   briefingSlug,
   items,
 }: Props): React.JSX.Element {
-  const pathname = usePathname()
-
-  const overviewHref = briefingOverviewHref(briefingSlug)
   const entries: Entry[] = useMemo(() => {
     const list: Entry[] = [
       {
         key: 'overview',
         label: 'Executive Summary',
-        href: overviewHref,
+        domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
       },
     ]
     for (const item of items) {
       list.push({
         key: item.id,
         label: item.title,
-        href: briefingItemHref(briefingSlug, item.id),
+        domId: briefingItemDomId(item.id),
       })
     }
     return list
-  }, [items, briefingSlug, overviewHref])
+  }, [items])
+
+  const [activeKey, setActiveKey] = useState<string>(entries[0]?.key ?? '')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (entries.length === 0) return
+
+    let raf = 0
+
+    function pickActive() {
+      raf = 0
+      let bestKey = entries[0]?.key ?? ''
+      let bestTop = -Infinity
+      for (const e of entries) {
+        const el = document.getElementById(e.domId)
+        if (!el) continue
+        const top = el.getBoundingClientRect().top
+        // Sections at or above the offset line are candidates. The one
+        // closest to the line (largest top that's still <= offset) wins.
+        if (top - HEADER_OFFSET <= 1 && top > bestTop) {
+          bestTop = top
+          bestKey = e.key
+        }
+      }
+      setActiveKey(bestKey)
+    }
+
+    function onScroll() {
+      if (raf === 0) raf = requestAnimationFrame(pickActive)
+    }
+
+    pickActive()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+      if (raf !== 0) cancelAnimationFrame(raf)
+    }
+  }, [entries, briefingSlug])
+
+  function onJump(e: React.MouseEvent<HTMLAnchorElement>, domId: string) {
+    if (typeof window === 'undefined') return
+    const target = document.getElementById(domId)
+    if (!target) return
+    e.preventDefault()
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState(null, '', `#${domId}`)
+    }
+  }
 
   return (
     <ul className="flex list-none flex-col gap-0.5">
       {entries.map((e) => {
-        const isActive = pathname === e.href
+        const isActive = activeKey === e.key
         return (
           <li key={e.key}>
-            <Link
-              href={e.href}
+            <a
+              href={`#${e.domId}`}
+              onClick={(ev) => onJump(ev, e.domId)}
               className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
                 isActive
                   ? 'bg-muted font-semibold text-foreground'
@@ -66,7 +122,7 @@ export default function DetailToc({
               }`}
             >
               <span className="min-w-0">{e.label}</span>
-            </Link>
+            </a>
           </li>
         )
       })}

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -167,12 +167,18 @@ export default function DetailToc({
             <a
               href={`#${e.domId}`}
               onClick={(ev) => onJump(ev, e)}
-              className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
+              className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
                 isActive
                   ? 'bg-muted font-semibold text-foreground'
                   : 'text-foreground hover:bg-muted/60'
               }`}
             >
+              <span
+                aria-hidden
+                className={`size-2 shrink-0 rounded-full ${
+                  isActive ? 'bg-info-600' : 'bg-transparent'
+                }`}
+              />
               <span className="min-w-0">{e.label}</span>
             </a>
           </li>

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -27,7 +27,7 @@ export default function ExecutiveSummaryCard({
   return (
     <article
       id={domId}
-      className="flex scroll-mt-[104px] flex-col gap-2 rounded-2xl border border-border bg-card p-6"
+      className="flex scroll-mt-[104px] flex-col gap-2 rounded-2xl border border-border bg-card p-6 lg:scroll-mt-3"
     >
       <div className="flex items-start justify-between gap-3">
         <h2 className="text-2xl font-semibold text-foreground">

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -27,7 +27,7 @@ export default function ExecutiveSummaryCard({
   return (
     <article
       id={domId}
-      className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-6"
+      className="flex scroll-mt-[104px] flex-col gap-2 rounded-2xl border border-border bg-card p-6"
     >
       <div className="flex items-start justify-between gap-3">
         <h2 className="text-2xl font-semibold text-foreground">

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { useEffect, useMemo, useState } from 'react'
 import {
   List,
   ChevronUp,
@@ -19,8 +17,8 @@ import {
   SheetTitle,
 } from '@styleguide'
 import {
-  briefingItemHref,
-  briefingOverviewHref,
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemDomId,
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
@@ -30,32 +28,104 @@ type Props = {
   items: Item[]
 }
 
+type Entry = {
+  key: string
+  label: string
+  domId: string
+}
+
 /**
  * Mobile-only bottom dock visible below the lg breakpoint:
  *
- *  - Left pill: name of the current page (Executive Summary or agenda item)
- *    + chevron, opens a bottom Sheet for navigation.
+ *  - Left pill: name of the section currently in view + chevron, opens a
+ *    bottom Sheet listing every section.
  *  - Right FABs: Download, Add notes, and Ask AI.
  *
- * Selecting an entry navigates to that page; the Sheet closes on tap.
+ * Tapping an entry scrolls to that section on the same page; the Sheet
+ * closes on tap.
  */
 export default function MobileBottomBar({
   briefingSlug,
   items,
 }: Props): React.JSX.Element {
-  const pathname = usePathname()
   const [open, setOpen] = useState(false)
   const { openAddNoteTopLevel, openAskAiTopLevel } = useAnnotationsCtx()
 
-  const overviewHref = briefingOverviewHref(briefingSlug)
+  const entries: Entry[] = useMemo(() => {
+    const list: Entry[] = [
+      {
+        key: 'overview',
+        label: 'Executive Summary',
+        domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+      },
+    ]
+    for (const item of items) {
+      list.push({
+        key: item.id,
+        label: item.title,
+        domId: briefingItemDomId(item.id),
+      })
+    }
+    return list
+  }, [items])
 
-  const currentLabel = useMemo(() => {
-    if (pathname === overviewHref) return 'Executive Summary'
-    const match = items.find(
-      (a) => pathname === briefingItemHref(briefingSlug, a.id),
-    )
-    return match?.title ?? 'Executive Summary'
-  }, [items, briefingSlug, overviewHref, pathname])
+  const [activeKey, setActiveKey] = useState<string>(entries[0]?.key ?? '')
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (entries.length === 0) return
+
+    let raf = 0
+
+    function pickActive() {
+      raf = 0
+      let bestKey = entries[0]?.key ?? ''
+      let bestTop = -Infinity
+      for (const e of entries) {
+        const el = document.getElementById(e.domId)
+        if (!el) continue
+        const top = el.getBoundingClientRect().top
+        // Mirror DetailToc's scroll-spy: pick the section whose top is
+        // closest to (but above) the sticky-header offset line.
+        if (top - 104 <= 1 && top > bestTop) {
+          bestTop = top
+          bestKey = e.key
+        }
+      }
+      setActiveKey(bestKey)
+    }
+
+    function onScroll() {
+      if (raf === 0) raf = requestAnimationFrame(pickActive)
+    }
+
+    pickActive()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+      if (raf !== 0) cancelAnimationFrame(raf)
+    }
+  }, [entries, briefingSlug])
+
+  const currentLabel =
+    entries.find((e) => e.key === activeKey)?.label ?? 'Executive Summary'
+
+  function onJump(
+    ev: React.MouseEvent<HTMLAnchorElement>,
+    domId: string,
+  ): void {
+    if (typeof window === 'undefined') return
+    const target = document.getElementById(domId)
+    if (!target) return
+    ev.preventDefault()
+    setOpen(false)
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState(null, '', `#${domId}`)
+    }
+  }
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-sidebar/95 backdrop-blur supports-[backdrop-filter]:bg-sidebar/80 lg:hidden">
@@ -82,35 +152,21 @@ export default function MobileBottomBar({
               <SheetTitle>Jump to section</SheetTitle>
             </SheetHeader>
             <ul className="mt-3 flex list-none flex-col gap-0.5 overflow-y-auto">
-              <li>
-                <Link
-                  href={overviewHref}
-                  onClick={() => setOpen(false)}
-                  className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
-                    pathname === overviewHref
-                      ? 'bg-muted font-semibold text-foreground'
-                      : 'text-foreground hover:bg-muted/60'
-                  }`}
-                >
-                  Executive Summary
-                </Link>
-              </li>
-              {items.map((a) => {
-                const href = briefingItemHref(briefingSlug, a.id)
-                const isActive = pathname === href
+              {entries.map((e) => {
+                const isActive = activeKey === e.key
                 return (
-                  <li key={a.id}>
-                    <Link
-                      href={href}
-                      onClick={() => setOpen(false)}
+                  <li key={e.key}>
+                    <a
+                      href={`#${e.domId}`}
+                      onClick={(ev) => onJump(ev, e.domId)}
                       className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
                         isActive
                           ? 'bg-muted font-semibold text-foreground'
                           : 'text-foreground hover:bg-muted/60'
                       }`}
                     >
-                      {a.title}
-                    </Link>
+                      {e.label}
+                    </a>
                   </li>
                 )
               })}

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -99,12 +99,18 @@ export default function MobileBottomBar({
       if (raf === 0) raf = requestAnimationFrame(pickActive)
     }
 
+    // Listen on both window (mobile document scroll) and the briefing
+    // content pane (desktop, where the right column scrolls). Element
+    // scroll events don't bubble, so we attach directly to the pane.
+    const pane = document.getElementById('briefing-detail-pane')
     pickActive()
     window.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
+    pane?.addEventListener('scroll', onScroll, { passive: true })
     return () => {
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)
+      pane?.removeEventListener('scroll', onScroll)
       if (raf !== 0) cancelAnimationFrame(raf)
     }
   }, [entries, briefingSlug])

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -88,9 +88,7 @@ export default function MobileBottomBar({
       // scrolls — window on mobile, the briefing pane at lg+.
       const paneScrolls =
         !!pane && window.matchMedia('(min-width: 1024px)').matches
-      const containerTop = paneScrolls
-        ? pane.getBoundingClientRect().top
-        : 0
+      const containerTop = paneScrolls ? pane.getBoundingClientRect().top : 0
       const offset = paneScrolls ? 12 : 104
 
       let bestKey = entries[0]?.key ?? ''

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -191,13 +191,19 @@ export default function MobileBottomBar({
                     <a
                       href={`#${e.domId}`}
                       onClick={(ev) => onJump(ev, e)}
-                      className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
+                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
                         isActive
                           ? 'bg-muted font-semibold text-foreground'
                           : 'text-foreground hover:bg-muted/60'
                       }`}
                     >
-                      {e.label}
+                      <span
+                        aria-hidden
+                        className={`size-2 shrink-0 rounded-full ${
+                          isActive ? 'bg-info-600' : 'bg-transparent'
+                        }`}
+                      />
+                      <span className="min-w-0">{e.label}</span>
                     </a>
                   </li>
                 )

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -70,24 +70,36 @@ export default function MobileBottomBar({
   }, [items])
 
   const [activeKey, setActiveKey] = useState<string>(entries[0]?.key ?? '')
+  // Pinned on tap; cleared on any real wheel/touch/key scroll. Lets the
+  // tapped entry stay current even when the scroll container can't bring
+  // its section all the way to the active line.
+  const [pinnedKey, setPinnedKey] = useState<string | null>(null)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (entries.length === 0) return
 
     let raf = 0
+    const pane = document.getElementById('briefing-detail-pane')
 
     function pickActive() {
       raf = 0
+      // Mirror DetailToc: measure relative to whichever container actually
+      // scrolls — window on mobile, the briefing pane at lg+.
+      const paneScrolls =
+        !!pane && window.matchMedia('(min-width: 1024px)').matches
+      const containerTop = paneScrolls
+        ? pane.getBoundingClientRect().top
+        : 0
+      const offset = paneScrolls ? 12 : 104
+
       let bestKey = entries[0]?.key ?? ''
       let bestTop = -Infinity
       for (const e of entries) {
         const el = document.getElementById(e.domId)
         if (!el) continue
-        const top = el.getBoundingClientRect().top
-        // Mirror DetailToc's scroll-spy: pick the section whose top is
-        // closest to (but above) the sticky-header offset line.
-        if (top - 104 <= 1 && top > bestTop) {
+        const top = el.getBoundingClientRect().top - containerTop
+        if (top - offset <= 1 && top > bestTop) {
           bestTop = top
           bestKey = e.key
         }
@@ -99,37 +111,51 @@ export default function MobileBottomBar({
       if (raf === 0) raf = requestAnimationFrame(pickActive)
     }
 
+    function onUserInput() {
+      setPinnedKey(null)
+    }
+
     // Listen on both window (mobile document scroll) and the briefing
     // content pane (desktop, where the right column scrolls). Element
     // scroll events don't bubble, so we attach directly to the pane.
-    const pane = document.getElementById('briefing-detail-pane')
+    // Wheel/touch/key clear any tap-pinned highlight; the smooth-scroll
+    // animation doesn't fire them, so the pin survives the animation.
     pickActive()
     window.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
+    window.addEventListener('wheel', onUserInput, { passive: true })
+    window.addEventListener('touchstart', onUserInput, { passive: true })
+    window.addEventListener('keydown', onUserInput)
     pane?.addEventListener('scroll', onScroll, { passive: true })
+    pane?.addEventListener('wheel', onUserInput, { passive: true })
+    pane?.addEventListener('touchstart', onUserInput, { passive: true })
     return () => {
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)
+      window.removeEventListener('wheel', onUserInput)
+      window.removeEventListener('touchstart', onUserInput)
+      window.removeEventListener('keydown', onUserInput)
       pane?.removeEventListener('scroll', onScroll)
+      pane?.removeEventListener('wheel', onUserInput)
+      pane?.removeEventListener('touchstart', onUserInput)
       if (raf !== 0) cancelAnimationFrame(raf)
     }
   }, [entries, briefingSlug])
 
+  const displayedKey = pinnedKey ?? activeKey
   const currentLabel =
-    entries.find((e) => e.key === activeKey)?.label ?? 'Executive Summary'
+    entries.find((e) => e.key === displayedKey)?.label ?? 'Executive Summary'
 
-  function onJump(
-    ev: React.MouseEvent<HTMLAnchorElement>,
-    domId: string,
-  ): void {
+  function onJump(ev: React.MouseEvent<HTMLAnchorElement>, entry: Entry): void {
     if (typeof window === 'undefined') return
-    const target = document.getElementById(domId)
+    const target = document.getElementById(entry.domId)
     if (!target) return
     ev.preventDefault()
+    setPinnedKey(entry.key)
     setOpen(false)
     target.scrollIntoView({ behavior: 'smooth', block: 'start' })
     if (window.history && window.history.replaceState) {
-      window.history.replaceState(null, '', `#${domId}`)
+      window.history.replaceState(null, '', `#${entry.domId}`)
     }
   }
 
@@ -159,12 +185,12 @@ export default function MobileBottomBar({
             </SheetHeader>
             <ul className="mt-3 flex list-none flex-col gap-0.5 overflow-y-auto">
               {entries.map((e) => {
-                const isActive = activeKey === e.key
+                const isActive = displayedKey === e.key
                 return (
                   <li key={e.key}>
                     <a
                       href={`#${e.domId}`}
-                      onClick={(ev) => onJump(ev, e.domId)}
+                      onClick={(ev) => onJump(ev, e)}
                       className={`flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
                         isActive
                           ? 'bg-muted font-semibold text-foreground'

--- a/app/shared/briefings/routes.ts
+++ b/app/shared/briefings/routes.ts
@@ -1,7 +1,16 @@
 /**
  * Canonical paths for the briefings UI. Centralized so layout, TOC,
  * mobile bar, and any future deep links agree on the URL shape.
+ *
+ * All agenda items render inline on the overview page; per-item navigation
+ * is a hash anchor on that same page rather than a sub-route.
  */
+
+export const BRIEFING_EXECUTIVE_SUMMARY_DOM_ID = 'briefing-executive-summary'
+
+export function briefingItemDomId(itemId: string): string {
+  return `briefing-item-${itemId}`
+}
 
 export function briefingsLandingHref(): string {
   return '/dashboard/briefings'
@@ -12,5 +21,5 @@ export function briefingOverviewHref(slug: string): string {
 }
 
 export function briefingItemHref(slug: string, itemId: string): string {
-  return `/dashboard/briefings/${slug}/${itemId}`
+  return `${briefingOverviewHref(slug)}#${briefingItemDomId(itemId)}`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large UX/routing change (redirects, dual scroll containers, client scroll-spy) could affect deep links and desktop/mobile scroll behavior, but no auth or data-layer changes.
> 
> **Overview**
> Briefing detail is now a **single scrollable page**: the overview route renders the executive summary plus **every** agenda item inline (featured = full card + read-aloud/feedback; others = “What to expect” only). Per-item URLs no longer render their own page—they **redirect** to the overview with the matching **hash** so bookmarks and PDF links still work.
> 
> **Desktop (lg+)** uses a fixed-height layout: the sidebar stays in place while only `#briefing-detail-pane` scrolls. **TOC and mobile “Jump to section”** use hash links with smooth scroll, `replaceState` for the URL, and a shared **scroll-spy** (rAF-throttled, listening on both `window` and the content pane). Section cards get **`scroll-mt-[104px]`** so jumps align under the sticky header.
> 
> Shared **`briefingItemDomId` / `BRIEFING_EXECUTIVE_SUMMARY_DOM_ID`** and **`briefingItemHref`** now point at overview + hash instead of a sub-route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ab16d6ba74426cd704d0efc55208e91dfd2fff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->