### PR TITLE
Constituent Download Refactor

### DIFF
--- a/app/dashboard/contacts/[[...attr]]/components/Download.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/Download.tsx
@@ -14,7 +14,7 @@ import { Lock } from '@mui/icons-material'
 import { LuDownload } from 'react-icons/lu'
 import { useEffect, useRef, useState } from 'react'
 import { useSnackbar } from 'helpers/useSnackbar'
-import { getCookie } from 'helpers/cookieHelper'
+import { deleteCookie, getCookie } from 'helpers/cookieHelper'
 
 const DOWNLOAD_COOKIE_NAME = 'gp_download'
 const DOWNLOAD_COOKIE_POLL_MS = 250
@@ -39,7 +39,7 @@ export default function Download() {
   const showProUpgradeModal = useShowContactProModal()
   const { customSegments, currentSegment, canUseProFeatures } =
     useContactsTable()
-  const { successSnackbar } = useSnackbar()
+  const { successSnackbar, errorSnackbar } = useSnackbar()
   const [isPreparing, setIsPreparing] = useState(false)
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -107,19 +107,39 @@ export default function Download() {
     // Poll for the gp_download cookie set by gp-api. The browser commits
     // cookies from a download response, so the moment the cookie appears we
     // know the server has actually started streaming and can swap the
-    // "preparing" feedback for a "started" confirmation.
+    // "preparing" feedback for a "started" confirmation. Each download mints
+    // a fresh UUID server-side and overwrites the previous value, so the
+    // `current !== cookieBeforeClick` check still detects subsequent
+    // downloads, but we proactively clear the cookie on success/timeout to
+    // avoid stale state surviving across navigations.
     pollIntervalRef.current = setInterval(() => {
       const current = readDownloadCookie()
       if (current && current !== cookieBeforeClick) {
         clearDownloadWatchers()
+        deleteCookie(DOWNLOAD_COOKIE_NAME)
         setIsPreparing(false)
         successSnackbar('Download started', { autoHideDuration: 3000 })
       }
     }, DOWNLOAD_COOKIE_POLL_MS)
 
+    // The fallback fires for two distinct cases we cannot disambiguate from
+    // the client (top-level downloads expose no programmatic completion):
+    //   1. A real error path (4xx/5xx, network failure) — the cookie never
+    //      arrives and the user genuinely needs to retry.
+    //   2. A successful download whose handshake we missed (proxy stripped
+    //      Set-Cookie, or TTFB exceeded the fallback window for a very large
+    //      district). In this case bytes ARE streaming to disk.
+    // A categorical "Download failed" message would lie to users in case 2,
+    // so we surface a neutral conditional prompt that's actionable in case 1
+    // and harmless in case 2.
     fallbackTimeoutRef.current = setTimeout(() => {
       clearDownloadWatchers()
+      deleteCookie(DOWNLOAD_COOKIE_NAME)
       setIsPreparing(false)
+      errorSnackbar(
+        "If your download hasn't started, please try again.",
+        { autoHideDuration: 6000 },
+      )
     }, DOWNLOAD_FALLBACK_TIMEOUT_MS)
 
     // We cannot observe completion of a top-level download, so fire the

--- a/app/dashboard/contacts/[[...attr]]/components/Download.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/Download.tsx
@@ -136,10 +136,9 @@ export default function Download() {
       clearDownloadWatchers()
       deleteCookie(DOWNLOAD_COOKIE_NAME)
       setIsPreparing(false)
-      errorSnackbar(
-        "If your download hasn't started, please try again.",
-        { autoHideDuration: 6000 },
-      )
+      errorSnackbar("If your download hasn't started, please try again.", {
+        autoHideDuration: 6000,
+      })
     }, DOWNLOAD_FALLBACK_TIMEOUT_MS)
 
     // We cannot observe completion of a top-level download, so fire the

--- a/app/dashboard/contacts/[[...attr]]/components/Download.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/Download.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { IconButton } from '@styleguide'
-import { clientRequest, type RequestOptions } from 'gpApi/typed-request'
 import { useContactsTable } from '../hooks/ContactsTableProvider'
 import { type SegmentResponse } from './shared/contacts-types'
 import { dateUsHelper } from 'helpers/dateHelper'
@@ -19,31 +18,41 @@ export default function Download() {
   const { customSegments, currentSegment, canUseProFeatures } =
     useContactsTable()
 
-  const handleDownload = async (): Promise<void> => {
+  // Trigger the contacts CSV download via a top-level browser navigation so
+  // bytes stream directly to disk. Avoids buffering the entire response (up
+  // to ~700 MB for a 1M-row district) into a JS Blob, which would OOM mid-
+  // tier laptops and show no download progress. Auth + the
+  // `x-organization-slug` header are added automatically by Next.js
+  // middleware in `helpers/handleApiRequestRewrite.ts` when the request
+  // passes through `/api/v1/...`.
+  const handleDownload = (): void => {
     if (!canUseProFeatures) {
       showProUpgradeModal(true)
       return
     }
-    try {
-      const { data: blob } = await clientRequest(
-        'GET /v1/contacts/download',
-        { ...(currentSegment ? { segment: currentSegment } : {}) },
-        { responseType: 'blob' } as unknown as RequestOptions,
-      )
-      const url = window.URL.createObjectURL(blob)
-      const link = document.createElement('a')
-      link.href = url
-      const dateStr = dateUsHelper(new Date()).replace(/ /g, '_')
-      link.setAttribute('download', `contacts_${dateStr}.csv`)
-      document.body.appendChild(link)
-      link.click()
 
-      window.URL.revokeObjectURL(url)
-      document.body.removeChild(link)
-      trackEvent(EVENTS.Contacts.Download, generateProperties())
-    } catch (err) {
-      console.error('Failed to download contacts', err)
+    const query = new URLSearchParams()
+    if (currentSegment) {
+      query.set('segment', currentSegment)
     }
+    const queryString = query.toString()
+    const href = `/api/v1/contacts/download${
+      queryString ? `?${queryString}` : ''
+    }`
+    const dateStr = dateUsHelper(new Date()).replace(/ /g, '_')
+
+    const link = document.createElement('a')
+    link.href = href
+    link.setAttribute('download', `contacts_${dateStr}.csv`)
+    link.rel = 'noopener'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+
+    // We cannot observe completion of a top-level download, so fire the
+    // analytics event at click time. The download will continue in the
+    // browser's native UI even if the user navigates away.
+    trackEvent(EVENTS.Contacts.Download, generateProperties())
   }
 
   const generateProperties = (): Record<

--- a/app/dashboard/contacts/[[...attr]]/components/Download.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/Download.tsx
@@ -12,11 +12,54 @@ import {
 import { useShowContactProModal } from '../hooks/ContactProModal'
 import { Lock } from '@mui/icons-material'
 import { LuDownload } from 'react-icons/lu'
+import { useEffect, useRef, useState } from 'react'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { getCookie } from 'helpers/cookieHelper'
+
+const DOWNLOAD_COOKIE_NAME = 'gp_download'
+const DOWNLOAD_COOKIE_POLL_MS = 250
+// Fallback in case the server-side cookie handshake is missing (older deploy,
+// proxy stripped Set-Cookie, etc.). Long enough to overlap with first byte on
+// large districts, short enough to avoid leaving a stuck spinner forever.
+const DOWNLOAD_FALLBACK_TIMEOUT_MS = 15000
+
+// `getCookie` returns `string | false`; normalize to `string | null` and
+// guard against `decodeURI` throwing on a malformed cookie value (which
+// would otherwise surface as an uncaught error inside the 250ms poll).
+const readDownloadCookie = (): string | null => {
+  try {
+    const value = getCookie(DOWNLOAD_COOKIE_NAME)
+    return value === false ? null : value
+  } catch {
+    return null
+  }
+}
 
 export default function Download() {
   const showProUpgradeModal = useShowContactProModal()
   const { customSegments, currentSegment, canUseProFeatures } =
     useContactsTable()
+  const { successSnackbar } = useSnackbar()
+  const [isPreparing, setIsPreparing] = useState(false)
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearDownloadWatchers = (): void => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current)
+      pollIntervalRef.current = null
+    }
+    if (fallbackTimeoutRef.current) {
+      clearTimeout(fallbackTimeoutRef.current)
+      fallbackTimeoutRef.current = null
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      clearDownloadWatchers()
+    }
+  }, [])
 
   // Trigger the contacts CSV download via a top-level browser navigation so
   // bytes stream directly to disk. Avoids buffering the entire response (up
@@ -30,6 +73,16 @@ export default function Download() {
       showProUpgradeModal(true)
       return
     }
+
+    // Snapshot the current value of the download cookie so a stale token from
+    // a previous download doesn't make the spinner clear instantly.
+    const cookieBeforeClick = readDownloadCookie()
+
+    setIsPreparing(true)
+    successSnackbar(
+      'Preparing your download. Large districts can take 10-15 seconds...',
+      { autoHideDuration: 12000 },
+    )
 
     const query = new URLSearchParams()
     if (currentSegment) {
@@ -48,6 +101,26 @@ export default function Download() {
     document.body.appendChild(link)
     link.click()
     link.remove()
+
+    clearDownloadWatchers()
+
+    // Poll for the gp_download cookie set by gp-api. The browser commits
+    // cookies from a download response, so the moment the cookie appears we
+    // know the server has actually started streaming and can swap the
+    // "preparing" feedback for a "started" confirmation.
+    pollIntervalRef.current = setInterval(() => {
+      const current = readDownloadCookie()
+      if (current && current !== cookieBeforeClick) {
+        clearDownloadWatchers()
+        setIsPreparing(false)
+        successSnackbar('Download started', { autoHideDuration: 3000 })
+      }
+    }, DOWNLOAD_COOKIE_POLL_MS)
+
+    fallbackTimeoutRef.current = setTimeout(() => {
+      clearDownloadWatchers()
+      setIsPreparing(false)
+    }, DOWNLOAD_FALLBACK_TIMEOUT_MS)
 
     // We cannot observe completion of a top-level download, so fire the
     // analytics event at click time. The download will continue in the
@@ -104,6 +177,7 @@ export default function Download() {
       <IconButton
         variant="outline"
         onClick={handleDownload}
+        loading={isPreparing}
         className="hidden md:flex"
       >
         {!canUseProFeatures ? <Lock /> : <LuDownload />}


### PR DESCRIPTION
These PRs enable a EO to download a 700K district in ~15 seconds


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how authenticated pro users export potentially large contact datasets; behavior depends on middleware auth rewrite and a server-set download cookie, with only a timeout fallback if the handshake fails.
> 
> **Overview**
> **Contacts CSV export** no longer loads the file through `clientRequest` as a **Blob**. It now kicks off a **native browser download** against `/api/v1/contacts/download` (with optional `segment` query), so large exports can **stream to disk** instead of exhausting memory on big districts.
> 
> While the file prepares, the button shows a **loading** state and a snackbar warns that large districts may take 10–15 seconds. The client **polls** the `gp_download` cookie (with a **15s fallback**) to detect when the API has started the response, then confirms **“Download started”** and clears the spinner. **Analytics** for the download event fire at **click** time because completion isn’t observable for top-level downloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e2641d32463e7f4b985789839387ee1363d7be9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->