### PR TITLE
Add campaign committee to campaign update in CommitteeCheckPage

### DIFF
--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
@@ -90,6 +90,10 @@ const CommitteeCheckPage = ({
       setLoadingCampaignUpdate(true)
       await updateCampaign([
         {
+          key: 'details.campaignCommittee',
+          value: campaignCommittee,
+        },
+        {
           key: 'details.einNumber',
           value: einInputValue,
         },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field addition to an existing updateCampaign call in the pro sign-up flow; no auth or security impact.
> 
> **Overview**
> Fixes a gap in the Pro upgrade **committee check** step: when the user clicks **Next**, the campaign update now also persists **`details.campaignCommittee`** from the form, alongside the existing EIN and `validatedEin` fields.
> 
> Previously only EIN-related fields were sent, so the committee name entered on this page could be lost after continuing to the service agreement step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63668af631aff66b318b65f10a6252e75167f671. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->