### PR TITLE
feat(briefings): popover composer for thumbs-down agenda-item feedback

### DIFF
--- a/app/dashboard/briefings/components/detail/FeedbackRow.test.tsx
+++ b/app/dashboard/briefings/components/detail/FeedbackRow.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import FeedbackRow from './FeedbackRow'
+
+// Stub the hook so the test can drive setFeedback / clearFeedback without
+// the real React Query mutation lifecycle. Each test recreates `current`
+// via `feedbackByItemId` to mirror what the hook would return after the
+// optimistic update fires.
+const setFeedbackMock = vi.fn()
+const clearFeedbackMock = vi.fn()
+let mockState: {
+  feedbackByItemId: Record<string, 'positive' | 'negative' | undefined>
+  commentByItemId: Record<string, string | null | undefined>
+} = {
+  feedbackByItemId: {},
+  commentByItemId: {},
+}
+
+vi.mock('@shared/briefings/use-briefing-feedback', () => ({
+  useBriefingFeedback: () => ({
+    feedbackByItemId: mockState.feedbackByItemId,
+    commentByItemId: mockState.commentByItemId,
+    isLoading: false,
+    setFeedback: setFeedbackMock,
+    clearFeedback: clearFeedbackMock,
+  }),
+}))
+
+const MEETING_DATE = '2026-06-08'
+const ITEM_ID = 'item_alpha'
+
+beforeEach(() => {
+  setFeedbackMock.mockReset()
+  clearFeedbackMock.mockReset()
+  mockState = { feedbackByItemId: {}, commentByItemId: {} }
+})
+
+describe('<FeedbackRow> thumbs-up path', () => {
+  it('clicking thumbs-up sets positive without opening the composer', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^yes$/i }))
+
+    expect(setFeedbackMock).toHaveBeenCalledWith(ITEM_ID, 'positive')
+    // Composer should never render for a positive vote.
+    expect(
+      screen.queryByPlaceholderText(/tell us what was off/i),
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('<FeedbackRow> thumbs-down composer', () => {
+  it('clicking thumbs-down sets negative immediately AND opens the composer', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+
+    expect(setFeedbackMock).toHaveBeenCalledWith(ITEM_ID, 'negative')
+    expect(setFeedbackMock).toHaveBeenCalledTimes(1)
+    // Composer is now open.
+    expect(
+      await screen.findByPlaceholderText(/tell us what was off/i),
+    ).toBeInTheDocument()
+  })
+
+  it('Save fires a second setFeedback call carrying the typed comment (trimmed)', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+    const textarea = await screen.findByPlaceholderText(/tell us what was off/i)
+    await user.type(textarea, '  the summary missed the rezoning  ')
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    // First call: the immediate vote (no comment).
+    expect(setFeedbackMock.mock.calls[0]).toEqual([ITEM_ID, 'negative'])
+    // Second call: the popover Save, with trimmed comment.
+    expect(setFeedbackMock.mock.calls[1]).toEqual([
+      ITEM_ID,
+      'negative',
+      'the summary missed the rezoning',
+    ])
+    // Composer closes after Save.
+    expect(
+      screen.queryByPlaceholderText(/tell us what was off/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Save with an empty / whitespace-only textarea sends null (clear)', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+    await screen.findByPlaceholderText(/tell us what was off/i)
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(setFeedbackMock.mock.calls[1]).toEqual([ITEM_ID, 'negative', null])
+  })
+
+  it('"Not now" closes the composer without a second setFeedback call', async () => {
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+    await screen.findByPlaceholderText(/tell us what was off/i)
+    await user.click(screen.getByRole('button', { name: /not now/i }))
+
+    expect(setFeedbackMock).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByPlaceholderText(/tell us what was off/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it('prefills the textarea with a previously-stored comment when the user re-opens via thumbs-down', async () => {
+    mockState = {
+      feedbackByItemId: { [ITEM_ID]: undefined },
+      commentByItemId: { [ITEM_ID]: 'older note' },
+    }
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+    const textarea = (await screen.findByPlaceholderText(
+      /tell us what was off/i,
+    )) as HTMLTextAreaElement
+    expect(textarea.value).toBe('older note')
+  })
+
+  it('clicking thumbs-down while already negative clears the vote and does NOT open the composer', async () => {
+    mockState = {
+      feedbackByItemId: { [ITEM_ID]: 'negative' },
+      commentByItemId: { [ITEM_ID]: null },
+    }
+    const user = userEvent.setup()
+    render(<FeedbackRow meetingDate={MEETING_DATE} itemId={ITEM_ID} />)
+
+    await user.click(screen.getByRole('button', { name: /^no$/i }))
+
+    expect(clearFeedbackMock).toHaveBeenCalledWith(ITEM_ID)
+    expect(setFeedbackMock).not.toHaveBeenCalled()
+    expect(
+      screen.queryByPlaceholderText(/tell us what was off/i),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/briefings/components/detail/FeedbackRow.tsx
+++ b/app/dashboard/briefings/components/detail/FeedbackRow.tsx
@@ -1,7 +1,15 @@
 'use client'
 
+import { useState } from 'react'
 import { ThumbsUp, ThumbsDown } from 'lucide-react'
-import { IconButton } from '@styleguide'
+import {
+  Button,
+  IconButton,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  Textarea,
+} from '@styleguide'
 import { useBriefingFeedback } from '@shared/briefings/use-briefing-feedback'
 import type { ArtifactFeedbackKind } from '@shared/briefings/feedback-api'
 
@@ -10,20 +18,55 @@ type Props = {
   itemId: string
 }
 
+const COMMENT_MAX_CHARS = 2000
+
 export default function FeedbackRow({
   meetingDate,
   itemId,
 }: Props): React.JSX.Element {
-  const { feedbackByItemId, setFeedback, clearFeedback } =
+  const { feedbackByItemId, commentByItemId, setFeedback, clearFeedback } =
     useBriefingFeedback(meetingDate)
   const current = feedbackByItemId[itemId]
+
+  // Composer state. Opens automatically when the user transitions INTO
+  // 'negative' (so the optional "tell us why" prompt is right next to the
+  // click). Stays closed otherwise — re-clicking the thumb toggles the
+  // vote off, and clicking thumbs-up never opens the composer.
+  const [composerOpen, setComposerOpen] = useState(false)
+  const [draftComment, setDraftComment] = useState('')
 
   function vote(target: ArtifactFeedbackKind) {
     if (current === target) {
       clearFeedback(itemId)
-    } else {
-      setFeedback(itemId, target)
+      setComposerOpen(false)
+      return
     }
+    if (target === 'negative') {
+      // Cast the vote immediately so the row reflects the user's choice
+      // even if they dismiss the composer without saving.
+      setFeedback(itemId, target)
+      // Prefill from any previously-stored comment so the user can edit
+      // rather than retype. Empty string when there isn't one (also when
+      // the row was just optimistically created).
+      setDraftComment(commentByItemId[itemId] ?? '')
+      setComposerOpen(true)
+      return
+    }
+    setFeedback(itemId, target)
+  }
+
+  function saveComment() {
+    // Pass the trimmed string verbatim — empty string is a valid "clear"
+    // signal but the user can still close without saving to keep what's
+    // already stored.
+    const trimmed = draftComment.trim()
+    setFeedback(itemId, 'negative', trimmed.length === 0 ? null : trimmed)
+    setComposerOpen(false)
+  }
+
+  function dismissComposer(nextOpen: boolean) {
+    if (nextOpen) return
+    setComposerOpen(false)
   }
 
   return (
@@ -46,21 +89,61 @@ export default function FeedbackRow({
       >
         <ThumbsUp className="size-4" aria-hidden />
       </IconButton>
-      <IconButton
-        type="button"
-        size="small"
-        variant="ghost"
-        aria-label="No"
-        aria-pressed={current === 'negative'}
-        onClick={() => vote('negative')}
-        className={
-          current === 'negative'
-            ? 'text-destructive hover:text-destructive'
-            : 'text-muted-foreground hover:text-foreground'
-        }
-      >
-        <ThumbsDown className="size-4" aria-hidden />
-      </IconButton>
+      <Popover open={composerOpen} onOpenChange={dismissComposer}>
+        <PopoverAnchor asChild>
+          <IconButton
+            type="button"
+            size="small"
+            variant="ghost"
+            aria-label="No"
+            aria-pressed={current === 'negative'}
+            onClick={() => vote('negative')}
+            className={
+              current === 'negative'
+                ? 'text-destructive hover:text-destructive'
+                : 'text-muted-foreground hover:text-foreground'
+            }
+          >
+            <ThumbsDown className="size-4" aria-hidden />
+          </IconButton>
+        </PopoverAnchor>
+        <PopoverContent
+          align="end"
+          side="bottom"
+          className="flex w-80 flex-col gap-3 p-4"
+        >
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-foreground">
+              What was wrong?
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Optional — your note helps us improve the briefing.
+            </p>
+          </div>
+          <Textarea
+            value={draftComment}
+            onChange={(e) => setDraftComment(e.target.value)}
+            placeholder="Tell us what was off…"
+            rows={3}
+            maxLength={COMMENT_MAX_CHARS}
+            aria-label="Feedback comment"
+            className="resize-none"
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="link"
+              size="small"
+              onClick={() => setComposerOpen(false)}
+            >
+              Not now
+            </Button>
+            <Button type="button" size="small" onClick={saveComment}>
+              Save
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   )
 }

--- a/app/shared/briefings/feedback-api.ts
+++ b/app/shared/briefings/feedback-api.ts
@@ -12,6 +12,8 @@ export interface ArtifactFeedback {
   submitterUserId: number
   artifactId: string
   feedback: ArtifactFeedbackKind
+  /** Optional free-text the submitter attached. `null` if none. */
+  comment: string | null
   createdAt: string
   updatedAt: string
 }
@@ -23,6 +25,7 @@ function fromApi(row: ApiArtifactFeedback): ArtifactFeedback {
     submitterUserId: row.submitter_user_id,
     artifactId: row.artifact_id,
     feedback: row.feedback,
+    comment: row.comment,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -41,10 +44,19 @@ export const briefingFeedbackApi = {
     meetingDate: string,
     itemId: string,
     feedback: ArtifactFeedbackKind,
+    // `undefined` (the default) means "leave any existing comment alone".
+    // Pass `null` to clear, a string to set/replace. Mirrors the API
+    // contract: `comment` is optional on the request body.
+    comment?: string | null,
   ): Promise<ArtifactFeedback> {
     const res = await clientRequest(
       'PUT /v1/meetings/:date/briefing/items/:itemId/feedback',
-      { date: meetingDate, itemId, feedback },
+      {
+        date: meetingDate,
+        itemId,
+        feedback,
+        ...(comment === undefined ? {} : { comment }),
+      },
     )
     return fromApi(res.data)
   },

--- a/app/shared/briefings/use-briefing-feedback.test.tsx
+++ b/app/shared/briefings/use-briefing-feedback.test.tsx
@@ -42,6 +42,7 @@ const fakeRow = (overrides: Partial<ArtifactFeedback>): ArtifactFeedback => ({
   submitterUserId: 1,
   artifactId: ITEM_ID,
   feedback: 'positive',
+  comment: null,
   createdAt: '2026-06-08T00:00:00.000Z',
   updatedAt: '2026-06-08T00:00:00.000Z',
   ...overrides,
@@ -223,6 +224,157 @@ describe('useBriefingFeedback', () => {
     await waitFor(() =>
       expect(result.current.feedbackByItemId[ITEM_ID]).toBe('positive'),
     )
+  })
+
+  describe('comment plumbing', () => {
+    it('passes a string comment through to briefingFeedbackApi.set and reflects it in commentByItemId optimistically', async () => {
+      listMock.mockResolvedValue([
+        fakeRow({ id: 'srv-1', artifactId: ITEM_ID, feedback: 'negative' }),
+      ])
+      let resolveSet!: (row: ArtifactFeedback) => void
+      setMock.mockImplementation(
+        () =>
+          new Promise<ArtifactFeedback>((resolve) => {
+            resolveSet = resolve
+          }),
+      )
+
+      const qc = newClient()
+      const { result } = renderHook(() => useBriefingFeedback(MEETING_DATE), {
+        wrapper: wrapper(qc),
+      })
+      await waitFor(() =>
+        expect(result.current.feedbackByItemId[ITEM_ID]).toBe('negative'),
+      )
+
+      act(() => {
+        result.current.setFeedback(ITEM_ID, 'negative', 'missed the rezoning')
+      })
+
+      await waitFor(() =>
+        expect(result.current.commentByItemId[ITEM_ID]).toBe(
+          'missed the rezoning',
+        ),
+      )
+      expect(setMock).toHaveBeenCalledWith(
+        MEETING_DATE,
+        ITEM_ID,
+        'negative',
+        'missed the rezoning',
+      )
+
+      await act(async () => {
+        resolveSet(
+          fakeRow({
+            id: 'srv-1',
+            feedback: 'negative',
+            comment: 'missed the rezoning',
+          }),
+        )
+      })
+    })
+
+    it('preserves an existing comment when setFeedback is called without one (undefined)', async () => {
+      listMock.mockResolvedValue([
+        fakeRow({
+          id: 'srv-1',
+          artifactId: ITEM_ID,
+          feedback: 'negative',
+          comment: 'previously typed',
+        }),
+      ])
+      // Keep the mutation in flight so `onSettled` can't trigger a
+      // refetch that clobbers the optimistic state we're asserting on.
+      let resolveSet!: (row: ArtifactFeedback) => void
+      setMock.mockImplementation(
+        () =>
+          new Promise<ArtifactFeedback>((resolve) => {
+            resolveSet = resolve
+          }),
+      )
+
+      const qc = newClient()
+      const { result } = renderHook(() => useBriefingFeedback(MEETING_DATE), {
+        wrapper: wrapper(qc),
+      })
+      await waitFor(() =>
+        expect(result.current.commentByItemId[ITEM_ID]).toBe(
+          'previously typed',
+        ),
+      )
+
+      // Re-vote without a comment arg — the optimistic update must keep
+      // 'previously typed' visible.
+      act(() => {
+        result.current.setFeedback(ITEM_ID, 'negative')
+      })
+      await waitFor(() => expect(setMock).toHaveBeenCalledTimes(1))
+      expect(result.current.commentByItemId[ITEM_ID]).toBe('previously typed')
+      // The wire call must omit `comment` entirely (4th arg undefined).
+      expect(setMock).toHaveBeenLastCalledWith(
+        MEETING_DATE,
+        ITEM_ID,
+        'negative',
+        undefined,
+      )
+
+      await act(async () => {
+        resolveSet(
+          fakeRow({
+            id: 'srv-1',
+            feedback: 'negative',
+            comment: 'previously typed',
+          }),
+        )
+      })
+    })
+
+    it('passes null to clear an existing comment', async () => {
+      listMock.mockResolvedValue([
+        fakeRow({
+          id: 'srv-1',
+          artifactId: ITEM_ID,
+          feedback: 'negative',
+          comment: 'to be cleared',
+        }),
+      ])
+      // Defer the mutation so the post-mutation invalidate-and-refetch
+      // can't replay listMock's stale snapshot over the optimistic clear.
+      let resolveSet!: (row: ArtifactFeedback) => void
+      setMock.mockImplementation(
+        () =>
+          new Promise<ArtifactFeedback>((resolve) => {
+            resolveSet = resolve
+          }),
+      )
+
+      const qc = newClient()
+      const { result } = renderHook(() => useBriefingFeedback(MEETING_DATE), {
+        wrapper: wrapper(qc),
+      })
+      await waitFor(() =>
+        expect(result.current.commentByItemId[ITEM_ID]).toBe('to be cleared'),
+      )
+
+      act(() => {
+        result.current.setFeedback(ITEM_ID, 'negative', null)
+      })
+      await waitFor(() =>
+        expect(result.current.commentByItemId[ITEM_ID]).toBeNull(),
+      )
+      expect(setMock).toHaveBeenLastCalledWith(
+        MEETING_DATE,
+        ITEM_ID,
+        'negative',
+        null,
+      )
+
+      await act(async () => {
+        resolveSet(
+          fakeRow({ id: 'srv-1', feedback: 'negative', comment: null }),
+        )
+      })
+    })
   })
 
   it('exposes stable setFeedback / clearFeedback references across renders', async () => {

--- a/app/shared/briefings/use-briefing-feedback.ts
+++ b/app/shared/briefings/use-briefing-feedback.ts
@@ -27,30 +27,51 @@ export function useBriefingFeedback(meetingDate: string) {
     return map
   }, [list.data])
 
+  const commentByItemId = useMemo(() => {
+    // `undefined` = no row for this item; `null` = row exists with no
+    // comment; string = stored comment. The composer needs the
+    // distinction so it knows whether to prefill the textarea.
+    const map: Record<string, string | null | undefined> = {}
+    for (const row of list.data ?? []) {
+      map[row.artifactId] = row.comment
+    }
+    return map
+  }, [list.data])
+
   const setMutation = useMutation({
     mutationFn: ({
       itemId,
       feedback,
+      comment,
     }: {
       itemId: string
       feedback: ArtifactFeedbackKind
-    }) => briefingFeedbackApi.set(meetingDate, itemId, feedback),
-    onMutate: async ({ itemId, feedback }) => {
+      // `undefined` preserves the existing comment; `null` clears it;
+      // string replaces it. Mirrors the API contract.
+      comment?: string | null
+    }) => briefingFeedbackApi.set(meetingDate, itemId, feedback, comment),
+    onMutate: async ({ itemId, feedback, comment }) => {
       await qc.cancelQueries({ queryKey })
       const previous = qc.getQueryData<ArtifactFeedback[]>(queryKey) ?? []
       const others = previous.filter((row) => row.artifactId !== itemId)
       const existing = previous.find((row) => row.artifactId === itemId)
       const now = new Date().toISOString()
+      // Match the server's `undefined = preserve, null/string = overwrite`
+      // contract in the optimistic copy so the UI doesn't briefly show a
+      // wrong comment value mid-mutation.
+      const nextComment =
+        comment === undefined ? existing?.comment ?? null : comment
       const next: ArtifactFeedback[] = [
         ...others,
         existing
-          ? { ...existing, feedback, updatedAt: now }
+          ? { ...existing, feedback, comment: nextComment, updatedAt: now }
           : {
               id: `optimistic-${itemId}`,
               organizationSlug: '',
               submitterUserId: -1,
               artifactId: itemId,
               feedback,
+              comment: nextComment,
               createdAt: now,
               updatedAt: now,
             },
@@ -94,8 +115,8 @@ export function useBriefingFeedback(meetingDate: string) {
   const clearFeedbackMutate = clearMutation.mutate
 
   const setFeedback = useCallback(
-    (itemId: string, feedback: ArtifactFeedbackKind) =>
-      setFeedbackMutate({ itemId, feedback }),
+    (itemId: string, feedback: ArtifactFeedbackKind, comment?: string | null) =>
+      setFeedbackMutate({ itemId, feedback, comment }),
     [setFeedbackMutate],
   )
 
@@ -106,6 +127,7 @@ export function useBriefingFeedback(meetingDate: string) {
 
   return {
     feedbackByItemId,
+    commentByItemId,
     isLoading: list.isLoading,
     setFeedback,
     clearFeedback,

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -304,7 +304,14 @@ export type APIEndpoints = {
     Response: { feedback: ApiArtifactFeedback[] }
   }
   'PUT /v1/meetings/:date/briefing/items/:itemId/feedback': {
-    Request: { date: string; itemId: string; feedback: ApiArtifactFeedbackKind }
+    Request: {
+      date: string
+      itemId: string
+      feedback: ApiArtifactFeedbackKind
+      // Optional free-text. Omit to leave the existing comment untouched;
+      // pass `null` to clear it; pass a string to set / replace it.
+      comment?: string | null
+    }
     Response: ApiArtifactFeedback
   }
   'DELETE /v1/meetings/:date/briefing/items/:itemId/feedback': {
@@ -452,6 +459,7 @@ export interface ApiArtifactFeedback {
   artifact_type: ApiArtifactResourceType
   artifact_id: string
   feedback: ApiArtifactFeedbackKind
+  comment: string | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped UI and briefing-feedback client changes with well-tested comment semantics; no auth, payments, or core infrastructure.
> 
> **Overview**
> Adds **optional free-text comments** when users give thumbs-down on agenda-item briefing summaries.
> 
> **`FeedbackRow`** now opens a **popover composer** on first thumbs-down: the negative vote is sent immediately, then the user can **Save** (trimmed comment, or `null` to clear), **Not now** (dismiss without a second write), or toggle thumbs-down again to **clear** the vote. Thumbs-up behavior is unchanged. Comments are prefilled from stored values via new **`commentByItemId`** from **`useBriefingFeedback`**.
> 
> The **feedback API layer** (`feedback-api`, `gpApi` types) gains an optional **`comment`** on PUT with **omit = preserve**, **`null` = clear**, **string = set**. **`setFeedback`** and optimistic cache updates follow that contract. New **`FeedbackRow`** and hook tests cover the flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb65b4fe0304f10da5e238ff08b7ced03929018b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->