### PR TITLE
Feature/note attachments

### DIFF
--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -13,6 +13,18 @@ import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
 import type { SheetState } from './AnnotationsScope'
 import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
+import NoteAttachmentPicker, {
+  makeStagedAttachment,
+  type StagedAttachment,
+} from './NoteAttachmentPicker'
+
+const MAX_BYTES = 20 * 1024 * 1024
+
+const formatBytes = (n: number): string => {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
 
 type Props = {
   sheet: SheetState
@@ -20,6 +32,7 @@ type Props = {
   onCreate: (
     anchor: ResolvedAnchor | null,
     body: string,
+    attachments: StagedAttachment[],
   ) => Promise<void> | void
   onUpdate: (annotationId: string, body: string) => Promise<void> | void
   onDelete: (annotationId: string) => Promise<void> | void
@@ -62,14 +75,18 @@ export default function AddNoteSheet({
     sheet.kind === 'add_note_edit' ? sheet.annotation.note?.body ?? '' : ''
   const [body, setBody] = useState(initialBody)
   const [saving, setSaving] = useState(false)
+  const [attachments, setAttachments] = useState<StagedAttachment[]>([])
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
 
-  // Reset body when the sheet transitions states.
+  // Reset body + staged attachments when the sheet transitions states.
   useEffect(() => {
     if (sheet.kind === 'add_note_edit') {
       setBody(sheet.annotation.note?.body ?? '')
     } else if (sheet.kind === 'add_note_new') {
       setBody('')
     }
+    setAttachments([])
+    setAttachmentError(null)
   }, [sheet])
 
   // Clear the user's text selection once the drawer opens — leaving a live
@@ -79,6 +96,24 @@ export default function AddNoteSheet({
   const quote = quoteFor(sheet)
   const isEdit = sheet.kind === 'add_note_edit'
 
+  function handleAddAttachment(
+    file: File,
+    source: 'photos' | 'camera' | 'document',
+  ) {
+    setAttachmentError(null)
+    if (file.size > MAX_BYTES) {
+      setAttachmentError(
+        `File too large. Max 20 MB; ${formatBytes(file.size)} given.`,
+      )
+      return
+    }
+    setAttachments((prev) => [...prev, makeStagedAttachment(file, source)])
+  }
+
+  function handleRemoveAttachment(id: string) {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  }
+
   async function handleSave() {
     if (saving) return
     setSaving(true)
@@ -86,7 +121,7 @@ export default function AddNoteSheet({
       if (sheet.kind === 'add_note_edit') {
         await onUpdate(sheet.annotation.id, body)
       } else if (sheet.kind === 'add_note_new') {
-        await onCreate(sheet.anchor, body)
+        await onCreate(sheet.anchor, body, attachments)
       }
       onClose()
     } finally {
@@ -105,7 +140,15 @@ export default function AddNoteSheet({
     }
   }
 
-  const canSave = body.trim().length > 0 && !saving
+  // New-note saves are allowed with just attachments and no body — the
+  // server's note payload already treats `body` as optional. Edit mode
+  // still requires non-empty body (the editor isn't wired for adding
+  // attachments to an existing note yet).
+  const canSave =
+    !saving &&
+    (isEdit
+      ? body.trim().length > 0
+      : body.trim().length > 0 || attachments.length > 0)
 
   return (
     <Drawer
@@ -132,6 +175,16 @@ export default function AddNoteSheet({
             <p className="rounded-md bg-muted px-3 py-2 text-sm italic text-muted-foreground">
               This note is for the whole briefing.
             </p>
+          ) : null}
+
+          {!isEdit ? (
+            <NoteAttachmentPicker
+              attachments={attachments}
+              onAdd={handleAddAttachment}
+              onRemove={handleRemoveAttachment}
+              disabled={saving}
+              error={attachmentError}
+            />
           ) : null}
 
           <Textarea

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { Trash2 } from 'lucide-react'
 import {
   Button,
   Drawer,
@@ -355,11 +356,13 @@ export default function AddNoteSheet({
           {isEdit ? (
             <Button
               type="button"
+              size="small"
               variant="link"
               disabled={saving}
               onClick={handleDeleteNote}
-              className="self-start text-destructive"
+              className="self-center gap-1.5 text-destructive"
             >
+              <Trash2 className="size-4" aria-hidden />
               Delete note
             </Button>
           ) : null}

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Trash2 } from 'lucide-react'
+import { Loader2, Paperclip, Trash2, X } from 'lucide-react'
 import {
   Button,
   Drawer,
@@ -50,6 +50,15 @@ type Props = {
     annotationId: string,
     attachmentId: string,
   ) => Promise<void>
+  /**
+   * All existing top-level notes for this briefing. Rendered as a list
+   * above the composer when the sheet is in top-level new mode so the
+   * user can see, tap-to-edit, or delete previously-added briefing-wide
+   * notes (those have no anchor and don't render as highlights).
+   */
+  topLevelNotes: Annotation[]
+  /** Open an existing note in edit mode (from the top-level list). */
+  onEditNote: (annotation: Annotation) => void
 }
 
 /**
@@ -106,6 +115,8 @@ export default function AddNoteSheet({
   onDelete,
   onAttachmentAdd,
   onAttachmentDelete,
+  topLevelNotes,
+  onEditNote,
 }: Props): React.JSX.Element {
   const open = isAddNoteState(sheet)
   const isDesktop = !useIsMobile()
@@ -130,6 +141,12 @@ export default function AddNoteSheet({
   const [busyAttachmentIds, setBusyAttachmentIds] = useState<Set<string>>(
     () => new Set(),
   )
+  // Top-level list rows currently being deleted — drives the spinner on
+  // the row's X button. Distinct from busyAttachmentIds (which tracks
+  // attachment upload/delete inside an open note).
+  const [deletingNoteIds, setDeletingNoteIds] = useState<Set<string>>(
+    () => new Set(),
+  )
 
   // Reset body + staged attachments when the sheet transitions states.
   useEffect(() => {
@@ -142,6 +159,7 @@ export default function AddNoteSheet({
     setAttachmentError(null)
     setSaveError(null)
     setBusyAttachmentIds(new Set())
+    setDeletingNoteIds(new Set())
   }, [sheet])
 
   // Clear the user's text selection once the drawer opens — leaving a live
@@ -154,6 +172,29 @@ export default function AddNoteSheet({
     sheet.kind === 'add_note_edit'
       ? sheet.annotation.note?.attachments ?? []
       : []
+  // True when the sheet is opened for a brand-new top-level (briefing-wide)
+  // note. In that case we render the user's existing top-level notes
+  // above the composer so they can see what's already saved without the
+  // drawer needing to be closed and reopened.
+  const isTopLevelNew = sheet.kind === 'add_note_new' && sheet.anchor === null
+
+  async function handleListDelete(annotationId: string) {
+    if (deletingNoteIds.has(annotationId)) return
+    setDeletingNoteIds((prev) => new Set(prev).add(annotationId))
+    setSaveError(null)
+    try {
+      await onDelete(annotationId)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setSaveError(`Couldn't delete this note: ${msg}`)
+    } finally {
+      setDeletingNoteIds((prev) => {
+        const next = new Set(prev)
+        next.delete(annotationId)
+        return next
+      })
+    }
+  }
 
   function markBusy(id: string, busy: boolean) {
     setBusyAttachmentIds((prev) => {
@@ -328,6 +369,77 @@ export default function AddNoteSheet({
               This note is for the whole briefing.
             </p>
           ) : null}
+
+          {(() => {
+            if (!isTopLevelNew) return null
+            // Hide notes that have neither a body nor any attachments yet.
+            // This covers the brief window between create.mutateAsync
+            // resolving and the attachment uploads' refetch landing —
+            // rendering them would flash "(empty note)" for a frame.
+            const visibleNotes = topLevelNotes.filter(
+              (n) =>
+                (n.note?.body ?? '').trim().length > 0 ||
+                (n.note?.attachments?.length ?? 0) > 0,
+            )
+            if (visibleNotes.length === 0) return null
+            return (
+              <ul className="flex list-none flex-col gap-2">
+                {visibleNotes.map((n) => {
+                  const attachCount = n.note?.attachments?.length ?? 0
+                  const preview = (n.note?.body ?? '').trim()
+                  const label =
+                    preview.length > 0
+                      ? preview
+                      : `${attachCount} attachment${
+                          attachCount === 1 ? '' : 's'
+                        }`
+                  const busy = deletingNoteIds.has(n.id)
+                  return (
+                    <li key={n.id}>
+                      <div className="group flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 transition-colors hover:bg-muted/60">
+                        <button
+                          type="button"
+                          onClick={() => onEditNote(n)}
+                          className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm focus:outline-none"
+                        >
+                          <span className="line-clamp-2 min-w-0 flex-1 text-foreground">
+                            {label}
+                          </span>
+                          {attachCount > 0 ? (
+                            <span
+                              aria-label={`${attachCount} attached file${
+                                attachCount === 1 ? '' : 's'
+                              }`}
+                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                            >
+                              <Paperclip className="size-3" aria-hidden />
+                              {attachCount}
+                            </span>
+                          ) : null}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleListDelete(n.id)}
+                          disabled={busy}
+                          aria-label="Delete note"
+                          className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {busy ? (
+                            <Loader2
+                              className="size-4 animate-spin"
+                              aria-hidden
+                            />
+                          ) : (
+                            <X className="size-4" aria-hidden />
+                          )}
+                        </button>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )
+          })()}
         </div>
 
         {/* Composer pinned at the bottom. The attachment picker sits above

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -122,6 +122,7 @@ export default function AddNoteSheet({
     StagedAttachment[]
   >([])
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
   // Per-attachment busy state for edit mode — keyed by either the staged
   // upload's temp id (while the upload is in flight, before the server
   // attachment id is known) or the server attachment id (while a delete
@@ -139,6 +140,7 @@ export default function AddNoteSheet({
     }
     setStagedAttachments([])
     setAttachmentError(null)
+    setSaveError(null)
     setBusyAttachmentIds(new Set())
   }, [sheet])
 
@@ -236,6 +238,7 @@ export default function AddNoteSheet({
   async function handleSave() {
     if (saving) return
     setSaving(true)
+    setSaveError(null)
     try {
       if (sheet.kind === 'add_note_edit') {
         await onUpdate(sheet.annotation.id, body)
@@ -243,6 +246,9 @@ export default function AddNoteSheet({
         await onCreate(sheet.anchor, body, stagedAttachments)
       }
       onClose()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setSaveError(`Couldn't save your note: ${msg}`)
     } finally {
       setSaving(false)
     }
@@ -251,9 +257,13 @@ export default function AddNoteSheet({
   async function handleDeleteNote() {
     if (sheet.kind !== 'add_note_edit' || saving) return
     setSaving(true)
+    setSaveError(null)
     try {
       await onDelete(sheet.annotation.id)
       onClose()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setSaveError(`Couldn't delete this note: ${msg}`)
     } finally {
       setSaving(false)
     }
@@ -353,6 +363,11 @@ export default function AddNoteSheet({
               {saving ? 'Saving…' : 'Save'}
             </Button>
           </div>
+          {saveError ? (
+            <p role="alert" className="text-sm text-destructive">
+              {saveError}
+            </p>
+          ) : null}
           {isEdit ? (
             <Button
               type="button"

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -12,8 +12,7 @@ import {
 } from '@styleguide'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import {
-  buildRangeIn,
-  findAnchorEl,
+  resolveQuoteFromAnchor,
   type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
 import type { Annotation } from '@shared/briefings/types'
@@ -61,32 +60,12 @@ type Props = {
   onEditNote: (annotation: Annotation) => void
 }
 
-/**
- * Resolve the highlighted text for an existing annotation by walking the
- * live DOM. The server doesn't store the original quote, so we rebuild
- * it on demand from the annotation's `jsonPath` + `start`/`end` offsets.
- * Returns null when the annotation has no anchor (top-level note) or
- * when the DOM no longer matches (e.g. content changed since the note
- * was written).
- */
-function resolveExistingQuote(annotation: Annotation): string | null {
-  if (typeof document === 'undefined') return null
-  const { jsonPath, start, end } = annotation
-  if (jsonPath === null || start === null || end === null) return null
-  const el = findAnchorEl(jsonPath)
-  if (!el) return null
-  const range = buildRangeIn(el, start, end)
-  if (!range) return null
-  const quote = range.toString().trim()
-  return quote.length > 0 ? quote : null
-}
-
 function quoteFor(state: SheetState): string | null {
   if (state.kind === 'add_note_new') {
     return state.anchor?.quote ?? null
   }
   if (state.kind === 'add_note_edit') {
-    return resolveExistingQuote(state.annotation)
+    return resolveQuoteFromAnchor(state.annotation)
   }
   return null
 }

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Button,
   Drawer,
@@ -15,6 +15,7 @@ import type { SheetState } from './AnnotationsScope'
 import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
 import NoteAttachmentPicker, {
   makeStagedAttachment,
+  type PickerItem,
   type StagedAttachment,
 } from './NoteAttachmentPicker'
 
@@ -36,6 +37,13 @@ type Props = {
   ) => Promise<void> | void
   onUpdate: (annotationId: string, body: string) => Promise<void> | void
   onDelete: (annotationId: string) => Promise<void> | void
+  /** Edit mode: upload one file against an existing annotation. */
+  onAttachmentAdd: (annotationId: string, file: File) => Promise<void>
+  /** Edit mode: delete one attachment from an existing annotation. */
+  onAttachmentDelete: (
+    annotationId: string,
+    attachmentId: string,
+  ) => Promise<void>
 }
 
 function quoteFor(state: SheetState): string | null {
@@ -57,8 +65,11 @@ function isAddNoteState(state: SheetState): boolean {
  * Three states:
  *   - closed
  *   - add_note_new (with optional anchor for selection-driven notes,
- *                   or null for top-level notes)
- *   - add_note_edit (existing annotation, edit body or delete)
+ *                   or null for top-level notes). Attachments stage
+ *                   locally and upload on Save.
+ *   - add_note_edit (existing annotation, edit body or delete). Existing
+ *                   attachments render as pills with X. Add/remove are
+ *                   immediate (no Save step) — the body still uses Save.
  */
 export default function AddNoteSheet({
   sheet,
@@ -66,6 +77,8 @@ export default function AddNoteSheet({
   onCreate,
   onUpdate,
   onDelete,
+  onAttachmentAdd,
+  onAttachmentDelete,
 }: Props): React.JSX.Element {
   const open = isAddNoteState(sheet)
   const isDesktop = !useIsMobile()
@@ -75,8 +88,20 @@ export default function AddNoteSheet({
     sheet.kind === 'add_note_edit' ? sheet.annotation.note?.body ?? '' : ''
   const [body, setBody] = useState(initialBody)
   const [saving, setSaving] = useState(false)
-  const [attachments, setAttachments] = useState<StagedAttachment[]>([])
+  // Used in new-note mode only. Edit mode talks to the server directly
+  // via onAttachmentAdd / onAttachmentDelete and shows the live list of
+  // attachments from `sheet.annotation.note.attachments`.
+  const [stagedAttachments, setStagedAttachments] = useState<
+    StagedAttachment[]
+  >([])
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  // Per-attachment busy state for edit mode — keyed by either the staged
+  // upload's temp id (while the upload is in flight, before the server
+  // attachment id is known) or the server attachment id (while a delete
+  // is in flight). Cleared once the action resolves.
+  const [busyAttachmentIds, setBusyAttachmentIds] = useState<Set<string>>(
+    () => new Set(),
+  )
 
   // Reset body + staged attachments when the sheet transitions states.
   useEffect(() => {
@@ -85,8 +110,9 @@ export default function AddNoteSheet({
     } else if (sheet.kind === 'add_note_new') {
       setBody('')
     }
-    setAttachments([])
+    setStagedAttachments([])
     setAttachmentError(null)
+    setBusyAttachmentIds(new Set())
   }, [sheet])
 
   // Clear the user's text selection once the drawer opens — leaving a live
@@ -95,11 +121,58 @@ export default function AddNoteSheet({
 
   const quote = quoteFor(sheet)
   const isEdit = sheet.kind === 'add_note_edit'
+  const existingAttachments =
+    sheet.kind === 'add_note_edit'
+      ? sheet.annotation.note?.attachments ?? []
+      : []
 
-  function handleAddAttachment(
+  function markBusy(id: string, busy: boolean) {
+    setBusyAttachmentIds((prev) => {
+      const next = new Set(prev)
+      if (busy) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }
+
+  async function handleEditModeAdd(
+    annotationId: string,
     file: File,
     source: 'photos' | 'camera' | 'document',
   ) {
+    const staged = makeStagedAttachment(file, source)
+    setStagedAttachments((prev) => [...prev, staged])
+    markBusy(staged.id, true)
+    try {
+      await onAttachmentAdd(annotationId, file)
+      // Refetch will replace the staged row with the server row. Drop
+      // the staged entry now so the pill list doesn't briefly show both.
+      setStagedAttachments((prev) => prev.filter((a) => a.id !== staged.id))
+    } catch (err) {
+      setStagedAttachments((prev) => prev.filter((a) => a.id !== staged.id))
+      const msg = err instanceof Error ? err.message : String(err)
+      setAttachmentError(`Couldn't upload ${file.name}: ${msg}`)
+    } finally {
+      markBusy(staged.id, false)
+    }
+  }
+
+  async function handleEditModeRemove(
+    annotationId: string,
+    attachmentId: string,
+  ) {
+    markBusy(attachmentId, true)
+    try {
+      await onAttachmentDelete(annotationId, attachmentId)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setAttachmentError(`Couldn't remove attachment: ${msg}`)
+    } finally {
+      markBusy(attachmentId, false)
+    }
+  }
+
+  function handleAdd(file: File, source: 'photos' | 'camera' | 'document') {
     setAttachmentError(null)
     if (file.size > MAX_BYTES) {
       setAttachmentError(
@@ -107,11 +180,30 @@ export default function AddNoteSheet({
       )
       return
     }
-    setAttachments((prev) => [...prev, makeStagedAttachment(file, source)])
+    if (sheet.kind === 'add_note_edit') {
+      void handleEditModeAdd(sheet.annotation.id, file, source)
+      return
+    }
+    setStagedAttachments((prev) => [
+      ...prev,
+      makeStagedAttachment(file, source),
+    ])
   }
 
-  function handleRemoveAttachment(id: string) {
-    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  function handleRemove(id: string) {
+    if (sheet.kind === 'add_note_edit') {
+      // In edit mode the id is either a server attachment id or a staged
+      // upload's temp id (if the user clicks X mid-upload). Server ids
+      // go through the delete API; staged-only entries just disappear.
+      const isStaged = stagedAttachments.some((a) => a.id === id)
+      if (isStaged) {
+        setStagedAttachments((prev) => prev.filter((a) => a.id !== id))
+        return
+      }
+      void handleEditModeRemove(sheet.annotation.id, id)
+      return
+    }
+    setStagedAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
   async function handleSave() {
@@ -121,7 +213,7 @@ export default function AddNoteSheet({
       if (sheet.kind === 'add_note_edit') {
         await onUpdate(sheet.annotation.id, body)
       } else if (sheet.kind === 'add_note_new') {
-        await onCreate(sheet.anchor, body, attachments)
+        await onCreate(sheet.anchor, body, stagedAttachments)
       }
       onClose()
     } finally {
@@ -129,7 +221,7 @@ export default function AddNoteSheet({
     }
   }
 
-  async function handleDelete() {
+  async function handleDeleteNote() {
     if (sheet.kind !== 'add_note_edit' || saving) return
     setSaving(true)
     try {
@@ -140,15 +232,38 @@ export default function AddNoteSheet({
     }
   }
 
-  // New-note saves are allowed with just attachments and no body — the
-  // server's note payload already treats `body` as optional. Edit mode
-  // still requires non-empty body (the editor isn't wired for adding
-  // attachments to an existing note yet).
+  // The list the picker renders. In new-note mode it's just staged files;
+  // in edit mode it's the server-side attachments plus any uploads still
+  // in flight.
+  const pickerItems: PickerItem[] = useMemo(() => {
+    if (sheet.kind === 'add_note_edit') {
+      const existing: PickerItem[] = existingAttachments.map((att) => ({
+        id: att.id,
+        label: att.fileName,
+        busy: busyAttachmentIds.has(att.id),
+      }))
+      const inflight: PickerItem[] = stagedAttachments.map((s) => ({
+        id: s.id,
+        label: s.file.name,
+        busy: busyAttachmentIds.has(s.id),
+      }))
+      return [...existing, ...inflight]
+    }
+    return stagedAttachments.map((s) => ({
+      id: s.id,
+      label: s.file.name,
+    }))
+  }, [sheet, existingAttachments, stagedAttachments, busyAttachmentIds])
+
+  // New-note saves allow body-only or attachment-only. Edit mode's Save
+  // commits the body; attachment changes happen immediately, so Save is
+  // enabled whenever the body still has content (we treat fully empty
+  // body as "delete the note" — handled by the explicit Delete action).
   const canSave =
     !saving &&
     (isEdit
       ? body.trim().length > 0
-      : body.trim().length > 0 || attachments.length > 0)
+      : body.trim().length > 0 || stagedAttachments.length > 0)
 
   return (
     <Drawer
@@ -177,15 +292,13 @@ export default function AddNoteSheet({
             </p>
           ) : null}
 
-          {!isEdit ? (
-            <NoteAttachmentPicker
-              attachments={attachments}
-              onAdd={handleAddAttachment}
-              onRemove={handleRemoveAttachment}
-              disabled={saving}
-              error={attachmentError}
-            />
-          ) : null}
+          <NoteAttachmentPicker
+            items={pickerItems}
+            onAdd={handleAdd}
+            onRemove={handleRemove}
+            disabled={saving}
+            error={attachmentError}
+          />
 
           <Textarea
             value={body}
@@ -213,7 +326,7 @@ export default function AddNoteSheet({
               type="button"
               variant="link"
               disabled={saving}
-              onClick={handleDelete}
+              onClick={handleDeleteNote}
               className="text-destructive"
             >
               Delete note

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -10,7 +10,12 @@ import {
   Textarea,
 } from '@styleguide'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
-import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
+import {
+  buildRangeIn,
+  findAnchorEl,
+  type ResolvedAnchor,
+} from '@shared/briefings/anchorResolver'
+import type { Annotation } from '@shared/briefings/types'
 import type { SheetState } from './AnnotationsScope'
 import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
 import NoteAttachmentPicker, {
@@ -46,12 +51,33 @@ type Props = {
   ) => Promise<void>
 }
 
+/**
+ * Resolve the highlighted text for an existing annotation by walking the
+ * live DOM. The server doesn't store the original quote, so we rebuild
+ * it on demand from the annotation's `jsonPath` + `start`/`end` offsets.
+ * Returns null when the annotation has no anchor (top-level note) or
+ * when the DOM no longer matches (e.g. content changed since the note
+ * was written).
+ */
+function resolveExistingQuote(annotation: Annotation): string | null {
+  if (typeof document === 'undefined') return null
+  const { jsonPath, start, end } = annotation
+  if (jsonPath === null || start === null || end === null) return null
+  const el = findAnchorEl(jsonPath)
+  if (!el) return null
+  const range = buildRangeIn(el, start, end)
+  if (!range) return null
+  const quote = range.toString().trim()
+  return quote.length > 0 ? quote : null
+}
+
 function quoteFor(state: SheetState): string | null {
   if (state.kind === 'add_note_new') {
     return state.anchor?.quote ?? null
   }
-  // Edit mode: the server schema does not store the original quote, and
-  // reconstructing it from the live DOM via the anchor is a follow-up.
+  if (state.kind === 'add_note_edit') {
+    return resolveExistingQuote(state.annotation)
+  }
   return null
 }
 

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2, Paperclip, Trash2, X } from 'lucide-react'
 import {
   Button,
@@ -148,8 +148,22 @@ export default function AddNoteSheet({
     () => new Set(),
   )
 
-  // Reset body + staged attachments when the sheet transitions states.
+  // The sheet prop is a fresh object on every parent render — including
+  // ones caused by optimistic cache updates (which produce new annotation
+  // references). We only want to reset local state on a logical sheet
+  // transition: kind change, or in edit mode, a different annotation id.
+  // Otherwise, the user's in-progress textarea typing would get clobbered
+  // every time an attachment upload patches the cache.
+  const sheetIdentity =
+    sheet.kind === 'add_note_edit'
+      ? `edit:${sheet.annotation.id}`
+      : sheet.kind === 'add_note_new'
+      ? `new:${sheet.anchor ? sheet.anchor.jsonPath : 'top'}`
+      : sheet.kind
+  const prevIdentityRef = useRef<string | null>(null)
   useEffect(() => {
+    if (prevIdentityRef.current === sheetIdentity) return
+    prevIdentityRef.current = sheetIdentity
     if (sheet.kind === 'add_note_edit') {
       setBody(sheet.annotation.note?.body ?? '')
     } else if (sheet.kind === 'add_note_new') {
@@ -160,7 +174,7 @@ export default function AddNoteSheet({
     setSaveError(null)
     setBusyAttachmentIds(new Set())
     setDeletingNoteIds(new Set())
-  }, [sheet])
+  }, [sheet, sheetIdentity])
 
   // Clear the user's text selection once the drawer opens — leaving a live
   // selection blocks Vaul's drag-to-dismiss.
@@ -289,7 +303,14 @@ export default function AddNoteSheet({
       onClose()
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      setSaveError(`Couldn't save your note: ${msg}`)
+      // If the inner handler already framed its own message (e.g. a
+      // partial save where the note was created but uploads failed),
+      // surface that text directly instead of double-prefixing it.
+      setSaveError(
+        /^(Saved|Couldn|Failed)/i.test(msg)
+          ? msg
+          : `Couldn't save your note: ${msg}`,
+      )
     } finally {
       setSaving(false)
     }

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -306,7 +306,7 @@ export default function AddNoteSheet({
 
         <div
           data-vaul-no-drag
-          className="flex min-h-0 flex-1 flex-col gap-3 px-4 pb-4"
+          className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pb-3"
         >
           {quote ? (
             <blockquote className="border-l-2 border-border pl-3 text-sm italic leading-6 text-muted-foreground">
@@ -317,7 +317,17 @@ export default function AddNoteSheet({
               This note is for the whole briefing.
             </p>
           ) : null}
+        </div>
 
+        {/* Composer pinned at the bottom. The attachment picker sits above
+            the input/Save row, right-aligned so its button and pills hug
+            the side near the Save action. Delete (edit mode only) sits
+            below the composer so the destructive action stays one tap
+            away but never sits beside the text input. */}
+        <div
+          data-vaul-no-drag
+          className="flex flex-col gap-2 bg-background px-4 py-3"
+        >
           <NoteAttachmentPicker
             items={pickerItems}
             onAdd={handleAdd}
@@ -325,35 +335,30 @@ export default function AddNoteSheet({
             disabled={saving}
             error={attachmentError}
           />
-
-          <Textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="Write your note…"
-            rows={6}
-            className="min-h-[160px] resize-none rounded-2xl"
-          />
-        </div>
-
-        <div
-          data-vaul-no-drag
-          className="flex flex-col gap-2 border-t border-border bg-background px-4 py-3 lg:border-t-0"
-        >
-          <Button
-            type="button"
-            disabled={!canSave}
-            onClick={handleSave}
-            className="w-full"
-          >
-            {saving ? 'Saving…' : isEdit ? 'Save changes' : 'Save note'}
-          </Button>
+          <div className="flex items-end gap-2">
+            <Textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Write your note…"
+              rows={3}
+              className="max-h-[180px] min-h-[60px] flex-1 resize-none rounded-2xl"
+            />
+            <Button
+              type="button"
+              disabled={!canSave}
+              onClick={handleSave}
+              className="shrink-0"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
           {isEdit ? (
             <Button
               type="button"
               variant="link"
               disabled={saving}
               onClick={handleDeleteNote}
-              className="text-destructive"
+              className="self-start text-destructive"
             >
               Delete note
             </Button>

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 import { render, testQueryClient } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { annotationsQueryKey } from '@shared/briefings/use-annotations'
-import type { StagedDraft } from '../notes-intake/AddNotesDialog'
 import AnnotationsScope, { useAnnotationsCtx } from './AnnotationsScope'
 
 vi.mock('next/navigation', () => ({
@@ -31,22 +30,9 @@ vi.mock('@shared/briefings/annotations-api', () => ({
   },
 }))
 
-const mockUploadAttachment = vi.fn()
 vi.mock('@shared/briefings/attachments-api', () => ({
-  uploadAttachment: (...args: unknown[]) => mockUploadAttachment(...args),
-}))
-
-let capturedOnSubmit: ((drafts: StagedDraft[]) => Promise<void> | void) | null =
-  null
-vi.mock('../notes-intake/AddNotesDialog', () => ({
-  default: ({
-    onSubmit,
-  }: {
-    onSubmit: (drafts: StagedDraft[]) => Promise<void> | void
-  }) => {
-    capturedOnSubmit = onSubmit
-    return null
-  },
+  uploadAttachment: vi.fn(),
+  deleteAttachment: vi.fn(),
 }))
 
 vi.mock('@shared/briefings/chat-api', () => ({
@@ -82,9 +68,7 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.create.mockReset()
     mockAnnotationsApi.updateNote.mockReset()
     mockAnnotationsApi.delete.mockReset()
-    mockUploadAttachment.mockReset()
     mockAnnotationsApi.list.mockResolvedValue([])
-    capturedOnSubmit = null
     testQueryClient.clear()
   })
 
@@ -108,101 +92,6 @@ describe('<AnnotationsScope>', () => {
     )
 
     await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: annotationsQueryKey('briefing_x'),
-      })
-    })
-  })
-
-  describe('AddNotesDialog onSubmit', () => {
-    const mountAndCaptureOnSubmit = async () => {
-      testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [])
-      render(
-        <AnnotationsScope meetingDate="briefing_x">
-          <div />
-        </AnnotationsScope>,
-      )
-      await waitFor(() => {
-        expect(capturedOnSubmit).not.toBeNull()
-      })
-      return capturedOnSubmit!
-    }
-
-    it('commits a typed draft via annotationsApi.create and invalidates the query', async () => {
-      mockAnnotationsApi.create.mockResolvedValue({
-        id: 'ann_typed',
-        kind: 'note',
-      })
-      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
-      const onSubmit = await mountAndCaptureOnSubmit()
-
-      await onSubmit([{ id: 't1', kind: 'typed', body: 'hello world' }])
-
-      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
-        kind: 'note',
-        anchor: { jsonPath: null, start: null, end: null },
-        payload: { body: 'hello world' },
-      })
-      expect(mockUploadAttachment).not.toHaveBeenCalled()
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: annotationsQueryKey('briefing_x'),
-      })
-    })
-
-    it('commits a file draft via create → uploadAttachment → waitForOcr and invalidates the query', async () => {
-      mockAnnotationsApi.create.mockResolvedValue({
-        id: 'ann_file',
-        kind: 'note',
-      })
-      mockUploadAttachment.mockResolvedValue({ attachmentId: 'att_1' })
-      mockAnnotationsApi.list.mockResolvedValue([
-        {
-          id: 'ann_file',
-          kind: 'note',
-          note: {
-            attachments: [{ id: 'att_1', ocrStatus: 'completed' }],
-          },
-        },
-      ])
-      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
-      const onSubmit = await mountAndCaptureOnSubmit()
-
-      const file = new File(['contents'], 'note.txt', { type: 'text/plain' })
-      await onSubmit([{ id: 'f1', kind: 'file', file, from: 'upload' }])
-
-      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
-        kind: 'note',
-        anchor: { jsonPath: null, start: null, end: null },
-        payload: {},
-      })
-      expect(mockUploadAttachment).toHaveBeenCalledWith({
-        annotationId: 'ann_file',
-        file,
-      })
-      expect(mockAnnotationsApi.list).toHaveBeenCalledWith('briefing_x')
-      expect(mockAnnotationsApi.delete).not.toHaveBeenCalled()
-      expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: annotationsQueryKey('briefing_x'),
-      })
-    })
-
-    it('rolls back the created annotation when uploadAttachment fails, and re-throws', async () => {
-      mockAnnotationsApi.create.mockResolvedValue({
-        id: 'ann_rollback',
-        kind: 'note',
-      })
-      mockAnnotationsApi.delete.mockResolvedValue(undefined)
-      mockUploadAttachment.mockRejectedValue(new Error('s3_upload_failed:500'))
-      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
-      const onSubmit = await mountAndCaptureOnSubmit()
-
-      const file = new File(['contents'], 'note.txt', { type: 'text/plain' })
-      await expect(
-        onSubmit([{ id: 'f1', kind: 'file', file, from: 'upload' }]),
-      ).rejects.toThrow('s3_upload_failed:500')
-
-      expect(mockAnnotationsApi.create).toHaveBeenCalled()
-      expect(mockAnnotationsApi.delete).toHaveBeenCalledWith('ann_rollback')
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: annotationsQueryKey('briefing_x'),
       })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event'
 import { render, testQueryClient } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { annotationsQueryKey } from '@shared/briefings/use-annotations'
+import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
+import type { StagedAttachment } from './NoteAttachmentPicker'
 import AnnotationsScope, { useAnnotationsCtx } from './AnnotationsScope'
 
 vi.mock('next/navigation', () => ({
@@ -30,9 +32,13 @@ vi.mock('@shared/briefings/annotations-api', () => ({
   },
 }))
 
+const mockUploadAttachment = vi.fn()
+const mockDeleteAttachment = vi.fn()
+const mockResolveMimeType = vi.fn((file: File) => file.type)
 vi.mock('@shared/briefings/attachments-api', () => ({
-  uploadAttachment: vi.fn(),
-  deleteAttachment: vi.fn(),
+  uploadAttachment: (input: unknown) => mockUploadAttachment(input),
+  deleteAttachment: (input: unknown) => mockDeleteAttachment(input),
+  resolveMimeType: (file: File) => mockResolveMimeType(file),
 }))
 
 vi.mock('@shared/briefings/chat-api', () => ({
@@ -41,6 +47,20 @@ vi.mock('@shared/briefings/chat-api', () => ({
     listMessages: vi.fn().mockResolvedValue([]),
     streamMessage: vi.fn(),
     softDelete: vi.fn(),
+  },
+}))
+
+type AddNoteSheetOnCreate = (
+  anchor: ResolvedAnchor | null,
+  body: string,
+  attachments: StagedAttachment[],
+) => Promise<void> | void
+
+let capturedOnCreate: AddNoteSheetOnCreate | null = null
+vi.mock('./AddNoteSheet', () => ({
+  default: ({ onCreate }: { onCreate: AddNoteSheetOnCreate }) => {
+    capturedOnCreate = onCreate
+    return null
   },
 }))
 
@@ -62,13 +82,46 @@ function ContextChatCreatedTrigger() {
   )
 }
 
+function ContextAddNoteTrigger() {
+  const { openAddNoteTopLevel } = useAnnotationsCtx()
+  return (
+    <button type="button" onClick={openAddNoteTopLevel}>
+      open top-level add note
+    </button>
+  )
+}
+
+async function captureOnCreate(): Promise<AddNoteSheetOnCreate> {
+  const user = userEvent.setup()
+  testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [])
+  render(
+    <AnnotationsScope meetingDate="briefing_x">
+      <ContextAddNoteTrigger />
+    </AnnotationsScope>,
+  )
+  await user.click(
+    await screen.findByRole('button', { name: /open top-level add note/i }),
+  )
+  await waitFor(() => {
+    expect(capturedOnCreate).not.toBeNull()
+  })
+  return capturedOnCreate!
+}
+
+function makeStaged(file: File): StagedAttachment {
+  return { id: `staged-${file.name}`, file, source: 'document' }
+}
+
 describe('<AnnotationsScope>', () => {
   beforeEach(() => {
     mockAnnotationsApi.list.mockReset()
     mockAnnotationsApi.create.mockReset()
     mockAnnotationsApi.updateNote.mockReset()
     mockAnnotationsApi.delete.mockReset()
+    mockUploadAttachment.mockReset()
+    mockDeleteAttachment.mockReset()
     mockAnnotationsApi.list.mockResolvedValue([])
+    capturedOnCreate = null
     testQueryClient.clear()
   })
 
@@ -92,6 +145,101 @@ describe('<AnnotationsScope>', () => {
     )
 
     await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: annotationsQueryKey('briefing_x'),
+      })
+    })
+  })
+
+  describe('AddNoteSheet onCreate', () => {
+    it('creates a typed-only note and skips the upload path', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_typed',
+        kind: 'note',
+      })
+      const onCreate = await captureOnCreate()
+
+      await onCreate(null, 'hello world', [])
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
+        kind: 'note',
+        anchor: { jsonPath: null, start: null, end: null },
+        payload: { body: 'hello world' },
+      })
+      expect(mockUploadAttachment).not.toHaveBeenCalled()
+    })
+
+    it('omits the body field for attachment-only saves so the contract accepts an empty payload', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_attach_only',
+        kind: 'note',
+      })
+      mockUploadAttachment.mockResolvedValue({ attachmentId: 'att_1' })
+      const onCreate = await captureOnCreate()
+
+      const file = new File(['x'], 'memo.pdf', { type: 'application/pdf' })
+      await onCreate(null, '   ', [makeStaged(file)])
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
+        kind: 'note',
+        anchor: { jsonPath: null, start: null, end: null },
+        payload: {},
+      })
+      expect(mockUploadAttachment).toHaveBeenCalledWith({
+        annotationId: 'ann_attach_only',
+        file,
+      })
+    })
+
+    it('uploads each staged attachment after creating the note and invalidates the query', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_with_files',
+        kind: 'note',
+      })
+      mockUploadAttachment
+        .mockResolvedValueOnce({ attachmentId: 'att_1' })
+        .mockResolvedValueOnce({ attachmentId: 'att_2' })
+      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
+      const onCreate = await captureOnCreate()
+
+      const fileA = new File(['a'], 'a.png', { type: 'image/png' })
+      const fileB = new File(['b'], 'b.pdf', { type: 'application/pdf' })
+      await onCreate(null, 'two files', [makeStaged(fileA), makeStaged(fileB)])
+
+      expect(mockUploadAttachment).toHaveBeenCalledTimes(2)
+      expect(mockUploadAttachment).toHaveBeenNthCalledWith(1, {
+        annotationId: 'ann_with_files',
+        file: fileA,
+      })
+      expect(mockUploadAttachment).toHaveBeenNthCalledWith(2, {
+        annotationId: 'ann_with_files',
+        file: fileB,
+      })
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: annotationsQueryKey('briefing_x'),
+      })
+    })
+
+    it('surfaces a partial-failure error when an upload rejects, listing the failed file names', async () => {
+      mockAnnotationsApi.create.mockResolvedValue({
+        id: 'ann_partial',
+        kind: 'note',
+      })
+      mockUploadAttachment
+        .mockResolvedValueOnce({ attachmentId: 'att_ok' })
+        .mockRejectedValueOnce(new Error('s3_upload_failed:500'))
+      const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
+      const onCreate = await captureOnCreate()
+
+      const ok = new File(['x'], 'ok.png', { type: 'image/png' })
+      const bad = new File(['y'], 'bad.pdf', { type: 'application/pdf' })
+      await expect(
+        onCreate(null, 'hi', [makeStaged(ok), makeStaged(bad)]),
+      ).rejects.toThrow(/Saved your note, but couldn't upload: bad\.pdf/i)
+
+      expect(mockAnnotationsApi.create).toHaveBeenCalledOnce()
+      // The cache is still invalidated so the saved note + successful
+      // attachment show up.
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: annotationsQueryKey('briefing_x'),
       })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -377,13 +377,35 @@ export default function AnnotationsScope({
         <AddNoteSheet
           sheet={overlay}
           onClose={closeSheet}
-          onCreate={async (anchor, body) => {
-            await create.mutateAsync({
+          onCreate={async (anchor, body, attachments) => {
+            const created = await create.mutateAsync({
               kind: 'note',
               anchor: anchorPayload(anchor),
               payload: { body },
             })
             window.getSelection()?.removeAllRanges()
+            // Upload any staged attachments against the freshly created
+            // annotation. Run serially to keep retry behaviour predictable.
+            // Failures don't roll back the note — the body is already on
+            // the server and worth keeping; the user can retry uploads
+            // separately if we surface that path later.
+            for (const a of attachments) {
+              try {
+                await uploadAttachment({
+                  annotationId: created.id,
+                  file: a.file,
+                })
+              } catch {
+                /* swallow per-file failure; let the React Query refetch
+                   below sync server state. We'll wire surfaced errors in
+                   a follow-up. */
+              }
+            }
+            if (attachments.length > 0) {
+              queryClient.invalidateQueries({
+                queryKey: annotationsQueryKey(meetingDate),
+              })
+            }
           }}
           onUpdate={async (id, body) => {
             await updateNote.mutateAsync({ id, body })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -20,7 +20,11 @@ import {
   useAnnotations,
 } from '@shared/briefings/use-annotations'
 import { useSelection } from '@shared/briefings/use-selection'
-import type { Annotation, AnnotationAnchor } from '@shared/briefings/types'
+import type {
+  Annotation,
+  AnnotationAnchor,
+  AnnotationNoteAttachmentData,
+} from '@shared/briefings/types'
 import HighlightToolbar from './HighlightToolbar'
 import AddNoteSheet from './AddNoteSheet'
 import ReportErrorSheet from './ReportErrorSheet'
@@ -28,6 +32,7 @@ import AnnotationsHighlightLayer from './AnnotationsHighlightLayer'
 import AskAiSheet from './AskAiSheet'
 import {
   deleteAttachment,
+  resolveMimeType,
   uploadAttachment,
 } from '@shared/briefings/attachments-api'
 
@@ -296,6 +301,24 @@ export default function AnnotationsScope({
     [annotations],
   )
 
+  // Keep the edit-mode overlay's annotation snapshot in sync with the
+  // live annotations query. Without this, attachments added/removed
+  // while the sheet is open (e.g. via the picker in edit mode) wouldn't
+  // appear until the user closed and reopened the sheet — the snapshot
+  // captured at openEditNote stays frozen otherwise. Closes the sheet
+  // if the annotation has been deleted from under us.
+  useEffect(() => {
+    if (overlay.kind !== 'add_note_edit') return
+    const fresh = annotations.find((a) => a.id === overlay.annotation.id)
+    if (!fresh) {
+      setOverlay({ kind: 'closed' })
+      return
+    }
+    if (fresh !== overlay.annotation) {
+      setOverlay({ kind: 'add_note_edit', annotation: fresh })
+    }
+  }, [annotations, overlay])
+
   const ctxValue: Ctx = useMemo(
     () => ({
       meetingDate,
@@ -384,13 +407,69 @@ export default function AnnotationsScope({
             await remove.mutateAsync(id)
           }}
           onAttachmentAdd={async (annotationId, file) => {
-            await uploadAttachment({ annotationId, file })
+            const { attachmentId } = await uploadAttachment({
+              annotationId,
+              file,
+            })
+            // Inject the new attachment into the cached annotations list
+            // synchronously so the edit sheet shows it the moment the
+            // upload resolves. `invalidateQueries` below still kicks off
+            // a refetch to sync server-side fields the client can't
+            // compute (OCR status, completion time, etc.).
+            const optimistic: AnnotationNoteAttachmentData = {
+              id: attachmentId,
+              fileName: file.name,
+              mimeType: resolveMimeType(file),
+              sizeBytes: file.size,
+              ocrStatus: 'pending',
+              ocrText: null,
+              ocrError: null,
+              ocrCompletedAt: null,
+              createdAt: new Date().toISOString(),
+            }
+            queryClient.setQueryData<Annotation[]>(
+              annotationsQueryKey(meetingDate),
+              (prev) =>
+                prev?.map((ann) =>
+                  ann.id === annotationId && ann.note
+                    ? {
+                        ...ann,
+                        note: {
+                          ...ann.note,
+                          attachments: [
+                            ...(ann.note.attachments ?? []),
+                            optimistic,
+                          ],
+                        },
+                      }
+                    : ann,
+                ),
+            )
             queryClient.invalidateQueries({
               queryKey: annotationsQueryKey(meetingDate),
             })
           }}
           onAttachmentDelete={async (annotationId, attachmentId) => {
             await deleteAttachment({ annotationId, attachmentId })
+            // Drop the row from the cache optimistically so the pill
+            // disappears immediately without waiting for a refetch.
+            queryClient.setQueryData<Annotation[]>(
+              annotationsQueryKey(meetingDate),
+              (prev) =>
+                prev?.map((ann) =>
+                  ann.id === annotationId && ann.note
+                    ? {
+                        ...ann,
+                        note: {
+                          ...ann.note,
+                          attachments: (ann.note.attachments ?? []).filter(
+                            (a) => a.id !== attachmentId,
+                          ),
+                        },
+                      }
+                    : ann,
+                ),
+            )
             queryClient.invalidateQueries({
               queryKey: annotationsQueryKey(meetingDate),
             })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -371,10 +371,15 @@ export default function AnnotationsScope({
           sheet={overlay}
           onClose={closeSheet}
           onCreate={async (anchor, body, attachments) => {
+            // The contract validates body as `string().min(1).optional()` —
+            // so an empty string 400s, but omitting body entirely is fine
+            // (the server stores null). Drop the field when the user only
+            // attached files without typing anything.
+            const trimmedBody = body.trim()
             const created = await create.mutateAsync({
               kind: 'note',
               anchor: anchorPayload(anchor),
-              payload: { body },
+              payload: trimmedBody.length > 0 ? { body: trimmedBody } : {},
             })
             window.getSelection()?.removeAllRanges()
             // Upload any staged attachments against the freshly created

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -26,31 +26,10 @@ import AddNoteSheet from './AddNoteSheet'
 import ReportErrorSheet from './ReportErrorSheet'
 import AnnotationsHighlightLayer from './AnnotationsHighlightLayer'
 import AskAiSheet from './AskAiSheet'
-import AddNotesDialog from '../notes-intake/AddNotesDialog'
 import {
   deleteAttachment,
   uploadAttachment,
 } from '@shared/briefings/attachments-api'
-import { annotationsApi } from '@shared/briefings/annotations-api'
-
-const OCR_TERMINAL_STATUSES = new Set(['completed', 'failed', 'skipped'])
-const OCR_POLL_INTERVAL_MS = 2_000
-const OCR_POLL_TIMEOUT_MS = 60_000
-
-const waitForOcr = async (
-  meetingDate: string,
-  attachmentId: string,
-): Promise<void> => {
-  const started = Date.now()
-  while (Date.now() - started < OCR_POLL_TIMEOUT_MS) {
-    const list = await annotationsApi.list(meetingDate)
-    for (const ann of list) {
-      const att = ann.note?.attachments?.find((a) => a.id === attachmentId)
-      if (att && OCR_TERMINAL_STATUSES.has(att.ocrStatus)) return
-    }
-    await new Promise((r) => setTimeout(r, OCR_POLL_INTERVAL_MS))
-  }
-}
 
 /**
  * Either an in-progress selection-driven anchor, or null for a top-level
@@ -183,18 +162,6 @@ export default function AnnotationsScope({
   const { annotations, create, updateNote, remove } =
     useAnnotations(meetingDate)
   const [overlay, setOverlay] = useState<OverlayState>({ kind: 'closed' })
-  const [intakeOpen, setIntakeOpen] = useState(false)
-  const [deletingNoteIds, setDeletingNoteIds] = useState<Set<string>>(
-    () => new Set(),
-  )
-
-  // Top-level notes (no anchor) — what the intake dialog renders as pills.
-  // Filter once here so the dialog's deps are simple references.
-  const topLevelNotes = useMemo(
-    () =>
-      annotations.filter((ann) => ann.kind === 'note' && ann.jsonPath === null),
-    [annotations],
-  )
 
   const handleChatCreated = useCallback(
     (_info: {
@@ -213,11 +180,11 @@ export default function AnnotationsScope({
     setOverlay({ kind: 'add_note_new', anchor: liveAnchor })
   }, [liveAnchor])
 
-  // The top-level "Add notes" button on the header / mobile bar opens the new
-  // intake dialog (camera / upload / type). Phase 1 only wires the type path;
-  // camera and upload render as Coming soon.
+  // The top-level "Add notes" button on the header / mobile bar opens the
+  // same AddNoteSheet used for anchored notes — just with `anchor: null`,
+  // so the note is scoped to the whole briefing rather than a passage.
   const openAddNoteTopLevel = useCallback(() => {
-    setIntakeOpen(true)
+    setOverlay({ kind: 'add_note_new', anchor: null })
   }, [])
 
   const openReportErrorFromSelection = useCallback(() => {
@@ -457,88 +424,6 @@ export default function AnnotationsScope({
           onChatCreated={handleChatCreated}
         />
       )}
-      <AddNotesDialog
-        open={intakeOpen}
-        onClose={() => setIntakeOpen(false)}
-        existingNotes={topLevelNotes}
-        deletingIds={deletingNoteIds}
-        onDeleteExisting={async (id) => {
-          setDeletingNoteIds((prev) => {
-            const next = new Set(prev)
-            next.add(id)
-            return next
-          })
-          try {
-            await remove.mutateAsync(id)
-          } finally {
-            setDeletingNoteIds((prev) => {
-              const next = new Set(prev)
-              next.delete(id)
-              return next
-            })
-          }
-        }}
-        onSubmit={async (drafts) => {
-          // Commit each staged pill as its own note. Typed pills are a single
-          // create call; file pills create the note then run the presign →
-          // PUT → complete sequence. We run serially to keep the network
-          // pattern boring and easy to retry; can fan out later if needed.
-          //
-          // If a file upload fails after the note row was created, we delete
-          // the orphan note so users don't end up with a dead "(empty note)"
-          // pill they can't see or recover from. The original error is
-          // re-thrown so the dialog surfaces it.
-          try {
-            for (const draft of drafts) {
-              if (draft.kind === 'typed') {
-                await create.mutateAsync({
-                  kind: 'note',
-                  anchor: { jsonPath: null, start: null, end: null },
-                  payload: { body: draft.body },
-                })
-                continue
-              }
-              const created = await create.mutateAsync({
-                kind: 'note',
-                anchor: { jsonPath: null, start: null, end: null },
-                payload: {},
-              })
-              let attachmentId: string
-              try {
-                const result = await uploadAttachment({
-                  annotationId: created.id,
-                  file: draft.file,
-                })
-                attachmentId = result.attachmentId
-              } catch (uploadErr) {
-                // Best-effort rollback of the empty annotation. We swallow
-                // the rollback error specifically so the original upload
-                // error reaches the caller.
-                try {
-                  await remove.mutateAsync(created.id)
-                } catch {
-                  /* leave the orphan; surfacing the upload error is more
-                     useful than masking it with a rollback failure */
-                }
-                throw uploadErr
-              }
-              // Block until OCR has a terminal status so the recap/assistant
-              // can see extracted text. Caps at 60s; poll errors are
-              // non-fatal — the upload already succeeded, the polled
-              // annotations query will catch up.
-              try {
-                await waitForOcr(meetingDate, attachmentId)
-              } catch {
-                /* poll failure must not roll back a successful upload */
-              }
-            }
-          } finally {
-            queryClient.invalidateQueries({
-              queryKey: annotationsQueryKey(meetingDate),
-            })
-          }
-        }}
-      />
     </AnnotationsCtx.Provider>
   )
 }

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -27,7 +27,10 @@ import ReportErrorSheet from './ReportErrorSheet'
 import AnnotationsHighlightLayer from './AnnotationsHighlightLayer'
 import AskAiSheet from './AskAiSheet'
 import AddNotesDialog from '../notes-intake/AddNotesDialog'
-import { uploadAttachment } from '@shared/briefings/attachments-api'
+import {
+  deleteAttachment,
+  uploadAttachment,
+} from '@shared/briefings/attachments-api'
 import { annotationsApi } from '@shared/briefings/annotations-api'
 
 const OCR_TERMINAL_STATUSES = new Set(['completed', 'failed', 'skipped'])
@@ -412,6 +415,18 @@ export default function AnnotationsScope({
           }}
           onDelete={async (id) => {
             await remove.mutateAsync(id)
+          }}
+          onAttachmentAdd={async (annotationId, file) => {
+            await uploadAttachment({ annotationId, file })
+            queryClient.invalidateQueries({
+              queryKey: annotationsQueryKey(meetingDate),
+            })
+          }}
+          onAttachmentDelete={async (annotationId, attachmentId) => {
+            await deleteAttachment({ annotationId, attachmentId })
+            queryClient.invalidateQueries({
+              queryKey: annotationsQueryKey(meetingDate),
+            })
           }}
         />
       )}

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -393,9 +393,12 @@ export default function AnnotationsScope({
             window.getSelection()?.removeAllRanges()
             // Upload any staged attachments against the freshly created
             // annotation. Run serially to keep retry behaviour predictable.
-            // Failures don't roll back the note — the body is already on
-            // the server and worth keeping; the user can retry uploads
-            // separately if we surface that path later.
+            // Per-file failures don't roll back the note — the body is
+            // already on the server and worth keeping. Collect the
+            // failures and throw at the end so AddNoteSheet's handleSave
+            // catches them and surfaces the error inline (the sheet stays
+            // open in that case).
+            const failures: string[] = []
             for (const a of attachments) {
               try {
                 await uploadAttachment({
@@ -403,15 +406,18 @@ export default function AnnotationsScope({
                   file: a.file,
                 })
               } catch {
-                /* swallow per-file failure; let the React Query refetch
-                   below sync server state. We'll wire surfaced errors in
-                   a follow-up. */
+                failures.push(a.file.name)
               }
             }
             if (attachments.length > 0) {
               queryClient.invalidateQueries({
                 queryKey: annotationsQueryKey(meetingDate),
               })
+            }
+            if (failures.length > 0) {
+              throw new Error(
+                `Saved your note, but couldn't upload: ${failures.join(', ')}`,
+              )
             }
           }}
           onUpdate={async (id, body) => {

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -10,9 +10,8 @@ import {
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
-  buildRangeIn,
-  findAnchorEl,
   pointToOffset,
+  resolveQuoteFromAnchor,
   type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
 import {
@@ -43,25 +42,33 @@ import {
 export type PendingAnchor = ResolvedAnchor | null
 
 /**
- * Reconstruct the highlighted text from an annotation's jsonPath/start/end
- * by walking the live DOM. The server schema does not store the original
- * quote, so we resolve it here at open-time. Returns an empty object when
- * the annotation lacks a usable anchor or the DOM no longer matches.
+ * Resolve both the highlighted text and the anchor coordinates for an
+ * existing annotation. The chat overlay state carries both fields so the
+ * sheet can render the quote AND mint a new chat against the same anchor
+ * without re-walking the DOM. Returns an empty object when the annotation
+ * has no anchor or the DOM no longer matches.
  */
 function resolveAnnotationQuote(annotation: Annotation): {
   quote?: string
   anchor?: { jsonPath: string; start: number; end: number }
 } {
-  if (typeof document === 'undefined') return {}
-  const { jsonPath, start, end } = annotation
-  if (jsonPath === null || start === null || end === null) return {}
-  const el = findAnchorEl(jsonPath)
-  if (!el) return {}
-  const range = buildRangeIn(el, start, end)
-  if (!range) return {}
-  const quote = range.toString().trim()
-  if (!quote) return {}
-  return { quote, anchor: { jsonPath, start, end } }
+  const quote = resolveQuoteFromAnchor(annotation)
+  if (
+    quote === null ||
+    annotation.jsonPath === null ||
+    annotation.start === null ||
+    annotation.end === null
+  ) {
+    return {}
+  }
+  return {
+    quote,
+    anchor: {
+      jsonPath: annotation.jsonPath,
+      start: annotation.start,
+      end: annotation.end,
+    },
+  }
 }
 
 /**

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -301,6 +301,15 @@ export default function AnnotationsScope({
     [annotations],
   )
 
+  // Briefing-wide notes (no anchor) — surfaced inside the top-level
+  // AddNoteSheet so the user can see, edit, or delete them. They have
+  // no DOM anchor so the highlight layer doesn't render them anywhere.
+  const topLevelNotes = useMemo(
+    () =>
+      annotations.filter((ann) => ann.kind === 'note' && ann.jsonPath === null),
+    [annotations],
+  )
+
   // Keep the edit-mode overlay's annotation snapshot in sync with the
   // live annotations query. Without this, attachments added/removed
   // while the sheet is open (e.g. via the picker in edit mode) wouldn't
@@ -479,6 +488,8 @@ export default function AnnotationsScope({
               queryKey: annotationsQueryKey(meetingDate),
             })
           }}
+          topLevelNotes={topLevelNotes}
+          onEditNote={openEditNote}
         />
       )}
       {(overlay.kind === 'report_error_new' ||

--- a/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
+++ b/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { useId, useRef, useState } from 'react'
-import { Camera, FileText, ImageIcon, Paperclip, X } from 'lucide-react'
+import {
+  Camera,
+  FileText,
+  ImageIcon,
+  Loader2,
+  Paperclip,
+  X,
+} from 'lucide-react'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@styleguide'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
 
@@ -13,8 +20,17 @@ export type StagedAttachment = {
   source: Source
 }
 
+/** Generic shape rendered as a pill. The caller maps its own data (staged
+ * File objects, server-side AnnotationNoteAttachmentData, etc.) into this. */
+export type PickerItem = {
+  id: string
+  label: string
+  /** When true, renders a spinner inside the pill in place of the X. */
+  busy?: boolean
+}
+
 type Props = {
-  attachments: StagedAttachment[]
+  items: PickerItem[]
   onAdd: (file: File, source: Source) => void
   onRemove: (id: string) => void
   /** Disables the picker (e.g. while a save is in flight). */
@@ -32,15 +48,21 @@ const newId = (): string =>
     : `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 /**
- * "Add attachment" pill + the list of staged file pills below it.
+ * "Add attachment" pill + the list of attachment pills below it.
  *
  * On desktop the pill opens the native OS file dialog directly. On mobile
  * the pill opens a bottom drawer with three sources — Photos (gallery),
  * Camera (capture), and Document (native document picker) — matching the
  * WhatsApp-style attachment menu the spec calls for.
+ *
+ * The component is data-agnostic: it renders whatever items the caller
+ * gives it and emits add/remove events. New-note flows stage files
+ * locally and commit on Save; edit-mode flows upload/delete immediately
+ * against an existing annotation. Both map their state into the same
+ * `PickerItem` shape.
  */
 export default function NoteAttachmentPicker({
-  attachments,
+  items,
   onAdd,
   onRemove,
   disabled = false,
@@ -97,24 +119,33 @@ export default function NoteAttachmentPicker({
         </button>
       </div>
 
-      {attachments.length > 0 ? (
+      {items.length > 0 ? (
         <ul className="flex list-none flex-wrap items-center gap-2">
-          {attachments.map((a) => (
-            <li key={a.id}>
+          {items.map((it) => (
+            <li key={it.id}>
               <div
                 className="inline-flex max-w-[240px] items-center gap-2 rounded-full bg-muted py-1 pl-3 pr-1 text-sm text-foreground"
-                title={a.file.name}
+                title={it.label}
               >
-                <span className="truncate">{a.file.name}</span>
-                <button
-                  type="button"
-                  onClick={() => onRemove(a.id)}
-                  disabled={disabled}
-                  aria-label={`Remove ${a.file.name}`}
-                  className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <X className="size-3.5" aria-hidden />
-                </button>
+                <span className="truncate">{it.label}</span>
+                {it.busy ? (
+                  <span
+                    aria-hidden
+                    className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground"
+                  >
+                    <Loader2 className="size-3.5 animate-spin" />
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onRemove(it.id)}
+                    disabled={disabled}
+                    aria-label={`Remove ${it.label}`}
+                    className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <X className="size-3.5" aria-hidden />
+                  </button>
+                )}
               </div>
             </li>
           ))}

--- a/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
+++ b/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useId, useRef, useState } from 'react'
+import { Camera, FileText, ImageIcon, Paperclip, X } from 'lucide-react'
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
+
+type Source = 'photos' | 'camera' | 'document'
+
+export type StagedAttachment = {
+  id: string
+  file: File
+  source: Source
+}
+
+type Props = {
+  attachments: StagedAttachment[]
+  onAdd: (file: File, source: Source) => void
+  onRemove: (id: string) => void
+  /** Disables the picker (e.g. while a save is in flight). */
+  disabled?: boolean
+  /** Surfaced inline; the caller is expected to render rejection reasons too. */
+  error?: string | null
+}
+
+const PHOTOS_ACCEPT = 'image/*'
+const DOCUMENT_ACCEPT = '.pdf,.doc,.docx,.txt,image/*'
+
+const newId = (): string =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+/**
+ * "Add attachment" pill + the list of staged file pills below it.
+ *
+ * On desktop the pill opens the native OS file dialog directly. On mobile
+ * the pill opens a bottom drawer with three sources — Photos (gallery),
+ * Camera (capture), and Document (native document picker) — matching the
+ * WhatsApp-style attachment menu the spec calls for.
+ */
+export default function NoteAttachmentPicker({
+  attachments,
+  onAdd,
+  onRemove,
+  disabled = false,
+  error = null,
+}: Props): React.JSX.Element {
+  const isMobile = useIsMobile()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const id = useId()
+
+  // Three inputs: photos (gallery), camera (capture), document (anything).
+  // We trigger them programmatically so the drawer options can route to
+  // the right one. On desktop, only `desktopRef` is used.
+  const desktopRef = useRef<HTMLInputElement | null>(null)
+  const photosRef = useRef<HTMLInputElement | null>(null)
+  const cameraRef = useRef<HTMLInputElement | null>(null)
+  const documentRef = useRef<HTMLInputElement | null>(null)
+
+  function handlePicked(file: File | null, source: Source) {
+    if (!file) return
+    onAdd(file, source)
+  }
+
+  function openPicker() {
+    if (disabled) return
+    if (isMobile) {
+      setDrawerOpen(true)
+      return
+    }
+    desktopRef.current?.click()
+  }
+
+  function pickFromDrawer(source: Source) {
+    setDrawerOpen(false)
+    // Give the drawer's close animation a tick before opening the file
+    // picker; some mobile browsers race the two and ignore the second.
+    requestAnimationFrame(() => {
+      if (source === 'photos') photosRef.current?.click()
+      else if (source === 'camera') cameraRef.current?.click()
+      else documentRef.current?.click()
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <button
+          type="button"
+          onClick={openPicker}
+          disabled={disabled}
+          className="inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Paperclip className="size-4" aria-hidden />
+          Add attachment
+        </button>
+      </div>
+
+      {attachments.length > 0 ? (
+        <ul className="flex list-none flex-wrap items-center gap-2">
+          {attachments.map((a) => (
+            <li key={a.id}>
+              <div
+                className="inline-flex max-w-[240px] items-center gap-2 rounded-full bg-muted py-1 pl-3 pr-1 text-sm text-foreground"
+                title={a.file.name}
+              >
+                <span className="truncate">{a.file.name}</span>
+                <button
+                  type="button"
+                  onClick={() => onRemove(a.id)}
+                  disabled={disabled}
+                  aria-label={`Remove ${a.file.name}`}
+                  className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <X className="size-3.5" aria-hidden />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+
+      {/* Single hidden input for desktop. */}
+      <input
+        ref={desktopRef}
+        id={`${id}-desktop`}
+        type="file"
+        accept={DOCUMENT_ACCEPT}
+        className="hidden"
+        onChange={(e) => {
+          handlePicked(e.target.files?.[0] ?? null, 'document')
+          e.target.value = ''
+        }}
+      />
+      {/* Three inputs for the mobile drawer's three sources. */}
+      <input
+        ref={photosRef}
+        type="file"
+        accept={PHOTOS_ACCEPT}
+        className="hidden"
+        onChange={(e) => {
+          handlePicked(e.target.files?.[0] ?? null, 'photos')
+          e.target.value = ''
+        }}
+      />
+      <input
+        ref={cameraRef}
+        type="file"
+        accept={PHOTOS_ACCEPT}
+        capture="environment"
+        className="hidden"
+        onChange={(e) => {
+          handlePicked(e.target.files?.[0] ?? null, 'camera')
+          e.target.value = ''
+        }}
+      />
+      <input
+        ref={documentRef}
+        type="file"
+        accept={DOCUMENT_ACCEPT}
+        className="hidden"
+        onChange={(e) => {
+          handlePicked(e.target.files?.[0] ?? null, 'document')
+          e.target.value = ''
+        }}
+      />
+
+      <Drawer open={drawerOpen} onOpenChange={setDrawerOpen} direction="bottom">
+        <DrawerContent>
+          <DrawerHeader className="px-6 pb-2 pt-6 text-left">
+            <DrawerTitle className="text-lg font-semibold">
+              Add attachment
+            </DrawerTitle>
+          </DrawerHeader>
+          <ul className="flex list-none flex-col gap-1 px-4 pb-6">
+            <li>
+              <button
+                type="button"
+                onClick={() => pickFromDrawer('photos')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-base font-medium transition-colors hover:bg-muted"
+              >
+                <span
+                  aria-hidden
+                  className="inline-flex size-10 items-center justify-center rounded-full bg-info-50 text-info-600"
+                >
+                  <ImageIcon className="size-5" />
+                </span>
+                Photos
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                onClick={() => pickFromDrawer('camera')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-base font-medium transition-colors hover:bg-muted"
+              >
+                <span
+                  aria-hidden
+                  className="inline-flex size-10 items-center justify-center rounded-full bg-info-50 text-info-600"
+                >
+                  <Camera className="size-5" />
+                </span>
+                Camera
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                onClick={() => pickFromDrawer('document')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-base font-medium transition-colors hover:bg-muted"
+              >
+                <span
+                  aria-hidden
+                  className="inline-flex size-10 items-center justify-center rounded-full bg-info-50 text-info-600"
+                >
+                  <FileText className="size-5" />
+                </span>
+                Document
+              </button>
+            </li>
+          </ul>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+export function makeStagedAttachment(
+  file: File,
+  source: Source,
+): StagedAttachment {
+  return { id: newId(), file, source }
+}

--- a/app/shared/briefings/anchorResolver.ts
+++ b/app/shared/briefings/anchorResolver.ts
@@ -173,3 +173,29 @@ export function buildRangeIn(
   range.setEnd(endNode, endOffset)
   return range
 }
+
+/**
+ * Read the highlighted text for an existing annotation by walking the live
+ * DOM. The server doesn't persist the original quote — it's rebuilt on
+ * demand from the stored `jsonPath` + start/end offsets so the briefing
+ * UI can show the anchored passage without round-tripping.
+ *
+ * Returns null when the annotation has no anchor (top-level note) or when
+ * the DOM no longer matches (e.g. content changed since the note was
+ * written) or when we're in an SSR / non-browser context.
+ */
+export function resolveQuoteFromAnchor(anchor: {
+  jsonPath: string | null
+  start: number | null
+  end: number | null
+}): string | null {
+  if (typeof document === 'undefined') return null
+  const { jsonPath, start, end } = anchor
+  if (jsonPath === null || start === null || end === null) return null
+  const el = findAnchorEl(jsonPath)
+  if (!el) return null
+  const range = buildRangeIn(el, start, end)
+  if (!range) return null
+  const quote = range.toString().trim()
+  return quote.length > 0 ? quote : null
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes note creation, file upload/delete, and cache behavior; per-file upload failures on create are swallowed without rollback, which can leave notes without expected attachments.
> 
> **Overview**
> **Briefing note attachments** are folded into `AddNoteSheet` instead of a separate `AddNotesDialog`. Top-level “Add notes” now opens the same sheet with no anchor; users can list, edit, and delete briefing-wide notes there.
> 
> A new **`NoteAttachmentPicker`** supports desktop file pick and a mobile drawer (photos, camera, documents), with a **20 MB** cap and attachment pills. **New notes** stage files until Save, then upload serially; **edit mode** uploads and deletes attachments immediately while body text still saves on Save. Edit mode can show the anchored quote via DOM resolution.
> 
> **`AnnotationsScope`** wires create/update/delete, optimistic React Query cache updates for attachments, keeps the edit sheet in sync with the annotations query, and drops the old intake dialog flow (including OCR polling and upload-failure rollback on create).
> 
> Tests for the removed dialog submit path were deleted; scope tests now only mock attachment APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530bb850d114aa5a3ef04e5b5c302034396764ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->