### PR TITLE
Land EOs on Meetings, not Polls, when switching into an EO org

### DIFF
--- a/app/shared/organization-picker.test.tsx
+++ b/app/shared/organization-picker.test.tsx
@@ -11,11 +11,17 @@ import {
   useOrganization,
 } from './organization-picker'
 
+const mockRouterPush = vi.fn()
+const mockRouterReplace = vi.fn()
+
 vi.mock('next/navigation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('next/navigation')>()
   return {
     ...actual,
-    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
+    useRouter: vi.fn(() => ({
+      push: mockRouterPush,
+      replace: mockRouterReplace,
+    })),
     usePathname: vi.fn(() => '/dashboard'),
   }
 })
@@ -73,6 +79,8 @@ const orgs: Organization[] = [
 beforeEach(() => {
   mockSetCookie.mockClear()
   mockGetCookie.mockReset().mockReturnValue(false)
+  mockRouterPush.mockClear()
+  mockRouterReplace.mockClear()
 })
 
 describe('OrganizationProvider', () => {
@@ -211,6 +219,34 @@ describe('OrganizationPicker', () => {
     await waitFor(() => {
       expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-two')
     })
+  })
+
+  it('routes to /dashboard/briefings when switching to an elected office org', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+
+    await user.click(screen.getByText('Organization One'))
+    await user.click(screen.getByText('Organization Two'))
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard/briefings')
+    })
+  })
+
+  it('routes to /dashboard when switching to a non-elected-office org', async () => {
+    const user = userEvent.setup()
+    mockGetCookie.mockImplementation((name: string) =>
+      name === 'organization-slug' ? 'org-two' : false,
+    )
+    renderPicker()
+
+    await user.click(screen.getByText('Organization Two'))
+    await user.click(screen.getByText('Organization One'))
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith('/dashboard')
+    })
+    expect(mockRouterPush).not.toHaveBeenCalledWith('/dashboard/briefings')
   })
 
   it('fetches organizations from the API', async () => {

--- a/app/shared/organization-picker.tsx
+++ b/app/shared/organization-picker.tsx
@@ -141,7 +141,7 @@ export const OrganizationPicker = () => {
 
     const isOnSharedPage = SHARED_PATHS.some((p) => pathname?.startsWith(p))
     if (!isOnSharedPage) {
-      router.push(org.electedOfficeId ? '/dashboard/polls' : '/dashboard')
+      router.push(org.electedOfficeId ? '/dashboard/briefings' : '/dashboard')
     }
   }
 

--- a/e2e-tests/tests/app/organizations/org-switcher.spec.ts
+++ b/e2e-tests/tests/app/organizations/org-switcher.spec.ts
@@ -41,7 +41,7 @@ test.describe('Organization Switcher', () => {
     await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15000 })
   })
 
-  test('switching to elected office org routes to /dashboard/polls', async ({
+  test('switching to elected office org routes to /dashboard/briefings', async ({
     page,
   }) => {
     await setupElectedOfficeUser(page)
@@ -60,7 +60,7 @@ test.describe('Organization Switcher', () => {
 
     // Switch back to EO
     await switchOrganization(page, eoOrgName)
-    await expect(page).toHaveURL(/\/dashboard\/polls/, { timeout: 15000 })
+    await expect(page).toHaveURL(/\/dashboard\/briefings/, { timeout: 15000 })
   })
 
   test('org selection persists across page reload', async ({ page }) => {


### PR DESCRIPTION
## Summary

Meetings is the primary surface for Elected Officials, but the org-picker callback was still pushing them to Polls whenever they switched into an EO organization. This was inconsistent with the `/dashboard` root, which already redirects EOs to `/dashboard/briefings`. New and returning EOs should land on the same place regardless of whether they got there via root redirect or via the org switcher.

Deep links and manual navigation are unaffected — only the default entry point when entering EO mode via the org picker changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single client-side redirect path change with no auth, data, or API impact.
> 
> **Overview**
> When switching into an **Elected Official** organization via the org picker (and not on a shared profile/campaign path), the default navigation now goes to **`/dashboard/briefings`** instead of **`/dashboard/polls`**, matching the EO landing behavior used from the dashboard root.
> 
> Deep links and other routes are unchanged; only this org-switch default destination is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd8135ed97fdf18bc61fee4fa04cc8ed7402738. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->