### PR TITLE
fix(briefings): lock scrollspy during TOC-click smooth-scroll

### DIFF
--- a/app/dashboard/briefings/[slug]/layout.tsx
+++ b/app/dashboard/briefings/[slug]/layout.tsx
@@ -93,7 +93,12 @@ export default async function BriefingChromeLayout({
                     // equivalent web API; its floating selection action
                     // bar still appears.
                     style={{ WebkitTouchCallout: 'none' }}
-                    className="flex flex-col gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto"
+                    // `lg:p-0.5` leaves room for the active card's
+                    // `ring-2` highlight. Without it `overflow-y: auto`
+                    // forces `overflow-x: auto` (per CSS spec) and the
+                    // ring renders clipped against the pane's left/right
+                    // edges.
+                    className="flex flex-col gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:p-0.5"
                   >
                     {children}
                   </div>

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -96,6 +96,11 @@ export default function ActiveCardScrollSpy({
   const lastSpyPickKeyRef = useRef<string | null>(null)
   const isLockedRef = useRef(false)
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Key whose external set triggered the current lock. Used by the safety
+  // timer to distinguish "smooth-scroll completed" (scroll events arrived,
+  // viewport moved) from "no scroll happened at all" (card body click on
+  // an already-visible card).
+  const lockedForKeyRef = useRef<string | null>(null)
   // The scroll-watch effect publishes its `pick` function here so the
   // lock release path can run a final pick to sync the highlight to the
   // actual landed scroll position.
@@ -118,10 +123,17 @@ export default function ActiveCardScrollSpy({
     if (!activeCard) return
     if (activeCard.key === lastSpyPickKeyRef.current) return
     isLockedRef.current = true
+    lockedForKeyRef.current = activeCard.key
     if (lockTimerRef.current !== null) clearTimeout(lockTimerRef.current)
     lockTimerRef.current = setTimeout(() => {
       isLockedRef.current = false
       lockTimerRef.current = null
+      // Skip the reconcile pick if the active card is still the one that
+      // triggered the lock — no scroll events arrived (e.g. a card body
+      // click on an already-visible card), so the user's selection is
+      // the definitive state and running pick() would overwrite it with
+      // the spy's scroll-position guess.
+      if (activeKeyRef.current === lockedForKeyRef.current) return
       runPickRef.current?.()
     }, LOCK_MAX_MS)
   }, [activeCard])

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -34,6 +34,18 @@ const ACTIVE_LINE_FRACTION = 0.35
 // so the active line lands inside the visible briefing content.
 const MOBILE_HEADER_BAND = 88
 
+// Once an external `setActiveCard` fires (TOC click, card body click), the
+// spy locks itself off while the smooth-scroll plays out so its
+// scroll-driven picks don't fight the user's destination. A single
+// timer governs the lock lifecycle:
+//   - Set to LOCK_MAX_MS at lock activation. This is the safety net for
+//     the "destination already in view, no scroll events fire" case.
+//   - Reset to SCROLL_SETTLE_MS on every scroll event during the lock.
+//     Once scroll events stop arriving for SCROLL_SETTLE_MS, the
+//     programmatic smooth-scroll has finished and the lock releases.
+const SCROLL_SETTLE_MS = 200
+const LOCK_MAX_MS = 1500
+
 /**
  * Watches the briefing scroll container and updates `activeCard` to
  * whichever card is currently at the top of the viewport. Pure side
@@ -41,8 +53,9 @@ const MOBILE_HEADER_BAND = 88
  * briefing items in so we can address them by domId / jsonPath.
  *
  * The spy intentionally does NOT scroll; it only reads scroll position.
- * Activation via card click and legend click stays in those components
- * and continues to work — the spy then takes over as the user scrolls.
+ * Activation via TOC click and card click sets `activeCard` directly and
+ * the spy backs off for the duration of the smooth-scroll so it doesn't
+ * rewind the highlight to the card currently at the active line.
  */
 export default function ActiveCardScrollSpy({
   items,
@@ -78,6 +91,41 @@ export default function ActiveCardScrollSpy({
     activeKeyRef.current = activeCard?.key ?? null
   }, [activeCard])
 
+  // Lock state shared between the activation effect (below) and the
+  // scroll-watch effect (further down).
+  const lastSpyPickKeyRef = useRef<string | null>(null)
+  const isLockedRef = useRef(false)
+  const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The scroll-watch effect publishes its `pick` function here so the
+  // lock release path can run a final pick to sync the highlight to the
+  // actual landed scroll position.
+  const runPickRef = useRef<(() => void) | null>(null)
+
+  // Activate the lock whenever `activeCard` changes to a key the spy
+  // didn't dispatch itself. Start the safety timer immediately so the
+  // lock releases even if no scroll events ever arrive (e.g. clicking a
+  // TOC entry whose target is already in view).
+  //
+  // First run is treated as "the spy already agrees" so an initial
+  // hash-deep-link doesn't suppress the mount-time sync pick.
+  const hasInitedActiveSyncRef = useRef(false)
+  useEffect(() => {
+    if (!hasInitedActiveSyncRef.current) {
+      hasInitedActiveSyncRef.current = true
+      lastSpyPickKeyRef.current = activeCard?.key ?? null
+      return
+    }
+    if (!activeCard) return
+    if (activeCard.key === lastSpyPickKeyRef.current) return
+    isLockedRef.current = true
+    if (lockTimerRef.current !== null) clearTimeout(lockTimerRef.current)
+    lockTimerRef.current = setTimeout(() => {
+      isLockedRef.current = false
+      lockTimerRef.current = null
+      runPickRef.current?.()
+    }, LOCK_MAX_MS)
+  }, [activeCard])
+
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (entries.length === 0) return
@@ -87,6 +135,7 @@ export default function ActiveCardScrollSpy({
 
     function pick() {
       raf = 0
+      if (isLockedRef.current) return
       const paneScrolls =
         !!pane && window.matchMedia('(min-width: 1024px)').matches
       const containerRect = paneScrolls
@@ -121,6 +170,7 @@ export default function ActiveCardScrollSpy({
       if (bestKey === null || bestKey === activeKeyRef.current) return
       const matched = entries.find((e) => e.key === bestKey)
       if (!matched) return
+      lastSpyPickKeyRef.current = matched.key
       setActiveCard({
         key: matched.key,
         jsonPath: matched.jsonPath,
@@ -129,7 +179,26 @@ export default function ActiveCardScrollSpy({
       })
     }
 
+    runPickRef.current = () => {
+      if (raf === 0) raf = requestAnimationFrame(pick)
+    }
+
     function onScroll() {
+      if (isLockedRef.current) {
+        // While locked, scroll events restart the timer with the shorter
+        // settle window. The lock releases SCROLL_SETTLE_MS after the
+        // last scroll event — i.e. once the programmatic smooth-scroll
+        // has finished. The original LOCK_MAX_MS countdown was a safety
+        // net for the no-scroll-events case; once scrolls start arriving
+        // we can use a tighter bound.
+        if (lockTimerRef.current !== null) clearTimeout(lockTimerRef.current)
+        lockTimerRef.current = setTimeout(() => {
+          isLockedRef.current = false
+          lockTimerRef.current = null
+          if (raf === 0) raf = requestAnimationFrame(pick)
+        }, SCROLL_SETTLE_MS)
+        return
+      }
       if (raf === 0) raf = requestAnimationFrame(pick)
     }
 
@@ -152,6 +221,7 @@ export default function ActiveCardScrollSpy({
       window.removeEventListener('resize', onScroll)
       pane?.removeEventListener('scroll', onScroll)
       if (raf !== 0) cancelAnimationFrame(raf)
+      runPickRef.current = null
     }
   }, [entries, setActiveCard])
 

--- a/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
+++ b/app/dashboard/briefings/components/detail/ActiveCardScrollSpy.tsx
@@ -203,8 +203,17 @@ export default function ActiveCardScrollSpy({
         // has finished. The original LOCK_MAX_MS countdown was a safety
         // net for the no-scroll-events case; once scrolls start arriving
         // we can use a tighter bound.
+        //
+        // Snapshot the lock-triggering key so a click that happens mid-
+        // scroll (which updates `lockedForKeyRef` to the new key and
+        // re-arms the activation-effect's safety timer) isn't undone
+        // when the OLD click's tail scroll-events finally settle. Without
+        // this guard, the stale settle callback would release the lock
+        // and run pick() while the new click's scroll is still playing.
+        const keyAtScrollEvent = lockedForKeyRef.current
         if (lockTimerRef.current !== null) clearTimeout(lockTimerRef.current)
         lockTimerRef.current = setTimeout(() => {
+          if (lockedForKeyRef.current !== keyAtScrollEvent) return
           isLockedRef.current = false
           lockTimerRef.current = null
           if (raf === 0) raf = requestAnimationFrame(pick)

--- a/app/dashboard/briefings/components/detail/DetailToc.tsx
+++ b/app/dashboard/briefings/components/detail/DetailToc.tsx
@@ -29,15 +29,16 @@ type Entry = {
  * Sidebar TOC. All agenda items render inline on the briefing detail
  * page, so the TOC scrolls within the page rather than navigating.
  *
- * The active entry is owned by `ActiveCardScrollSpy`, which tracks scroll
- * position. Clicking an entry only triggers the smooth-scroll — the spy
- * updates the highlight as the page passes each card on the way down.
+ * Clicking an entry immediately marks it active and starts the
+ * smooth-scroll. `ActiveCardScrollSpy` detects the external set, locks
+ * itself off so the spy doesn't fight the click destination during the
+ * scroll, and resumes scroll-driven updates once the scroll settles.
  */
 export default function DetailToc({
   briefingSlug,
   items,
 }: Props): React.JSX.Element {
-  const { activeCard } = useAnnotationsCtx()
+  const { activeCard, setActiveCard } = useAnnotationsCtx()
 
   const entries: Entry[] = useMemo(() => {
     const list: Entry[] = [
@@ -64,12 +65,16 @@ export default function DetailToc({
   function onJump(e: React.MouseEvent<HTMLAnchorElement>, entry: Entry) {
     if (typeof window === 'undefined') return
     e.preventDefault()
-    // Don't preemptively mark the destination as active. The scrollspy
-    // updates `activeCard` as the smooth-scroll passes each card, so an
-    // up-front `setActiveCard` would only flash the destination as active
-    // for one frame before the spy rewinds the highlight back to the card
-    // currently at the active line. Letting the spy own the transition
-    // produces a single continuous scroll-through highlight.
+    // Set active immediately so the highlight tracks user intent. The
+    // scrollspy detects an external set and locks during the smooth-
+    // scroll so it doesn't fight back as the page passes intermediate
+    // cards.
+    setActiveCard({
+      key: entry.key,
+      jsonPath: entry.jsonPath,
+      titleJsonPath: entry.titleJsonPath,
+      title: entry.label,
+    })
     const target = document.getElementById(entry.domId)
     if (target) {
       target.scrollIntoView({ behavior: 'smooth', block: 'start' })


### PR DESCRIPTION
## Summary

Two prior attempts at fixing the TOC-click highlight behavior altered the scrollspy's active-line algorithm. Each introduced its own regressions. Switching to a simple lock-based approach instead.

## How it works

TOC click now sets `activeCard` immediately (highlighting the clicked entry) and the scrollspy detects the external set and stops updating for the duration of the smooth-scroll. A single timer governs the lock lifecycle:

- Set to **1.5s** on activation so the lock releases even if no scroll events ever arrive (e.g. clicking a card already in view).
- Reset to **200ms** on each scroll event. The lock releases 200ms after the last scroll event — i.e. once the programmatic smooth-scroll has finished.

On release, a final \`pick()\` runs so the highlight syncs to wherever the page actually landed — covers the case where the document bottomed out before the click target reached the active line.

Initial mount is treated as \"the spy already agrees\" so a hash-deep-link doesn't suppress the mount-time sync pick.

## Also included

The ring-clip fix from the prior revision: \`lg:p-0.5\` on the scroll pane prevents \`overflow-y: auto\` (which implicitly clips horizontally per CSS spec) from cropping the active card's 2px outset ring.