### PR TITLE
fix(org-picker): persist selected org across sessions

### DIFF
--- a/app/shared/hooks/useSelectedOrgSlug.ts
+++ b/app/shared/hooks/useSelectedOrgSlug.ts
@@ -13,10 +13,21 @@ import { ORGANIZATIONS_QUERY_KEY } from '@shared/organization-picker'
 // prior unauthenticated session (an empty array). This hook keeps the
 // cache and selected slug in sync with the latest server-provided
 // organizations so the provider never serves stale/empty state.
-export const useSelectedOrgSlug = (initialOrganizations: Organization[]) => {
+//
+// The initial slug must be sourced from the server (via next/headers) and
+// passed in: useState initializers can't read document.cookie during SSR,
+// so resolving the cookie client-side only would briefly render the
+// fallback org on the server and then mismatch on hydration.
+export const useSelectedOrgSlug = (
+  initialOrganizations: Organization[],
+  initialSlug: string | null,
+) => {
   const queryClient = useQueryClient()
   const [selectedSlug, setSelectedSlug] = useState(() =>
-    resolveSlug(initialOrganizations),
+    pickSlug(
+      initialOrganizations,
+      (initialSlug ?? getCookie(ORG_SLUG_COOKIE)) || null,
+    ),
   )
 
   useEffect(() => {
@@ -27,15 +38,23 @@ export const useSelectedOrgSlug = (initialOrganizations: Organization[]) => {
         const stillValid = initialOrganizations.some((o) => o.slug === prev)
         if (stillValid) return prev
       }
-      return resolveSlug(initialOrganizations)
+      return pickSlug(
+        initialOrganizations,
+        (initialSlug ?? getCookie(ORG_SLUG_COOKIE)) || null,
+      )
     })
-  }, [initialOrganizations, queryClient])
+  }, [initialOrganizations, initialSlug, queryClient])
 
   return [selectedSlug, setSelectedSlug] as const
 }
 
-export const resolveSlug = (organizations: Organization[]): string | null => {
-  const cookieSlug = getCookie(ORG_SLUG_COOKIE) || null
-  const isValid = organizations.some((o) => o.slug === cookieSlug)
-  return isValid ? cookieSlug : organizations[0]?.slug ?? null
+const pickSlug = (
+  organizations: Organization[],
+  candidate: string | null | false,
+): string | null => {
+  const isValid = candidate && organizations.some((o) => o.slug === candidate)
+  return isValid ? (candidate as string) : (organizations[0]?.slug ?? null)
 }
+
+export const resolveSlug = (organizations: Organization[]): string | null =>
+  pickSlug(organizations, getCookie(ORG_SLUG_COOKIE) || null)

--- a/app/shared/hooks/useSelectedOrgSlug.ts
+++ b/app/shared/hooks/useSelectedOrgSlug.ts
@@ -53,7 +53,7 @@ const pickSlug = (
   candidate: string | null | false,
 ): string | null => {
   const isValid = candidate && organizations.some((o) => o.slug === candidate)
-  return isValid ? (candidate as string) : (organizations[0]?.slug ?? null)
+  return isValid ? (candidate as string) : organizations[0]?.slug ?? null
 }
 
 export const resolveSlug = (organizations: Organization[]): string | null =>

--- a/app/shared/layouts/PageWrapper.tsx
+++ b/app/shared/layouts/PageWrapper.tsx
@@ -20,6 +20,8 @@ import { OrganizationProvider } from '@shared/organization-picker'
 import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
 import { ClerkProvider } from '@clerk/nextjs'
 import { auth } from '@clerk/nextjs/server'
+import { cookies } from 'next/headers'
+import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { ReactQueryProvider } from '@shared/query-client'
 import { FeatureFlagsProvider } from '@shared/experiments/FeatureFlagsProvider'
 
@@ -33,11 +35,13 @@ const PageWrapper = async ({
   const { userId } = await auth()
   const isAuthed = !!userId
 
-  const [pathname, campaign, organizations] = await Promise.all([
+  const [pathname, campaign, organizations, cookieStore] = await Promise.all([
     getReqPathname(),
     isAuthed ? fetchUserCampaign() : Promise.resolve(null),
     isAuthed ? getCurrentUserOrganizations() : Promise.resolve([]),
+    cookies(),
   ])
+  const initialOrgSlug = cookieStore.get(ORG_SLUG_COOKIE)?.value ?? null
 
   return (
     <ClerkProvider>
@@ -46,7 +50,10 @@ const PageWrapper = async ({
           <FeatureFlagsProvider>
             <AmplitudeInit />
             <ImpersonatingTracker />
-            <OrganizationProvider initialOrganizations={organizations}>
+            <OrganizationProvider
+              initialOrganizations={organizations}
+              initialSlug={initialOrgSlug}
+            >
               <CampaignProvider campaign={campaign}>
                 <SentryIdentifier />
                 <CampaignStatusProvider>

--- a/app/shared/organization-picker.test.tsx
+++ b/app/shared/organization-picker.test.tsx
@@ -299,8 +299,9 @@ describe('X-Organization-Slug header attachment', () => {
   })
 
   it('handleApiRequestRewrite attaches the header from cookies', async () => {
-    const { handleApiRequestRewrite } =
-      await import('helpers/handleApiRequestRewrite')
+    const { handleApiRequestRewrite } = await import(
+      'helpers/handleApiRequestRewrite'
+    )
 
     const reqUrl = new URL('http://localhost:4000/api/v1/organizations')
     const request = new Request(reqUrl.toString())
@@ -326,8 +327,9 @@ describe('X-Organization-Slug header attachment', () => {
   })
 
   it('handleApiRequestRewrite does not attach header when no org cookie exists', async () => {
-    const { handleApiRequestRewrite } =
-      await import('helpers/handleApiRequestRewrite')
+    const { handleApiRequestRewrite } = await import(
+      'helpers/handleApiRequestRewrite'
+    )
 
     const reqUrl = new URL('http://localhost:4000/api/v1/organizations')
     const request = new Request(reqUrl.toString())

--- a/app/shared/organization-picker.test.tsx
+++ b/app/shared/organization-picker.test.tsx
@@ -76,7 +76,7 @@ beforeEach(() => {
 })
 
 describe('OrganizationProvider', () => {
-  it('provides the first organization as default when no cookie is set', () => {
+  it('provides the first organization as default when no initial slug is set', () => {
     const Probe = () => {
       const org = useOrganization()
       return <div data-testid="org">{org?.slug}</div>
@@ -89,10 +89,24 @@ describe('OrganizationProvider', () => {
     )
 
     expect(screen.getByTestId('org')).toHaveTextContent('org-one')
-    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
   })
 
-  it('selects the org matching the cookie slug', () => {
+  it('selects the org matching the initialSlug prop', () => {
+    const Probe = () => {
+      const org = useOrganization()
+      return <div data-testid="org">{org?.slug}</div>
+    }
+
+    render(
+      <OrganizationProvider initialOrganizations={orgs} initialSlug="org-two">
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    expect(screen.getByTestId('org')).toHaveTextContent('org-two')
+  })
+
+  it('falls back to the cookie when no initialSlug is provided', () => {
     mockGetCookie.mockImplementation((name: string) =>
       name === 'organization-slug' ? 'org-two' : false,
     )
@@ -111,24 +125,22 @@ describe('OrganizationProvider', () => {
     expect(screen.getByTestId('org')).toHaveTextContent('org-two')
   })
 
-  it('falls back to first org when cookie slug does not match any org', () => {
-    mockGetCookie.mockImplementation((name: string) =>
-      name === 'organization-slug' ? 'nonexistent' : false,
-    )
-
+  it('falls back to first org when initialSlug does not match any org', () => {
     const Probe = () => {
       const org = useOrganization()
       return <div data-testid="org">{org?.slug}</div>
     }
 
     render(
-      <OrganizationProvider initialOrganizations={orgs}>
+      <OrganizationProvider
+        initialOrganizations={orgs}
+        initialSlug="nonexistent"
+      >
         <Probe />
       </OrganizationProvider>,
     )
 
     expect(screen.getByTestId('org')).toHaveTextContent('org-one')
-    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
   })
 
   it('renders children without context when no organizations exist', () => {
@@ -287,9 +299,8 @@ describe('X-Organization-Slug header attachment', () => {
   })
 
   it('handleApiRequestRewrite attaches the header from cookies', async () => {
-    const { handleApiRequestRewrite } = await import(
-      'helpers/handleApiRequestRewrite'
-    )
+    const { handleApiRequestRewrite } =
+      await import('helpers/handleApiRequestRewrite')
 
     const reqUrl = new URL('http://localhost:4000/api/v1/organizations')
     const request = new Request(reqUrl.toString())
@@ -315,9 +326,8 @@ describe('X-Organization-Slug header attachment', () => {
   })
 
   it('handleApiRequestRewrite does not attach header when no org cookie exists', async () => {
-    const { handleApiRequestRewrite } = await import(
-      'helpers/handleApiRequestRewrite'
-    )
+    const { handleApiRequestRewrite } =
+      await import('helpers/handleApiRequestRewrite')
 
     const reqUrl = new URL('http://localhost:4000/api/v1/organizations')
     const request = new Request(reqUrl.toString())

--- a/app/shared/organization-picker.test.tsx
+++ b/app/shared/organization-picker.test.tsx
@@ -169,6 +169,81 @@ describe('OrganizationProvider', () => {
     expect(screen.getByTestId('elected')).toHaveTextContent('false')
   })
 
+  it('resolves the org after initialOrganizations transitions from empty to populated', async () => {
+    const Probe = () => {
+      const org = useOrganization()
+      return <div data-testid="org">{org?.slug ?? 'none'}</div>
+    }
+
+    const { rerender } = render(
+      <OrganizationProvider initialOrganizations={[]}>
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    expect(screen.getByTestId('org')).toHaveTextContent('none')
+
+    rerender(
+      <OrganizationProvider initialOrganizations={orgs}>
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org')).toHaveTextContent('org-one')
+    })
+  })
+
+  it('resolves to the cookie-pointed org after initialOrganizations populates (effect-path fallback)', async () => {
+    mockGetCookie.mockImplementation((name: string) =>
+      name === 'organization-slug' ? 'org-two' : false,
+    )
+
+    const Probe = () => {
+      const org = useOrganization()
+      return <div data-testid="org">{org?.slug ?? 'none'}</div>
+    }
+
+    const { rerender } = render(
+      <OrganizationProvider initialOrganizations={[]}>
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    rerender(
+      <OrganizationProvider initialOrganizations={orgs}>
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org')).toHaveTextContent('org-two')
+    })
+  })
+
+  it('rewrites the cookie when initialSlug points to an org not in the list (stale-cookie fallback)', async () => {
+    mockGetCookie.mockImplementation((name: string) =>
+      name === 'organization-slug' ? 'stale-org' : false,
+    )
+
+    const Probe = () => {
+      const org = useOrganization()
+      return <div data-testid="org">{org?.slug ?? 'none'}</div>
+    }
+
+    render(
+      <OrganizationProvider initialOrganizations={orgs} initialSlug="stale-org">
+        <Probe />
+      </OrganizationProvider>,
+    )
+
+    expect(screen.getByTestId('org')).toHaveTextContent('org-one')
+
+    await waitFor(() => {
+      expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
+    })
+  })
+
   it('throws when useOrganization is used outside the provider', () => {
     const Probe = () => {
       useOrganization()

--- a/app/shared/organization-picker.tsx
+++ b/app/shared/organization-picker.tsx
@@ -4,7 +4,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   type ReactNode,
 } from 'react'
@@ -61,6 +60,7 @@ export const useSetOrganizationSlug = () => {
 interface OrganizationProviderProps {
   children: ReactNode
   initialOrganizations: Organization[]
+  initialSlug?: string | null
 }
 
 export const ORGANIZATIONS_QUERY_KEY = ['organizations']
@@ -68,6 +68,7 @@ export const ORGANIZATIONS_QUERY_KEY = ['organizations']
 export const OrganizationProvider = ({
   children,
   initialOrganizations,
+  initialSlug = null,
 }: OrganizationProviderProps) => {
   const queryClient = useQueryClient()
 
@@ -80,20 +81,16 @@ export const OrganizationProvider = ({
     initialData: initialOrganizations,
   })
 
-  const [selectedSlug, setRawSelectedSlug] =
-    useSelectedOrgSlug(initialOrganizations)
+  const [selectedSlug, setRawSelectedSlug] = useSelectedOrgSlug(
+    initialOrganizations,
+    initialSlug,
+  )
 
   const selectedOrganization = useMemo(
     () =>
       organizations.find((o) => o.slug === selectedSlug) ?? organizations[0],
     [organizations, selectedSlug],
   )
-
-  useEffect(() => {
-    if (selectedOrganization) {
-      setCookie(ORG_SLUG_COOKIE, selectedOrganization.slug)
-    }
-  }, [selectedOrganization])
 
   const setSelectedSlug = useCallback(
     (slug: string) => {

--- a/app/shared/organization-picker.tsx
+++ b/app/shared/organization-picker.tsx
@@ -4,13 +4,14 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   type ReactNode,
 } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { clientRequest } from 'gpApi/typed-request'
 import { Organization } from 'gpApi/api-endpoints'
-import { setCookie } from 'helpers/cookieHelper'
+import { getCookie, setCookie } from 'helpers/cookieHelper'
 import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { useSelectedOrgSlug } from '@shared/hooks/useSelectedOrgSlug'
 import {
@@ -91,6 +92,21 @@ export const OrganizationProvider = ({
       organizations.find((o) => o.slug === selectedSlug) ?? organizations[0],
     [organizations, selectedSlug],
   )
+
+  // If the resolved slug diverges from the cookie (e.g. cookie pointed at an
+  // org the user no longer has access to, so pickSlug fell back to
+  // organizations[0]), rewrite the cookie. gpFetch, clientFetch, and middleware
+  // read the cookie directly for the X-Organization-Slug header, so a stale
+  // cookie would make the API see the wrong slug while the UI shows the
+  // fallback. This fires only on a genuine mismatch — SSR/client agree on
+  // first render because initialSlug is sourced from the cookie server-side.
+  useEffect(() => {
+    const resolved = selectedOrganization?.slug
+    if (!resolved) return
+    if (resolved !== getCookie(ORG_SLUG_COOKIE)) {
+      setCookie(ORG_SLUG_COOKIE, resolved)
+    }
+  }, [selectedOrganization?.slug])
 
   const setSelectedSlug = useCallback(
     (slug: string) => {


### PR DESCRIPTION
## Why

A user's selected organization in the org picker was reset to the first/default org on every new session, undoing any previous switch to an elected-office org.

The cookie itself has a 120-day expiry and survives logout/login, so on paper the selection should persist. The breakdown happens during SSR + hydration:

- `useSelectedOrgSlug`'s `useState` initializer calls `getCookie()`, which returns `false` when there is no `window` (i.e. during SSR). The server therefore seeds state with `organizations[0]` (the fallback), not the user's actual cookie value.
- On hydration the initializer re-runs on the client and reads the real cookie, but the `OrganizationProvider`'s `useEffect` (`setCookie(ORG_SLUG_COOKIE, selectedOrganization.slug)`) can fire with the server's fallback value before reconciliation settles, overwriting the cookie back to the first org. Once that happens the user's selection is gone — and stays gone on every subsequent session.

The fix sources the initial slug from the server via `next/headers` and passes it down as `initialSlug` so the server and client agree from the very first render. The redundant cookie-writing effect is removed; the picker, onboarding flow, and `/post-auth-redirect` already write the cookie explicitly on user action, so the effect was load-bearing for nothing but the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the active org is chosen on every authed page load and removes automatic cookie sync on render; wrong slug wiring could mis-route API context until the user switches orgs.
> 
> **Overview**
> Fixes org picker resetting to the first org across sessions by aligning **server and client** on the selected slug from the first paint.
> 
> **`PageWrapper`** reads `organization-slug` via `next/headers` and passes it as **`initialSlug`** into **`OrganizationProvider`**. **`useSelectedOrgSlug`** now takes that prop and uses shared **`pickSlug`** logic (server slug first, then client cookie, then first org).
> 
> Removes the provider **`useEffect`** that wrote the org cookie whenever `selectedOrganization` changed— that could run with the SSR fallback org during hydration and **overwrite** the user’s real cookie. Cookies are still set on explicit org switches via **`setSelectedSlug`**.
> 
> Tests cover **`initialSlug`**, cookie fallback, and invalid-slug fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f04671fdcd6b4e48adedbde6607c2b3c7ad87a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->