### PR TITLE
Feature/active card notes

### DIFF
--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -6,6 +6,7 @@ import { getBriefingBySlug } from '@shared/briefings/server'
 import {
   BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
   BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
   briefingsLandingHref,
 } from '@shared/briefings/routes'
 import serveAccess from '../../shared/serveAccess'
@@ -63,6 +64,7 @@ export default async function BriefingChromeLayout({
         initialActiveCard={{
           key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
           jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+          titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
           title: 'Executive Summary',
         }}
       >

--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -10,6 +10,7 @@ import {
 } from '@shared/briefings/routes'
 import serveAccess from '../../shared/serveAccess'
 import DashboardLayout from '../../shared/DashboardLayout'
+import ActiveCardScrollSpy from '../components/detail/ActiveCardScrollSpy'
 import DetailHeader from '../components/detail/DetailHeader'
 import DetailToc from '../components/detail/DetailToc'
 import MobileBottomBar from '../components/detail/MobileBottomBar'
@@ -65,6 +66,7 @@ export default async function BriefingChromeLayout({
           title: 'Executive Summary',
         }}
       >
+        <ActiveCardScrollSpy items={briefing.items} />
         <div className="relative">
           {/* lg+: constrain the whole briefing area to viewport height and
               disable document-level scroll. The sidebar pane stays

--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -3,7 +3,11 @@ import { notFound } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { APP_BASE } from 'appEnv'
 import { getBriefingBySlug } from '@shared/briefings/server'
-import { briefingsLandingHref } from '@shared/briefings/routes'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingsLandingHref,
+} from '@shared/briefings/routes'
 import serveAccess from '../../shared/serveAccess'
 import DashboardLayout from '../../shared/DashboardLayout'
 import DetailHeader from '../components/detail/DetailHeader'
@@ -53,7 +57,14 @@ export default async function BriefingChromeLayout({
       showAlert={false}
       wrapperClassName="!p-0"
     >
-      <AnnotationsScope meetingDate={slug}>
+      <AnnotationsScope
+        meetingDate={slug}
+        initialActiveCard={{
+          key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+          jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+          title: 'Executive Summary',
+        }}
+      >
         <div className="relative">
           {/* lg+: constrain the whole briefing area to viewport height and
               disable document-level scroll. The sidebar pane stays

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
@@ -63,7 +63,8 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        topLevelNotes={[]}
+        notesForActiveCard={[]}
+        activeCardTitle="Executive Summary"
         onEditNote={vi.fn()}
       />,
     )
@@ -103,7 +104,8 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        topLevelNotes={[]}
+        notesForActiveCard={[]}
+        activeCardTitle="Executive Summary"
         onEditNote={vi.fn()}
       />,
     )
@@ -144,7 +146,8 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        topLevelNotes={[]}
+        notesForActiveCard={[]}
+        activeCardTitle="Executive Summary"
         onEditNote={vi.fn()}
       />,
     )
@@ -180,7 +183,8 @@ describe('<AddNoteSheet> edit-mode attachment error reporting', () => {
         onDelete={vi.fn()}
         onAttachmentAdd={onAttachmentAdd}
         onAttachmentDelete={vi.fn()}
-        topLevelNotes={[]}
+        notesForActiveCard={[]}
+        activeCardTitle="Executive Summary"
         onEditNote={vi.fn()}
       />,
     )
@@ -240,7 +244,8 @@ describe('<AddNoteSheet> edit-mode attachment error reporting', () => {
         onDelete={vi.fn()}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={onAttachmentDelete}
-        topLevelNotes={[]}
+        notesForActiveCard={[]}
+        activeCardTitle="Executive Summary"
         onEditNote={vi.fn()}
       />,
     )

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
@@ -63,9 +63,7 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        notesForActiveCard={[]}
         activeCardTitle="Executive Summary"
-        onEditNote={vi.fn()}
       />,
     )
 
@@ -104,9 +102,7 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        notesForActiveCard={[]}
         activeCardTitle="Executive Summary"
-        onEditNote={vi.fn()}
       />,
     )
 
@@ -146,9 +142,7 @@ describe('<AddNoteSheet> error surfacing', () => {
         onDelete={onDelete}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={vi.fn()}
-        notesForActiveCard={[]}
         activeCardTitle="Executive Summary"
-        onEditNote={vi.fn()}
       />,
     )
 
@@ -183,9 +177,7 @@ describe('<AddNoteSheet> edit-mode attachment error reporting', () => {
         onDelete={vi.fn()}
         onAttachmentAdd={onAttachmentAdd}
         onAttachmentDelete={vi.fn()}
-        notesForActiveCard={[]}
         activeCardTitle="Executive Summary"
-        onEditNote={vi.fn()}
       />,
     )
 
@@ -244,9 +236,7 @@ describe('<AddNoteSheet> edit-mode attachment error reporting', () => {
         onDelete={vi.fn()}
         onAttachmentAdd={vi.fn()}
         onAttachmentDelete={onAttachmentDelete}
-        notesForActiveCard={[]}
         activeCardTitle="Executive Summary"
-        onEditNote={vi.fn()}
       />,
     )
 

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Paperclip, Trash2, X } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import {
   Button,
   Drawer,
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-  Loader2Icon,
   Textarea,
 } from '@styleguide'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
@@ -17,7 +16,6 @@ import {
   resolveQuoteFromAnchor,
   type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
-import type { Annotation } from '@shared/briefings/types'
 import type { SheetState } from './AnnotationsScope'
 import type { PredictedPosition } from './enrichForCycler'
 import { useClearSelectionOnOpen } from './useClearSelectionOnOpen'
@@ -54,17 +52,8 @@ type Props = {
     annotationId: string,
     attachmentId: string,
   ) => Promise<void>
-  /**
-   * Existing card-level notes for the currently-active card. Rendered as
-   * a list above the composer when the sheet is in card-level new mode
-   * (anchor=null) so the user can see, tap-to-edit, or delete
-   * previously-added notes attached to this card.
-   */
-  notesForActiveCard: Annotation[]
   /** Title of the active card — drives the "Note on {title}" copy. */
   activeCardTitle: string | null
-  /** Open an existing note in edit mode (from the card-level list). */
-  onEditNote: (annotation: Annotation) => void
 }
 
 function quoteFor(state: SheetState): string | null {
@@ -102,9 +91,7 @@ export default function AddNoteSheet({
   onDelete,
   onAttachmentAdd,
   onAttachmentDelete,
-  notesForActiveCard,
   activeCardTitle,
-  onEditNote,
 }: Props): React.JSX.Element {
   const open = isAddNoteState(sheet)
   const isDesktop = !useIsMobile()
@@ -125,11 +112,6 @@ export default function AddNoteSheet({
   // Per-attachment busy state for edit mode — keyed by staged temp id (in
   // flight upload) or server attachment id (in flight delete).
   const [busyAttachmentIds, setBusyAttachmentIds] = useState<Set<string>>(
-    () => new Set(),
-  )
-  // Top-level list rows being deleted — drives the spinner on the X
-  // button. Distinct from busyAttachmentIds.
-  const [deletingNoteIds, setDeletingNoteIds] = useState<Set<string>>(
     () => new Set(),
   )
 
@@ -158,7 +140,6 @@ export default function AddNoteSheet({
     setAttachmentError(null)
     setSaveError(null)
     setBusyAttachmentIds(new Set())
-    setDeletingNoteIds(new Set())
   }, [sheet, sheetIdentity])
 
   // Clear the user's text selection once the drawer opens — leaving a live
@@ -171,29 +152,6 @@ export default function AddNoteSheet({
     sheet.kind === 'add_note_edit'
       ? sheet.annotation.note?.attachments ?? []
       : []
-  // True when the sheet is opened for a brand-new top-level (briefing-wide)
-  // note. In that case we render the user's existing top-level notes
-  // above the composer so they can see what's already saved without the
-  // drawer needing to be closed and reopened.
-  const isTopLevelNew = sheet.kind === 'add_note_new' && sheet.anchor === null
-
-  async function handleListDelete(annotationId: string) {
-    if (deletingNoteIds.has(annotationId)) return
-    setDeletingNoteIds((prev) => new Set(prev).add(annotationId))
-    setSaveError(null)
-    try {
-      await onDelete(annotationId)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      setSaveError(`Couldn't delete this note: ${msg}`)
-    } finally {
-      setDeletingNoteIds((prev) => {
-        const next = new Set(prev)
-        next.delete(annotationId)
-        return next
-      })
-    }
-  }
 
   function markBusy(id: string, busy: boolean) {
     setBusyAttachmentIds((prev) => {
@@ -403,77 +361,6 @@ export default function AddNoteSheet({
               <span className="font-medium not-italic">{activeCardTitle}</span>
             </p>
           ) : null}
-
-          {(() => {
-            if (!isTopLevelNew) return null
-            // Hide notes that have neither a body nor any attachments yet.
-            // This covers the brief window between create.mutateAsync
-            // resolving and the attachment uploads' refetch landing —
-            // rendering them would flash "(empty note)" for a frame.
-            const visibleNotes = notesForActiveCard.filter(
-              (n) =>
-                (n.note?.body ?? '').trim().length > 0 ||
-                (n.note?.attachments?.length ?? 0) > 0,
-            )
-            if (visibleNotes.length === 0) return null
-            return (
-              <ul className="flex list-none flex-col gap-2">
-                {visibleNotes.map((n) => {
-                  const attachCount = n.note?.attachments?.length ?? 0
-                  const preview = (n.note?.body ?? '').trim()
-                  const label =
-                    preview.length > 0
-                      ? preview
-                      : `${attachCount} attachment${
-                          attachCount === 1 ? '' : 's'
-                        }`
-                  const busy = deletingNoteIds.has(n.id)
-                  return (
-                    <li key={n.id}>
-                      <div className="group flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 transition-colors hover:bg-muted/60">
-                        <button
-                          type="button"
-                          onClick={() => onEditNote(n)}
-                          className="flex min-w-0 flex-1 items-center gap-2 text-left text-sm focus:outline-none"
-                        >
-                          <span className="line-clamp-2 min-w-0 flex-1 text-foreground">
-                            {label}
-                          </span>
-                          {attachCount > 0 ? (
-                            <span
-                              aria-label={`${attachCount} attached file${
-                                attachCount === 1 ? '' : 's'
-                              }`}
-                              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-                            >
-                              <Paperclip className="size-3" aria-hidden />
-                              {attachCount}
-                            </span>
-                          ) : null}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => void handleListDelete(n.id)}
-                          disabled={busy}
-                          aria-label="Delete note"
-                          className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
-                        >
-                          {busy ? (
-                            <Loader2Icon
-                              className="size-4 animate-spin"
-                              aria-hidden
-                            />
-                          ) : (
-                            <X className="size-4" aria-hidden />
-                          )}
-                        </button>
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-            )
-          })()}
         </div>
 
         {/* Composer pinned at the bottom. The attachment picker sits above

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -55,13 +55,15 @@ type Props = {
     attachmentId: string,
   ) => Promise<void>
   /**
-   * All existing top-level notes for this briefing. Rendered as a list
-   * above the composer when the sheet is in top-level new mode so the
-   * user can see, tap-to-edit, or delete previously-added briefing-wide
-   * notes (those have no anchor and don't render as highlights).
+   * Existing card-level notes for the currently-active card. Rendered as
+   * a list above the composer when the sheet is in card-level new mode
+   * (anchor=null) so the user can see, tap-to-edit, or delete
+   * previously-added notes attached to this card.
    */
-  topLevelNotes: Annotation[]
-  /** Open an existing note in edit mode (from the top-level list). */
+  notesForActiveCard: Annotation[]
+  /** Title of the active card — drives the "Note on {title}" copy. */
+  activeCardTitle: string | null
+  /** Open an existing note in edit mode (from the card-level list). */
   onEditNote: (annotation: Annotation) => void
 }
 
@@ -100,7 +102,8 @@ export default function AddNoteSheet({
   onDelete,
   onAttachmentAdd,
   onAttachmentDelete,
-  topLevelNotes,
+  notesForActiveCard,
+  activeCardTitle,
   onEditNote,
 }: Props): React.JSX.Element {
   const open = isAddNoteState(sheet)
@@ -394,9 +397,10 @@ export default function AddNoteSheet({
         >
           {quote ? (
             <AnchoredQuote text={quote} showLabel={false} />
-          ) : !isEdit ? (
+          ) : !isEdit && activeCardTitle ? (
             <p className="rounded-md bg-muted px-3 py-2 text-sm italic text-muted-foreground">
-              This note is for the whole briefing.
+              Note on{' '}
+              <span className="font-medium not-italic">{activeCardTitle}</span>
             </p>
           ) : null}
 
@@ -406,7 +410,7 @@ export default function AddNoteSheet({
             // This covers the brief window between create.mutateAsync
             // resolving and the attachment uploads' refetch landing —
             // rendering them would flash "(empty note)" for a frame.
-            const visibleNotes = topLevelNotes.filter(
+            const visibleNotes = notesForActiveCard.filter(
               (n) =>
                 (n.note?.body ?? '').trim().length > 0 ||
                 (n.note?.attachments?.length ?? 0) > 0,

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -148,10 +148,6 @@ export default function AddNoteSheet({
 
   const quote = quoteFor(sheet)
   const isEdit = sheet.kind === 'add_note_edit'
-  const existingAttachments =
-    sheet.kind === 'add_note_edit'
-      ? sheet.annotation.note?.attachments ?? []
-      : []
 
   function markBusy(id: string, busy: boolean) {
     setBusyAttachmentIds((prev) => {
@@ -295,10 +291,14 @@ export default function AddNoteSheet({
 
   // The list the picker renders. In new-note mode it's just staged files;
   // in edit mode it's the server-side attachments plus any uploads still
-  // in flight.
+  // in flight. We re-derive `existingAttachments` inside the memo so the
+  // `?? []` fallback doesn't churn its identity across renders and trip
+  // react-hooks/exhaustive-deps.
   const pickerItems: PickerItem[] = useMemo(() => {
     if (sheet.kind === 'add_note_edit') {
-      const existing: PickerItem[] = existingAttachments.map((att) => ({
+      const existing: PickerItem[] = (
+        sheet.annotation.note?.attachments ?? []
+      ).map((att) => ({
         id: att.id,
         label: att.fileName,
         busy: busyAttachmentIds.has(att.id),
@@ -314,7 +314,7 @@ export default function AddNoteSheet({
       id: s.id,
       label: s.file.name,
     }))
-  }, [sheet, existingAttachments, stagedAttachments, busyAttachmentIds])
+  }, [sheet, stagedAttachments, busyAttachmentIds])
 
   // New-note saves allow body-only or attachment-only. Edit mode's Save
   // commits the body; attachment changes happen immediately, so Save is

--- a/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
@@ -44,6 +44,15 @@ const STYLE_TAG_ID = 'briefing-annotation-highlight-style'
  * its text highlight darken together whichever one the user points at.
  */
 const STYLE_RULES = `
+/* Suppress the OS text-selection callout (iOS Safari's Copy / Look Up /
+   Share menu, the native long-press handler) on annotation-enabled
+   passages so only the briefing's HighlightToolbar surfaces on
+   selection. We still allow selection itself — the toolbar reads the
+   live selection — and the callout suppression is iOS-specific, which
+   is where the conflict is most visible. */
+[data-briefing-json-path] {
+  -webkit-touch-callout: none;
+}
 ::highlight(${HIGHLIGHT_NAMES.note}) {
   background-color: color-mix(in srgb, var(--info, #1b6afc) 22%, transparent);
   color: inherit;

--- a/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
@@ -6,11 +6,19 @@ import {
   buildRangeIn,
   findAnchorEl,
   pointToOffset,
+  type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
 import type { Annotation, AnnotationKind } from '@shared/briefings/types'
 
 type Props = {
   annotations: Annotation[]
+  /**
+   * The user's live (or just-captured) selection. On touch devices
+   * useSelection wipes the native Selection immediately to suppress
+   * iOS's edit menu, so we repaint the same range here as a CSS
+   * Highlight to keep the visual "this is what you selected" cue.
+   */
+  pendingAnchor: ResolvedAnchor | null
 }
 
 type ResolvedRange = {
@@ -24,6 +32,11 @@ const HIGHLIGHT_NAMES: Record<AnnotationKind, string> = {
   bug_report: 'briefing-annotation-bug',
 }
 const HOVER_NAME = 'briefing-annotation-hover'
+// Painted as a stand-in for the native OS selection on touch devices —
+// useSelection clears the native Selection right after capturing the
+// anchor (to dismiss iOS's edit menu), so without this overlay the user
+// would see no visible cue for what they just selected.
+const PENDING_SELECTION_NAME = 'briefing-pending-selection'
 const NOTE_MARKER_CLASS = 'briefing-note-marker'
 const CHAT_MARKER_CLASS = 'briefing-chat-marker'
 const BUG_MARKER_CLASS = 'briefing-bug-marker'
@@ -72,6 +85,12 @@ const STYLE_RULES = `
 }
 ::highlight(${HOVER_NAME}) {
   background-color: color-mix(in srgb, var(--foreground, #161f31) 12%, transparent);
+}
+::highlight(${PENDING_SELECTION_NAME}) {
+  /* Mimics the iOS / desktop blue selection tint so the user still sees
+     what they selected after we've wiped the native Selection. */
+  background-color: color-mix(in srgb, var(--info, #1b6afc) 28%, transparent);
+  color: inherit;
 }
 .${NOTE_MARKER_CLASS},
 .${CHAT_MARKER_CLASS},
@@ -192,6 +211,7 @@ function findMarker(annotationId: string): HTMLElement | null {
 
 export default function AnnotationsHighlightLayer({
   annotations,
+  pendingAnchor,
 }: Props): null {
   const pathname = usePathname()
   const resolvedRef = useRef<ResolvedRange[]>([])
@@ -341,6 +361,51 @@ export default function AnnotationsHighlightLayer({
       removeAllMarkers()
     }
   }, [annotations, pathname])
+
+  // Pending-selection overlay. Repaints whenever the live anchor changes
+  // (including null → cleared). Independent of the annotations effect
+  // above so capturing a selection doesn't churn the persistent
+  // annotation highlights.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const CSSAny = CSS as unknown as {
+      highlights?: {
+        set(name: string, h: unknown): void
+        delete(name: string): void
+      }
+    }
+    const HighlightCtorMaybe = (
+      window as unknown as {
+        Highlight?: new (...ranges: Range[]) => unknown
+      }
+    ).Highlight
+    if (!CSSAny.highlights || !HighlightCtorMaybe) return
+    const HighlightCtor = HighlightCtorMaybe
+
+    if (
+      !pendingAnchor ||
+      pendingAnchor.jsonPath === null ||
+      pendingAnchor.start === null ||
+      pendingAnchor.end === null
+    ) {
+      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
+      return
+    }
+    const el = findAnchorEl(pendingAnchor.jsonPath)
+    if (!el) {
+      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
+      return
+    }
+    const range = buildRangeIn(el, pendingAnchor.start, pendingAnchor.end)
+    if (!range) {
+      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
+      return
+    }
+    CSSAny.highlights.set(PENDING_SELECTION_NAME, new HighlightCtor(range))
+    return () => {
+      CSSAny.highlights?.delete(PENDING_SELECTION_NAME)
+    }
+  }, [pendingAnchor])
 
   return null
 }

--- a/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
@@ -6,19 +6,11 @@ import {
   buildRangeIn,
   findAnchorEl,
   pointToOffset,
-  type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
 import type { Annotation, AnnotationKind } from '@shared/briefings/types'
 
 type Props = {
   annotations: Annotation[]
-  /**
-   * The user's live (or just-captured) selection. On touch devices
-   * useSelection wipes the native Selection immediately to suppress
-   * iOS's edit menu, so we repaint the same range here as a CSS
-   * Highlight to keep the visual "this is what you selected" cue.
-   */
-  pendingAnchor: ResolvedAnchor | null
 }
 
 type ResolvedRange = {
@@ -32,11 +24,6 @@ const HIGHLIGHT_NAMES: Record<AnnotationKind, string> = {
   bug_report: 'briefing-annotation-bug',
 }
 const HOVER_NAME = 'briefing-annotation-hover'
-// Painted as a stand-in for the native OS selection on touch devices —
-// useSelection clears the native Selection right after capturing the
-// anchor (to dismiss iOS's edit menu), so without this overlay the user
-// would see no visible cue for what they just selected.
-const PENDING_SELECTION_NAME = 'briefing-pending-selection'
 const NOTE_MARKER_CLASS = 'briefing-note-marker'
 const CHAT_MARKER_CLASS = 'briefing-chat-marker'
 const BUG_MARKER_CLASS = 'briefing-bug-marker'
@@ -85,12 +72,6 @@ const STYLE_RULES = `
 }
 ::highlight(${HOVER_NAME}) {
   background-color: color-mix(in srgb, var(--foreground, #161f31) 12%, transparent);
-}
-::highlight(${PENDING_SELECTION_NAME}) {
-  /* Mimics the iOS / desktop blue selection tint so the user still sees
-     what they selected after we've wiped the native Selection. */
-  background-color: color-mix(in srgb, var(--info, #1b6afc) 28%, transparent);
-  color: inherit;
 }
 .${NOTE_MARKER_CLASS},
 .${CHAT_MARKER_CLASS},
@@ -211,7 +192,6 @@ function findMarker(annotationId: string): HTMLElement | null {
 
 export default function AnnotationsHighlightLayer({
   annotations,
-  pendingAnchor,
 }: Props): null {
   const pathname = usePathname()
   const resolvedRef = useRef<ResolvedRange[]>([])
@@ -361,51 +341,6 @@ export default function AnnotationsHighlightLayer({
       removeAllMarkers()
     }
   }, [annotations, pathname])
-
-  // Pending-selection overlay. Repaints whenever the live anchor changes
-  // (including null → cleared). Independent of the annotations effect
-  // above so capturing a selection doesn't churn the persistent
-  // annotation highlights.
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const CSSAny = CSS as unknown as {
-      highlights?: {
-        set(name: string, h: unknown): void
-        delete(name: string): void
-      }
-    }
-    const HighlightCtorMaybe = (
-      window as unknown as {
-        Highlight?: new (...ranges: Range[]) => unknown
-      }
-    ).Highlight
-    if (!CSSAny.highlights || !HighlightCtorMaybe) return
-    const HighlightCtor = HighlightCtorMaybe
-
-    if (
-      !pendingAnchor ||
-      pendingAnchor.jsonPath === null ||
-      pendingAnchor.start === null ||
-      pendingAnchor.end === null
-    ) {
-      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
-      return
-    }
-    const el = findAnchorEl(pendingAnchor.jsonPath)
-    if (!el) {
-      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
-      return
-    }
-    const range = buildRangeIn(el, pendingAnchor.start, pendingAnchor.end)
-    if (!range) {
-      CSSAny.highlights.delete(PENDING_SELECTION_NAME)
-      return
-    }
-    CSSAny.highlights.set(PENDING_SELECTION_NAME, new HighlightCtor(range))
-    return () => {
-      CSSAny.highlights?.delete(PENDING_SELECTION_NAME)
-    }
-  }, [pendingAnchor])
 
   return null
 }

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -802,6 +802,95 @@ describe('<AnnotationsScope>', () => {
     })
   })
 
+  describe('openAddNoteTopLevel routing', () => {
+    it('opens the notes surface focused on the existing card-level note when one is already attached to the active card', async () => {
+      // Seed a card-level note matching the default active card (Executive
+      // Summary): jsonPath set to the card root, start/end null. The
+      // "Add note" header button should open the notes cycler focused on
+      // this note rather than the new-note sheet — that's the new
+      // single-card-note-per-card constraint.
+      const user = userEvent.setup()
+      const existing: Annotation = {
+        ...makeNoteAnnotation('ann_existing_card'),
+        // makeNoteAnnotation already uses /executiveSummary as the
+        // jsonPath, but spell it out here so the linkage to the active
+        // card's jsonPath is obvious.
+        jsonPath: '/executiveSummary',
+        start: null,
+        end: null,
+      }
+      testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [
+        existing,
+      ])
+
+      render(
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            title: 'Executive Summary',
+          }}
+        >
+          <ContextAddNoteTrigger />
+        </AnnotationsScope>,
+      )
+
+      await user.click(
+        await screen.findByRole('button', { name: /open top-level add note/i }),
+      )
+
+      // The notes cycler (vaul drawer) should be open. AddNoteSheet (the
+      // single-note edit sheet, mocked above) must NOT have mounted —
+      // we route directly to the cycler so pagination between notes
+      // works the same as for passage-anchored notes.
+      await waitFor(() => {
+        expect(document.querySelector('[data-vaul-overlay]')).toHaveAttribute(
+          'data-state',
+          'open',
+        )
+      })
+      expect(addNoteSheetIsMounted).toBe(false)
+    })
+
+    it('opens the new-note sheet when the active card has no card-level note yet', async () => {
+      // Seed only a passage-anchored note (start/end set) — that
+      // shouldn't count as a card-level note for the active card, so
+      // the header button should open the new-note sheet as usual.
+      const user = userEvent.setup()
+      const passageNote: Annotation = {
+        ...makeNoteAnnotation('ann_passage'),
+        jsonPath: '/executiveSummary',
+        start: 0,
+        end: 5,
+      }
+      testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [
+        passageNote,
+      ])
+
+      render(
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            title: 'Executive Summary',
+          }}
+        >
+          <ContextAddNoteTrigger />
+        </AnnotationsScope>,
+      )
+
+      await user.click(
+        await screen.findByRole('button', { name: /open top-level add note/i }),
+      )
+
+      await waitFor(() => {
+        expect(addNoteSheetIsMounted).toBe(true)
+      })
+    })
+  })
+
   describe('AddNoteSheet onCreate', () => {
     it('creates a typed-only note and skips the upload path', async () => {
       mockAnnotationsApi.create.mockResolvedValue({

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -334,6 +334,7 @@ async function captureOnCreate(): Promise<AddNoteSheetOnCreate> {
       initialActiveCard={{
         key: 'briefing-executive-summary',
         jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
         title: 'Executive Summary',
       }}
     >
@@ -392,6 +393,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -449,6 +451,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -509,6 +512,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -561,6 +565,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -604,6 +609,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -652,6 +658,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -699,6 +706,7 @@ describe('<AnnotationsScope>', () => {
         initialActiveCard={{
           key: 'briefing-executive-summary',
           jsonPath: '/executiveSummary',
+          titleJsonPath: '/executive_summary/title',
           title: 'Executive Summary',
         }}
       >
@@ -752,6 +760,7 @@ describe('<AnnotationsScope>', () => {
           initialActiveCard={{
             key: 'briefing-executive-summary',
             jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
             title: 'Executive Summary',
           }}
         >
@@ -829,6 +838,7 @@ describe('<AnnotationsScope>', () => {
           initialActiveCard={{
             key: 'briefing-executive-summary',
             jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
             title: 'Executive Summary',
           }}
         >
@@ -874,6 +884,7 @@ describe('<AnnotationsScope>', () => {
           initialActiveCard={{
             key: 'briefing-executive-summary',
             jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
             title: 'Executive Summary',
           }}
         >
@@ -1037,6 +1048,7 @@ describe('<AnnotationsScope>', () => {
           initialActiveCard={{
             key: 'briefing-executive-summary',
             jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
             title: 'Executive Summary',
           }}
         >
@@ -1083,6 +1095,7 @@ describe('<AnnotationsScope>', () => {
           initialActiveCard={{
             key: 'briefing-executive-summary',
             jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
             title: 'Executive Summary',
           }}
         >

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -306,7 +306,9 @@ function makeNoteAnnotation(id: string): Annotation {
     resourceType: 'briefing',
     resourceId: 'briefing_x',
     authorUserId: 1,
-    jsonPath: null,
+    // Card-level note: jsonPath points at a card, start/end null. Legacy
+    // null-jsonPath notes are intentionally filtered out by the scope.
+    jsonPath: '/executiveSummary',
     start: null,
     end: null,
     createdAt: '2025-01-01T00:00:00.000Z',
@@ -327,7 +329,14 @@ async function captureOnCreate(): Promise<AddNoteSheetOnCreate> {
   const user = userEvent.setup()
   testQueryClient.setQueryData(annotationsQueryKey('briefing_x'), [])
   render(
-    <AnnotationsScope meetingDate="briefing_x">
+    <AnnotationsScope
+      meetingDate="briefing_x"
+      initialActiveCard={{
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        title: 'Executive Summary',
+      }}
+    >
       <ContextAddNoteTrigger />
     </AnnotationsScope>,
   )
@@ -378,7 +387,14 @@ describe('<AnnotationsScope>', () => {
     ])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <OpenNotesSurfaceTrigger annotationId="ann_X" />
       </AnnotationsScope>,
     )
@@ -428,7 +444,14 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.list.mockResolvedValue([newAnn])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <AddNoteFromSelectionTrigger />
       </AnnotationsScope>,
     )
@@ -446,7 +469,9 @@ describe('<AnnotationsScope>', () => {
 
     expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
       kind: 'note',
-      anchor: { jsonPath: null, start: null, end: null },
+      // No live selection in this test → null anchor on the sheet → the
+      // scope falls back to the active card (Executive Summary).
+      anchor: { jsonPath: '/executiveSummary', start: null, end: null },
       payload: { body: 'hello world' },
     })
 
@@ -479,7 +504,14 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.list.mockResolvedValue([newBug])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <ReportErrorFromSelectionTrigger />
       </AnnotationsScope>,
     )
@@ -524,7 +556,14 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.list.mockResolvedValue([newAnn])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <AddNoteThenSwitchSurfacesTrigger />
       </AnnotationsScope>,
     )
@@ -560,7 +599,14 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.list.mockResolvedValue([newBug])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <ReportErrorThenSwitchSurfacesTrigger />
       </AnnotationsScope>,
     )
@@ -601,7 +647,14 @@ describe('<AnnotationsScope>', () => {
     mockAnnotationsApi.list.mockResolvedValue([newAnn])
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <AddNoteThenSwitchSurfacesTrigger />
       </AnnotationsScope>,
     )
@@ -641,7 +694,14 @@ describe('<AnnotationsScope>', () => {
     const invalidateSpy = vi.spyOn(testQueryClient, 'invalidateQueries')
 
     render(
-      <AnnotationsScope meetingDate="briefing_x">
+      <AnnotationsScope
+        meetingDate="briefing_x"
+        initialActiveCard={{
+          key: 'briefing-executive-summary',
+          jsonPath: '/executiveSummary',
+          title: 'Executive Summary',
+        }}
+      >
         <ContextChatCreatedTrigger />
       </AnnotationsScope>,
     )
@@ -687,7 +747,16 @@ describe('<AnnotationsScope>', () => {
       })
 
       render(
-        <AnnotationsScope meetingDate="briefing_x">{null}</AnnotationsScope>,
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            title: 'Executive Summary',
+          }}
+        >
+          {null}
+        </AnnotationsScope>,
       )
 
       // Click "Ask AI" on the selection → overlay flips to surface_chats
@@ -745,7 +814,7 @@ describe('<AnnotationsScope>', () => {
 
       expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
         kind: 'note',
-        anchor: { jsonPath: null, start: null, end: null },
+        anchor: { jsonPath: '/executiveSummary', start: null, end: null },
         payload: { body: 'hello world' },
       })
       expect(mockUploadAttachment).not.toHaveBeenCalled()
@@ -764,7 +833,7 @@ describe('<AnnotationsScope>', () => {
 
       expect(mockAnnotationsApi.create).toHaveBeenCalledWith('briefing_x', {
         kind: 'note',
-        anchor: { jsonPath: null, start: null, end: null },
+        anchor: { jsonPath: '/executiveSummary', start: null, end: null },
         payload: {},
       })
       expect(mockUploadAttachment).toHaveBeenCalledWith({
@@ -874,7 +943,14 @@ describe('<AnnotationsScope>', () => {
       mockUploadAttachment.mockRejectedValueOnce(new Error('s3 down'))
 
       render(
-        <AnnotationsScope meetingDate="briefing_x">
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            title: 'Executive Summary',
+          }}
+        >
           <ContextAddNoteTrigger />
         </AnnotationsScope>,
       )
@@ -913,7 +989,14 @@ describe('<AnnotationsScope>', () => {
       mockAnnotationsApi.list.mockResolvedValue([ann])
 
       render(
-        <AnnotationsScope meetingDate="briefing_x">
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            title: 'Executive Summary',
+          }}
+        >
           <EditNoteTrigger annotation={ann} />
         </AnnotationsScope>,
       )

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -411,6 +411,26 @@ export default function AnnotationsScope({
     return () => document.removeEventListener('click', onClick)
   }, [annotations])
 
+  // Suppress the OS context menu / selection callout on annotation-
+  // enabled passages so only the briefing's HighlightToolbar surfaces
+  // on text selection. iOS's long-press menu is handled via
+  // `-webkit-touch-callout: none` in AnnotationsHighlightLayer's CSS,
+  // but Android Chrome and desktop browsers still fire `contextmenu` on
+  // long-press / right-click — preventDefault here suppresses that
+  // path. Selection itself still works (the toolbar reads it via
+  // useSelection); we're only blocking the system menu.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    function onContextMenu(e: MouseEvent) {
+      if (!(e.target instanceof HTMLElement)) return
+      if (e.target.closest('[data-briefing-json-path]')) {
+        e.preventDefault()
+      }
+    }
+    document.addEventListener('contextmenu', onContextMenu)
+    return () => document.removeEventListener('contextmenu', onContextMenu)
+  }, [])
+
   const topLevelChatAnnotationId = useMemo(
     () => annotations.find((a) => a.kind === 'chat' && a.jsonPath === null)?.id,
     [annotations],

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -230,10 +230,11 @@ export default function AnnotationsScope({
   // The top-level "Add notes" button on the header / mobile bar attaches
   // the note to whichever card is currently active. A card may carry at
   // most one card-level note — if the active card already has one, open
-  // it for editing rather than starting a second. Otherwise open the
-  // new-note sheet with a null `anchor`; the scope's onCreate handler
-  // resolves the card's jsonPath at save time (see the AddNoteSheet
-  // onCreate prop below). If no card is active, the button does nothing.
+  // the notes cycler focused on it (matching the click-into-a-passage-
+  // anchored-highlight flow, so users can page between notes from the
+  // same entry point). Otherwise open the new-note sheet with a null
+  // `anchor`; the scope's onCreate handler resolves the card's jsonPath
+  // at save time. If no card is active, the button does nothing.
   const openAddNoteTopLevel = useCallback(() => {
     if (!activeCard) return
     const existing = annotations.find(
@@ -244,7 +245,7 @@ export default function AnnotationsScope({
         a.end === null,
     )
     if (existing) {
-      setOverlay({ kind: 'add_note_edit', annotation: existing })
+      setOverlay({ kind: 'surface_notes', initialAnnotationId: existing.id })
       return
     }
     setOverlay({ kind: 'add_note_new', anchor: null })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -560,7 +560,10 @@ export default function AnnotationsScope({
   return (
     <AnnotationsCtx.Provider value={ctxValue}>
       {children}
-      <AnnotationsHighlightLayer annotations={annotations} />
+      <AnnotationsHighlightLayer
+        annotations={annotations}
+        pendingAnchor={liveAnchor}
+      />
       <HighlightToolbar
         anchor={liveAnchor}
         onAddNote={openAddNoteFromSelection}

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -77,6 +77,27 @@ export type OverlayState =
  */
 export type SheetState = OverlayState
 
+/**
+ * The user-active card on the briefing detail page. Drives the blue
+ * outline rendered on the card itself and the highlighted entry in the
+ * sidebar legend. Also determines where the top-of-page "Add note"
+ * button attaches new notes — they get this card's `jsonPath` as their
+ * anchor (with `start`/`end` null, marking them as card-level rather
+ * than passage-level).
+ */
+export type ActiveCard = {
+  /** Stable identity used by the legend to highlight the matching entry. */
+  key: string
+  /**
+   * Canonical jsonPath for this card as a whole (no field suffix).
+   * `/executiveSummary` for the exec summary, `/items/{index}` for an
+   * agenda item.
+   */
+  jsonPath: string
+  /** Display title — used by AddNoteSheet for the "Note on …" copy. */
+  title: string
+}
+
 type Ctx = {
   meetingDate: string
   /**
@@ -86,6 +107,15 @@ type Ctx = {
    * no top-level chat exists yet — first open will mint one.
    */
   topLevelChatAnnotationId?: string
+  /** Live annotations list — exposed so cards can render their own
+   *  card-level notes inline without re-fetching. */
+  annotations: Annotation[]
+  /** Currently-focused card. Null only briefly before the layout sets a
+   *  default; the header "Add note" button is disabled while null. */
+  activeCard: ActiveCard | null
+  /** Set when the user clicks the card body or a legend entry. Pure
+   *  state; does NOT scroll the pane (legend handles scrolling). */
+  setActiveCard: (card: ActiveCard) => void
   openAddNoteFromSelection: () => void
   openAddNoteTopLevel: () => void
   openReportErrorFromSelection: () => void
@@ -127,6 +157,12 @@ type Props = {
    * `:date` param in the meeting briefing endpoints.
    */
   meetingDate: string
+  /**
+   * The card that should be active before the user clicks anything —
+   * typically the Executive Summary. Optional only because some test
+   * mounts don't need an active card.
+   */
+  initialActiveCard?: ActiveCard
   children: React.ReactNode
 }
 
@@ -150,6 +186,7 @@ function anchorPayload(anchor: PendingAnchor): AnnotationAnchor {
  */
 export default function AnnotationsScope({
   meetingDate,
+  initialActiveCard,
   children,
 }: Props): React.JSX.Element {
   const liveAnchor = useSelection()
@@ -157,6 +194,9 @@ export default function AnnotationsScope({
   const { annotations, create, updateNote, remove } =
     useAnnotations(meetingDate)
   const [overlay, setOverlay] = useState<OverlayState>({ kind: 'closed' })
+  const [activeCard, setActiveCard] = useState<ActiveCard | null>(
+    initialActiveCard ?? null,
+  )
   // Holds the id of a chat freshly-minted from a pending-anchor preempt.
   // Defer the handoff until React Query refetch settles and the new chat
   // appears in `annotations`; otherwise the cycler binds to an id
@@ -187,12 +227,15 @@ export default function AnnotationsScope({
     setOverlay({ kind: 'add_note_new', anchor: liveAnchor })
   }, [liveAnchor])
 
-  // The top-level "Add notes" button on the header / mobile bar opens the
-  // same AddNoteSheet used for anchored notes — just with `anchor: null`,
-  // so the note is scoped to the whole briefing rather than a passage.
+  // The top-level "Add notes" button on the header / mobile bar attaches
+  // the note to whichever card is currently active. The sheet receives a
+  // null `anchor` (no passage selection) and the scope's onCreate handler
+  // resolves the card's jsonPath at save time — see the AddNoteSheet
+  // onCreate prop below. If no card is active, the button does nothing.
   const openAddNoteTopLevel = useCallback(() => {
+    if (!activeCard) return
     setOverlay({ kind: 'add_note_new', anchor: null })
-  }, [])
+  }, [activeCard])
 
   const openReportErrorFromSelection = useCallback(() => {
     setOverlay({ kind: 'report_error_new', anchor: liveAnchor })
@@ -359,24 +402,46 @@ export default function AnnotationsScope({
     [annotations],
   )
 
+  // Legacy briefing-wide notes (jsonPath === null) come from the old
+  // top-level intake that no longer exists. They aren't surfaced in any
+  // UI any more — neither as inline card rows nor in the NotesSurface
+  // list nor in the count badge — but the rows are kept in the database
+  // so we can recover or migrate them later if needed. Everything else
+  // (real card-level + passage-anchored notes) flows through unchanged.
+  const visibleAnnotations = useMemo(
+    () =>
+      annotations.filter((a) => !(a.kind === 'note' && a.jsonPath === null)),
+    [annotations],
+  )
+
   const { notesCount, chatsCount, bugReportsCount } = useMemo(() => {
     let n = 0
     let c = 0
     let b = 0
-    for (const a of annotations) {
+    for (const a of visibleAnnotations) {
       if (a.kind === 'note') n++
       else if (a.kind === 'chat') c++
       else if (a.kind === 'bug_report') b++
     }
     return { notesCount: n, chatsCount: c, bugReportsCount: b }
-  }, [annotations])
+  }, [visibleAnnotations])
 
-  // Briefing-wide notes (no anchor) — surfaced inside the top-level
-  // AddNoteSheet so the user can see, edit, or delete them.
-  const topLevelNotes = useMemo(
+  // Card-level notes for the active card — jsonPath matches the card, no
+  // passage offsets. Surfaced inside the AddNoteSheet's card-level mode
+  // list and inline at the bottom of the card itself. Returns [] when no
+  // card is active so the sheet renders nothing.
+  const notesForActiveCard = useMemo(
     () =>
-      annotations.filter((ann) => ann.kind === 'note' && ann.jsonPath === null),
-    [annotations],
+      activeCard
+        ? annotations.filter(
+            (ann) =>
+              ann.kind === 'note' &&
+              ann.jsonPath === activeCard.jsonPath &&
+              ann.start === null &&
+              ann.end === null,
+          )
+        : [],
+    [annotations, activeCard],
   )
 
   // Memoize position calculations — both helpers scan annotations and the
@@ -438,6 +503,9 @@ export default function AnnotationsScope({
     () => ({
       meetingDate,
       topLevelChatAnnotationId,
+      annotations: visibleAnnotations,
+      activeCard,
+      setActiveCard,
       openAddNoteFromSelection,
       openAddNoteTopLevel,
       openReportErrorFromSelection,
@@ -455,6 +523,8 @@ export default function AnnotationsScope({
     [
       meetingDate,
       topLevelChatAnnotationId,
+      visibleAnnotations,
+      activeCard,
       openAddNoteFromSelection,
       openAddNoteTopLevel,
       openReportErrorFromSelection,
@@ -504,9 +574,18 @@ export default function AnnotationsScope({
             // body is `string().min(1).optional()` server-side — omit when
             // the user only attached files without typing.
             const trimmedBody = body.trim()
+            // anchor=null from the top-of-page "Add note" button means
+            // "attach to the active card." We translate that here so the
+            // note carries the card's jsonPath with null start/end — the
+            // schema convention for card-level (not passage-level) notes.
+            const resolvedAnchor: AnnotationAnchor = anchor
+              ? anchorPayload(anchor)
+              : activeCard
+              ? { jsonPath: activeCard.jsonPath, start: null, end: null }
+              : EMPTY_ANCHOR
             const created = await create.mutateAsync({
               kind: 'note',
-              anchor: anchorPayload(anchor),
+              anchor: resolvedAnchor,
               payload: trimmedBody.length > 0 ? { body: trimmedBody } : {},
             })
             window.getSelection()?.removeAllRanges()
@@ -629,7 +708,8 @@ export default function AnnotationsScope({
               queryKey: annotationsQueryKey(meetingDate),
             })
           }}
-          topLevelNotes={topLevelNotes}
+          notesForActiveCard={notesForActiveCard}
+          activeCardTitle={activeCard?.title ?? null}
           onEditNote={openEditNote}
         />
       )}
@@ -662,7 +742,7 @@ export default function AnnotationsScope({
       <NotesSurface
         open={overlay.kind === 'surface_notes'}
         onClose={closeSheet}
-        annotations={annotations}
+        annotations={visibleAnnotations}
         onEditNote={(ann) =>
           setOverlay({ kind: 'add_note_edit', annotation: ann })
         }

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -12,6 +12,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import {
   EMPTY_ANCHOR,
+  findAnchorEl,
   pointToOffset,
   type ResolvedAnchor,
 } from '@shared/briefings/anchorResolver'
@@ -91,9 +92,18 @@ export type ActiveCard = {
   /**
    * Canonical jsonPath for this card as a whole (no field suffix).
    * `/executiveSummary` for the exec summary, `/items/{index}` for an
-   * agenda item.
+   * agenda item. Card-level notes use this directly with null offsets.
    */
   jsonPath: string
+  /**
+   * JsonPath of the card's title element. Used when the user starts a
+   * card-level chat from the header — the new chat is anchored to the
+   * title (jsonPath + start=0 + end=title.length) just as if the user
+   * had highlighted the title themselves. There must be a DOM element
+   * carrying this path under `data-briefing-json-path` so the anchor
+   * resolves back to a quote.
+   */
+  titleJsonPath: string
   /** Display title — used by AddNoteSheet for the "Note on …" copy. */
   title: string
 }
@@ -123,6 +133,14 @@ type Ctx = {
   openViewReport: (annotation: Annotation) => void
   openNotesSurface: (initialAnnotationId?: string) => void
   openChatsSurface: (initialAnnotationId?: string) => void
+  /**
+   * Opens a chat scoped to the active card. If one already exists at
+   * the card's title anchor, focuses the cycler on it; otherwise mints
+   * a new chat against the title (jsonPath + start=0 + end=title.length).
+   * Header "Briefing assistant" + mobile FAB route here so the chat
+   * always carries a meaningful card-level anchor.
+   */
+  openCardLevelChat: () => void
   openBugReportsSurface: (initialAnnotationId?: string) => void
   notesCount: number
   chatsCount: number
@@ -270,6 +288,40 @@ export default function AnnotationsScope({
   const openChatsSurface = useCallback((initialAnnotationId?: string) => {
     setOverlay({ kind: 'surface_chats', initialAnnotationId })
   }, [])
+
+  // Card-level chat entry point. If a chat already exists anchored to
+  // the active card's title, open the cycler focused on it; otherwise
+  // mint a new chat with a pendingAnchor pointing at the title (start=0
+  // → end=title.length, equivalent to highlighting the title manually).
+  // Bails when no card is active.
+  const openCardLevelChat = useCallback(() => {
+    if (!activeCard) return
+    const titlePath = activeCard.titleJsonPath
+    const existing = annotations.find(
+      (a) => a.kind === 'chat' && a.jsonPath === titlePath,
+    )
+    if (existing) {
+      setOverlay({
+        kind: 'surface_chats',
+        initialAnnotationId: existing.id,
+      })
+      return
+    }
+    // Resolve the title element so we can capture its current text
+    // length as the anchor end. If the element is missing (briefing
+    // hasn't hydrated yet, schema mismatch), fall back to opening the
+    // generic chats surface — better than throwing.
+    const el = findAnchorEl(titlePath)
+    const titleLen = el?.textContent?.length ?? 0
+    if (titleLen === 0) {
+      setOverlay({ kind: 'surface_chats' })
+      return
+    }
+    setOverlay({
+      kind: 'surface_chats',
+      pendingAnchor: { jsonPath: titlePath, start: 0, end: titleLen },
+    })
+  }, [activeCard, annotations])
 
   const openBugReportsSurface = useCallback((initialAnnotationId?: string) => {
     setOverlay({ kind: 'surface_bug_reports', initialAnnotationId })
@@ -529,6 +581,7 @@ export default function AnnotationsScope({
       openViewReport,
       openNotesSurface,
       openChatsSurface,
+      openCardLevelChat,
       openBugReportsSurface,
       notesCount,
       chatsCount,
@@ -548,6 +601,7 @@ export default function AnnotationsScope({
       openViewReport,
       openNotesSurface,
       openChatsSurface,
+      openCardLevelChat,
       openBugReportsSurface,
       notesCount,
       chatsCount,

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -228,14 +228,27 @@ export default function AnnotationsScope({
   }, [liveAnchor])
 
   // The top-level "Add notes" button on the header / mobile bar attaches
-  // the note to whichever card is currently active. The sheet receives a
-  // null `anchor` (no passage selection) and the scope's onCreate handler
-  // resolves the card's jsonPath at save time — see the AddNoteSheet
-  // onCreate prop below. If no card is active, the button does nothing.
+  // the note to whichever card is currently active. A card may carry at
+  // most one card-level note — if the active card already has one, open
+  // it for editing rather than starting a second. Otherwise open the
+  // new-note sheet with a null `anchor`; the scope's onCreate handler
+  // resolves the card's jsonPath at save time (see the AddNoteSheet
+  // onCreate prop below). If no card is active, the button does nothing.
   const openAddNoteTopLevel = useCallback(() => {
     if (!activeCard) return
+    const existing = annotations.find(
+      (a) =>
+        a.kind === 'note' &&
+        a.jsonPath === activeCard.jsonPath &&
+        a.start === null &&
+        a.end === null,
+    )
+    if (existing) {
+      setOverlay({ kind: 'add_note_edit', annotation: existing })
+      return
+    }
     setOverlay({ kind: 'add_note_new', anchor: null })
-  }, [activeCard])
+  }, [activeCard, annotations])
 
   const openReportErrorFromSelection = useCallback(() => {
     setOverlay({ kind: 'report_error_new', anchor: liveAnchor })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -439,24 +439,6 @@ export default function AnnotationsScope({
     return { notesCount: n, chatsCount: c, bugReportsCount: b }
   }, [visibleAnnotations])
 
-  // Card-level notes for the active card — jsonPath matches the card, no
-  // passage offsets. Surfaced inside the AddNoteSheet's card-level mode
-  // list and inline at the bottom of the card itself. Returns [] when no
-  // card is active so the sheet renders nothing.
-  const notesForActiveCard = useMemo(
-    () =>
-      activeCard
-        ? annotations.filter(
-            (ann) =>
-              ann.kind === 'note' &&
-              ann.jsonPath === activeCard.jsonPath &&
-              ann.start === null &&
-              ann.end === null,
-          )
-        : [],
-    [annotations, activeCard],
-  )
-
   // Memoize position calculations — both helpers scan annotations and the
   // predict path walks the DOM via querySelectorAll, so we don't want them
   // re-running on every parent render while a sheet is open.
@@ -721,9 +703,7 @@ export default function AnnotationsScope({
               queryKey: annotationsQueryKey(meetingDate),
             })
           }}
-          notesForActiveCard={notesForActiveCard}
           activeCardTitle={activeCard?.title ?? null}
-          onEditNote={openEditNote}
         />
       )}
       {(overlay.kind === 'report_error_new' ||

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -560,10 +560,7 @@ export default function AnnotationsScope({
   return (
     <AnnotationsCtx.Provider value={ctxValue}>
       {children}
-      <AnnotationsHighlightLayer
-        annotations={annotations}
-        pendingAnchor={liveAnchor}
-      />
+      <AnnotationsHighlightLayer annotations={annotations} />
       <HighlightToolbar
         anchor={liveAnchor}
         onAddNote={openAddNoteFromSelection}

--- a/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
+++ b/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
@@ -45,15 +45,9 @@ export default function HighlightToolbar({
   const top = Math.max(margin, rect.top - 48)
 
   function dismiss() {
-    if (typeof window === 'undefined') return
-    window.getSelection()?.removeAllRanges()
-    // On touch devices, useSelection clears the native selection right
-    // after capture (to dismiss iOS's edit menu), so by the time the
-    // user clicks X the live selection is already empty — removeAllRanges
-    // is a no-op and no `selectionchange` event fires on its own. Dispatch
-    // one manually so the hook drops the captured anchor and the toolbar
-    // unmounts.
-    document.dispatchEvent(new Event('selectionchange'))
+    if (typeof window !== 'undefined') {
+      window.getSelection()?.removeAllRanges()
+    }
   }
 
   return (

--- a/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
+++ b/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
@@ -45,9 +45,15 @@ export default function HighlightToolbar({
   const top = Math.max(margin, rect.top - 48)
 
   function dismiss() {
-    if (typeof window !== 'undefined') {
-      window.getSelection()?.removeAllRanges()
-    }
+    if (typeof window === 'undefined') return
+    window.getSelection()?.removeAllRanges()
+    // On touch devices, useSelection clears the native selection right
+    // after capture (to dismiss iOS's edit menu), so by the time the
+    // user clicks X the live selection is already empty — removeAllRanges
+    // is a no-op and no `selectionchange` event fires on its own. Dispatch
+    // one manually so the hook drops the captured anchor and the toolbar
+    // unmounts.
+    document.dispatchEvent(new Event('selectionchange'))
   }
 
   return (

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -4,8 +4,10 @@ import { useEffect, useMemo, useRef } from 'react'
 import {
   BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
   BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
   briefingItemCardPath,
   briefingItemDomId,
+  briefingItemTitlePath,
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
 import {
@@ -51,6 +53,7 @@ export default function ActiveCardScrollSpy({
       {
         key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
         jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+        titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
         title: 'Executive Summary',
         domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
       },
@@ -59,6 +62,7 @@ export default function ActiveCardScrollSpy({
       list.push({
         key: briefingItemDomId(item.id),
         jsonPath: briefingItemCardPath(idx),
+        titleJsonPath: briefingItemTitlePath(idx),
         title: item.title,
         domId: briefingItemDomId(item.id),
       })
@@ -120,6 +124,7 @@ export default function ActiveCardScrollSpy({
       setActiveCard({
         key: matched.key,
         jsonPath: matched.jsonPath,
+        titleJsonPath: matched.titleJsonPath,
         title: matched.title,
       })
     }

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useMemo, useRef } from 'react'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemCardPath,
+  briefingItemDomId,
+} from '@shared/briefings/routes'
+import type { Item } from '@shared/briefings/types'
+import {
+  useAnnotationsCtx,
+  type ActiveCard,
+} from '../annotations/AnnotationsScope'
+
+type Props = {
+  items: Item[]
+}
+
+type Entry = ActiveCard & { domId: string }
+
+// Active line offsets, mirroring CardLevelNotesList / scroll-mt: the
+// document-scroll model on mobile lands cards 104px below the viewport
+// (under the sticky DetailHeader); the pane-scroll model at lg+ has no
+// sticky header inside the pane, so a much smaller breathing margin
+// (12px) is enough to mark a card as "in view."
+const MOBILE_HEADER_OFFSET = 104
+const DESKTOP_PANE_OFFSET = 12
+
+/**
+ * Watches the briefing scroll container and updates `activeCard` to
+ * whichever card is currently at the top of the viewport. Pure side
+ * effect — renders nothing. Mount once near the layout root and pass the
+ * briefing items in so we can address them by domId / jsonPath.
+ *
+ * The spy intentionally does NOT scroll; it only reads scroll position.
+ * Activation via card click and legend click stays in those components
+ * and continues to work — the spy then takes over as the user scrolls.
+ */
+export default function ActiveCardScrollSpy({
+  items,
+}: Props): React.JSX.Element | null {
+  const { activeCard, setActiveCard } = useAnnotationsCtx()
+  const entries: Entry[] = useMemo(() => {
+    const list: Entry[] = [
+      {
+        key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+        jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+        title: 'Executive Summary',
+        domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+      },
+    ]
+    items.forEach((item, idx) => {
+      list.push({
+        key: briefingItemDomId(item.id),
+        jsonPath: briefingItemCardPath(idx),
+        title: item.title,
+        domId: briefingItemDomId(item.id),
+      })
+    })
+    return list
+  }, [items])
+
+  // Latest activeCard.key without forcing the effect to re-bind whenever
+  // it changes — we read it inside the listener to decide whether to
+  // dispatch a new setActiveCard.
+  const activeKeyRef = useRef<string | null>(activeCard?.key ?? null)
+  useEffect(() => {
+    activeKeyRef.current = activeCard?.key ?? null
+  }, [activeCard])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (entries.length === 0) return
+
+    const pane = document.getElementById('briefing-detail-pane')
+    let raf = 0
+
+    function pick() {
+      raf = 0
+      const paneScrolls =
+        !!pane && window.matchMedia('(min-width: 1024px)').matches
+      const containerTop = paneScrolls ? pane.getBoundingClientRect().top : 0
+      const offset = paneScrolls ? DESKTOP_PANE_OFFSET : MOBILE_HEADER_OFFSET
+
+      // Pick the card whose top sits closest to (but above) the offset
+      // line. Same algorithm the legend used to drive its dot indicator,
+      // now centralized so card outline + legend stay in sync via the
+      // shared `activeCard` state.
+      let bestKey = entries[0]?.key ?? null
+      let bestTop = -Infinity
+      for (const e of entries) {
+        const el = document.getElementById(e.domId)
+        if (!el) continue
+        const top = el.getBoundingClientRect().top - containerTop
+        if (top - offset <= 1 && top > bestTop) {
+          bestTop = top
+          bestKey = e.key
+        }
+      }
+
+      if (bestKey === null || bestKey === activeKeyRef.current) return
+      const matched = entries.find((e) => e.key === bestKey)
+      if (!matched) return
+      setActiveCard({
+        key: matched.key,
+        jsonPath: matched.jsonPath,
+        title: matched.title,
+      })
+    }
+
+    function onScroll() {
+      if (raf === 0) raf = requestAnimationFrame(pick)
+    }
+
+    // Mobile uses the document scroll; desktop scrolls the right pane.
+    // Element scroll events don't bubble, so we attach to both. resize
+    // is included because crossing the lg breakpoint changes which
+    // container scrolls.
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    pane?.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+      pane?.removeEventListener('scroll', onScroll)
+      if (raf !== 0) cancelAnimationFrame(raf)
+    }
+  }, [entries, setActiveCard])
+
+  return null
+}

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -19,13 +19,18 @@ type Props = {
 
 type Entry = ActiveCard & { domId: string }
 
-// Active line offsets, mirroring CardLevelNotesList / scroll-mt: the
-// document-scroll model on mobile lands cards 104px below the viewport
-// (under the sticky DetailHeader); the pane-scroll model at lg+ has no
-// sticky header inside the pane, so a much smaller breathing margin
-// (12px) is enough to mark a card as "in view."
-const MOBILE_HEADER_OFFSET = 104
-const DESKTOP_PANE_OFFSET = 12
+// Where the "active line" sits inside the scroll container. Activation
+// fires when a card's top crosses (i.e. scrolls above) this line — so a
+// large fraction means the card has to be substantially in view before
+// it becomes active, avoiding the jitter where merely revealing the
+// bottom of card N+1 prematurely activated it. 35% of the container
+// height feels close to "the user is reading this card now," matching
+// the behaviour of standard docs scroll-spies.
+const ACTIVE_LINE_FRACTION = 0.35
+// Mobile scroll uses the document, so the sticky DetailHeader sits on
+// top of the viewport. Reserve its height before applying the fraction
+// so the active line lands inside the visible briefing content.
+const MOBILE_HEADER_BAND = 88
 
 /**
  * Watches the briefing scroll container and updates `activeCard` to
@@ -80,8 +85,18 @@ export default function ActiveCardScrollSpy({
       raf = 0
       const paneScrolls =
         !!pane && window.matchMedia('(min-width: 1024px)').matches
-      const containerTop = paneScrolls ? pane.getBoundingClientRect().top : 0
-      const offset = paneScrolls ? DESKTOP_PANE_OFFSET : MOBILE_HEADER_OFFSET
+      const containerRect = paneScrolls
+        ? pane.getBoundingClientRect()
+        : { top: 0, height: window.innerHeight }
+      const containerTop = containerRect.top
+      const visibleHeight = paneScrolls
+        ? containerRect.height
+        : Math.max(0, window.innerHeight - MOBILE_HEADER_BAND)
+      // Active line sits ~a third of the way down the visible scroll
+      // area. A card becomes active only once its top has scrolled past
+      // this line — i.e. it's been "read into" by the user, not merely
+      // peeking up from the bottom of the viewport.
+      const offset = Math.max(40, visibleHeight * ACTIVE_LINE_FRACTION)
 
       // Pick the card whose top sits closest to (but above) the offset
       // line. Same algorithm the legend used to drive its dot indicator,

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -135,6 +135,13 @@ export default function ActiveCardScrollSpy({
     window.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
     pane?.addEventListener('scroll', onScroll, { passive: true })
+
+    // Sync once on mount so deep-link hashes, browser scroll restoration,
+    // and Next.js scroll preservation don't leave the active card stuck
+    // on whichever card was the layout default (usually Executive
+    // Summary). Defer to the next frame so layout has settled and DOM
+    // measurements are correct.
+    raf = requestAnimationFrame(pick)
     return () => {
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
@@ -4,6 +4,18 @@ import { render } from 'helpers/test-utils/render'
 import AgendaItemCard from './AgendaItemCard'
 import type { Item, Source } from '@shared/briefings/types'
 
+// AgendaItemCard now consumes AnnotationsScope context for active-card
+// state and inline card-level notes. Stub it out so the card renders in
+// isolation — active-state behaviour is exercised in the scope's own tests.
+vi.mock('../annotations/AnnotationsScope', () => ({
+  useAnnotationsCtx: () => ({
+    annotations: [],
+    activeCard: null,
+    setActiveCard: vi.fn(),
+    openEditNote: vi.fn(),
+  }),
+}))
+
 vi.mock('../../shared/useReadAloud', () => ({
   useReadAloud: () => ({
     status: 'idle',

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -8,7 +8,10 @@ import {
   toDisplaySource,
   type DisplaySource,
 } from '@shared/briefings/displaySource'
-import { briefingItemCardPath } from '@shared/briefings/routes'
+import {
+  briefingItemCardPath,
+  briefingItemTitlePath,
+} from '@shared/briefings/routes'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
@@ -189,10 +192,16 @@ const AgendaItemCard = ({
   analyticsLabel,
 }: Props): React.JSX.Element => {
   const base = briefingItemCardPath(itemIndex)
+  const titlePath = briefingItemTitlePath(itemIndex)
   const { activeCard, setActiveCard } = useAnnotationsCtx()
   const isActive = activeCard?.key === domId
   const activate = () =>
-    setActiveCard({ key: domId, jsonPath: base, title: item.title })
+    setActiveCard({
+      key: domId,
+      jsonPath: base,
+      titleJsonPath: titlePath,
+      title: item.title,
+    })
   const display = item.display
   const sentiment = display.constituent_sentiment
   const budget = display.budget_impact
@@ -230,9 +239,13 @@ const AgendaItemCard = ({
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
+          {/* `select-none` reserves the title as the card-level chat
+              anchor — see openCardLevelChat. Users don't need (and we
+              don't want) to highlight it themselves. Body text inside
+              the card remains selectable. */}
           <h3
-            className="text-lg font-semibold text-foreground"
-            data-briefing-json-path={`${base}/title`}
+            className="select-none text-lg font-semibold text-foreground"
+            data-briefing-json-path={titlePath}
           >
             {item.title}
           </h3>

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -8,11 +8,14 @@ import {
   toDisplaySource,
   type DisplaySource,
 } from '@shared/briefings/displaySource'
+import { briefingItemCardPath } from '@shared/briefings/routes'
+import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
 import SourcesCollapsible from './SourcesCollapsible'
 import FeedbackRow from './FeedbackRow'
 import ReadAloudButton from './ReadAloudButton'
+import CardLevelNotesList from './CardLevelNotesList'
 
 type Variant = 'full' | 'whatToExpectOnly'
 
@@ -185,7 +188,11 @@ const AgendaItemCard = ({
   speechText,
   analyticsLabel,
 }: Props): React.JSX.Element => {
-  const base = `/items/${itemIndex}`
+  const base = briefingItemCardPath(itemIndex)
+  const { activeCard, setActiveCard } = useAnnotationsCtx()
+  const isActive = activeCard?.key === domId
+  const activate = () =>
+    setActiveCard({ key: domId, jsonPath: base, title: item.title })
   const display = item.display
   const sentiment = display.constituent_sentiment
   const budget = display.budget_impact
@@ -208,7 +215,13 @@ const AgendaItemCard = ({
   return (
     <article
       id={domId}
-      className="flex scroll-mt-[104px] flex-col gap-4 rounded-2xl border border-border bg-card p-6 lg:scroll-mt-3"
+      onClick={activate}
+      aria-current={isActive ? 'true' : undefined}
+      className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-4 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
+        isActive
+          ? 'border-info-600 ring-2 ring-info-600/40'
+          : 'border-border hover:border-foreground/20'
+      }`}
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
@@ -324,6 +337,7 @@ const AgendaItemCard = ({
           ) : null}
         </>
       )}
+      <CardLevelNotesList cardPath={base} />
     </article>
   )
 }

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -216,6 +216,11 @@ const AgendaItemCard = ({
     <article
       id={domId}
       onClick={activate}
+      // Make the card root addressable in the cycler's DOM-order index.
+      // Card-level notes use this exact path as their jsonPath; without
+      // an element carrying it, `enrichForCycler` couldn't place them in
+      // document order and dropped them to the end of the list.
+      data-briefing-json-path={base}
       aria-current={isActive ? 'true' : undefined}
       className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-4 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
         isActive

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -13,7 +13,10 @@ type Props = {
   cardPath: string
 }
 
-const PREVIEW_CHARS = 120
+// Roughly "a word or two" — typical card-level note rows show e.g.
+// "Follow up with..." rather than a sentence. The CSS truncate on the
+// snippet span will further cut it off if the row's max width is reached.
+const PREVIEW_CHARS = 24
 
 const truncate = (text: string, max: number): string =>
   text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text
@@ -51,7 +54,7 @@ export default function CardLevelNotesList({
   if (cardNotes.length === 0) return null
 
   return (
-    <ul className="flex list-none flex-col gap-1.5 pt-1">
+    <ul className="flex list-none flex-col items-start gap-1.5 pt-1">
       {cardNotes.map((n) => {
         const body = (n.note?.body ?? '').trim()
         const attachmentCount = n.note?.attachments?.length ?? 0
@@ -69,7 +72,7 @@ export default function CardLevelNotesList({
                 e.stopPropagation()
                 openEditNote(n)
               }}
-              className="group flex w-full items-baseline gap-2 rounded-md px-1 py-1 text-left text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
+              className="group inline-flex max-w-full items-baseline gap-2 rounded-md px-1 py-1 text-left text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
             >
               <span className="shrink-0 font-semibold text-foreground">
                 Note:
@@ -77,9 +80,11 @@ export default function CardLevelNotesList({
               {/* Visually mirrors the passage-anchored note highlight:
                   same info-tinted background, same trailing note marker.
                   Padding + rounded corners give it the "highlight pill"
-                  look the highlight-layer paints via CSS Highlights. */}
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 rounded-sm bg-[color-mix(in_srgb,var(--info,#1b6afc)_22%,transparent)] px-1.5 py-0.5 transition-colors group-hover:bg-[color-mix(in_srgb,var(--info,#1b6afc)_32%,transparent)]">
-                <span className="min-w-0 flex-1 truncate">{preview}</span>
+                  look the highlight-layer paints via CSS Highlights.
+                  Sized to its content with a cap so a long note doesn't
+                  span the whole card. */}
+              <span className="inline-flex max-w-[260px] items-center gap-1.5 rounded-sm bg-[color-mix(in_srgb,var(--info,#1b6afc)_22%,transparent)] px-1.5 py-0.5 transition-colors group-hover:bg-[color-mix(in_srgb,var(--info,#1b6afc)_32%,transparent)]">
+                <span className="min-w-0 truncate">{preview}</span>
                 <MessageSquare
                   className="size-3.5 shrink-0 text-info-600"
                   aria-hidden

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useMemo } from 'react'
+import { MessageSquare } from 'lucide-react'
+import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
+
+type Props = {
+  /**
+   * Canonical jsonPath of the card these notes belong to. Notes match when
+   * their jsonPath equals this value AND their `start`/`end` are null —
+   * the convention for card-level (not passage-level) notes.
+   */
+  cardPath: string
+}
+
+const PREVIEW_CHARS = 120
+
+const truncate = (text: string, max: number): string =>
+  text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text
+
+/**
+ * Renders the card-level notes attached to a given card as inline rows at
+ * the bottom of the card. Each row mirrors the highlight-layer treatment
+ * (info-tinted background, note icon, "Note:" prefix) so users can tell at
+ * a glance that the row is a saved note. Clicking a row opens it in the
+ * annotation edit sheet.
+ *
+ * Renders nothing when there are no matching notes — callers can mount it
+ * unconditionally without leaving an empty container behind.
+ */
+export default function CardLevelNotesList({
+  cardPath,
+}: Props): React.JSX.Element | null {
+  const { annotations, openEditNote } = useAnnotationsCtx()
+  const cardNotes = useMemo(
+    () =>
+      annotations.filter(
+        (a) =>
+          a.kind === 'note' &&
+          a.jsonPath === cardPath &&
+          a.start === null &&
+          a.end === null,
+      ),
+    [annotations, cardPath],
+  )
+
+  if (cardNotes.length === 0) return null
+
+  return (
+    <ul className="flex list-none flex-col gap-1.5 pt-1">
+      {cardNotes.map((n) => {
+        const body = (n.note?.body ?? '').trim()
+        const attachmentCount = n.note?.attachments?.length ?? 0
+        const preview =
+          body.length > 0
+            ? truncate(body, PREVIEW_CHARS)
+            : attachmentCount > 0
+            ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
+            : '(empty note)'
+        return (
+          <li key={n.id}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                openEditNote(n)
+              }}
+              className="flex w-full items-center gap-2 rounded-md bg-info-600/15 px-3 py-2 text-left text-sm text-info-700 transition-colors hover:bg-info-600/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
+            >
+              <MessageSquare
+                className="size-4 shrink-0 text-info-600"
+                aria-hidden
+              />
+              <span className="min-w-0 flex-1 truncate">
+                <span className="font-semibold">Note:</span> {preview}
+              </span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -38,7 +38,7 @@ const truncate = (text: string, max: number): string =>
 export default function CardLevelNotesList({
   cardPath,
 }: Props): React.JSX.Element | null {
-  const { annotations, openEditNote } = useAnnotationsCtx()
+  const { annotations, openNotesSurface } = useAnnotationsCtx()
   const cardNotes = useMemo(
     () =>
       annotations.filter(
@@ -70,7 +70,7 @@ export default function CardLevelNotesList({
               type="button"
               onClick={(e) => {
                 e.stopPropagation()
-                openEditNote(n)
+                openNotesSurface(n.id)
               }}
               className="group inline-flex max-w-full items-baseline gap-2 rounded-md px-1 py-1 text-left text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
             >

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -62,8 +62,8 @@ export default function CardLevelNotesList({
           body.length > 0
             ? truncate(body, PREVIEW_CHARS)
             : attachmentCount > 0
-              ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
-              : '(empty note)'
+            ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
+            : '(empty note)'
         return (
           <li key={n.id}>
             <button
@@ -78,12 +78,11 @@ export default function CardLevelNotesList({
                 Note:
               </span>
               {/* Visually mirrors the passage-anchored note highlight:
-                  same info-tinted background, same trailing note marker.
-                  Padding + rounded corners give it the "highlight pill"
-                  look the highlight-layer paints via CSS Highlights.
+                  info-tinted pill, trailing note marker. Tokens — not
+                  raw CSS-var brackets — per CLAUDE.md (Design Tokens).
                   Sized to its content with a cap so a long note doesn't
                   span the whole card. */}
-              <span className="inline-flex max-w-[260px] items-center gap-1.5 rounded-sm bg-[color-mix(in_srgb,var(--info,#1b6afc)_22%,transparent)] px-1.5 py-0.5 transition-colors group-hover:bg-[color-mix(in_srgb,var(--info,#1b6afc)_32%,transparent)]">
+              <span className="inline-flex max-w-[260px] items-center gap-1.5 rounded-sm bg-info-50 px-1.5 py-0.5 transition-colors group-hover:bg-info-100">
                 <span className="min-w-0 truncate">{preview}</span>
                 <MessageSquare
                   className="size-3.5 shrink-0 text-info-600"

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -20,10 +20,14 @@ const truncate = (text: string, max: number): string =>
 
 /**
  * Renders the card-level notes attached to a given card as inline rows at
- * the bottom of the card. Each row mirrors the highlight-layer treatment
- * (info-tinted background, note icon, "Note:" prefix) so users can tell at
- * a glance that the row is a saved note. Clicking a row opens it in the
- * annotation edit sheet.
+ * the bottom of the card. Each row is laid out as
+ *
+ *   Note: [ {snippet}  📝 ]
+ *
+ * where the bracketed span mirrors the highlight-layer treatment used for
+ * passage-anchored notes — same info-tinted background, same trailing
+ * note marker — so the row reads as "this is a saved note about this
+ * card." Clicking a row opens it in the annotation edit sheet.
  *
  * Renders nothing when there are no matching notes — callers can mount it
  * unconditionally without leaving an empty container behind.
@@ -55,8 +59,8 @@ export default function CardLevelNotesList({
           body.length > 0
             ? truncate(body, PREVIEW_CHARS)
             : attachmentCount > 0
-            ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
-            : '(empty note)'
+              ? `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`
+              : '(empty note)'
         return (
           <li key={n.id}>
             <button
@@ -65,14 +69,21 @@ export default function CardLevelNotesList({
                 e.stopPropagation()
                 openEditNote(n)
               }}
-              className="flex w-full items-center gap-2 rounded-md bg-info-600/15 px-3 py-2 text-left text-sm text-info-700 transition-colors hover:bg-info-600/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
+              className="group flex w-full items-baseline gap-2 rounded-md px-1 py-1 text-left text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-info-600/60"
             >
-              <MessageSquare
-                className="size-4 shrink-0 text-info-600"
-                aria-hidden
-              />
-              <span className="min-w-0 flex-1 truncate">
-                <span className="font-semibold">Note:</span> {preview}
+              <span className="shrink-0 font-semibold text-foreground">
+                Note:
+              </span>
+              {/* Visually mirrors the passage-anchored note highlight:
+                  same info-tinted background, same trailing note marker.
+                  Padding + rounded corners give it the "highlight pill"
+                  look the highlight-layer paints via CSS Highlights. */}
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 rounded-sm bg-[color-mix(in_srgb,var(--info,#1b6afc)_22%,transparent)] px-1.5 py-0.5 transition-colors group-hover:bg-[color-mix(in_srgb,var(--info,#1b6afc)_32%,transparent)]">
+                <span className="min-w-0 flex-1 truncate">{preview}</span>
+                <MessageSquare
+                  className="size-3.5 shrink-0 text-info-600"
+                  aria-hidden
+                />
               </span>
             </button>
           </li>

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
@@ -18,6 +18,9 @@ function setCtx(overrides: Partial<Ctx> = {}) {
   mockedUseAnnotationsCtx.mockReturnValue({
     meetingDate: '2026-01-01',
     topLevelChatAnnotationId: undefined,
+    annotations: [],
+    activeCard: null,
+    setActiveCard: vi.fn(),
     openAddNoteFromSelection: vi.fn(),
     openAddNoteTopLevel: vi.fn(),
     openReportErrorFromSelection: vi.fn(),

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
@@ -28,6 +28,7 @@ function setCtx(overrides: Partial<Ctx> = {}) {
     openViewReport: vi.fn(),
     openNotesSurface: vi.fn(),
     openChatsSurface: vi.fn(),
+    openCardLevelChat: vi.fn(),
     openBugReportsSurface: vi.fn(),
     notesCount: 0,
     chatsCount: 0,
@@ -65,6 +66,7 @@ describe('<DetailHeaderActions>', () => {
       activeCard: {
         key: 'briefing-executive-summary',
         jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
         title: 'Executive Summary',
       },
     })
@@ -84,6 +86,7 @@ describe('<DetailHeaderActions>', () => {
       activeCard: {
         key: 'briefing-executive-summary',
         jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
         title: 'Executive Summary',
       },
     })
@@ -98,13 +101,29 @@ describe('<DetailHeaderActions>', () => {
     expect(screen.getByRole('button', { name: /^add note$/i })).toBeDisabled()
   })
 
-  it('opens the chats surface when the Briefing assistant button is clicked', async () => {
-    const openChatsSurface = vi.fn()
-    setCtx({ openChatsSurface })
+  it('calls openCardLevelChat when the Briefing assistant button is clicked with an active card', async () => {
+    const openCardLevelChat = vi.fn()
+    setCtx({
+      openCardLevelChat,
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
+        title: 'Executive Summary',
+      },
+    })
     render(<DetailHeaderActions briefing={briefingStub} />)
     await userEvent.click(
       screen.getByRole('button', { name: /briefing assistant/i }),
     )
-    expect(openChatsSurface).toHaveBeenCalledTimes(1)
+    expect(openCardLevelChat).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the Briefing assistant button when no card is active', () => {
+    setCtx({ activeCard: null })
+    render(<DetailHeaderActions briefing={briefingStub} />)
+    expect(
+      screen.getByRole('button', { name: /briefing assistant/i }),
+    ).toBeDisabled()
   })
 })

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
@@ -60,21 +60,42 @@ describe('<DetailHeaderActions>', () => {
     mockedUseAnnotationsCtx.mockReset()
   })
 
-  it('renders Notes and Briefing assistant buttons', () => {
-    setCtx()
+  it('renders Add note and Briefing assistant buttons', () => {
+    setCtx({
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        title: 'Executive Summary',
+      },
+    })
     render(<DetailHeaderActions briefing={briefingStub} />)
-    expect(screen.getByRole('button', { name: /^notes$/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^add note$/i }),
+    ).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /briefing assistant/i }),
     ).toBeInTheDocument()
   })
 
-  it('opens the notes surface when the Notes button is clicked', async () => {
-    const openNotesSurface = vi.fn()
-    setCtx({ openNotesSurface })
+  it('calls openAddNoteTopLevel when the Add note button is clicked with an active card', async () => {
+    const openAddNoteTopLevel = vi.fn()
+    setCtx({
+      openAddNoteTopLevel,
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        title: 'Executive Summary',
+      },
+    })
     render(<DetailHeaderActions briefing={briefingStub} />)
-    await userEvent.click(screen.getByRole('button', { name: /^notes$/i }))
-    expect(openNotesSurface).toHaveBeenCalledTimes(1)
+    await userEvent.click(screen.getByRole('button', { name: /^add note$/i }))
+    expect(openAddNoteTopLevel).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Add note when no card is active', () => {
+    setCtx({ activeCard: null })
+    render(<DetailHeaderActions briefing={briefingStub} />)
+    expect(screen.getByRole('button', { name: /^add note$/i })).toBeDisabled()
   })
 
   it('opens the chats surface when the Briefing assistant button is clicked', async () => {

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -19,7 +19,9 @@ type Props = {
  * Sticky header actions on desktop. Download builds the briefing PDF in
  * the browser via @react-pdf/renderer. "Add note" attaches a new note to
  * the currently-active card (disabled when no card is active). "Briefing
- * assistant" opens the chats cycler.
+ * assistant" opens (or creates) a chat anchored to the active card's
+ * title — the same shape a manual highlight-then-Ask-AI on the title
+ * would produce.
  */
 export default function DetailHeaderActions({
   briefing,
@@ -27,7 +29,7 @@ export default function DetailHeaderActions({
   meetingMetaLine,
   liveBriefingUrl,
 }: Props): React.JSX.Element {
-  const { openAddNoteTopLevel, openChatsSurface, activeCard } =
+  const { openAddNoteTopLevel, openCardLevelChat, activeCard } =
     useAnnotationsCtx()
   const [downloading, setDownloading] = useState(false)
 
@@ -69,7 +71,15 @@ export default function DetailHeaderActions({
         <MessageSquare className="size-4" aria-hidden />
         Add note
       </Button>
-      <Button onClick={() => openChatsSurface()}>
+      <Button
+        onClick={openCardLevelChat}
+        disabled={!activeCard}
+        title={
+          activeCard
+            ? `Ask AI about ${activeCard.title}`
+            : 'Click a card to make it active first'
+        }
+      >
         <Sparkles className="size-4" aria-hidden />
         Briefing assistant
       </Button>

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -16,10 +16,10 @@ type Props = {
 }
 
 /**
- * Sticky header actions on desktop. Download builds the briefing PDF in the
- * browser via @react-pdf/renderer; the "Add notes" and "Briefing assistant"
- * buttons open the cycler surfaces (notes / chats) so the user lands on
- * existing annotations first, with a new-item CTA inside the empty state.
+ * Sticky header actions on desktop. Download builds the briefing PDF in
+ * the browser via @react-pdf/renderer. "Add note" attaches a new note to
+ * the currently-active card (disabled when no card is active). "Briefing
+ * assistant" opens the chats cycler.
  */
 export default function DetailHeaderActions({
   briefing,
@@ -27,7 +27,8 @@ export default function DetailHeaderActions({
   meetingMetaLine,
   liveBriefingUrl,
 }: Props): React.JSX.Element {
-  const { openNotesSurface, openChatsSurface } = useAnnotationsCtx()
+  const { openAddNoteTopLevel, openChatsSurface, activeCard } =
+    useAnnotationsCtx()
   const [downloading, setDownloading] = useState(false)
 
   const onDownload = async () => {
@@ -55,9 +56,18 @@ export default function DetailHeaderActions({
         )}
         {downloading ? 'Preparing…' : 'Download'}
       </Button>
-      <Button variant="outline" onClick={() => openNotesSurface()}>
+      <Button
+        variant="outline"
+        onClick={openAddNoteTopLevel}
+        disabled={!activeCard}
+        title={
+          activeCard
+            ? `Add a note to ${activeCard.title}`
+            : 'Click a card to make it active first'
+        }
+      >
         <MessageSquare className="size-4" aria-hidden />
-        Notes
+        Add note
       </Button>
       <Button onClick={() => openChatsSurface()}>
         <Sparkles className="size-4" aria-hidden />

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import {
+  BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
   BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemCardPath,
   briefingItemDomId,
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
+import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 
 type Props = {
   briefingSlug: string
@@ -16,147 +19,65 @@ type Entry = {
   key: string
   label: string
   domId: string
+  jsonPath: string
 }
-
-// Distance below the top of the scroll container where the "current section"
-// line is drawn. Mobile uses the document scroll and sits below the sticky
-// DetailHeader (~88px + breathing room). Desktop scrolls inside the content
-// pane, which has no internal sticky header, so the line is just below the
-// pane's top edge. Both values track the corresponding `scroll-mt-*` on the
-// card roots so scroll target alignment and active-state detection agree.
-const MOBILE_HEADER_OFFSET = 104
-const DESKTOP_PANE_OFFSET = 12
 
 /**
  * Sidebar TOC. All agenda items render inline on the briefing detail
  * page, so the TOC scrolls within the page rather than navigating.
  *
- * Active state is a rAF-throttled scroll-spy: on every scroll frame we
- * pick the section whose top sits closest to (but above) the active-line
- * offset, measured relative to the active scroll container — `window` on
- * mobile, the `#briefing-detail-pane` element at lg+ where the pane owns
- * the scroll. One section is "active" per frame, so the highlight never
- * flickers during smooth scrolls.
+ * The active entry is whichever card the user most recently clicked —
+ * via the legend or via the card itself. General scrolling does NOT
+ * change the active card, so the legend stays in sync with user intent
+ * rather than scroll position.
  */
 export default function DetailToc({
   briefingSlug,
   items,
 }: Props): React.JSX.Element {
+  const { activeCard, setActiveCard } = useAnnotationsCtx()
+
   const entries: Entry[] = useMemo(() => {
     const list: Entry[] = [
       {
-        key: 'overview',
+        key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
         label: 'Executive Summary',
         domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+        jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
       },
     ]
-    for (const item of items) {
+    items.forEach((item, idx) => {
       list.push({
-        key: item.id,
+        key: briefingItemDomId(item.id),
         label: item.title,
         domId: briefingItemDomId(item.id),
+        jsonPath: briefingItemCardPath(idx),
       })
-    }
+    })
     return list
   }, [items])
 
-  const [activeKey, setActiveKey] = useState<string>(entries[0]?.key ?? '')
-  // When a user clicks a TOC entry, pin that entry as active until they
-  // perform a real manual scroll (wheel/touch/key). The smooth scroll
-  // animation fires `scroll` events too, but doesn't fire wheel/touch/key
-  // — so this lets the clicked entry stay highlighted even when the
-  // scroll container can't bring its section all the way to the active
-  // line (e.g. clicking one of the last entries when there isn't enough
-  // remaining scroll room below it).
-  const [pinnedKey, setPinnedKey] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    if (entries.length === 0) return
-
-    let raf = 0
-    const pane = document.getElementById('briefing-detail-pane')
-
-    function pickActive() {
-      raf = 0
-      // Pick the scroll container live each frame so a resize across the
-      // lg breakpoint switches modes without a remount.
-      const paneScrolls =
-        !!pane && window.matchMedia('(min-width: 1024px)').matches
-      const containerTop = paneScrolls ? pane.getBoundingClientRect().top : 0
-      const offset = paneScrolls ? DESKTOP_PANE_OFFSET : MOBILE_HEADER_OFFSET
-
-      let bestKey = entries[0]?.key ?? ''
-      let bestTop = -Infinity
-      for (const e of entries) {
-        const el = document.getElementById(e.domId)
-        if (!el) continue
-        // Section's top relative to the scroll container's top edge.
-        const top = el.getBoundingClientRect().top - containerTop
-        // Sections at or above the offset line are candidates. The one
-        // closest to the line (largest top that's still <= offset) wins.
-        if (top - offset <= 1 && top > bestTop) {
-          bestTop = top
-          bestKey = e.key
-        }
-      }
-      setActiveKey(bestKey)
-    }
-
-    function onScroll() {
-      if (raf === 0) raf = requestAnimationFrame(pickActive)
-    }
-
-    function onUserInput() {
-      setPinnedKey(null)
-    }
-
-    // Listen on both window (mobile, where the document scrolls) and the
-    // briefing content pane (desktop, where the right column scrolls
-    // independently). Element scroll events don't bubble, so we have to
-    // attach directly to the pane. Wheel/touch/key events clear any
-    // click-pinned highlight — the smooth-scroll animation doesn't fire
-    // them, so the pin survives the animation.
-    pickActive()
-    window.addEventListener('scroll', onScroll, { passive: true })
-    window.addEventListener('resize', onScroll)
-    window.addEventListener('wheel', onUserInput, { passive: true })
-    window.addEventListener('touchstart', onUserInput, { passive: true })
-    window.addEventListener('keydown', onUserInput)
-    pane?.addEventListener('scroll', onScroll, { passive: true })
-    pane?.addEventListener('wheel', onUserInput, { passive: true })
-    pane?.addEventListener('touchstart', onUserInput, { passive: true })
-    return () => {
-      window.removeEventListener('scroll', onScroll)
-      window.removeEventListener('resize', onScroll)
-      window.removeEventListener('wheel', onUserInput)
-      window.removeEventListener('touchstart', onUserInput)
-      window.removeEventListener('keydown', onUserInput)
-      pane?.removeEventListener('scroll', onScroll)
-      pane?.removeEventListener('wheel', onUserInput)
-      pane?.removeEventListener('touchstart', onUserInput)
-      if (raf !== 0) cancelAnimationFrame(raf)
-    }
-  }, [entries, briefingSlug])
-
   function onJump(e: React.MouseEvent<HTMLAnchorElement>, entry: Entry) {
     if (typeof window === 'undefined') return
-    const target = document.getElementById(entry.domId)
-    if (!target) return
     e.preventDefault()
-    setPinnedKey(entry.key)
-    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    setActiveCard({
+      key: entry.key,
+      jsonPath: entry.jsonPath,
+      title: entry.label,
+    })
+    const target = document.getElementById(entry.domId)
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
     if (window.history && window.history.replaceState) {
       window.history.replaceState(null, '', `#${entry.domId}`)
     }
   }
 
-  const displayedKey = pinnedKey ?? activeKey
-
   return (
-    <ul className="flex list-none flex-col gap-0.5">
+    <ul className="flex list-none flex-col gap-0.5" data-testid={briefingSlug}>
       {entries.map((e) => {
-        const isActive = displayedKey === e.key
+        const isActive = activeCard?.key === e.key
         return (
           <li key={e.key}>
             <a

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -4,8 +4,10 @@ import { useMemo } from 'react'
 import {
   BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
   BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
   briefingItemCardPath,
   briefingItemDomId,
+  briefingItemTitlePath,
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
@@ -20,6 +22,7 @@ type Entry = {
   label: string
   domId: string
   jsonPath: string
+  titleJsonPath: string
 }
 
 /**
@@ -44,6 +47,7 @@ export default function DetailToc({
         label: 'Executive Summary',
         domId: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
         jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+        titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
       },
     ]
     items.forEach((item, idx) => {
@@ -52,6 +56,7 @@ export default function DetailToc({
         label: item.title,
         domId: briefingItemDomId(item.id),
         jsonPath: briefingItemCardPath(idx),
+        titleJsonPath: briefingItemTitlePath(idx),
       })
     })
     return list
@@ -63,6 +68,7 @@ export default function DetailToc({
     setActiveCard({
       key: entry.key,
       jsonPath: entry.jsonPath,
+      titleJsonPath: entry.titleJsonPath,
       title: entry.label,
     })
     const target = document.getElementById(entry.domId)

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { MeetingBriefingOutput } from 'gpApi/generated/agent-job-contracts'
-import { briefingItemDomId } from '@shared/briefings/routes'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+  briefingItemDomId,
+} from '@shared/briefings/routes'
+import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
+import CardLevelNotesList from './CardLevelNotesList'
 import ReadAloudButton from './ReadAloudButton'
 
 type Props = {
@@ -42,10 +47,24 @@ export default function ExecutiveSummaryCard({
   speechText,
   analyticsLabel,
 }: Props): React.JSX.Element {
+  const { activeCard, setActiveCard } = useAnnotationsCtx()
+  const isActive = activeCard?.key === domId
+  const activate = () =>
+    setActiveCard({
+      key: domId,
+      jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+      title: 'Executive Summary',
+    })
   return (
     <article
       id={domId}
-      className="flex scroll-mt-[104px] flex-col gap-3 rounded-2xl border border-border bg-card p-6 lg:scroll-mt-3"
+      onClick={activate}
+      aria-current={isActive ? 'true' : undefined}
+      className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-3 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
+        isActive
+          ? 'border-info-600 ring-2 ring-info-600/40'
+          : 'border-border hover:border-foreground/20'
+      }`}
     >
       <div className="flex items-start justify-between gap-3">
         <h2 className="text-2xl font-semibold text-foreground">
@@ -85,6 +104,7 @@ export default function ExecutiveSummaryCard({
           })}
         </ul>
       ) : null}
+      <CardLevelNotesList cardPath={BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH} />
     </article>
   )
 }

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -3,6 +3,7 @@
 import { MeetingBriefingOutput } from 'gpApi/generated/agent-job-contracts'
 import {
   BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+  BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
   briefingItemDomId,
 } from '@shared/briefings/routes'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
@@ -53,6 +54,7 @@ export default function ExecutiveSummaryCard({
     setActiveCard({
       key: domId,
       jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+      titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
       title: 'Executive Summary',
     })
   return (
@@ -71,7 +73,15 @@ export default function ExecutiveSummaryCard({
       }`}
     >
       <div className="flex items-start justify-between gap-3">
-        <h2 className="text-2xl font-semibold text-foreground">
+        {/* `data-briefing-json-path` makes the title resolvable as an
+            anchor target — card-level chats hang off this element.
+            `select-none` reserves the title for that role: the user
+            doesn't need to highlight it themselves; the "Briefing
+            assistant" button anchors here automatically. */}
+        <h2
+          className="select-none text-2xl font-semibold text-foreground"
+          data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
+        >
           Executive Summary
         </h2>
         <ReadAloudButton text={speechText} analyticsLabel={analyticsLabel} />

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -59,6 +59,10 @@ export default function ExecutiveSummaryCard({
     <article
       id={domId}
       onClick={activate}
+      // Make the card root addressable in the cycler's DOM-order index.
+      // Card-level notes carry this path; without it, the enricher
+      // couldn't slot them into document order.
+      data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH}
       aria-current={isActive ? 'true' : undefined}
       className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-3 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
         isActive

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -123,9 +123,16 @@ describe('<MobileBottomBar>', () => {
     expect(dock?.className ?? '').not.toMatch(/pointer-events-none/)
   })
 
-  it('opens the notes surface when the Notes button is clicked', async () => {
-    const openNotesSurface = vi.fn()
-    setCtx({ openNotesSurface })
+  it('calls openAddNoteTopLevel when the Add note button is clicked with an active card', async () => {
+    const openAddNoteTopLevel = vi.fn()
+    setCtx({
+      openAddNoteTopLevel,
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        title: 'Executive Summary',
+      },
+    })
     render(
       <MobileBottomBar
         briefing={briefingStub}
@@ -133,8 +140,10 @@ describe('<MobileBottomBar>', () => {
         items={makeItems(1)}
       />,
     )
-    await userEvent.click(screen.getByRole('button', { name: /open notes/i }))
-    expect(openNotesSurface).toHaveBeenCalledTimes(1)
+    await userEvent.click(
+      screen.getByRole('button', { name: /add a note to executive summary/i }),
+    )
+    expect(openAddNoteTopLevel).toHaveBeenCalledTimes(1)
   })
 
   it('opens the chats surface when the Briefing assistant button is clicked', async () => {

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -32,6 +32,9 @@ function setCtx(overrides: Partial<AnnotationsCtxValue> = {}) {
   const ctx: AnnotationsCtxValue = {
     meetingDate: '2026-01-01',
     topLevelChatAnnotationId: undefined,
+    annotations: [],
+    activeCard: null,
+    setActiveCard: vi.fn(),
     openAddNoteFromSelection: vi.fn(),
     openAddNoteTopLevel: vi.fn(),
     openReportErrorFromSelection: vi.fn(),

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -117,6 +117,7 @@ describe('<MobileBottomBar>', () => {
     // The page-selector pill is the first button whose label is just the
     // section name; the "Ask AI about Executive Summary" button also matches.
     const selector = selectorMatches[0]
+    if (!selector) throw new Error('selector button not rendered')
     const download = screen.getByRole('button', { name: /download pdf/i })
     const askAi = screen.getByRole('button', {
       name: /ask ai about executive summary/i,

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -42,6 +42,7 @@ function setCtx(overrides: Partial<AnnotationsCtxValue> = {}) {
     openViewReport: vi.fn(),
     openNotesSurface: vi.fn(),
     openChatsSurface: vi.fn(),
+    openCardLevelChat: vi.fn(),
     openBugReportsSurface: vi.fn(),
     notesCount: 0,
     chatsCount: 0,
@@ -94,7 +95,14 @@ describe('<MobileBottomBar>', () => {
   })
 
   it('renders the page-selector pill, Download, and Ask AI as siblings in one row on a solid panel', () => {
-    setCtx()
+    setCtx({
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
+        title: 'Executive Summary',
+      },
+    })
     render(
       <MobileBottomBar
         briefing={briefingStub}
@@ -103,10 +111,15 @@ describe('<MobileBottomBar>', () => {
       />,
     )
 
-    const selector = screen.getByRole('button', { name: /executive summary/i })
+    const selectorMatches = screen.getAllByRole('button', {
+      name: /executive summary/i,
+    })
+    // The page-selector pill is the first button whose label is just the
+    // section name; the "Ask AI about Executive Summary" button also matches.
+    const selector = selectorMatches[0]
     const download = screen.getByRole('button', { name: /download pdf/i })
     const askAi = screen.getByRole('button', {
-      name: /open briefing assistant/i,
+      name: /ask ai about executive summary/i,
     })
 
     // All three controls share a common ancestor (the dock row) so they
@@ -130,6 +143,7 @@ describe('<MobileBottomBar>', () => {
       activeCard: {
         key: 'briefing-executive-summary',
         jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
         title: 'Executive Summary',
       },
     })
@@ -146,9 +160,17 @@ describe('<MobileBottomBar>', () => {
     expect(openAddNoteTopLevel).toHaveBeenCalledTimes(1)
   })
 
-  it('opens the chats surface when the Briefing assistant button is clicked', async () => {
-    const openChatsSurface = vi.fn()
-    setCtx({ openChatsSurface })
+  it('calls openCardLevelChat when the Briefing assistant button is tapped with an active card', async () => {
+    const openCardLevelChat = vi.fn()
+    setCtx({
+      openCardLevelChat,
+      activeCard: {
+        key: 'briefing-executive-summary',
+        jsonPath: '/executiveSummary',
+        titleJsonPath: '/executive_summary/title',
+        title: 'Executive Summary',
+      },
+    })
     render(
       <MobileBottomBar
         briefing={briefingStub}
@@ -157,9 +179,9 @@ describe('<MobileBottomBar>', () => {
       />,
     )
     await userEvent.click(
-      screen.getByRole('button', { name: /open briefing assistant/i }),
+      screen.getByRole('button', { name: /ask ai about executive summary/i }),
     )
-    expect(openChatsSurface).toHaveBeenCalledTimes(1)
+    expect(openCardLevelChat).toHaveBeenCalledTimes(1)
   })
 
   it('calls downloadBriefingPdf with the briefing and lines when Download is clicked', async () => {

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -61,7 +61,7 @@ export default function MobileBottomBar({
 }: Props): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [downloading, setDownloading] = useState(false)
-  const { openAddNoteTopLevel, openChatsSurface, activeCard } =
+  const { openAddNoteTopLevel, openCardLevelChat, activeCard } =
     useAnnotationsCtx()
 
   const onDownload = async () => {
@@ -269,8 +269,13 @@ export default function MobileBottomBar({
         <IconButton
           type="button"
           size="medium"
-          aria-label="Open briefing assistant"
-          onClick={() => openChatsSurface()}
+          aria-label={
+            activeCard
+              ? `Ask AI about ${activeCard.title}`
+              : 'Click a card to make it active first'
+          }
+          onClick={openCardLevelChat}
+          disabled={!activeCard}
         >
           <Sparkles className="size-5" aria-hidden />
         </IconButton>

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -61,7 +61,8 @@ export default function MobileBottomBar({
 }: Props): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [downloading, setDownloading] = useState(false)
-  const { openNotesSurface, openChatsSurface } = useAnnotationsCtx()
+  const { openAddNoteTopLevel, openChatsSurface, activeCard } =
+    useAnnotationsCtx()
 
   const onDownload = async () => {
     setDownloading(true)
@@ -255,8 +256,13 @@ export default function MobileBottomBar({
           type="button"
           size="medium"
           variant="outline"
-          aria-label="Open notes"
-          onClick={() => openNotesSurface()}
+          aria-label={
+            activeCard
+              ? `Add a note to ${activeCard.title}`
+              : 'Click a card to make it active first'
+          }
+          onClick={openAddNoteTopLevel}
+          disabled={!activeCard}
         >
           <MessageSquare className="size-5" aria-hidden />
         </IconButton>

--- a/app/shared/briefings/routes.ts
+++ b/app/shared/briefings/routes.ts
@@ -15,6 +15,13 @@ export const BRIEFING_EXECUTIVE_SUMMARY_DOM_ID = 'briefing-executive-summary'
  */
 export const BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH = '/executiveSummary'
 
+/**
+ * JsonPath of the Executive Summary card's title element. A DOM
+ * element under this path is required so card-level chat anchors
+ * resolve back to a quote — see ExecutiveSummaryCard.
+ */
+export const BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH = '/executive_summary/title'
+
 export function briefingItemDomId(itemId: string): string {
   return `briefing-item-${itemId}`
 }
@@ -27,6 +34,16 @@ export function briefingItemDomId(itemId: string): string {
  */
 export function briefingItemCardPath(itemIndex: number): string {
   return `/items/${itemIndex}`
+}
+
+/**
+ * JsonPath of an agenda item card's title element. Card-level chats
+ * anchor here with `start`/`end` spanning the title's full text — that
+ * mirrors what would happen if the user highlighted the title and
+ * tapped "Ask AI" themselves.
+ */
+export function briefingItemTitlePath(itemIndex: number): string {
+  return `/items/${itemIndex}/title`
 }
 
 export function briefingsLandingHref(): string {

--- a/app/shared/briefings/routes.ts
+++ b/app/shared/briefings/routes.ts
@@ -8,8 +8,25 @@
 
 export const BRIEFING_EXECUTIVE_SUMMARY_DOM_ID = 'briefing-executive-summary'
 
+/**
+ * Canonical jsonPath identifying the Executive Summary card as a whole
+ * (not a specific passage inside it). Used as the anchor for card-level
+ * notes — `start`/`end` are null in that case.
+ */
+export const BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH = '/executiveSummary'
+
 export function briefingItemDomId(itemId: string): string {
   return `briefing-item-${itemId}`
+}
+
+/**
+ * Canonical jsonPath identifying an agenda item card as a whole. A
+ * card-level note carries this as its `jsonPath` with `start`/`end` set
+ * to null. Inline highlights inside the card keep using path suffixes
+ * (`/items/{idx}/title`, `/items/{idx}/display/summary`, etc.).
+ */
+export function briefingItemCardPath(itemIndex: number): string {
+  return `/items/${itemIndex}`
 }
 
 export function briefingsLandingHref(): string {

--- a/app/shared/briefings/use-selection.ts
+++ b/app/shared/briefings/use-selection.ts
@@ -3,19 +3,21 @@
 import { useEffect, useState } from 'react'
 import { resolveSelection, type ResolvedAnchor } from './anchorResolver'
 
-// On touch devices, iOS shows its "edit menu" (Copy / Look Up / Share /
-// etc.) any time the document carries a non-empty selection. Suppressing
-// the long-press callout via `-webkit-touch-callout: none` doesn't help
-// here — that property only covers the long-press fallback, not the
-// menu that follows a drag-select. The only reliable way to dismiss it
-// while preserving our own HighlightToolbar is to capture the anchor
-// state from the selection, then clear the OS selection programmatically.
+// iOS Safari shows its system edit menu (Copy / Look Up / Share / etc.)
+// as long as the document carries a non-empty selection. `-webkit-touch
+// -callout: none` only blocks the long-press callout fallback, not the
+// post-selection menu; clearing the selection on `touchend` is too late
+// because iOS shows the menu as soon as the first `selectionchange`
+// event lands. The only reliable way to keep the menu suppressed while
+// still acting on the user's selection is to capture the anchor into
+// React state on the very first `selectionchange` and clear the native
+// selection in the same tick. iOS never gets a window where it could
+// render its menu.
 //
-// `pendingClearUntil` is a short timestamp window during which we ignore
-// the resulting `selectionchange(null)` events so our captured anchor
-// survives. The window is intentionally short — long enough to absorb
-// browser-level event jitter, short enough that a follow-up user action
-// (new selection, dismiss) isn't suppressed.
+// Side effect: the user can't drag iOS's selection handles to extend the
+// initial word, because the native selection is gone immediately. They
+// must re-select to pick a different range — an acceptable trade-off
+// for an exclusive briefing toolbar on touch devices.
 const PROGRAMMATIC_CLEAR_WINDOW_MS = 200
 
 /**
@@ -23,14 +25,19 @@ const PROGRAMMATIC_CLEAR_WINDOW_MS = 200
  * briefing anchor when the user highlights text inside an element
  * carrying `data-briefing-json-path`.
  *
- * On touch devices the hook also clears the native selection right
- * after capturing the anchor — that's what suppresses the iOS edit
- * menu. The toolbar continues to render because the captured anchor is
- * held in React state, independent of the live `Selection` object.
+ * Two paths, branched on the device's input primary:
+ *   - Touch (hover:none + pointer:coarse): capture-and-clear on every
+ *     `selectionchange`. The captured anchor stays in React state so
+ *     the HighlightToolbar still renders; iOS never has a live
+ *     selection long enough to show its system menu.
+ *   - Mouse/desktop: legacy behavior — track the live selection via
+ *     `selectionchange` / `mouseup` / `keyup`. The visible OS selection
+ *     stays (useful for drag-to-read), and the system context menu on
+ *     right-click is suppressed elsewhere via a contextmenu listener.
  *
- * The X dismiss in HighlightToolbar must call into here to actually
- * reset state, not just `removeAllRanges()` — see the dispatched
- * `selectionchange` event in HighlightToolbar.dismiss for the wire-up.
+ * The X dismiss in HighlightToolbar must dispatch a synthetic
+ * `selectionchange` event so this hook drops state when the native
+ * selection is already empty (which it is, post-capture on touch).
  */
 export function useSelection(): ResolvedAnchor | null {
   const [anchor, setAnchor] = useState<ResolvedAnchor | null>(null)
@@ -38,18 +45,21 @@ export function useSelection(): ResolvedAnchor | null {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
+    const isTouchPrimary = window.matchMedia(
+      '(hover: none) and (pointer: coarse)',
+    ).matches
     let pendingClearUntil = 0
 
     function update() {
-      // While we're inside the programmatic-clear window, ignore any
-      // `selectionchange(null)` echoes. The captured anchor must
-      // survive so the HighlightToolbar stays mounted.
+      // While inside the programmatic-clear window, ignore `selection
+      // change(null)` echoes from our own `removeAllRanges` call. The
+      // captured anchor must survive so the HighlightToolbar stays.
       if (Date.now() < pendingClearUntil) return
       const sel = window.getSelection()
       setAnchor(resolveSelection(sel))
     }
 
-    function captureAndClearForTouch() {
+    function captureAndClear() {
       const sel = window.getSelection()
       const next = resolveSelection(sel)
       if (!next) return
@@ -58,18 +68,23 @@ export function useSelection(): ResolvedAnchor | null {
       sel?.removeAllRanges()
     }
 
-    document.addEventListener('selectionchange', update)
-    document.addEventListener('mouseup', update)
-    document.addEventListener('keyup', update)
-    // Touch-only path: after the gesture lifts, capture the anchor and
-    // wipe the OS selection. Desktop keeps the legacy mouseup path so
-    // dragging to read/measure still leaves the selection visible.
-    document.addEventListener('touchend', captureAndClearForTouch)
+    if (isTouchPrimary) {
+      // Order matters: the eager capture-and-clear runs first, then the
+      // suppression window blocks the `update` echo. addEventListener
+      // dispatches in registration order, so we register the capturer
+      // before the consumer.
+      document.addEventListener('selectionchange', captureAndClear)
+      document.addEventListener('selectionchange', update)
+    } else {
+      document.addEventListener('selectionchange', update)
+      document.addEventListener('mouseup', update)
+      document.addEventListener('keyup', update)
+    }
     return () => {
+      document.removeEventListener('selectionchange', captureAndClear)
       document.removeEventListener('selectionchange', update)
       document.removeEventListener('mouseup', update)
       document.removeEventListener('keyup', update)
-      document.removeEventListener('touchend', captureAndClearForTouch)
     }
   }, [])
 

--- a/app/shared/briefings/use-selection.ts
+++ b/app/shared/briefings/use-selection.ts
@@ -3,12 +3,34 @@
 import { useEffect, useState } from 'react'
 import { resolveSelection, type ResolvedAnchor } from './anchorResolver'
 
+// On touch devices, iOS shows its "edit menu" (Copy / Look Up / Share /
+// etc.) any time the document carries a non-empty selection. Suppressing
+// the long-press callout via `-webkit-touch-callout: none` doesn't help
+// here — that property only covers the long-press fallback, not the
+// menu that follows a drag-select. The only reliable way to dismiss it
+// while preserving our own HighlightToolbar is to capture the anchor
+// state from the selection, then clear the OS selection programmatically.
+//
+// `pendingClearUntil` is a short timestamp window during which we ignore
+// the resulting `selectionchange(null)` events so our captured anchor
+// survives. The window is intentionally short — long enough to absorb
+// browser-level event jitter, short enough that a follow-up user action
+// (new selection, dismiss) isn't suppressed.
+const PROGRAMMATIC_CLEAR_WINDOW_MS = 200
+
 /**
- * Hook that watches the document selection and resolves it into a briefing
- * anchor when the user highlights text inside an element carrying
- * `data-briefing-json-path`.
+ * Hook that watches the document selection and resolves it into a
+ * briefing anchor when the user highlights text inside an element
+ * carrying `data-briefing-json-path`.
  *
- * Returns the resolved anchor, or null if there is no valid selection.
+ * On touch devices the hook also clears the native selection right
+ * after capturing the anchor — that's what suppresses the iOS edit
+ * menu. The toolbar continues to render because the captured anchor is
+ * held in React state, independent of the live `Selection` object.
+ *
+ * The X dismiss in HighlightToolbar must call into here to actually
+ * reset state, not just `removeAllRanges()` — see the dispatched
+ * `selectionchange` event in HighlightToolbar.dismiss for the wire-up.
  */
 export function useSelection(): ResolvedAnchor | null {
   const [anchor, setAnchor] = useState<ResolvedAnchor | null>(null)
@@ -16,18 +38,38 @@ export function useSelection(): ResolvedAnchor | null {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
+    let pendingClearUntil = 0
+
     function update() {
+      // While we're inside the programmatic-clear window, ignore any
+      // `selectionchange(null)` echoes. The captured anchor must
+      // survive so the HighlightToolbar stays mounted.
+      if (Date.now() < pendingClearUntil) return
       const sel = window.getSelection()
       setAnchor(resolveSelection(sel))
+    }
+
+    function captureAndClearForTouch() {
+      const sel = window.getSelection()
+      const next = resolveSelection(sel)
+      if (!next) return
+      setAnchor(next)
+      pendingClearUntil = Date.now() + PROGRAMMATIC_CLEAR_WINDOW_MS
+      sel?.removeAllRanges()
     }
 
     document.addEventListener('selectionchange', update)
     document.addEventListener('mouseup', update)
     document.addEventListener('keyup', update)
+    // Touch-only path: after the gesture lifts, capture the anchor and
+    // wipe the OS selection. Desktop keeps the legacy mouseup path so
+    // dragging to read/measure still leaves the selection visible.
+    document.addEventListener('touchend', captureAndClearForTouch)
     return () => {
       document.removeEventListener('selectionchange', update)
       document.removeEventListener('mouseup', update)
       document.removeEventListener('keyup', update)
+      document.removeEventListener('touchend', captureAndClearForTouch)
     }
   }, [])
 

--- a/app/shared/briefings/use-selection.ts
+++ b/app/shared/briefings/use-selection.ts
@@ -3,41 +3,18 @@
 import { useEffect, useState } from 'react'
 import { resolveSelection, type ResolvedAnchor } from './anchorResolver'
 
-// iOS Safari shows its system edit menu (Copy / Look Up / Share / etc.)
-// as long as the document carries a non-empty selection. `-webkit-touch
-// -callout: none` only blocks the long-press callout fallback, not the
-// post-selection menu; clearing the selection on `touchend` is too late
-// because iOS shows the menu as soon as the first `selectionchange`
-// event lands. The only reliable way to keep the menu suppressed while
-// still acting on the user's selection is to capture the anchor into
-// React state on the very first `selectionchange` and clear the native
-// selection in the same tick. iOS never gets a window where it could
-// render its menu.
-//
-// Side effect: the user can't drag iOS's selection handles to extend the
-// initial word, because the native selection is gone immediately. They
-// must re-select to pick a different range — an acceptable trade-off
-// for an exclusive briefing toolbar on touch devices.
-const PROGRAMMATIC_CLEAR_WINDOW_MS = 200
-
 /**
- * Hook that watches the document selection and resolves it into a
- * briefing anchor when the user highlights text inside an element
- * carrying `data-briefing-json-path`.
+ * Hook that watches the document selection and resolves it into a briefing
+ * anchor when the user highlights text inside an element carrying
+ * `data-briefing-json-path`.
  *
- * Two paths, branched on the device's input primary:
- *   - Touch (hover:none + pointer:coarse): capture-and-clear on every
- *     `selectionchange`. The captured anchor stays in React state so
- *     the HighlightToolbar still renders; iOS never has a live
- *     selection long enough to show its system menu.
- *   - Mouse/desktop: legacy behavior — track the live selection via
- *     `selectionchange` / `mouseup` / `keyup`. The visible OS selection
- *     stays (useful for drag-to-read), and the system context menu on
- *     right-click is suppressed elsewhere via a contextmenu listener.
+ * Returns the resolved anchor, or null if there is no valid selection.
  *
- * The X dismiss in HighlightToolbar must dispatch a synthetic
- * `selectionchange` event so this hook drops state when the native
- * selection is already empty (which it is, post-capture on touch).
+ * Note on iOS Safari's selection menu: there's no DOM API to suppress
+ * the post-selection edit menu while keeping the native drag handles
+ * working — both are tied to the live Selection. We accept that the
+ * iOS menu may appear alongside our HighlightToolbar; the trade-off is
+ * preserving the native drag-to-extend gesture that users expect.
  */
 export function useSelection(): ResolvedAnchor | null {
   const [anchor, setAnchor] = useState<ResolvedAnchor | null>(null)
@@ -45,43 +22,15 @@ export function useSelection(): ResolvedAnchor | null {
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    const isTouchPrimary = window.matchMedia(
-      '(hover: none) and (pointer: coarse)',
-    ).matches
-    let pendingClearUntil = 0
-
     function update() {
-      // While inside the programmatic-clear window, ignore `selection
-      // change(null)` echoes from our own `removeAllRanges` call. The
-      // captured anchor must survive so the HighlightToolbar stays.
-      if (Date.now() < pendingClearUntil) return
       const sel = window.getSelection()
       setAnchor(resolveSelection(sel))
     }
 
-    function captureAndClear() {
-      const sel = window.getSelection()
-      const next = resolveSelection(sel)
-      if (!next) return
-      setAnchor(next)
-      pendingClearUntil = Date.now() + PROGRAMMATIC_CLEAR_WINDOW_MS
-      sel?.removeAllRanges()
-    }
-
-    if (isTouchPrimary) {
-      // Order matters: the eager capture-and-clear runs first, then the
-      // suppression window blocks the `update` echo. addEventListener
-      // dispatches in registration order, so we register the capturer
-      // before the consumer.
-      document.addEventListener('selectionchange', captureAndClear)
-      document.addEventListener('selectionchange', update)
-    } else {
-      document.addEventListener('selectionchange', update)
-      document.addEventListener('mouseup', update)
-      document.addEventListener('keyup', update)
-    }
+    document.addEventListener('selectionchange', update)
+    document.addEventListener('mouseup', update)
+    document.addEventListener('keyup', update)
     return () => {
-      document.removeEventListener('selectionchange', captureAndClear)
       document.removeEventListener('selectionchange', update)
       document.removeEventListener('mouseup', update)
       document.removeEventListener('keyup', update)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how new notes are anchored and which existing notes appear in the UI; legacy null-jsonPath notes are no longer visible without migration.
> 
> **Overview**
> Briefing detail now tracks an **active card** (Executive Summary or an agenda item) shared via `AnnotationsScope`. Cards are clickable with a focus ring; the sidebar TOC and new **`ActiveCardScrollSpy`** keep the highlight aligned with scroll and navigation. Header and mobile actions switch from opening the notes list to **Add note**, which attaches notes to the active card and is disabled until a card is active.
> 
> **Card-level notes** use canonical `jsonPath` values (`/executiveSummary`, `/items/{index}`) with null `start`/`end`. Saving from Add note without a text selection resolves the anchor to the active card. If that card already has a card-level note, Add note opens the notes cycler on it. **`CardLevelNotesList`** shows those notes inline on each card; Add note sheet copy is **Note on {title}** instead of briefing-wide messaging, and the old top-level note list in the sheet is removed.
> 
> Legacy notes with `jsonPath === null` are **hidden** from counts, surfaces, and inline UI but remain in the database. Shared route helpers and `data-briefing-json-path` on card roots support cycler ordering and anchoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d9a2a31879365d0e880a3ad5e3b9a23db2bc2c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->