### PR TITLE
feat(dashboard): rename Meetings to Briefing Assistant, show page title in mobile header

### DIFF
--- a/app/dashboard/shared/DashboardLayout.tsx
+++ b/app/dashboard/shared/DashboardLayout.tsx
@@ -104,7 +104,10 @@ const MOBILE_PAGE_TITLES: Array<[string, string]> = [
   ['/dashboard/briefings', 'Briefing Assistant'],
   ['/dashboard/outreach', 'Voter Outreach'],
   ['/dashboard/voter-records', 'Voter Data'],
-  ['/dashboard/contacts', 'Contacts'],
+  // Sidebar renders this item's `v2Name` ("Constituents") in place of its
+  // `label` ("Contacts") via `item.v2Name || label`. Keep the mobile title
+  // in sync so the same page reads the same name in both surfaces.
+  ['/dashboard/contacts', 'Constituents'],
   ['/dashboard/polls', 'Polls'],
   ['/dashboard/website', 'Website'],
   ['/dashboard/campaign-details', 'My Profile'],

--- a/app/dashboard/shared/DashboardLayout.tsx
+++ b/app/dashboard/shared/DashboardLayout.tsx
@@ -100,18 +100,48 @@ const DashboardLayout = ({
   )
 }
 
+const MOBILE_PAGE_TITLES: Array<[string, string]> = [
+  ['/dashboard/briefings', 'Briefing Assistant'],
+  ['/dashboard/outreach', 'Voter Outreach'],
+  ['/dashboard/voter-records', 'Voter Data'],
+  ['/dashboard/contacts', 'Contacts'],
+  ['/dashboard/polls', 'Polls'],
+  ['/dashboard/website', 'Website'],
+  ['/dashboard/campaign-details', 'My Profile'],
+  ['/dashboard/campaign-assistant', 'AI Assistant'],
+  ['/dashboard/content', 'Content Builder'],
+  ['/dashboard/door-knocking', 'Door Knocking'],
+]
+
+const getMobilePageTitle = (pathname: string | null): string | null => {
+  if (!pathname) return null
+  for (const [prefix, title] of MOBILE_PAGE_TITLES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) return title
+  }
+  return null
+}
+
 const MobileMenuTrigger = () => {
   const { setOpenMobile, openMobile } = useSidebar()
+  const pathname = usePathname()
+  const pageTitle = getMobilePageTitle(pathname)
   return (
     <>
       <div className="flex lg:hidden items-center justify-between h-16 px-4 bg-sidebar border-b border-sidebar-border">
-        <Link href="/dashboard">
-          <img
-            src="/images/logo/heart.svg"
-            alt="GoodParty.org"
-            className="h-6 w-8 object-contain"
-          />
-        </Link>
+        <div className="flex items-center gap-3 min-w-0">
+          <Link href="/dashboard" className="shrink-0">
+            <img
+              src="/images/logo/heart.svg"
+              alt="GoodParty.org"
+              className="h-6 w-8 object-contain"
+            />
+          </Link>
+          {pageTitle && (
+            <h1 className="truncate text-base font-semibold text-foreground">
+              {pageTitle}
+            </h1>
+          )}
+        </div>
         <button
           data-testid="mobile-menu-trigger"
           onClick={() => setOpenMobile(true)}

--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -211,7 +211,7 @@ const POLLS_MENU_ITEM: MenuItem = {
 
 const BRIEFINGS_MENU_ITEM: MenuItem = {
   id: 'briefings-dashboard',
-  label: 'Meetings',
+  label: 'Briefing Assistant',
   link: '/dashboard/briefings',
   icon: <MdFactCheck />,
   v2Icon: ClipboardList,


### PR DESCRIPTION
## Summary

Two changes to the dashboard chrome, both from the lovable mock at https://joy-nav-garden.lovable.app/briefings/town-hall:

1. **Sidebar entry rename**: \"Meetings\" → \"Briefing Assistant\". The surface is the AI-driven prep/notes layer over each meeting, not a generic meetings listing — the new name reflects that.
2. **Mobile page title**: the mobile header previously rendered logo + hamburger only, so any sub-route felt context-free. Show the current page title between the logo and the hamburger so the user has the same \"you are here\" cue the desktop sidebar provides.

Pages are mapped by path prefix in a small table colocated with the mobile header. Routes that don't match the table fall back to the original logo-only layout, so this can't break unfamiliar pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation and header copy; no auth, data, or API changes.
> 
> **Overview**
> Renames the elected-office sidebar entry from **Meetings** to **Briefing Assistant** so the nav matches the briefings product.
> 
> On **mobile** (`lg` hidden header), adds a path-prefix map and shows a truncated page title next to the logo for major dashboard routes (including Briefing Assistant); unmapped routes keep the logo-only header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f28043ec30c65fb795e8b1cd3ec76909e593f0c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->