### PR TITLE
fix(onboarding): store BallotReady race hash on details.raceId

### DIFF
--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -240,10 +240,10 @@ export default function OfficeStep({
     }
   }
 
-  // Enrich with electionDay + brPositionId + partisanType so matchesSelected
-  // can use the composite path on page reload for campaigns saved in the new
-  // BR-hash format. partisanType disambiguates partisan/non-partisan variants
-  // of the same office in the same election.
+  // Enrich with electionDay + brPositionId so matchesSelected can use the
+  // composite path on page reload for campaigns saved in the new BR-hash
+  // format. partisanType isn't carried — the lean list shape doesn't have
+  // it either, so the composite stops at (brPositionId, electionDay).
   const selectedOffice:
     | {
         id: string | number | undefined
@@ -252,7 +252,6 @@ export default function OfficeStep({
           electionDay?: string
         }
         brPositionId?: string
-        partisanType?: string
       }
     | false = existingRaceId
     ? {
@@ -262,7 +261,6 @@ export default function OfficeStep({
           electionDay: campaign?.details?.electionDate,
         },
         brPositionId: campaign?.organization?.positionId ?? undefined,
-        partisanType: campaign?.details?.partisanType ?? undefined,
       }
     : false
 

--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -106,7 +106,8 @@ export default function OfficeStep({
       step,
     })
 
-    const { position, election, id, filingPeriods, city } = state.ballotOffice
+    const { position, election, id, brPositionId, filingPeriods, city } =
+      state.ballotOffice
 
     const attr = [
       { key: 'details.electionId', value: election?.id },
@@ -168,10 +169,15 @@ export default function OfficeStep({
     const resolvedOrgSlug =
       organizationSlug ?? (campaign ? `campaign-${campaign.id}` : undefined)
 
-    if (resolvedOrgSlug && position?.id) {
+    // Prefer the top-level race.brPositionId — that's the BR position id the
+    // office-picker matches against (rowKey, matchesSelected). The nested
+    // position.id can differ (it's the RacePosition sub-object id) and would
+    // break the page-reload highlight if we persisted it here.
+    const ballotReadyPositionId = brPositionId ?? position?.id
+    if (resolvedOrgSlug && ballotReadyPositionId) {
       await clientRequest('PATCH /v1/organizations/:slug', {
         slug: resolvedOrgSlug,
-        ballotReadyPositionId: position.id,
+        ballotReadyPositionId,
       })
     }
 
@@ -192,7 +198,7 @@ export default function OfficeStep({
       })
       const createAttr = [
         ...attr,
-        { key: 'ballotReadyPositionId', value: position?.id },
+        { key: 'ballotReadyPositionId', value: ballotReadyPositionId },
       ]
       const newCampaign = await createCampaignWithOffice(createAttr)
       if (!newCampaign) {

--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -240,11 +240,10 @@ export default function OfficeStep({
     }
   }
 
-  // Carry electionDay + position id alongside the raw raceId so BallotRaces
-  // `matchesSelected` can highlight the saved selection via the composite
-  // (brPositionId, electionDay) path. Plain id matching no longer works for
-  // campaigns saved after the office-picker fix, since `details.raceId` is
-  // now a BR race hash and lean list `race.id` is a ZipToPosition UUID.
+  // Enrich with electionDay + brPositionId + partisanType so matchesSelected
+  // can use the composite path on page reload for campaigns saved in the new
+  // BR-hash format. partisanType disambiguates partisan/non-partisan variants
+  // of the same office in the same election.
   const selectedOffice:
     | {
         id: string | number | undefined
@@ -253,6 +252,7 @@ export default function OfficeStep({
           electionDay?: string
         }
         brPositionId?: string
+        partisanType?: string
       }
     | false = existingRaceId
     ? {
@@ -262,6 +262,7 @@ export default function OfficeStep({
           electionDay: campaign?.details?.electionDate,
         },
         brPositionId: campaign?.organization?.positionId ?? undefined,
+        partisanType: campaign?.details?.partisanType ?? undefined,
       }
     : false
 

--- a/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
+++ b/app/onboarding/[slug]/[step]/components/OfficeStep.tsx
@@ -234,15 +234,28 @@ export default function OfficeStep({
     }
   }
 
+  // Carry electionDay + position id alongside the raw raceId so BallotRaces
+  // `matchesSelected` can highlight the saved selection via the composite
+  // (brPositionId, electionDay) path. Plain id matching no longer works for
+  // campaigns saved after the office-picker fix, since `details.raceId` is
+  // now a BR race hash and lean list `race.id` is a ZipToPosition UUID.
   const selectedOffice:
     | {
         id: string | number | undefined
-        election: { id: string | number | null | undefined }
+        election: {
+          id: string | number | null | undefined
+          electionDay?: string
+        }
+        brPositionId?: string
       }
     | false = existingRaceId
     ? {
         id: existingRaceId,
-        election: { id: existingElectionId },
+        election: {
+          id: existingElectionId,
+          electionDay: campaign?.details?.electionDate,
+        },
+        brPositionId: campaign?.organization?.positionId ?? undefined,
       }
     : false
 

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.test.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.test.tsx
@@ -269,4 +269,55 @@ describe('BallotRaces', () => {
 
     expect(onSelect).not.toHaveBeenCalled()
   })
+
+  it('pre-highlights the matching card via the (brPositionId, electionDay) composite when selectedOffice has only the persisted enrichment', async () => {
+    // OfficeStep now hands a "lean persisted" selectedOffice (no `position`,
+    // no top-level Race shape — just `id`, `election.electionDay`, and
+    // `brPositionId`). matchesSelected has to use the composite path; the
+    // id-fallback would miss because lean list rows carry the ZipToPosition
+    // UUID on `id` while the persisted shape carries the BR race hash there.
+    const mayor: Race = {
+      id: 'zip-to-pos-uuid-1',
+      brPositionId: 'br-pos-mayor',
+      position: { id: 'pos-1', name: 'Mayor' },
+      election: { id: 'elec-1', electionDay: '2026-11-03' },
+    }
+    const councilSeat1: Race = {
+      id: 'zip-to-pos-uuid-2',
+      brPositionId: 'br-pos-council',
+      position: { id: 'pos-2', name: 'Council Seat 1' },
+      election: { id: 'elec-1', electionDay: '2026-11-03' },
+    }
+
+    useQueryMock.mockReturnValue({
+      isPending: false,
+      data: {
+        sortedRaces: [mayor, councilSeat1],
+        fuse: {
+          search: () => [{ item: mayor }, { item: councilSeat1 }],
+        },
+      },
+    })
+
+    render(
+      <BallotRaces
+        campaign={campaign}
+        onSelect={vi.fn()}
+        zip="78701"
+        selectedOffice={{
+          id: 'br-race-hash-1',
+          election: { id: 'elec-1', electionDay: '2026-11-03' },
+          brPositionId: 'br-pos-mayor',
+        }}
+      />,
+    )
+
+    const mayorCard = screen.getByText('Mayor').closest('div[class*="border"]')
+    const councilCard = screen
+      .getByText('Council Seat 1')
+      .closest('div[class*="border"]')
+
+    expect(mayorCard?.className).toContain('border-black')
+    expect(councilCard?.className).not.toContain('border-black')
+  })
 })

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.test.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.test.tsx
@@ -219,7 +219,9 @@ describe('BallotRaces', () => {
     await waitFor(() => {
       expect(onSelect).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: 'race-1',
+          // After hydration, id is the BallotReady race hash from
+          // /race-by-position (no longer overridden by the lean row's id).
+          id: 'br-original-id',
           brPositionId: 'br-pos-123',
           filingPeriods: [{ startOn: '2026-01-01', endOn: '2026-02-01' }],
           position: expect.objectContaining({ partisanType: 'partisan' }),

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
@@ -119,12 +119,12 @@ const matchesSelected = (
   const selectedDay = selectedAsRace.election?.electionDay
   if (selectedBrPos && selectedDay) {
     const raceBrPos = race.brPositionId ?? race.position?.id
-    return raceBrPos === selectedBrPos && race.election?.electionDay === selectedDay
+    return (
+      raceBrPos === selectedBrPos && race.election?.electionDay === selectedDay
+    )
   }
   return (
-    'id' in selected &&
-    selected.id !== undefined &&
-    race.id === selected.id
+    'id' in selected && selected.id !== undefined && race.id === selected.id
   )
 }
 

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
@@ -29,7 +29,6 @@ interface SelectedOffice {
   id?: string | number
   election?: { id?: string | number | null; electionDay?: string }
   brPositionId?: string
-  partisanType?: string
 }
 
 interface BallotRacesProps {
@@ -99,10 +98,11 @@ const getHighlightedText = (text: string, searchTerm: string): ReactNode => {
   )
 }
 
-// Composite (brPositionId, electionDay, partisanType) match when available;
-// id fallback for legacy UUID-format raceIds persisted before the
-// office-picker fix. partisanType is the tiebreaker for partisan/non-partisan
-// variants of the same office in the same election.
+// Composite (brPositionId, electionDay) match when available; id fallback
+// for legacy UUID-format raceIds persisted before the office-picker fix.
+// partisanType is intentionally not part of the composite — the lean list
+// from /races-by-year doesn't carry it, so including it would diverge from
+// the hydrated shape and drop the radio's highlight after hydration.
 const matchesSelected = (
   race: Race,
   selected: Race | SelectedOffice | false,
@@ -114,14 +114,8 @@ const matchesSelected = (
   const selectedDay = selectedAsRace.election?.electionDay
   if (selectedBrPos && selectedDay) {
     const raceBrPos = race.brPositionId ?? race.position?.id
-    const selectedPartisan =
-      (selected as SelectedOffice).partisanType ??
-      selectedAsRace.position?.partisanType ??
-      ''
     return (
-      raceBrPos === selectedBrPos &&
-      race.election?.electionDay === selectedDay &&
-      (race.position?.partisanType ?? '') === selectedPartisan
+      raceBrPos === selectedBrPos && race.election?.electionDay === selectedDay
     )
   }
   return (

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
@@ -97,6 +97,37 @@ const getHighlightedText = (text: string, searchTerm: string): ReactNode => {
   )
 }
 
+// Returns true when the selected item refers to the same race as `race`.
+// Uses (brPositionId + electionDay) composite when both sides have it (hydrated
+// Race or lean RaceListItem in the list), and falls back to plain id matching
+// when `selected` is just the persisted-from-prop shape ({ id, election }) —
+// preserving the existing "initial highlight from saved selection" behavior
+// without re-introducing the `id: race.id` override on hydrated races, which
+// silently overwrites the BallotReady race hash that downstream filing-fee
+// lookups depend on.
+const matchesSelected = (
+  race: Race,
+  selected:
+    | Race
+    | { id?: string | number; election?: { id?: string | number | null } }
+    | false,
+): boolean => {
+  if (!selected) return false
+  const selectedAsRace = selected as Race
+  const selectedBrPos =
+    selectedAsRace.brPositionId ?? selectedAsRace.position?.id
+  const selectedDay = selectedAsRace.election?.electionDay
+  if (selectedBrPos && selectedDay) {
+    const raceBrPos = race.brPositionId ?? race.position?.id
+    return raceBrPos === selectedBrPos && race.election?.electionDay === selectedDay
+  }
+  return (
+    'id' in selected &&
+    selected.id !== undefined &&
+    race.id === selected.id
+  )
+}
+
 export default function BallotRaces({
   campaign,
   onSelect,
@@ -169,7 +200,11 @@ export default function BallotRaces({
           electionDate: race.election.electionDay,
         },
       )
-      return { ...data, id: race.id }
+      // Pass the hydrated race through unchanged so `data.id` (the BallotReady
+      // race hash) ends up on the selected race. The card-selected check uses
+      // `matchesSelected` which compares via (brPositionId, electionDay), so
+      // dropping the previous `id: race.id` override no longer breaks the UI.
+      return data
     } catch {
       errorSnackbar('Could not load race details. Please try again.')
       return null
@@ -177,13 +212,13 @@ export default function BallotRaces({
   }
 
   const handleSelect = async (race: { id: string }) => {
-    if (race.id === (selected && 'id' in selected ? selected.id : undefined)) {
+    const matchedRace = races.find(({ id }) => id === race.id)
+    if (!matchedRace) {
       setSelected(false)
       onSelect(false)
       return
     }
-    const matchedRace = races.find(({ id }) => id === race.id)
-    if (!matchedRace) {
+    if (matchesSelected(matchedRace, selected)) {
       setSelected(false)
       onSelect(false)
       return
@@ -311,10 +346,7 @@ export default function BallotRaces({
                     ),
                   },
                 }}
-                selected={
-                  race?.id ===
-                  (selected && 'id' in selected ? selected.id : undefined)
-                }
+                selected={matchesSelected(race, selected)}
                 isHydrating={hydratingId === race.id}
                 selectCallback={handleSelect}
               />

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
@@ -29,6 +29,7 @@ interface SelectedOffice {
   id?: string | number
   election?: { id?: string | number | null; electionDay?: string }
   brPositionId?: string
+  partisanType?: string
 }
 
 interface BallotRacesProps {
@@ -98,13 +99,10 @@ const getHighlightedText = (text: string, searchTerm: string): ReactNode => {
   )
 }
 
-// Returns true when the selected item refers to the same race as `race`.
-// Uses (brPositionId + electionDay) composite when both sides have it — both
-// hydrated Race objects and the persisted-from-prop shape (which OfficeStep
-// now enriches with `brPositionId` + `election.electionDay`) carry the data.
-// Falls back to plain id matching for older saved selections where only
-// `{ id, election: { id } }` is available, preserving the "initial highlight
-// from saved selection" behavior for legacy UUID-format raceIds in the DB.
+// Composite (brPositionId, electionDay, partisanType) match when available;
+// id fallback for legacy UUID-format raceIds persisted before the
+// office-picker fix. partisanType is the tiebreaker for partisan/non-partisan
+// variants of the same office in the same election.
 const matchesSelected = (
   race: Race,
   selected: Race | SelectedOffice | false,
@@ -116,8 +114,14 @@ const matchesSelected = (
   const selectedDay = selectedAsRace.election?.electionDay
   if (selectedBrPos && selectedDay) {
     const raceBrPos = race.brPositionId ?? race.position?.id
+    const selectedPartisan =
+      (selected as SelectedOffice).partisanType ??
+      selectedAsRace.position?.partisanType ??
+      ''
     return (
-      raceBrPos === selectedBrPos && race.election?.electionDay === selectedDay
+      raceBrPos === selectedBrPos &&
+      race.election?.electionDay === selectedDay &&
+      (race.position?.partisanType ?? '') === selectedPartisan
     )
   }
   return (

--- a/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
+++ b/app/onboarding/[slug]/[step]/components/ballotOffices/BallotRaces.tsx
@@ -27,7 +27,8 @@ interface BallotRacesCampaign extends Campaign {
 
 interface SelectedOffice {
   id?: string | number
-  election?: { id?: string | number | null }
+  election?: { id?: string | number | null; electionDay?: string }
+  brPositionId?: string
 }
 
 interface BallotRacesProps {
@@ -98,19 +99,15 @@ const getHighlightedText = (text: string, searchTerm: string): ReactNode => {
 }
 
 // Returns true when the selected item refers to the same race as `race`.
-// Uses (brPositionId + electionDay) composite when both sides have it (hydrated
-// Race or lean RaceListItem in the list), and falls back to plain id matching
-// when `selected` is just the persisted-from-prop shape ({ id, election }) —
-// preserving the existing "initial highlight from saved selection" behavior
-// without re-introducing the `id: race.id` override on hydrated races, which
-// silently overwrites the BallotReady race hash that downstream filing-fee
-// lookups depend on.
+// Uses (brPositionId + electionDay) composite when both sides have it — both
+// hydrated Race objects and the persisted-from-prop shape (which OfficeStep
+// now enriches with `brPositionId` + `election.electionDay`) carry the data.
+// Falls back to plain id matching for older saved selections where only
+// `{ id, election: { id } }` is available, preserving the "initial highlight
+// from saved selection" behavior for legacy UUID-format raceIds in the DB.
 const matchesSelected = (
   race: Race,
-  selected:
-    | Race
-    | { id?: string | number; election?: { id?: string | number | null } }
-    | false,
+  selected: Race | SelectedOffice | false,
 ): boolean => {
   if (!selected) return false
   const selectedAsRace = selected as Race

--- a/app/onboarding/components/LocalNewsSourcesSection.tsx
+++ b/app/onboarding/components/LocalNewsSourcesSection.tsx
@@ -18,11 +18,19 @@ const LOCAL_NEWS_ROUTE = 'GET /v1/onboarding/local-news'
 const SENTRY_CONTEXT_FETCH_OUTLETS = 'onboarding.localNews.fetchOutlets'
 const COLLAPSED_OUTLETS_VISIBLE = 1
 const SKELETON_PLACEHOLDER_COUNT = 3
+// gp-api runs the AI call as a background promise and persists the result on
+// the campaign record. The endpoint returns either { status: 'pending' } or
+// { status: 'ready', outlets }. Poll while pending so we never hold an open
+// request across the Next.js proxy's 30s ceiling.
+const LOCAL_NEWS_POLL_INTERVAL_MS = 3_000
 
 interface Outlet {
   name: string
   type: OutletType
   description: string
+  email?: string | null
+  phone?: string | null
+  address?: string | null
 }
 
 interface OutletGroup {
@@ -44,6 +52,15 @@ const localNewsQueryOptions = (params: {
         state: params.state ?? '',
         office: params.office ?? '',
       }).then((res) => res.data),
+    refetchInterval: (query) =>
+      query.state.data?.status === 'pending'
+        ? LOCAL_NEWS_POLL_INTERVAL_MS
+        : false,
+    // Once we've got ready data, don't re-poll on remount or Strict-Mode
+    // effect double-runs.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 1,
   })
 
 export { localNewsQueryOptions }
@@ -249,8 +266,8 @@ export const LocalNewsSourcesSection = ({
   }, [query.error, state, office])
 
   const outlets: Outlet[] = useMemo(
-    () => query.data?.outlets ?? [],
-    [query.data?.outlets],
+    () => (query.data?.status === 'ready' ? query.data.outlets : []),
+    [query.data],
   )
 
   const groupedOutlets = useMemo(() => groupOutletsByType(outlets), [outlets])
@@ -276,7 +293,8 @@ export const LocalNewsSourcesSection = ({
   })
 
   const renderBody = () => {
-    if (query.isPending) return <LocalNewsSkeleton />
+    if (query.isPending || query.data?.status === 'pending')
+      return <LocalNewsSkeleton />
     if (query.error) {
       return (
         <p className="text-sm text-muted-foreground">

--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -323,4 +323,49 @@ describe('OfficeSelectionStep', () => {
     renderStep()
     expect(screen.getByText(/enter your zip code/i)).toBeInTheDocument()
   })
+
+  it('pre-highlights the matching radio when mounted with a persisted selected office', async () => {
+    // selectedRowKey(selected) must equal rowKey(race) for the lean list row
+    // to render checked on first render — covers the page-reload restore path
+    // for campaigns saved in the new BR-hash format.
+    mockClientFetch.mockResolvedValueOnce({
+      data: [
+        sampleRace(),
+        sampleRace({
+          id: 'race-2',
+          brPositionId: 'br-pos-2',
+          position: {
+            id: 'pos-2',
+            name: /mayor election date/i,
+            level: 'local',
+            state: 'WY',
+            electionFrequencies: [{ frequency: 4 }],
+            partisanType: 'nonpartisan',
+          },
+        }),
+      ],
+      ok: true,
+    } as unknown as Awaited<ReturnType<typeof clientFetch>>)
+
+    renderStep({
+      zip: '82001',
+      selected: {
+        raceId: 'persisted-br-hash',
+        positionId: 'br-pos-2',
+        positionName: 'Mayor',
+        electionDay: '2026-11-03',
+        partisanType: 'nonpartisan',
+      },
+    })
+
+    const mayorRadio = await screen.findByRole('radio', {
+      name: /mayor election date/i,
+    })
+    const councilRadio = await screen.findByRole('radio', {
+      name: /city council election date/i,
+    })
+
+    expect(mayorRadio).toBeChecked()
+    expect(councilRadio).not.toBeChecked()
+  })
 })

--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -188,7 +188,9 @@ describe('OfficeSelectionStep', () => {
     await waitFor(() => {
       expect(onSelect).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          raceId: 'race-1',
+          // After hydration, raceId is the BallotReady race hash returned by
+          // /race-by-position (no longer overridden by the lean search row's id).
+          raceId: 'race-server',
           positionId: 'pos-1',
           positionName: 'City Council',
           officeTermLength: '4 years',

--- a/app/onboarding/components/OfficeSelectionStep.test.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.test.tsx
@@ -190,8 +190,10 @@ describe('OfficeSelectionStep', () => {
         expect.objectContaining({
           // After hydration, raceId is the BallotReady race hash returned by
           // /race-by-position (no longer overridden by the lean search row's id).
+          // positionId prefers brPositionId to stay aligned with `rowKey` so the
+          // radio's selected key matches the row's key after hydration.
           raceId: 'race-server',
-          positionId: 'pos-1',
+          positionId: 'br-pos-1',
           positionName: 'City Council',
           officeTermLength: '4 years',
           electionDay: '2026-11-03',

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -180,27 +180,19 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
   }
 }
 
-// Stable per-row identity for UI selection state. Composed of BR position id +
-// electionDay because those exist on both the lean RaceListItem and the
-// hydrated RaceFull, so the radio key survives the lean → hydrated transition
-// without us needing to override the race's `id`. Letting `id` flow through
-// unchanged keeps the BallotReady race hash on `selected.raceId`, which is what
-// downstream (filing-fee lookup, etc.) actually wants.
-// `partisanType` is the tiebreaker — two Race rows can share the same
-// (brPositionId, electionDay) for partisan vs non-partisan variants of the
-// same office. Without it, `races.find(r => rowKey(r) === key)` always
-// resolves to the first match and React warns about duplicate keys.
+// Composite (brPositionId, electionDay) row key — both fields exist on the
+// lean RaceListItem and the hydrated RaceFull, so the key stays stable
+// across the optimistic→hydrated transition. partisanType is intentionally
+// NOT included: the lean schema doesn't carry it, so adding it would make
+// selectedRowKey (which picks up partisanType after hydration) diverge
+// from rowKey on the lean list and drop the radio's highlight.
 const rowKey = (race: Race): string =>
   `${race.brPositionId ?? race.position?.id ?? ''}|${
     race.election?.electionDay ?? ''
-  }|${race.position?.partisanType ?? ''}`
+  }`
 
 const selectedRowKey = (selected: SelectedOffice | undefined): string =>
-  selected
-    ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}|${
-        selected.partisanType ?? ''
-      }`
-    : ''
+  selected ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}` : ''
 
 const RaceListSkeleton = () => (
   <div aria-label="Loading offices" className="space-y-6" role="status">

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -185,7 +185,9 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
 // unchanged keeps the BallotReady race hash on `selected.raceId`, which is what
 // downstream (filing-fee lookup, etc.) actually wants.
 const rowKey = (race: Race): string =>
-  `${race.brPositionId ?? race.position?.id ?? ''}|${race.election?.electionDay ?? ''}`
+  `${race.brPositionId ?? race.position?.id ?? ''}|${
+    race.election?.electionDay ?? ''
+  }`
 
 const selectedRowKey = (selected: SelectedOffice | undefined): string =>
   selected ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}` : ''

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -157,7 +157,11 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
   const filingPeriod = race.filingPeriods?.[0]
   return {
     raceId: race.id,
-    positionId: race.position?.id,
+    // Lean RaceListItem carries the BR position id at the top level
+    // (`brPositionId`); the hydrated RaceFull surfaces it as `position.id`.
+    // Fall back across both shapes so `selected.positionId` is always the BR
+    // position id, regardless of which stage of selection we're at.
+    positionId: race.position?.id ?? race.brPositionId,
     positionName: race.position?.name ?? '',
     level: race.position?.level,
     city: race.city ?? undefined,
@@ -173,6 +177,18 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
     filingPeriodsEnd: filingPeriod?.endOn,
   }
 }
+
+// Stable per-row identity for UI selection state. Composed of BR position id +
+// electionDay because those exist on both the lean RaceListItem and the
+// hydrated RaceFull, so the radio key survives the lean → hydrated transition
+// without us needing to override the race's `id`. Letting `id` flow through
+// unchanged keeps the BallotReady race hash on `selected.raceId`, which is what
+// downstream (filing-fee lookup, etc.) actually wants.
+const rowKey = (race: Race): string =>
+  `${race.brPositionId ?? race.position?.id ?? ''}|${race.election?.electionDay ?? ''}`
+
+const selectedRowKey = (selected: SelectedOffice | undefined): string =>
+  selected ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}` : ''
 
 const RaceListSkeleton = () => (
   <div aria-label="Loading offices" className="space-y-6" role="status">
@@ -310,7 +326,12 @@ export const OfficeSelectionStep = ({
           electionDate: race.election.electionDay,
         },
       )
-      return { ...data, id: race.id }
+      // Pass the hydrated race through unchanged so `data.id` (the BallotReady
+      // race hash) ends up on `selected.raceId`. The radio's selection state
+      // doesn't depend on race-row id any more — it's keyed on
+      // (brPositionId, electionDay) via `rowKey` — so dropping the previous
+      // `id: race.id` override no longer breaks the picker.
+      return data
     } catch {
       errorSnackbar('Could not load race details. Please try again.')
       return null
@@ -318,7 +339,7 @@ export const OfficeSelectionStep = ({
   }
 
   const handleSelectRace = async (race: Race) => {
-    if (selected?.raceId === race.id) {
+    if (selectedRowKey(selected) === rowKey(race)) {
       pendingHydrationRaceIdRef.current = null
       onSelect(undefined)
       onHydratingChange?.(false)
@@ -447,9 +468,9 @@ export const OfficeSelectionStep = ({
               <RadioGroup
                 aria-label="Available offices"
                 className="flex flex-col"
-                value={selected?.raceId ?? ''}
-                onValueChange={(raceId) => {
-                  const race = races.find((r) => r.id === raceId)
+                value={selectedRowKey(selected)}
+                onValueChange={(key) => {
+                  const race = races.find((r) => rowKey(r) === key)
                   if (race) void handleSelectRace(race)
                 }}
               >
@@ -478,11 +499,12 @@ export const OfficeSelectionStep = ({
                       {yearRaces.map((race) => {
                         const positionName = race.position?.name ?? 'Office'
                         const cityLabel = race.city ? ` — ${race.city}` : ''
+                        const key = rowKey(race)
                         return (
                           <RadioCardItem
-                            key={race.id}
-                            value={race.id}
-                            id={`race-${race.id}`}
+                            key={key}
+                            value={key}
+                            id={`race-${key}`}
                             title={`${positionName}${cityLabel}`}
                             description={formatElectionDate(
                               race.election?.electionDay,

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -186,13 +186,21 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
 // without us needing to override the race's `id`. Letting `id` flow through
 // unchanged keeps the BallotReady race hash on `selected.raceId`, which is what
 // downstream (filing-fee lookup, etc.) actually wants.
+// `partisanType` is the tiebreaker — two Race rows can share the same
+// (brPositionId, electionDay) for partisan vs non-partisan variants of the
+// same office. Without it, `races.find(r => rowKey(r) === key)` always
+// resolves to the first match and React warns about duplicate keys.
 const rowKey = (race: Race): string =>
   `${race.brPositionId ?? race.position?.id ?? ''}|${
     race.election?.electionDay ?? ''
-  }`
+  }|${race.position?.partisanType ?? ''}`
 
 const selectedRowKey = (selected: SelectedOffice | undefined): string =>
-  selected ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}` : ''
+  selected
+    ? `${selected.positionId ?? ''}|${selected.electionDay ?? ''}|${
+        selected.partisanType ?? ''
+      }`
+    : ''
 
 const RaceListSkeleton = () => (
   <div aria-label="Loading offices" className="space-y-6" role="status">

--- a/app/onboarding/components/OfficeSelectionStep.tsx
+++ b/app/onboarding/components/OfficeSelectionStep.tsx
@@ -159,9 +159,11 @@ const toSelectedOffice = (race: Race): SelectedOffice => {
     raceId: race.id,
     // Lean RaceListItem carries the BR position id at the top level
     // (`brPositionId`); the hydrated RaceFull surfaces it as `position.id`.
-    // Fall back across both shapes so `selected.positionId` is always the BR
-    // position id, regardless of which stage of selection we're at.
-    positionId: race.position?.id ?? race.brPositionId,
+    // Priority matches `rowKey` below so `selectedRowKey` and `rowKey` always
+    // resolve to the same string for the same race — otherwise the radio
+    // loses its highlight after hydration when both fields exist with
+    // different values.
+    positionId: race.brPositionId ?? race.position?.id,
     positionName: race.position?.name ?? '',
     level: race.position?.level,
     city: race.city ?? undefined,

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -238,13 +238,19 @@ export type APIEndpoints = {
       state: string
       office: string
     }
-    Response: {
-      outlets: Array<{
-        name: string
-        type: 'TV' | 'print' | 'radio'
-        description: string
-      }>
-    }
+    Response:
+      | { status: 'pending' }
+      | {
+          status: 'ready'
+          outlets: Array<{
+            name: string
+            type: 'TV' | 'print' | 'radio'
+            description: string
+            email?: string | null
+            phone?: string | null
+            address?: string | null
+          }>
+        }
   }
 
   'GET /v1/onboarding/voter-issues': {


### PR DESCRIPTION
## Summary

Both office pickers (`OfficeSelectionStep` and the legacy `BallotRaces`) have been overriding the hydrated race's id with the lean search-row id in `hydrateRace`:

```ts
return { ...data, id: race.id }   // ← strips out data.id (the BR race hash)
```

Result: every campaign saved through either picker after this override landed has stored a `ZipToPosition.id` UUID on `campaign.details.raceId` instead of the BallotReady race hash. The election-api filing-fee lookup (and any other Race-by-id consumer) keys on `Race.br_hash_id`, so the wrong id silently broke the join.

This PR stops the bleed. A separate ticket ([ENG-10240](https://app.clickup.com/t/86ahq8uh1)) tracks migrating the existing UUID-format rows back to BR hashes.

## What changed

- **Dropped `id: race.id`** in both pickers' `hydrateRace` so `data.id` (the BR race hash from `/v1/elections/race-by-position`) flows through onto `selected.raceId`.
- **`OfficeSelectionStep`** — radio matching re-keyed on a composite `(brPositionId, electionDay)`. Both fields exist on the lean `RaceListItem` and the hydrated `RaceFull`, so the radio's selected state survives the lean → hydrated transition without depending on the race-row id format.
- **`BallotRaces`** — new `matchesSelected()` helper that prefers the composite comparison when both sides have it (hydrated / lean) and falls back to plain id comparison for the initial-from-prop shape, preserving the existing "highlight saved selection on first render" behavior for UUID-format raceIds already in the DB.
- **`toSelectedOffice`** falls back to `race.brPositionId` when `race.position?.id` is missing — covers the lean shape used during the optimistic select before hydration finishes.
- `OfficeStep.canSubmit` intentionally left alone; its `existingRaceId === id` comparison naturally heals after one save in the new format.

## Tests

Two assertions in `OfficeSelectionStep.test.tsx` and `BallotRaces.test.tsx` were encoding the old override behavior (`raceId: 'race-1'` / `id: 'race-1'` after hydration). Updated to assert the new (BR-hash) values the hydrated mock actually carries.

## Existing data

In-flight data is mixed (some BR hashes from pre-override / CRM / server pushes, some UUIDs from the override window). This PR doesn't touch existing rows — see [ENG-10240](https://app.clickup.com/t/86ahq8uh1) for the migration plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets saved on `campaign.details.raceId` and selection matching logic in two onboarding flows; wrong composite matching could break highlight/deselect, but scope is limited to office selection UI.
> 
> **Overview**
> Stops overwriting the hydrated race id with the lean search-row id in **`OfficeSelectionStep`** and **`BallotRaces`**, so **`details.raceId`** / **`selected.raceId`** keep the BallotReady hash from **`/v1/elections/race-by-position`** instead of a ZipToPosition UUID.
> 
> UI selection no longer depends on row **`id`**: **`OfficeSelectionStep`** keys radios on **`(positionId, electionDay)`** via **`rowKey`**, and **`BallotRaces`** uses **`matchesSelected`** (composite when possible, id fallback for saved UUID highlights). **`toSelectedOffice`** now sets **`positionId`** from **`brPositionId`** when **`position.id`** is missing on lean rows.
> 
> Tests were updated to expect the BR hash after hydration, not the lean list id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8a5cbcab181a83d6ea5430295106a4980835b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->