### PR TITLE
fix(briefings): force PDF download instead of inline open

### DIFF
--- a/app/dashboard/briefings/components/detail/ShareBriefingDrawer.test.tsx
+++ b/app/dashboard/briefings/components/detail/ShareBriefingDrawer.test.tsx
@@ -90,7 +90,7 @@ describe('<ShareBriefingDrawer>', () => {
       screen.getByRole('link', { name: /share via message/i }),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('link', { name: /download pdf/i }),
+      screen.getByRole('button', { name: /download pdf/i }),
     ).toBeInTheDocument()
   })
 
@@ -123,11 +123,31 @@ describe('<ShareBriefingDrawer>', () => {
     )
   })
 
-  it('Download button links to the same share URL with the download hint', () => {
+  it('Download button fetches the share URL and triggers a save-as via a blob', async () => {
+    // gp-api serves the PDF with `Content-Disposition: inline`, which makes
+    // `<a download>` unreliable across browsers. The drawer fetches the
+    // bytes and triggers a download against an object URL instead.
+    const pdfBytes = new Uint8Array([1, 2, 3])
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob([pdfBytes], { type: 'application/pdf' }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:mock-url')
+    const revokeObjectURL = vi
+      .spyOn(URL, 'revokeObjectURL')
+      .mockReturnValue(undefined)
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click')
+
     renderOpen()
-    const download = screen.getByRole('link', { name: /download pdf/i })
-    expect(download.getAttribute('href')).toBe(SHARE_URL)
-    expect(download.hasAttribute('download')).toBe(true)
+    await userEvent.click(screen.getByRole('button', { name: /download pdf/i }))
+
+    expect(fetchMock).toHaveBeenCalledWith(SHARE_URL, expect.any(Object))
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
   })
 
   it('Copy link writes the share URL to the clipboard', async () => {

--- a/app/dashboard/briefings/components/detail/ShareBriefingDrawer.tsx
+++ b/app/dashboard/briefings/components/detail/ShareBriefingDrawer.tsx
@@ -143,6 +143,30 @@ export default function ShareBriefingDrawer({
     }, COPIED_FEEDBACK_MS)
   }, [writeClipboard])
 
+  // A plain `<a href={pdfUrl} download>` is unreliable here: gp-api serves
+  // the PDF with `Content-Disposition: inline`, and browsers — especially
+  // Chrome with its built-in PDF viewer — frequently ignore the `download`
+  // hint and open the file inline instead. Fetching the bytes and
+  // triggering a download against a blob URL forces save-as behavior
+  // regardless of the server's disposition header.
+  const onDownload = useCallback(async () => {
+    try {
+      const res = await fetch(shareUrl, { credentials: 'include' })
+      if (!res.ok) return
+      const blob = await res.blob()
+      const objectUrl = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = objectUrl
+      anchor.download = `${briefing.title || 'briefing'}.pdf`
+      document.body.appendChild(anchor)
+      anchor.click()
+      anchor.remove()
+      URL.revokeObjectURL(objectUrl)
+    } catch {
+      // Network/parse failures leave the UI unchanged; the user can retry.
+    }
+  }, [shareUrl, briefing.title])
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -183,13 +207,12 @@ export default function ShareBriefingDrawer({
             </a>
           </ShareAction>
 
-          <ShareAction asChild label="Download" ariaLabel="Download PDF">
-            {/* `download` hints the browser to save the file; the server
-                sends `Content-Disposition: inline` so a non-saving open
-                in a new tab also works fine. */}
-            <a href={shareUrl} download>
-              <DownloadIcon className="size-5" aria-hidden />
-            </a>
+          <ShareAction
+            label="Download"
+            ariaLabel="Download PDF"
+            onClick={onDownload}
+          >
+            <DownloadIcon className="size-5" aria-hidden />
           </ShareAction>
         </div>
 


### PR DESCRIPTION
## Summary

The Download button in the briefing share drawer was navigating the current tab to the PDF viewer instead of saving the file.

The button was a plain `<a href={pdfUrl} download>`. Browsers — especially Chrome with its built-in PDF viewer — ignore the `download` attribute when the server sends `Content-Disposition: inline`, which gp-api does on this endpoint (so that Email / Message recipients can preview before downloading). The `download` hint was load-bearing for the button but unreliable.

Fix: fetch the PDF as a blob and trigger a programmatic download against an object URL. This forces save-as regardless of the server's disposition header, and lets us name the file after the briefing instead of dropping the user with a bare UUID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX fix in the share drawer; uses the same authenticated share URL with silent failure on fetch errors.
> 
> **Overview**
> The briefing share drawer’s **Download** action no longer uses a plain `<a download>` link to the public PDF URL. It now **fetches the PDF with credentials**, builds a blob URL, and triggers a programmatic save so browsers respect save-as even when gp-api returns `Content-Disposition: inline` (which was causing inline PDF viewing, especially in Chrome).
> 
> Saved files are named from the briefing title (e.g. `City Council….pdf`) instead of relying on the server’s default filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a36d8728f5db479f4d37408ba4053ccd980de9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->