### PR TITLE
fix(briefings): sort executive summary items by agenda order

### DIFF
--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -60,6 +60,7 @@ export default async function Page({
       <TrackBriefingViewed briefingId={slug} />
       <ExecutiveSummaryCard
         summary={briefing.executive_summary}
+        agendaItemIds={briefing.items.map((item) => item.id)}
         domId={BRIEFING_EXECUTIVE_SUMMARY_DOM_ID}
         speechText={speechText}
         analyticsLabel="briefing"

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -12,6 +12,13 @@ import ReadAloudButton from './ReadAloudButton'
 
 type Props = {
   summary: MeetingBriefingOutput['executive_summary']
+  /**
+   * Ordered list of agenda item ids from the top-level `items[]`. Used to
+   * sort the executive summary's items into agenda order — the upstream
+   * generator is supposed to emit them in that order already, but in
+   * practice sometimes returns them out of sequence.
+   */
+  agendaItemIds: string[]
   domId: string
   /**
    * Pre-rendered plain-text version of the briefing for the speech
@@ -44,6 +51,7 @@ const onJump = (
  */
 export default function ExecutiveSummaryCard({
   summary,
+  agendaItemIds,
   domId,
   speechText,
   analyticsLabel,
@@ -56,6 +64,15 @@ export default function ExecutiveSummaryCard({
       jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
       titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
       title: 'Executive Summary',
+    })
+  const orderIndex = new Map(agendaItemIds.map((id, i) => [id, i]))
+  const orderedItems = summary.items
+    .map((item, originalIndex) => ({ item, originalIndex }))
+    .sort((a, b) => {
+      const ai = orderIndex.get(a.item.item_id) ?? Number.MAX_SAFE_INTEGER
+      const bi = orderIndex.get(b.item.item_id) ?? Number.MAX_SAFE_INTEGER
+      if (ai !== bi) return ai - bi
+      return a.originalIndex - b.originalIndex
     })
   return (
     <article
@@ -92,15 +109,15 @@ export default function ExecutiveSummaryCard({
       >
         {summary.lead_in}
       </p>
-      {summary.items.length > 0 ? (
+      {orderedItems.length > 0 ? (
         <ul className="list-disc! flex flex-col gap-2 pl-5 text-sm leading-6">
-          {summary.items.map((item, i) => {
+          {orderedItems.map(({ item, originalIndex }) => {
             const itemDomId = briefingItemDomId(item.item_id)
             return (
               <li
                 key={item.item_id}
                 className="list-item!"
-                data-briefing-json-path={`/executive_summary/items/${i}`}
+                data-briefing-json-path={`/executive_summary/items/${originalIndex}`}
               >
                 <a
                   href={`#${itemDomId}`}


### PR DESCRIPTION
## Summary

We've seen briefings render with executive-summary items out of sequence relative to their agenda position. The generator contract requires them to be in agenda order, but the data isn't reliably matching that — this is a defensive client-side sort so users see a coherent order regardless of what the generator emits.

The sort is keyed off each summary item's `item_id` and its position in top-level `briefing.items`. Items with no matching agenda entry fall to the end in their original order. Original JSON-path indices are preserved on `data-briefing-json-path` so the annotation/selection layer continues to resolve correctly.

Worth investigating upstream too — this fix masks the symptom but the generator should still emit in-order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only ordering on the briefing detail page with stable annotation paths; no auth, API, or data persistence changes.
> 
> **Overview**
> Executive summary bullets on the briefing detail page are now **sorted to match agenda item order** from `briefing.items`, instead of trusting the generator’s order when it comes back wrong.
> 
> The page passes **`agendaItemIds`** into `ExecutiveSummaryCard`, which builds a position map and sorts summary rows by `item_id`. Unknown ids stay at the end in their original order. **`data-briefing-json-path`** still uses each row’s **original index** in the payload so annotations and selection keep pointing at the right JSON paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b7ba570fdbf595e624538a594af51c489c74db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->