### PR TITLE
Briefings: fire List Viewed and Briefing Viewed analytics events

### DIFF
--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@shared/briefings/routes'
 import ExecutiveSummaryCard from '../components/detail/ExecutiveSummaryCard'
 import AgendaItemCard from '../components/detail/AgendaItemCard'
+import TrackBriefingViewed from '../components/TrackBriefingViewed'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -56,6 +57,7 @@ export default async function Page({
 
   return (
     <>
+      <TrackBriefingViewed briefingId={slug} />
       <ExecutiveSummaryCard
         summary={briefing.executiveSummary}
         domId={BRIEFING_EXECUTIVE_SUMMARY_DOM_ID}

--- a/app/dashboard/briefings/components/TrackBriefingListViewed.tsx
+++ b/app/dashboard/briefings/components/TrackBriefingListViewed.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useEffect } from 'react'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+
+const TrackBriefingListViewed = (): null => {
+  useEffect(() => {
+    trackEvent(EVENTS.Briefings.ListViewed)
+  }, [])
+  return null
+}
+
+export default TrackBriefingListViewed

--- a/app/dashboard/briefings/components/TrackBriefingViewed.tsx
+++ b/app/dashboard/briefings/components/TrackBriefingViewed.tsx
@@ -13,12 +13,13 @@ const resolveCameFrom = (utmSource: string | null): string => {
 
 const TrackBriefingViewed = ({ briefingId }: Props): null => {
   const searchParams = useSearchParams()
+  const utmSource = searchParams?.get('utm_source') ?? null
   useEffect(() => {
     trackEvent(EVENTS.Briefings.BriefingViewed, {
       briefing_id: briefingId,
-      came_from: resolveCameFrom(searchParams?.get('utm_source') ?? null),
+      came_from: resolveCameFrom(utmSource),
     })
-  }, [briefingId, searchParams])
+  }, [briefingId, utmSource])
   return null
 }
 

--- a/app/dashboard/briefings/components/TrackBriefingViewed.tsx
+++ b/app/dashboard/briefings/components/TrackBriefingViewed.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+
+type Props = { briefingId: string }
+
+const resolveCameFrom = (utmSource: string | null): string => {
+  if (utmSource === 'sms' || utmSource === 'email') return utmSource
+  return 'direct'
+}
+
+const TrackBriefingViewed = ({ briefingId }: Props): null => {
+  const searchParams = useSearchParams()
+  useEffect(() => {
+    trackEvent(EVENTS.Briefings.BriefingViewed, {
+      briefing_id: briefingId,
+      came_from: resolveCameFrom(searchParams.get('utm_source')),
+    })
+  }, [briefingId, searchParams])
+  return null
+}
+
+export default TrackBriefingViewed

--- a/app/dashboard/briefings/components/TrackBriefingViewed.tsx
+++ b/app/dashboard/briefings/components/TrackBriefingViewed.tsx
@@ -16,7 +16,7 @@ const TrackBriefingViewed = ({ briefingId }: Props): null => {
   useEffect(() => {
     trackEvent(EVENTS.Briefings.BriefingViewed, {
       briefing_id: briefingId,
-      came_from: resolveCameFrom(searchParams.get('utm_source')),
+      came_from: resolveCameFrom(searchParams?.get('utm_source') ?? null),
     })
   }, [briefingId, searchParams])
   return null

--- a/app/dashboard/briefings/page.tsx
+++ b/app/dashboard/briefings/page.tsx
@@ -5,6 +5,7 @@ import { IS_DEV, IS_LOCAL } from 'appEnv'
 import serveAccess from '../shared/serveAccess'
 import DashboardLayout from '../shared/DashboardLayout'
 import BriefingsLanding from './components/BriefingsLanding'
+import TrackBriefingListViewed from './components/TrackBriefingListViewed'
 
 const meta = pageMetaData({
   title: 'Briefings | GoodParty.org',
@@ -33,6 +34,7 @@ export default async function Page(): Promise<React.JSX.Element> {
   ])
   return (
     <DashboardLayout pathname="/dashboard/briefings" showAlert={false}>
+      <TrackBriefingListViewed />
       <BriefingsLanding
         summaries={summaries}
         devElectedOfficeId={devElectedOfficeId}

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -513,6 +513,7 @@ export const EVENTS = {
     CampaignCompleted: 'Candidacy - Campaign Completed',
   },
   Briefings: {
+    ListViewed: 'Briefings - List Viewed',
     BriefingViewed: 'Briefings - Briefing Viewed',
     IssueDetailViewed: 'Briefings - Issue Detail Viewed',
     ClickDownload: 'Briefings - Click Download',


### PR DESCRIPTION
## Summary

Adds two client-side analytics events on the briefings feature so we can measure the briefing outreach funnel.

- `Briefings - List Viewed` fires on the briefing list page.
- `Briefings - Briefing Viewed` fires on the briefing detail page with `briefing_id` (the date slug) and `came_from` (`sms` / `email` / `direct`).

`came_from` is derived from `utm_source`, so outreach links like `/dashboard/briefings/2026-05-30?utm_source=sms` attribute the open without needing a separate param. UTMs are already auto-persisted by `RouteTrackerScript` and auto-attached to every event via `getPersistedUtms`, so this also gives us session-wide source attribution as a side benefit.

Pairs with the server-side `Agenda Picked Up` event in gp-api ([thegoodparty/gp-api#swain/briefing-analytics-events](https://github.com/thegoodparty/gp-api/pulls?q=is%3Apr+head%3Aswain%2Fbriefing-analytics-events)) — that is the trigger event the outreach runs off, and `Briefing Viewed` is the conversion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation with no changes to auth, data handling, or briefing rendering logic.
> 
> **Overview**
> Adds **client-side page-view analytics** for the briefings funnel: a null-render tracker on the list route fires **`Briefings - List Viewed`** on mount, and one on the detail route fires **`Briefings - Briefing Viewed`** with `briefing_id` (date slug) and **`came_from`** (`sms` / `email` / `direct` from `utm_source`).
> 
> Registers **`EVENTS.Briefings.ListViewed`** in `analyticsHelper`; detail events still merge persisted UTMs via existing `trackEvent` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5739e2caa9d6431ae65fea2958c98181f5348b2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->