### PR TITLE
Feature/briefing stakeholder feedback

### DIFF
--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
@@ -226,13 +226,15 @@ describe('<AddNoteSheet> error surfacing', () => {
   })
 })
 
-describe('<AddNoteSheet> create-mode counter', () => {
-  it('renders the "Note N of M" counter text but NO chevron buttons (cycler owns navigation)', async () => {
+describe('<AddNoteSheet> header status pill', () => {
+  it('shows "New Note" while creating (the counter is meaningless before save) and no cycler chevrons', async () => {
     const sheet: SheetState = { kind: 'add_note_new', anchor: null }
 
     render(
       <AddNoteSheet
         sheet={sheet}
+        // Even when the parent passes a position (some flows do, some
+        // don't), create mode ignores it — the note doesn't exist yet.
         position={{ position: 3, total: 3 }}
         onClose={vi.fn()}
         onCreate={vi.fn()}
@@ -244,13 +246,38 @@ describe('<AddNoteSheet> create-mode counter', () => {
       />,
     )
 
-    expect(await screen.findByText(/note 3 of 3/i)).toBeInTheDocument()
+    expect(await screen.findByText(/^new note$/i)).toBeInTheDocument()
+    expect(screen.queryByText(/note 3 of 3/i)).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /previous note/i }),
     ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: /next note/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('shows the "Note N of M" counter in edit mode where the position is real', async () => {
+    const sheet: SheetState = {
+      kind: 'add_note_edit',
+      annotation: makeEditAnnotation(),
+    }
+
+    render(
+      <AddNoteSheet
+        sheet={sheet}
+        position={{ position: 2, total: 5 }}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onAttachmentAdd={vi.fn()}
+        onAttachmentDelete={vi.fn()}
+        activeCardTitle="Executive Summary"
+      />,
+    )
+
+    expect(await screen.findByText(/note 2 of 5/i)).toBeInTheDocument()
+    expect(screen.queryByText(/^new note$/i)).not.toBeInTheDocument()
   })
 })
 

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
@@ -77,9 +77,10 @@ describe('<AddNoteSheet> card-level section header', () => {
       resourceType: 'briefing',
       resourceId: 'briefing_1',
       authorUserId: 1,
-      // `/executive_summary` → sectionLabelFromPath returns
-      // "EXECUTIVE SUMMARY" without needing `briefingItems`.
-      jsonPath: '/executive_summary',
+      // `/executiveSummary` is the canonical card jsonPath the rest of
+      // the app uses (see ActiveCard in AnnotationsScope). The label
+      // helper accepts the camelCase form without needing `briefingItems`.
+      jsonPath: '/executiveSummary',
       start: null,
       end: null,
       createdAt: '2026-05-26T00:00:00.000Z',

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.test.tsx
@@ -43,6 +43,75 @@ function makeEditAnnotation(
   }
 }
 
+describe('<AddNoteSheet> card-level section header', () => {
+  // Anchored notes get the full AnchoredQuote (label + quoted text); the
+  // tests below assert the parallel behavior for card-level notes — no
+  // quote, but the same uppercase section header so the user can see
+  // which card the note belongs to.
+  it('shows the active card title as an uppercase section label when creating a card-level note (anchor null, no quote)', () => {
+    const sheet: SheetState = { kind: 'add_note_new', anchor: null }
+
+    render(
+      <AddNoteSheet
+        sheet={sheet}
+        position={null}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onAttachmentAdd={vi.fn()}
+        onAttachmentDelete={vi.fn()}
+        activeCardTitle="Executive Summary"
+      />,
+    )
+
+    expect(screen.getByText('EXECUTIVE SUMMARY')).toBeInTheDocument()
+    // No quoted text — no `“"` (curly open-quote) on the page.
+    expect(screen.queryByText(/“/)).not.toBeInTheDocument()
+  })
+
+  it('shows the section label (derived from jsonPath) when editing a card-level note that has no offsets', () => {
+    const annotation: Annotation = {
+      id: 'ann_card_edit',
+      kind: 'note',
+      resourceType: 'briefing',
+      resourceId: 'briefing_1',
+      authorUserId: 1,
+      // `/executive_summary` → sectionLabelFromPath returns
+      // "EXECUTIVE SUMMARY" without needing `briefingItems`.
+      jsonPath: '/executive_summary',
+      start: null,
+      end: null,
+      createdAt: '2026-05-26T00:00:00.000Z',
+      updatedAt: '2026-05-26T00:00:00.000Z',
+      note: {
+        id: 'note_card_edit',
+        body: 'card-level body',
+        attachments: [],
+        createdAt: '2026-05-26T00:00:00.000Z',
+        updatedAt: '2026-05-26T00:00:00.000Z',
+      },
+    }
+    const sheet: SheetState = { kind: 'add_note_edit', annotation }
+
+    render(
+      <AddNoteSheet
+        sheet={sheet}
+        position={null}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        onAttachmentAdd={vi.fn()}
+        onAttachmentDelete={vi.fn()}
+        activeCardTitle={null}
+      />,
+    )
+
+    expect(screen.getByText('EXECUTIVE SUMMARY')).toBeInTheDocument()
+  })
+})
+
 describe('<AddNoteSheet> error surfacing', () => {
   it('shows an inline error when onCreate rejects, keeps the sheet open, preserves the body, and reports to Sentry', async () => {
     reportErrorToSentryMock.mockReset()

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -400,6 +400,14 @@ export default function AddNoteSheet({
           data-vaul-no-drag
           className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pb-3 pt-4"
         >
+          {/* Section header. For anchored notes (`quote` set) we render
+              the full AnchoredQuote — label + quoted text. For card-level
+              notes (no quote) we still want the user to see WHICH card
+              they're noting; show the same uppercase label by itself.
+              `sectionLabel` is derived from `jsonPath` (works for edit
+              mode and selection-anchored new notes); `activeCardTitle`
+              is the fallback for top-level "Add notes" where `anchor`
+              is null and jsonPath is resolved at save time. */}
           {quote ? (
             <AnchoredQuote
               text={quote}
@@ -407,11 +415,10 @@ export default function AddNoteSheet({
               showLabel={sectionLabel !== null}
               label={sectionLabel ?? undefined}
             />
-          ) : !isEdit && activeCardTitle ? (
-            <p className="rounded-md bg-muted px-3 py-2 text-sm italic text-muted-foreground">
-              Note on{' '}
-              <span className="font-medium not-italic">{activeCardTitle}</span>
-            </p>
+          ) : sectionLabel || activeCardTitle ? (
+            <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {sectionLabel ?? activeCardTitle?.toUpperCase()}
+            </span>
           ) : null}
         </div>
 

--- a/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/AddNoteSheet.tsx
@@ -381,7 +381,18 @@ export default function AddNoteSheet({
           >
             {isEdit ? 'Edit note' : 'Add a note'}
           </DrawerTitle>
-          {position ? (
+          {/* In create mode the counter is meaningless (the note doesn't
+              exist yet, so there's no position to report) — show a "New
+              Note" pill instead. The "Note N of M" counter only renders
+              when editing an existing note where the cycler position is
+              real and useful. */}
+          {!isEdit ? (
+            <div className="flex items-center justify-center gap-3">
+              <span className="text-sm font-medium text-foreground">
+                New Note
+              </span>
+            </div>
+          ) : position ? (
             <div className="flex items-center justify-center gap-3">
               <span className="text-sm font-medium text-foreground">
                 Note {position.position} of {position.total}

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { render, testQueryClient } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { annotationsQueryKey } from '@shared/briefings/use-annotations'
+import { chatApi } from '@shared/briefings/chat-api'
 import type { Annotation } from '@shared/briefings/types'
 import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
 import type { StagedAttachment } from './NoteAttachmentPicker'
@@ -116,6 +117,7 @@ type BriefingAssistantSurfaceProps = {
     annotationId: string
     conversationId: string
   }) => void
+  onDeleteChat?: (annotation: Annotation) => Promise<void>
 }
 let captured_BriefingAssistantSurface: BriefingAssistantSurfaceProps = {
   open: false,
@@ -294,6 +296,15 @@ function ReportErrorThenSwitchSurfacesTrigger() {
         close sheet
       </button>
     </>
+  )
+}
+
+function OpenChatsSurfaceTrigger() {
+  const { openChatsSurface } = useAnnotationsCtx()
+  return (
+    <button type="button" onClick={() => openChatsSurface()}>
+      open chats surface
+    </button>
   )
 }
 
@@ -1325,6 +1336,68 @@ describe('<AnnotationsScope>', () => {
         expect(invalidateSpy).toHaveBeenCalledWith({
           queryKey: annotationsQueryKey('briefing_x'),
         })
+      })
+    })
+  })
+
+  describe('Chat delete', () => {
+    // After a chat is soft-deleted from the cycler footer the surface
+    // should close. Without this, the user would either see an empty
+    // state (last chat) or jump to an unrelated neighbor chat. Matches
+    // the user's mental model: confirm delete → done.
+    it('closes the chats surface after the chat soft-delete resolves', async () => {
+      const chatAnnotation: Annotation = {
+        id: 'ann_chat_delete',
+        kind: 'chat',
+        resourceType: 'briefing',
+        resourceId: 'briefing_x',
+        authorUserId: 1,
+        jsonPath: 'agenda.0.title',
+        start: 0,
+        end: 5,
+        createdAt: '2026-05-27T00:00:00.000Z',
+        updatedAt: '2026-05-27T00:00:00.000Z',
+      }
+      mockAnnotationsApi.list.mockResolvedValue([chatAnnotation])
+      const softDeleteMock = vi.mocked(chatApi.softDelete)
+      softDeleteMock.mockResolvedValue(undefined)
+
+      render(
+        <AnnotationsScope
+          meetingDate="briefing_x"
+          initialActiveCard={{
+            key: 'briefing-executive-summary',
+            jsonPath: '/executiveSummary',
+            titleJsonPath: '/executive_summary/title',
+            title: 'Executive Summary',
+          }}
+        >
+          <OpenChatsSurfaceTrigger />
+        </AnnotationsScope>,
+      )
+
+      // Wait for the chat annotation to be in the cache, then open the
+      // cycler surface focused on it.
+      await waitFor(() => {
+        expect(mockAnnotationsApi.list).toHaveBeenCalled()
+      })
+      await userEvent.click(
+        screen.getByRole('button', { name: /open chats surface/i }),
+      )
+      await waitFor(() => {
+        expect(captured_BriefingAssistantSurface.open).toBe(true)
+      })
+      expect(captured_BriefingAssistantSurface.onDeleteChat).toBeDefined()
+
+      // Fire the delete handler the inline footer wires through.
+      await act(async () => {
+        await captured_BriefingAssistantSurface.onDeleteChat?.(chatAnnotation)
+      })
+
+      // softDelete was invoked AND the surface closed.
+      expect(softDeleteMock).toHaveBeenCalledWith('ann_chat_delete')
+      await waitFor(() => {
+        expect(captured_BriefingAssistantSurface.open).toBe(false)
       })
     })
   })

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -888,6 +888,11 @@ export default function AnnotationsScope({
             annotationsQueryKey(meetingDate),
             (prev) => prev?.filter((a) => a.id !== ann.id),
           )
+          // Close the surface after a successful delete — the deleted
+          // chat is gone from the cycler, so keeping the sheet open
+          // would either show an empty state or jump to an unrelated
+          // chat. Match the user's mental model: confirm delete → done.
+          closeSheet()
         }}
       />
       <BugReportsSurface

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import type {
@@ -149,6 +149,63 @@ describe('<AskAiChatBody> deferred creation', () => {
       annotationId: 'ann_new_1',
       conversationId: 'conv_new_1',
     })
+  })
+
+  it('shows the "Thinking..." indicator and hides "Loading chat..." during the deferred-create gap', async () => {
+    const user = userEvent.setup()
+    // Hold create + verification read in flight so we can observe the
+    // gap UI between user click and runStream firing.
+    let resolveCreate!: (v: {
+      annotationId: string
+      conversationId: string
+    }) => void
+    createMock.mockImplementation(
+      () =>
+        new Promise<{ annotationId: string; conversationId: string }>(
+          (resolve) => {
+            resolveCreate = resolve
+          },
+        ),
+    )
+    listMessagesMock.mockResolvedValue([])
+    streamMessageMock.mockReturnValue(makeOkStream())
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'pre-flight gap test')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+
+    // Pre-create gap: the user's bubble is inside the conversation
+    // scroll region (the textarea also still contains the typed text
+    // until `setComposer('')` runs post-send, so we scope to the
+    // conversation testid to avoid double-matches), AND "Thinking..."
+    // is already showing, NOT the override-path "Loading chat..." text.
+    const conversation = await screen.findByTestId('ask-ai-conversation')
+    expect(
+      within(conversation).getByText('pre-flight gap test'),
+    ).toBeInTheDocument()
+    expect(
+      await within(conversation).findByText(/^thinking\.\.\.$/i),
+    ).toBeInTheDocument()
+    expect(
+      within(conversation).queryByText(/loading chat/i),
+    ).not.toBeInTheDocument()
+
+    // Resolve create so the rest of the flow can finish without dangling
+    // async work.
+    resolveCreate({
+      annotationId: 'ann_gap',
+      conversationId: 'conv_gap',
+    })
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
   })
 
   it('does NOT call onChatCreated when the first stream errors before completing — keeps the body alive for retry', async () => {

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -101,6 +101,8 @@ describe('<AskAiChatBody> deferred creation', () => {
       annotationId: 'ann_new_1',
       conversationId: 'conv_new_1',
     })
+    // Verification read after create — returns empty for a fresh chat.
+    listMessagesMock.mockResolvedValue([])
     streamMessageMock.mockReturnValue(makeOkStream())
 
     render(
@@ -123,7 +125,13 @@ describe('<AskAiChatBody> deferred creation', () => {
       anchor: EMPTY_ANCHOR,
     })
 
-    // After create, stream fires with the freshly-minted annotation id.
+    // Verification listMessages fires AFTER create, BEFORE stream — guards
+    // against the post-create settling race that surfaced as 100% first
+    // message failure before the warm-up read was reintroduced.
+    await waitFor(() => expect(listMessagesMock).toHaveBeenCalledTimes(1))
+    expect(listMessagesMock).toHaveBeenCalledWith('ann_new_1')
+
+    // After create + verification, stream fires with the freshly-minted id.
     await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
     expect(streamMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -156,6 +164,7 @@ describe('<AskAiChatBody> deferred creation', () => {
           },
         ),
     )
+    listMessagesMock.mockResolvedValue([])
     streamMessageMock.mockReturnValue(makeOkStream())
 
     render(
@@ -206,12 +215,14 @@ describe('<AskAiChatBody> deferred creation', () => {
     // The optimistic user bubble stays so the retry can resume.
     expect(screen.getByText('first try')).toBeInTheDocument()
 
-    // Now retry — create succeeds, stream emits.
+    // Now retry — create succeeds, verification read returns empty,
+    // stream emits.
     createMock.mockReset()
     createMock.mockResolvedValue({
       annotationId: 'ann_retry',
       conversationId: 'conv_retry',
     })
+    listMessagesMock.mockResolvedValue([])
     streamMessageMock.mockReturnValue(makeOkStream())
     await user.click(screen.getByRole('button', { name: /^retry$/i }))
 
@@ -231,6 +242,7 @@ describe('<AskAiChatBody> deferred creation', () => {
       annotationId: 'ann_reuse',
       conversationId: 'conv_reuse',
     })
+    listMessagesMock.mockResolvedValue([])
     streamMessageMock
       .mockReturnValueOnce(makeOkStream())
       .mockReturnValueOnce(makeOkStream())

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type {
+  ChatErrorCode,
+  ChatStreamEvent,
+} from '@shared/briefings/chat-events'
+import AskAiChatBody from './AskAiChatBody'
+import { EMPTY_ANCHOR } from '@shared/briefings/anchorResolver'
+
+// Stub `chatApi` so we can drive create / stream behavior from each test
+// and assert what the body actually fired.
+const createMock = vi.fn()
+const listMessagesMock = vi.fn()
+const streamMessageMock = vi.fn()
+const softDeleteMock = vi.fn()
+const sendInterruptMock = vi.fn()
+
+vi.mock('@shared/briefings/chat-api', () => ({
+  chatApi: {
+    createBriefingChat: (...args: unknown[]) => createMock(...args),
+    listMessages: (...args: unknown[]) => listMessagesMock(...args),
+    streamMessage: (...args: unknown[]) => streamMessageMock(...args),
+    softDelete: (...args: unknown[]) => softDeleteMock(...args),
+    sendInterrupt: (...args: unknown[]) => sendInterruptMock(...args),
+  },
+}))
+
+// Silence Sentry — we don't care about side effects, only the API calls.
+vi.mock('@shared/sentry', () => ({ reportErrorToSentry: vi.fn() }))
+
+// `useDictationAppend` reaches for browser APIs; stub it to a no-op for
+// these unit tests.
+vi.mock('../../shared/useDictationAppend', () => ({
+  useDictationAppend: () => ({
+    isRecording: false,
+    error: null,
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}))
+
+const MEETING_DATE = '2026-06-08'
+
+// Builds a stream that emits a tiny "ok" assistant turn so `sendContent`
+// resolves cleanly. Each test gets a fresh generator.
+function makeOkStream(): AsyncIterable<ChatStreamEvent> {
+  return (async function* () {
+    yield { type: 'text', delta: 'ok' } as ChatStreamEvent
+    yield {
+      type: 'done',
+      assistantMessageId: 'asst_1',
+    } as ChatStreamEvent
+  })()
+}
+
+function makeErrorStream(code: ChatErrorCode): AsyncIterable<ChatStreamEvent> {
+  return (async function* () {
+    yield {
+      type: 'error',
+      code,
+      retryable: true,
+    } as ChatStreamEvent
+  })()
+}
+
+beforeEach(() => {
+  createMock.mockReset()
+  listMessagesMock.mockReset()
+  streamMessageMock.mockReset()
+  softDeleteMock.mockReset()
+  sendInterruptMock.mockReset()
+})
+
+describe('<AskAiChatBody> deferred creation', () => {
+  it('does NOT call chatApi.createBriefingChat on mount when no annotationIdOverride is given', async () => {
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    // Composer is interactive immediately (no annotationId required to
+    // type into it).
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    expect(textarea).not.toBeDisabled()
+
+    // No server call has fired.
+    expect(createMock).not.toHaveBeenCalled()
+    expect(listMessagesMock).not.toHaveBeenCalled()
+  })
+
+  it('mints the chat row when the user sends their first message, then streams it', async () => {
+    const user = userEvent.setup()
+    const onChatCreated = vi.fn()
+    createMock.mockResolvedValue({
+      annotationId: 'ann_new_1',
+      conversationId: 'conv_new_1',
+    })
+    streamMessageMock.mockReturnValue(makeOkStream())
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        onChatCreated={onChatCreated}
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'what is on the agenda')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1))
+    expect(createMock).toHaveBeenCalledWith({
+      meetingDate: MEETING_DATE,
+      anchor: EMPTY_ANCHOR,
+    })
+
+    // After create, stream fires with the freshly-minted annotation id.
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
+    expect(streamMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        annotationId: 'ann_new_1',
+        content: 'what is on the agenda',
+      }),
+    )
+
+    // The cache-invalidation callback is fired exactly once, AFTER the
+    // first user send (not on mount).
+    await waitFor(() => expect(onChatCreated).toHaveBeenCalledTimes(1))
+    expect(onChatCreated).toHaveBeenCalledWith({
+      annotationId: 'ann_new_1',
+      conversationId: 'conv_new_1',
+    })
+  })
+
+  it('does not call create twice if the user double-taps Send', async () => {
+    const user = userEvent.setup()
+    // Hold the create promise in flight so the second click can race.
+    let resolveCreate!: (v: {
+      annotationId: string
+      conversationId: string
+    }) => void
+    createMock.mockImplementation(
+      () =>
+        new Promise<{ annotationId: string; conversationId: string }>(
+          (resolve) => {
+            resolveCreate = resolve
+          },
+        ),
+    )
+    streamMessageMock.mockReturnValue(makeOkStream())
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'hi')
+    const sendBtn = screen.getByRole('button', { name: /ask assistant/i })
+    await user.click(sendBtn)
+    // Second click happens while the first create is still pending.
+    await user.click(sendBtn)
+
+    expect(createMock).toHaveBeenCalledTimes(1)
+    // Resolve so the test cleans up.
+    resolveCreate({
+      annotationId: 'ann_dup_guard',
+      conversationId: 'conv_dup_guard',
+    })
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('surfaces a retryable error when create-on-send fails AND keeps the user message in history for retry', async () => {
+    const user = userEvent.setup()
+    createMock.mockRejectedValue(new Error('boom'))
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'first try')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/could not start chat/i)
+
+    // The optimistic user bubble stays so the retry can resume.
+    expect(screen.getByText('first try')).toBeInTheDocument()
+
+    // Now retry — create succeeds, stream emits.
+    createMock.mockReset()
+    createMock.mockResolvedValue({
+      annotationId: 'ann_retry',
+      conversationId: 'conv_retry',
+    })
+    streamMessageMock.mockReturnValue(makeOkStream())
+    await user.click(screen.getByRole('button', { name: /^retry$/i }))
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
+    expect(streamMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        annotationId: 'ann_retry',
+        content: 'first try',
+      }),
+    )
+  })
+
+  it('reuses the same annotationId for a second send (does not re-create)', async () => {
+    const user = userEvent.setup()
+    createMock.mockResolvedValue({
+      annotationId: 'ann_reuse',
+      conversationId: 'conv_reuse',
+    })
+    streamMessageMock
+      .mockReturnValueOnce(makeOkStream())
+      .mockReturnValueOnce(makeOkStream())
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'first')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
+
+    // Send a second message — create must NOT fire again, stream uses
+    // the same id.
+    await user.type(textarea, 'second')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(2))
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(streamMessageMock.mock.calls[1][0]).toMatchObject({
+      annotationId: 'ann_reuse',
+      content: 'second',
+    })
+  })
+})
+
+describe('<AskAiChatBody> override path still works', () => {
+  it('loads prior messages from an existing chat when annotationIdOverride is provided, without minting a new row', async () => {
+    listMessagesMock.mockResolvedValue([
+      { id: 'm1', role: 'user', content: 'historical question' },
+      { id: 'm2', role: 'assistant', content: 'historical answer' },
+    ])
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        annotationIdOverride="ann_existing"
+        composerVariant="block"
+        active
+      />,
+    )
+
+    await waitFor(() => expect(listMessagesMock).toHaveBeenCalledTimes(1))
+    expect(listMessagesMock).toHaveBeenCalledWith('ann_existing')
+    expect(createMock).not.toHaveBeenCalled()
+    expect(await screen.findByText('historical question')).toBeInTheDocument()
+    expect(screen.getByText('historical answer')).toBeInTheDocument()
+
+    // Suppress unused-variable lint on the error-path stub.
+    void makeErrorStream
+  })
+})

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -208,6 +208,55 @@ describe('<AskAiChatBody> deferred creation', () => {
     await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
   })
 
+  it('does NOT call createBriefingChat twice when the post-create verification GET fails and the user retries', async () => {
+    // Regression guard for the delegate-reviewer finding: if state
+    // commits happen AFTER `listMessages`, a thrown verification GET
+    // leaves `annotationId` null and the retry path re-creates the chat
+    // row server-side. Asserts the create is invoked exactly once even
+    // when the verification GET throws.
+    const user = userEvent.setup()
+    createMock.mockResolvedValue({
+      annotationId: 'ann_no_dup',
+      conversationId: 'conv_no_dup',
+    })
+    listMessagesMock.mockRejectedValueOnce(new Error('verification failed'))
+    streamMessageMock.mockReturnValue(makeOkStream())
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'first try')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+
+    // First send: create resolves, listMessages throws, error surfaces.
+    await screen.findByRole('alert')
+
+    // Retry — listMessages would succeed now, but the implementation
+    // should short-circuit via the cached annotationId and skip create
+    // entirely.
+    listMessagesMock.mockResolvedValueOnce([])
+    await user.click(screen.getByRole('button', { name: /^retry$/i }))
+
+    await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(1))
+    // The whole point of this test: create must NOT have been called a
+    // second time. The annotation row was minted on first send and
+    // persists on the server regardless of the verification outcome.
+    expect(createMock).toHaveBeenCalledTimes(1)
+    expect(streamMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        annotationId: 'ann_no_dup',
+        content: 'first try',
+      }),
+    )
+  })
+
   it('does NOT call onChatCreated when the first stream errors before completing — keeps the body alive for retry', async () => {
     const user = userEvent.setup()
     const onChatCreated = vi.fn()

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -303,7 +303,7 @@ describe('<AskAiChatBody> deferred creation', () => {
     await user.click(screen.getByRole('button', { name: /ask assistant/i }))
     await waitFor(() => expect(streamMessageMock).toHaveBeenCalledTimes(2))
     expect(createMock).toHaveBeenCalledTimes(1)
-    expect(streamMessageMock.mock.calls[1][0]).toMatchObject({
+    expect(streamMessageMock.mock.calls[1]?.[0]).toMatchObject({
       annotationId: 'ann_reuse',
       content: 'second',
     })

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.deferredCreate.test.tsx
@@ -141,12 +141,48 @@ describe('<AskAiChatBody> deferred creation', () => {
     )
 
     // The cache-invalidation callback is fired exactly once, AFTER the
-    // first user send (not on mount).
+    // first stream lands `done` (not on mount, and not immediately after
+    // create — firing it earlier triggers the host's overlay swap and
+    // unmounts the body mid-stream).
     await waitFor(() => expect(onChatCreated).toHaveBeenCalledTimes(1))
     expect(onChatCreated).toHaveBeenCalledWith({
       annotationId: 'ann_new_1',
       conversationId: 'conv_new_1',
     })
+  })
+
+  it('does NOT call onChatCreated when the first stream errors before completing — keeps the body alive for retry', async () => {
+    const user = userEvent.setup()
+    const onChatCreated = vi.fn()
+    createMock.mockResolvedValue({
+      annotationId: 'ann_errored',
+      conversationId: 'conv_errored',
+    })
+    listMessagesMock.mockResolvedValue([])
+    // Stream emits a retryable error event (no `done`).
+    streamMessageMock.mockReturnValue(makeErrorStream('upstream_unavailable'))
+
+    render(
+      <AskAiChatBody
+        meetingDate={MEETING_DATE}
+        anchor={null}
+        composerVariant="block"
+        onChatCreated={onChatCreated}
+        active
+      />,
+    )
+
+    const textarea = await screen.findByLabelText(/ask assistant message/i)
+    await user.type(textarea, 'will fail')
+    await user.click(screen.getByRole('button', { name: /ask assistant/i }))
+
+    // Stream fires, errors. The Retry affordance appears.
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: /^retry$/i })).toBeInTheDocument()
+
+    // Crucially, onChatCreated did NOT fire — otherwise the host would
+    // swap the overlay and unmount us mid-error.
+    expect(onChatCreated).not.toHaveBeenCalled()
   })
 
   it('does not call create twice if the user double-taps Send', async () => {
@@ -296,8 +332,5 @@ describe('<AskAiChatBody> override path still works', () => {
     expect(createMock).not.toHaveBeenCalled()
     expect(await screen.findByText('historical question')).toBeInTheDocument()
     expect(screen.getByText('historical answer')).toBeInTheDocument()
-
-    // Suppress unused-variable lint on the error-path stub.
-    void makeErrorStream
   })
 })

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -151,12 +151,19 @@ function messageToItem(msg: ChatMessage): ChatItem | null {
  * anchored selection, and reopening an existing chat annotation.
  *
  * Lifecycle:
- *  1. On mount, mint a briefing chat (annotationId + conversationId) unless
- *     `annotationIdOverride` is provided, then load prior messages.
- *  2. Empty state shows the three suggested pills + composer.
- *  3. Sending streams text deltas progressively. Errors render inline with a
- *     Retry button if the error is retryable.
- *  4. When `active` flips to false, abort the in-flight stream.
+ *  1. On mount:
+ *      - If `annotationIdOverride` is set, load its prior messages.
+ *      - Otherwise, do nothing. We defer `createBriefingChat` until the
+ *        user actually sends a first message — opening + dismissing the
+ *        sheet without typing no longer leaves an empty chat row in the
+ *        DB.
+ *  2. Empty state shows the three suggested pills + composer. Composer
+ *     is interactive even before any annotation exists.
+ *  3. Sending: if we don't have an `annotationId` yet (deferred case),
+ *     mint one via `chatApi.createBriefingChat`, then stream the user's
+ *     first turn. Subsequent sends reuse the minted id.
+ *  4. Errors render inline with a Retry button when retryable.
+ *  5. When `active` flips to false, abort the in-flight stream.
  */
 export default function AskAiChatBody({
   meetingDate,
@@ -180,7 +187,13 @@ export default function AskAiChatBody({
 
   const inputRef = useRef<HTMLInputElement | null>(null)
   const abortRef = useRef<AbortController | null>(null)
-  const initRequestedRef = useRef(false)
+  // `loadRequestedRef` is the override-path latch: we kick off
+  // `loadExistingChat` once per mount and skip subsequent runs even if
+  // deps change. `creatingRef` is the deferred-create latch: it stops a
+  // double-tap from minting two chat rows back-to-back inside
+  // `ensureAnnotationId`.
+  const loadRequestedRef = useRef(false)
+  const creatingRef = useRef(false)
   const sendingRef = useRef(false)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const wasAtBottomRef = useRef(true)
@@ -192,25 +205,17 @@ export default function AskAiChatBody({
     onChange: setComposer,
   })
 
-  const initialize = useCallback(async () => {
-    if (initRequestedRef.current) return
-    initRequestedRef.current = true
+  // Override path only — load prior messages for an existing chat
+  // annotation. New / deferred chats skip this entirely (they have no
+  // messages to load).
+  const loadExistingChat = useCallback(async () => {
+    if (!annotationIdOverride) return
+    if (loadRequestedRef.current) return
+    loadRequestedRef.current = true
     setCreating(true)
     try {
-      let activeId = annotationIdOverride ?? null
-      if (!activeId) {
-        const created = await chatApi.createBriefingChat({
-          meetingDate,
-          anchor: anchor ?? EMPTY_ANCHOR,
-        })
-        activeId = created.annotationId
-        onChatCreated?.({
-          annotationId: created.annotationId,
-          conversationId: created.conversationId,
-        })
-      }
-      setAnnotationId(activeId)
-      const msgs = await chatApi.listMessages(activeId)
+      setAnnotationId(annotationIdOverride)
+      const msgs = await chatApi.listMessages(annotationIdOverride)
       const items: ChatItem[] = []
       for (const m of msgs) {
         const it = messageToItem(m)
@@ -224,9 +229,9 @@ export default function AskAiChatBody({
         meetingDate,
         annotationIdOverride,
       })
-      initRequestedRef.current = false
+      loadRequestedRef.current = false
       setError({
-        message: 'Could not start chat. Try again.',
+        message: 'Could not load this chat. Try again.',
         retryable: true,
         lastUserContent: '',
         lastClientMessageId: '',
@@ -235,13 +240,47 @@ export default function AskAiChatBody({
     } finally {
       setCreating(false)
     }
-  }, [anchor, annotationIdOverride, meetingDate, onChatCreated])
+  }, [annotationIdOverride, meetingDate])
+
+  // Deferred create. Returns the existing annotationId if we already
+  // have one, otherwise mints a new chat row and returns its id. Null
+  // means "create failed" — the caller is responsible for surfacing the
+  // error with the right send context (last user content + client id).
+  const ensureAnnotationId = useCallback(async (): Promise<string | null> => {
+    if (annotationId) return annotationId
+    if (creatingRef.current) return null
+    creatingRef.current = true
+    setCreating(true)
+    try {
+      const created = await chatApi.createBriefingChat({
+        meetingDate,
+        anchor: anchor ?? EMPTY_ANCHOR,
+      })
+      setAnnotationId(created.annotationId)
+      onChatCreated?.({
+        annotationId: created.annotationId,
+        conversationId: created.conversationId,
+      })
+      return created.annotationId
+    } catch (err) {
+      reportErrorToSentry(err, {
+        surface: 'briefing-ask-ai',
+        phase: 'init',
+        meetingDate,
+      })
+      return null
+    } finally {
+      creatingRef.current = false
+      setCreating(false)
+    }
+  }, [annotationId, anchor, meetingDate, onChatCreated])
 
   useEffect(() => {
-    if (active && !initRequestedRef.current) {
-      void initialize()
-    }
-  }, [active, initialize])
+    if (!active) return
+    if (!annotationIdOverride) return
+    if (loadRequestedRef.current) return
+    void loadExistingChat()
+  }, [active, annotationIdOverride, loadExistingChat])
 
   // Notify the host surface whenever `sending || creating` flips, so it
   // can gate destructive actions (Delete chat) on the active annotation.
@@ -421,22 +460,47 @@ export default function AskAiChatBody({
     [meetingDate],
   )
 
+  // Stage 2 of a user turn — ensure we have an annotation id (lazy
+  // create when in deferred mode), then stream the message. Split from
+  // `sendContent` so the retry path can re-run this without re-adding
+  // the user's optimistic bubble to the history.
+  const executeUserTurn = useCallback(
+    async (content: string, clientMessageId: string) => {
+      let id = annotationId
+      if (!id) {
+        id = await ensureAnnotationId()
+        if (!id) {
+          setError({
+            message: 'Could not start chat. Try again.',
+            retryable: true,
+            lastUserContent: content,
+            lastClientMessageId: clientMessageId,
+            kind: 'init',
+          })
+          sendingRef.current = false
+          return
+        }
+      }
+      await runStream(id, content, clientMessageId)
+    },
+    [annotationId, ensureAnnotationId, runStream],
+  )
+
   const sendContent = useCallback(
     async (content: string) => {
       const trimmed = content.trim()
       if (!trimmed) return false
-      if (!annotationId) return false
-      if (sendingRef.current) return false
+      if (sendingRef.current || creatingRef.current) return false
       sendingRef.current = true
       const clientMessageId = newClientMessageId()
       setHistory((prev) => [
         ...prev,
         { kind: 'user', id: `local_${clientMessageId}`, content: trimmed },
       ])
-      await runStream(annotationId, trimmed, clientMessageId)
+      await executeUserTurn(trimmed, clientMessageId)
       return true
     },
-    [annotationId, runStream],
+    [executeUserTurn],
   )
 
   const onSend = useCallback(async () => {
@@ -448,16 +512,26 @@ export default function AskAiChatBody({
   const onRetry = useCallback(async () => {
     if (!error) return
     if (error.kind === 'init') {
+      // Two flavors of init failure:
+      //   - Override mode (no lastUserContent): the loader failed.
+      //     Re-run loadExistingChat.
+      //   - Deferred mode (lastUserContent set): create-on-send failed
+      //     AFTER we already pushed the user bubble onto history.
+      //     Re-run executeUserTurn so we don't duplicate the bubble.
       setError(null)
-      initRequestedRef.current = false
-      await initialize()
+      if (!error.lastUserContent || !error.lastClientMessageId) {
+        loadRequestedRef.current = false
+        await loadExistingChat()
+        return
+      }
+      await executeUserTurn(error.lastUserContent, error.lastClientMessageId)
       return
     }
     if (!annotationId) return
     const { lastUserContent, lastClientMessageId } = error
     if (!lastUserContent || !lastClientMessageId) return
     await runStream(annotationId, lastUserContent, lastClientMessageId)
-  }, [annotationId, error, initialize, runStream])
+  }, [annotationId, error, executeUserTurn, loadExistingChat, runStream])
 
   const onRetryInterrupted = useCallback(
     async (interruptedId: string) => {
@@ -699,12 +773,12 @@ export default function AskAiChatBody({
                 ) {
                   return
                 }
-                if (!annotationId || composer.trim().length === 0) return
+                if (composer.trim().length === 0) return
                 e.preventDefault()
                 void onSend()
               }}
               placeholder="Ask anything..."
-              disabled={sending || creating || !annotationId}
+              disabled={sending || creating}
               rows={3}
               className="min-h-[96px] resize-none rounded-2xl pr-12"
               aria-label="Ask Assistant message"
@@ -721,7 +795,7 @@ export default function AskAiChatBody({
             onClick={() => {
               void onSend()
             }}
-            disabled={!annotationId || composer.trim().length === 0}
+            disabled={composer.trim().length === 0 || sending || creating}
             loading={sending || creating}
             icon={<Sparkles className="size-4" aria-hidden />}
             iconPosition="left"
@@ -739,7 +813,7 @@ export default function AskAiChatBody({
             onChange={(e) => setComposer(e.target.value)}
             onKeyDown={onComposerKeyDown}
             placeholder="Ask anything about this briefing..."
-            disabled={sending || creating || !annotationId}
+            disabled={sending || creating}
             aria-label="Ask AI message"
           />
           <IconButton
@@ -750,7 +824,7 @@ export default function AskAiChatBody({
             onClick={() => {
               void onSend()
             }}
-            disabled={!annotationId || composer.trim().length === 0}
+            disabled={composer.trim().length === 0 || sending || creating}
             loading={sending || creating}
           >
             <Send className="size-4" aria-hidden />

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -191,9 +191,16 @@ export default function AskAiChatBody({
   // `loadExistingChat` once per mount and skip subsequent runs even if
   // deps change. `creatingRef` is the deferred-create latch: it stops a
   // double-tap from minting two chat rows back-to-back inside
-  // `ensureAnnotationId`.
+  // `ensureAnnotationId`. `pendingChatCreatedRef` stashes the create
+  // payload until the FIRST stream lands its `done` event — firing
+  // `onChatCreated` immediately would race the host surface's
+  // pending-anchor → cycler-focused swap and unmount us mid-stream.
   const loadRequestedRef = useRef(false)
   const creatingRef = useRef(false)
+  const pendingChatCreatedRef = useRef<{
+    annotationId: string
+    conversationId: string
+  } | null>(null)
   const sendingRef = useRef(false)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const wasAtBottomRef = useRef(true)
@@ -265,10 +272,14 @@ export default function AskAiChatBody({
       // Empty result for a freshly-minted chat is expected.
       await chatApi.listMessages(created.annotationId)
       setAnnotationId(created.annotationId)
-      onChatCreated?.({
+      // Defer `onChatCreated` until the first stream lands `done` —
+      // firing it here triggers the host's pending-anchor → cycler-
+      // focused overlay swap, which unmounts this `AskAiChatBody`
+      // mid-stream and discards the in-flight assistant response.
+      pendingChatCreatedRef.current = {
         annotationId: created.annotationId,
         conversationId: created.conversationId,
-      })
+      }
       return created.annotationId
     } catch (err) {
       reportErrorToSentry(err, {
@@ -281,7 +292,7 @@ export default function AskAiChatBody({
       creatingRef.current = false
       setCreating(false)
     }
-  }, [annotationId, anchor, meetingDate, onChatCreated])
+  }, [annotationId, anchor, meetingDate])
 
   useEffect(() => {
     if (!active) return
@@ -442,6 +453,16 @@ export default function AskAiChatBody({
             },
           ])
           setStreaming(null)
+          // First successful stream for a deferred-create chat — the
+          // conversation is now durable on the server. Safe to notify
+          // the host so it can swap the overlay from pending-anchor
+          // preempt to the cycler-focused view (which mounts a fresh
+          // body keyed on the new annotation id).
+          const pending = pendingChatCreatedRef.current
+          if (pending) {
+            pendingChatCreatedRef.current = null
+            onChatCreated?.(pending)
+          }
         }
       } catch (err) {
         reportErrorToSentry(err, {
@@ -465,7 +486,7 @@ export default function AskAiChatBody({
         abortRef.current = null
       }
     },
-    [meetingDate],
+    [meetingDate, onChatCreated],
   )
 
   // Stage 2 of a user turn — ensure we have an annotation id (lazy

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -511,6 +511,14 @@ export default function AskAiChatBody({
   // the user's optimistic bubble to the history.
   const executeUserTurn = useCallback(
     async (content: string, clientMessageId: string) => {
+      // Show the "Thinking..." indicator immediately — covers the
+      // deferred-create gap (createBriefingChat + verification read)
+      // before runStream's own setStreaming kicks in. Without this the
+      // user sees their bubble, then ~1s of silence, then "Thinking..."
+      // pops in — which they read as jarring. runStream re-sets these
+      // to the same values, so this is purely a pre-flight signal.
+      setSending(true)
+      setStreaming({ role: 'assistant', content: '' })
       let id = annotationId
       if (!id) {
         id = await ensureAnnotationId()
@@ -522,6 +530,10 @@ export default function AskAiChatBody({
             lastClientMessageId: clientMessageId,
             kind: 'init',
           })
+          // Clear the pre-flight indicators so the user isn't stuck
+          // looking at "Thinking..." when the chat couldn't start.
+          setStreaming(null)
+          setSending(false)
           sendingRef.current = false
           return
         }
@@ -656,7 +668,15 @@ export default function AskAiChatBody({
           }
           data-testid="ask-ai-conversation"
         >
-          {creating && (
+          {/* "Loading chat..." is for the override path (reopening an
+              existing chat while we fetch its message list). In the
+              deferred-create path the user has already pushed their own
+              bubble onto `history` synchronously inside `sendContent`,
+              so showing "Loading chat..." above their message would
+              read as confusing — the chat is already underway. Gate on
+              empty history so the text only shows when there's nothing
+              else to look at. */}
+          {creating && history.length === 0 && !streaming && (
             <div className="text-sm text-muted-foreground">Loading chat...</div>
           )}
 

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -66,6 +66,15 @@ type Props = {
    * annotation from being removed mid-network-call.
    */
   onSendingChange?: (sending: boolean) => void
+  /**
+   * Fires as soon as the deferred `createBriefingChat` resolves, well
+   * before the first stream completes (and before `onChatCreated`,
+   * which is intentionally deferred to stream success to avoid
+   * unmounting us mid-stream). The host surface uses this to render
+   * the Delete chat button against the freshly-minted annotation while
+   * the user is still in the empty-state composer.
+   */
+  onAnnotationIdReady?: (annotationId: string) => void
 }
 
 type StreamingMessage = {
@@ -175,6 +184,7 @@ export default function AskAiChatBody({
   onChatCreated,
   composerVariant = 'inline',
   onSendingChange,
+  onAnnotationIdReady,
 }: Props): React.JSX.Element {
   const [annotationId, setAnnotationId] = useState<string | null>(null)
   const [history, setHistory] = useState<ChatItem[]>([])
@@ -272,6 +282,12 @@ export default function AskAiChatBody({
       // Empty result for a freshly-minted chat is expected.
       await chatApi.listMessages(created.annotationId)
       setAnnotationId(created.annotationId)
+      // Tell the host the annotation now exists so it can render
+      // Delete chat against it. Distinct from `onChatCreated` (which
+      // triggers the overlay swap and is intentionally deferred to
+      // stream success). `onAnnotationIdReady` fires here so the
+      // delete affordance is visible the moment the chat is minted.
+      onAnnotationIdReady?.(created.annotationId)
       // Defer `onChatCreated` until the first stream lands `done` —
       // firing it here triggers the host's pending-anchor → cycler-
       // focused overlay swap, which unmounts this `AskAiChatBody`
@@ -292,7 +308,7 @@ export default function AskAiChatBody({
       creatingRef.current = false
       setCreating(false)
     }
-  }, [annotationId, anchor, meetingDate])
+  }, [annotationId, anchor, meetingDate, onAnnotationIdReady])
 
   useEffect(() => {
     if (!active) return

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -273,14 +273,13 @@ export default function AskAiChatBody({
         meetingDate,
         anchor: anchor ?? EMPTY_ANCHOR,
       })
-      // Issue a verification GET before returning the id. The eager
-      // pre-refactor flow always did `listMessages` right after create;
-      // dropping it exposed a server-side settling window where the
-      // very next `POST /messages` would fail with the new annotation
-      // still not yet visible to its loadContext check. The GET both
-      // confirms readability and gives the server a beat to settle.
-      // Empty result for a freshly-minted chat is expected.
-      await chatApi.listMessages(created.annotationId)
+      // Commit state BEFORE the verification GET. If `listMessages`
+      // throws (server settling, transient 5xx, etc.), the chat row
+      // already exists server-side — a retry that re-runs this function
+      // must NOT call `createBriefingChat` again, or it'd produce a
+      // duplicate annotation. With `annotationId` set, the early-exit
+      // at the top of this function (`if (annotationId) return ...`)
+      // kicks in on retry and we go straight to `runStream`.
       setAnnotationId(created.annotationId)
       // Tell the host the annotation now exists so it can render
       // Delete chat against it. Distinct from `onChatCreated` (which
@@ -296,6 +295,14 @@ export default function AskAiChatBody({
         annotationId: created.annotationId,
         conversationId: created.conversationId,
       }
+      // Issue a verification GET. The eager pre-refactor flow always
+      // did `listMessages` right after create; dropping it exposed a
+      // server-side settling window where the very next `POST /messages`
+      // would fail with the new annotation still not yet visible to its
+      // loadContext check. The GET both confirms readability and gives
+      // the server a beat to settle. Empty result for a freshly-minted
+      // chat is expected.
+      await chatApi.listMessages(created.annotationId)
       return created.annotationId
     } catch (err) {
       reportErrorToSentry(err, {

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -256,6 +256,14 @@ export default function AskAiChatBody({
         meetingDate,
         anchor: anchor ?? EMPTY_ANCHOR,
       })
+      // Issue a verification GET before returning the id. The eager
+      // pre-refactor flow always did `listMessages` right after create;
+      // dropping it exposed a server-side settling window where the
+      // very next `POST /messages` would fail with the new annotation
+      // still not yet visible to its loadContext check. The GET both
+      // confirms readability and gives the server a beat to settle.
+      // Empty result for a freshly-minted chat is expected.
+      await chatApi.listMessages(created.annotationId)
       setAnnotationId(created.annotationId)
       onChatCreated?.({
         annotationId: created.annotationId,

--- a/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
+++ b/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
@@ -113,25 +113,29 @@ export default function AttachmentThumbnail({
   const cardClass =
     'group relative flex w-full flex-col overflow-hidden rounded-lg border border-border bg-muted/40 text-foreground'
 
-  // Big preview well: full container width with a 16:9 aspect ratio so
-  // the image is large enough to read on mobile (~360px wide → ~200px
-  // tall preview) without needing fixed pixel heights. Image stretches
-  // via `object-cover`; document icon centers at a generous `size-12`.
-  const previewAreaClass =
-    'relative flex aspect-video w-full items-center justify-center overflow-hidden bg-muted text-muted-foreground'
+  // When we have a real image to show, the preview wrapper drops its
+  // fixed aspect ratio and lets the `<img>` render at its natural
+  // proportions (full container width, height set by the image's own
+  // ratio). This avoids cropping that `object-cover` would impose and
+  // matches the user expectation: see the whole image, not a slice.
+  //
+  // For documents and for images whose URL is still resolving, we keep
+  // the 16:9 well so the card has substantial presence and a centered
+  // icon / spinner. Once a server-side image URL resolves we transition
+  // out of the aspect-video well into the natural-ratio image.
+  const isImageReady = isImage && url !== null
+  const previewWrapperClass = isImageReady
+    ? 'relative block w-full overflow-hidden bg-muted'
+    : 'relative flex aspect-video w-full items-center justify-center overflow-hidden bg-muted text-muted-foreground'
 
-  // For images, fall back to a spinner (not the document icon) while we
-  // resolve the URL — covers both the staged blob-URL effect setting on
-  // mount and the server-side signed-URL query in flight.
-  const previewContent =
-    isImage && url ? (
-      // eslint-disable-next-line @next/next/no-img-element -- presigned S3 / blob URL, not a stable Next image route
-      <img src={url} alt={item.label} className="size-full object-cover" />
-    ) : isImage ? (
-      <Loader2 className="size-8 animate-spin" aria-hidden />
-    ) : (
-      <FileText className="size-12" aria-hidden />
-    )
+  const previewContent = isImageReady ? (
+    // eslint-disable-next-line @next/next/no-img-element -- presigned S3 / blob URL, not a stable Next image route
+    <img src={url} alt={item.label} className="block h-auto w-full" />
+  ) : isImage ? (
+    <Loader2 className="size-8 animate-spin" aria-hidden />
+  ) : (
+    <FileText className="size-12" aria-hidden />
+  )
 
   const showRemove = onRemove !== undefined
 
@@ -142,13 +146,13 @@ export default function AttachmentThumbnail({
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className={`${previewAreaClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
+          className={`${previewWrapperClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
           aria-label={`Open ${item.label}`}
         >
           {previewContent}
         </a>
       ) : (
-        <span className={previewAreaClass}>{previewContent}</span>
+        <span className={previewWrapperClass}>{previewContent}</span>
       )}
       <span
         className="block w-full truncate border-t border-border bg-card px-3 py-2 text-sm text-foreground"

--- a/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
+++ b/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
@@ -9,7 +9,7 @@ import { useAttachmentDownloadUrl } from '@shared/briefings/use-attachment-downl
  */
 type CommonItem = {
   id: string
-  /** File name; rendered as `aria-label` / `title` on the thumbnail. */
+  /** File name; rendered as the row's primary label. */
   label: string
   /** Mime type drives the image-preview vs file-icon thumbnail choice. */
   mimeType: string
@@ -29,7 +29,7 @@ type CommonItem = {
  *
  * Same shape powers both the editable picker and the read-only view in
  * NotesSurface; pass `onRemove` to render the X overlay, omit it to
- * render a view-only tile.
+ * render a view-only row.
  */
 export type AttachmentItem =
   | (CommonItem & { kind: 'staged'; file: File })
@@ -42,8 +42,8 @@ export type AttachmentItem =
 type Props = {
   item: AttachmentItem
   /**
-   * When supplied, renders an X overlay that calls back with the item
-   * id. Omit (or pass undefined) for a read-only thumbnail — used by
+   * When supplied, renders an X button at the right of the row that
+   * calls back with the item id. Omit for a read-only row — used by
    * the note-view surface where attachments are display-only.
    */
   onRemove?: (id: string) => void
@@ -54,10 +54,11 @@ type Props = {
 const isImageMime = (mime: string): boolean => mime.startsWith('image/')
 
 /**
- * One attachment rendered as a clickable thumbnail tile. Click opens
- * the file in a new tab via the resolved URL (blob URL for staged
- * items, signed S3 URL for server items). Layout is fixed-size so a
- * grid of tiles doesn't reflow as URLs resolve.
+ * One attachment rendered as a full-width clickable row: small thumbnail
+ * on the left (image preview for image MIMEs, document icon for the
+ * rest), filename in the middle, optional remove (X) button on the
+ * right. Click the row to open the file in a new tab via the resolved
+ * URL (blob URL for staged items, signed S3 URL for server items).
  */
 export default function AttachmentThumbnail({
   item,
@@ -90,7 +91,7 @@ export default function AttachmentThumbnail({
     return () => URL.revokeObjectURL(url)
   }, [stagedFile])
 
-  // Server items: lazy-fetch the signed URL. Disabled for staged tiles
+  // Server items: lazy-fetch the signed URL. Disabled for staged rows
   // so we don't fire a phantom request.
   const isServer = item.kind === 'server'
   const annotationId = isServer ? item.annotationId : ''
@@ -105,13 +106,13 @@ export default function AttachmentThumbnail({
     item.kind === 'staged' ? objectUrl : downloadUrlQuery.data?.url ?? null
   const isImage = isImageMime(item.mimeType)
 
-  const tileClass =
-    'group relative inline-flex size-20 shrink-0 flex-col overflow-hidden rounded-lg border border-border bg-muted text-muted-foreground'
+  const rowClass =
+    'group relative flex w-full items-center gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground'
 
-  // Icon-area sizing: the parent is a fixed-size flex column with a label
-  // strip at the bottom, so the icon container uses `min-h-0 flex-1` to
-  // claim the remaining space and centers its child both axes.
-  const iconAreaClass = 'flex min-h-0 flex-1 items-center justify-center'
+  // Square thumbnail well: the image fills via `object-cover`, the
+  // document/loading icon centers inside.
+  const thumbWellClass =
+    'flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground'
 
   // For images, fall back to a spinner (not the document icon) while we
   // resolve the URL — covers both the staged blob-URL effect setting on
@@ -121,57 +122,66 @@ export default function AttachmentThumbnail({
       // eslint-disable-next-line @next/next/no-img-element -- presigned S3 / blob URL, not a stable Next image route
       <img src={url} alt={item.label} className="size-full object-cover" />
     ) : isImage ? (
-      <Loader2 className="size-6 animate-spin" aria-hidden />
+      <Loader2 className="size-5 animate-spin" aria-hidden />
     ) : (
-      <FileText className="size-7" aria-hidden />
+      <FileText className="size-5" aria-hidden />
     )
 
   const showRemove = onRemove !== undefined
 
+  // The link wraps the thumb + filename so the click target is the
+  // whole row except the X button. When there's no URL yet (e.g.
+  // signed-URL still loading), we render the same layout without an
+  // anchor so the row doesn't briefly turn into a non-clickable shell
+  // and back.
+  const labelText = (
+    <span className="min-w-0 flex-1 truncate" title={item.label}>
+      {item.label}
+    </span>
+  )
+
   return (
-    <div className={tileClass} title={item.label}>
+    <div className={rowClass}>
       {url ? (
         <a
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className={iconAreaClass}
+          className="flex min-w-0 flex-1 items-center gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label={`Open ${item.label}`}
         >
-          {thumbnailContent}
+          <span className={thumbWellClass}>{thumbnailContent}</span>
+          {labelText}
         </a>
       ) : (
-        <span className={iconAreaClass}>{thumbnailContent}</span>
+        <span className="flex min-w-0 flex-1 items-center gap-3">
+          <span className={thumbWellClass}>{thumbnailContent}</span>
+          {labelText}
+        </span>
       )}
-      {/* Filename strip — single truncated line at the bottom of the
-          square. `text-[10px]` keeps an ~12-char filename readable in the
-          80px-wide tile without forcing the whole pill any wider. */}
-      <span className="block w-full truncate border-t border-border bg-card px-1 py-0.5 text-center text-[10px] leading-tight text-muted-foreground">
-        {item.label}
-      </span>
       {showRemove ? (
         item.busy ? (
           <span
             aria-hidden
-            className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded-full bg-card text-muted-foreground"
+            className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground"
           >
-            <Loader2 className="size-3 animate-spin" />
+            <Loader2 className="size-3.5 animate-spin" />
           </span>
         ) : (
           <button
             type="button"
             onClick={(e) => {
               // Stops both bubble and default so the click doesn't also
-              // fire the thumbnail's `<a>` and open a tab.
+              // fire the row's `<a>` and open a tab.
               e.stopPropagation()
               e.preventDefault()
               onRemove(item.id)
             }}
             disabled={disabled}
             aria-label={`Remove ${item.label}`}
-            className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <X className="size-3" aria-hidden />
+            <X className="size-3.5" aria-hidden />
           </button>
         )
       ) : null}

--- a/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
+++ b/app/dashboard/briefings/components/annotations/AttachmentThumbnail.tsx
@@ -54,11 +54,15 @@ type Props = {
 const isImageMime = (mime: string): boolean => mime.startsWith('image/')
 
 /**
- * One attachment rendered as a full-width clickable row: small thumbnail
- * on the left (image preview for image MIMEs, document icon for the
- * rest), filename in the middle, optional remove (X) button on the
- * right. Click the row to open the file in a new tab via the resolved
- * URL (blob URL for staged items, signed S3 URL for server items).
+ * One attachment rendered as a full-width clickable card: a large
+ * `aspect-video` preview well on top (image at full container width for
+ * image MIMEs, large document icon centered for the rest), a filename
+ * strip beneath, and an optional remove (X) button overlaid on the
+ * top-right corner. Click the preview to open the file in a new tab
+ * via the resolved URL (blob URL for staged items, signed S3 URL for
+ * server items). The preview is intentionally big — the parent dropped
+ * inline tiles in favor of stacked full-width cards so users can
+ * actually see what they're attaching before saving.
  */
 export default function AttachmentThumbnail({
   item,
@@ -106,82 +110,75 @@ export default function AttachmentThumbnail({
     item.kind === 'staged' ? objectUrl : downloadUrlQuery.data?.url ?? null
   const isImage = isImageMime(item.mimeType)
 
-  const rowClass =
-    'group relative flex w-full items-center gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground'
+  const cardClass =
+    'group relative flex w-full flex-col overflow-hidden rounded-lg border border-border bg-muted/40 text-foreground'
 
-  // Square thumbnail well: the image fills via `object-cover`, the
-  // document/loading icon centers inside.
-  const thumbWellClass =
-    'flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted text-muted-foreground'
+  // Big preview well: full container width with a 16:9 aspect ratio so
+  // the image is large enough to read on mobile (~360px wide → ~200px
+  // tall preview) without needing fixed pixel heights. Image stretches
+  // via `object-cover`; document icon centers at a generous `size-12`.
+  const previewAreaClass =
+    'relative flex aspect-video w-full items-center justify-center overflow-hidden bg-muted text-muted-foreground'
 
   // For images, fall back to a spinner (not the document icon) while we
   // resolve the URL — covers both the staged blob-URL effect setting on
   // mount and the server-side signed-URL query in flight.
-  const thumbnailContent =
+  const previewContent =
     isImage && url ? (
       // eslint-disable-next-line @next/next/no-img-element -- presigned S3 / blob URL, not a stable Next image route
       <img src={url} alt={item.label} className="size-full object-cover" />
     ) : isImage ? (
-      <Loader2 className="size-5 animate-spin" aria-hidden />
+      <Loader2 className="size-8 animate-spin" aria-hidden />
     ) : (
-      <FileText className="size-5" aria-hidden />
+      <FileText className="size-12" aria-hidden />
     )
 
   const showRemove = onRemove !== undefined
 
-  // The link wraps the thumb + filename so the click target is the
-  // whole row except the X button. When there's no URL yet (e.g.
-  // signed-URL still loading), we render the same layout without an
-  // anchor so the row doesn't briefly turn into a non-clickable shell
-  // and back.
-  const labelText = (
-    <span className="min-w-0 flex-1 truncate" title={item.label}>
-      {item.label}
-    </span>
-  )
-
   return (
-    <div className={rowClass}>
+    <div className={cardClass}>
       {url ? (
         <a
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex min-w-0 flex-1 items-center gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={`${previewAreaClass} focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
           aria-label={`Open ${item.label}`}
         >
-          <span className={thumbWellClass}>{thumbnailContent}</span>
-          {labelText}
+          {previewContent}
         </a>
       ) : (
-        <span className="flex min-w-0 flex-1 items-center gap-3">
-          <span className={thumbWellClass}>{thumbnailContent}</span>
-          {labelText}
-        </span>
+        <span className={previewAreaClass}>{previewContent}</span>
       )}
+      <span
+        className="block w-full truncate border-t border-border bg-card px-3 py-2 text-sm text-foreground"
+        title={item.label}
+      >
+        {item.label}
+      </span>
       {showRemove ? (
         item.busy ? (
           <span
             aria-hidden
-            className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground"
+            className="absolute right-2 top-2 inline-flex size-7 items-center justify-center rounded-full bg-card/90 text-muted-foreground shadow-sm"
           >
-            <Loader2 className="size-3.5 animate-spin" />
+            <Loader2 className="size-4 animate-spin" />
           </span>
         ) : (
           <button
             type="button"
             onClick={(e) => {
               // Stops both bubble and default so the click doesn't also
-              // fire the row's `<a>` and open a tab.
+              // fire the preview's `<a>` and open a tab.
               e.stopPropagation()
               e.preventDefault()
               onRemove(item.id)
             }}
             disabled={disabled}
             aria-label={`Remove ${item.label}`}
-            className="inline-flex size-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+            className="absolute right-2 top-2 inline-flex size-7 items-center justify-center rounded-full bg-card/90 text-muted-foreground shadow-sm transition-colors hover:bg-card hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <X className="size-3.5" aria-hidden />
+            <X className="size-4" aria-hidden />
           </button>
         )
       ) : null}

--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.test.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.test.tsx
@@ -7,6 +7,11 @@ import { BriefingAssistantSurface } from './BriefingAssistantSurface'
 import { enrichForCycler } from './enrichForCycler'
 
 const askAiChatBodyState: { autoSending: boolean } = { autoSending: false }
+// Captures the latest `onAnnotationIdReady` so tests can fire it
+// directly and exercise the lift-state-up delete affordance path.
+let captured_AskAiChatBody_onAnnotationIdReady:
+  | ((annotationId: string) => void)
+  | null = null
 
 vi.mock('./AskAiChatBody', () => ({
   __esModule: true,
@@ -16,15 +21,18 @@ vi.mock('./AskAiChatBody', () => ({
       active,
       anchor,
       onSendingChange,
+      onAnnotationIdReady,
     }: {
       annotationIdOverride?: string
       active?: boolean
       anchor?: { jsonPath: string | null }
       onSendingChange?: (sending: boolean) => void
+      onAnnotationIdReady?: (annotationId: string) => void
     }) => {
       if (askAiChatBodyState.autoSending && onSendingChange) {
         onSendingChange(true)
       }
+      captured_AskAiChatBody_onAnnotationIdReady = onAnnotationIdReady ?? null
       return (
         <div
           data-testid="chat-body"
@@ -86,6 +94,7 @@ describe('<BriefingAssistantSurface>', () => {
     Element.prototype.scrollIntoView = vi.fn()
     vi.mocked(enrichForCycler).mockClear()
     askAiChatBodyState.autoSending = false
+    captured_AskAiChatBody_onAnnotationIdReady = null
   })
 
   describe('enrichment gating', () => {
@@ -349,6 +358,120 @@ describe('<BriefingAssistantSurface>', () => {
 
       const deleteButton = screen.getByRole('button', { name: /delete chat/i })
       expect(deleteButton).toBeDisabled()
+    })
+  })
+
+  describe('pending-anchor mint → delete affordance', () => {
+    // The pending-anchor empty-state lifecycle:
+    //   1. Surface opens with `pendingAnchor` and no chats → empty
+    //      composer renders, no Delete chat button (no row yet).
+    //   2. User sends. `AskAiChatBody.ensureAnnotationId` mints the row
+    //      and fires `onAnnotationIdReady`. We expose the synthetic
+    //      annotation up here so the footer can render Delete chat
+    //      against it WITHOUT waiting for the overlay swap that fires
+    //      on stream success (which users have reported as not landing
+    //      reliably).
+    //   3. While the stream is still in flight, AskAiChatBody fires
+    //      `onSendingChange(true)` and the button must be disabled —
+    //      the row exists but the conversation isn't durable yet.
+    it('renders no Delete chat button in pending-anchor empty state before any row is minted', () => {
+      render(
+        <BriefingAssistantSurface
+          open={true}
+          onClose={vi.fn()}
+          meetingDate="2026-05-14"
+          annotations={[]}
+          pendingAnchor={{ jsonPath: 'agenda.0.title', start: 0, end: 5 }}
+          onDeleteChat={vi.fn()}
+        />,
+      )
+
+      expect(
+        screen.queryByRole('button', { name: /delete chat/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the Delete chat button once AskAiChatBody fires onAnnotationIdReady, even before the overlay swap', async () => {
+      const onDeleteChat = vi.fn().mockResolvedValue(undefined)
+      const { rerender } = render(
+        <BriefingAssistantSurface
+          open={true}
+          onClose={vi.fn()}
+          meetingDate="2026-05-14"
+          annotations={[]}
+          pendingAnchor={{ jsonPath: 'agenda.0.title', start: 0, end: 5 }}
+          onDeleteChat={onDeleteChat}
+        />,
+      )
+
+      // The mocked AskAiChatBody captured the callback on mount.
+      expect(captured_AskAiChatBody_onAnnotationIdReady).not.toBeNull()
+
+      // Simulate `ensureAnnotationId` resolving with the new chat id.
+      captured_AskAiChatBody_onAnnotationIdReady?.('ann_minted_1')
+
+      // Force a re-render so the state update lands.
+      rerender(
+        <BriefingAssistantSurface
+          open={true}
+          onClose={vi.fn()}
+          meetingDate="2026-05-14"
+          annotations={[]}
+          pendingAnchor={{ jsonPath: 'agenda.0.title', start: 0, end: 5 }}
+          onDeleteChat={onDeleteChat}
+        />,
+      )
+
+      expect(
+        await screen.findByRole('button', { name: /delete chat/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('disables the Delete chat button while AskAiChatBody reports sending=true (stream in flight)', async () => {
+      // Both: the row is minted AND the stream is sending. The button
+      // must render (so the user can see it exists) but be disabled.
+      askAiChatBodyState.autoSending = true
+
+      render(
+        <BriefingAssistantSurface
+          open={true}
+          onClose={vi.fn()}
+          meetingDate="2026-05-14"
+          annotations={[]}
+          pendingAnchor={{ jsonPath: 'agenda.0.title', start: 0, end: 5 }}
+          onDeleteChat={vi.fn().mockResolvedValue(undefined)}
+        />,
+      )
+
+      captured_AskAiChatBody_onAnnotationIdReady?.('ann_minted_2')
+
+      const deleteButton = await screen.findByRole('button', {
+        name: /delete chat/i,
+      })
+      expect(deleteButton).toBeDisabled()
+    })
+
+    it('hides the Delete chat button when the synthetic anchor has no jsonPath (page-wide preempt)', () => {
+      render(
+        <BriefingAssistantSurface
+          open={true}
+          onClose={vi.fn()}
+          meetingDate="2026-05-14"
+          annotations={[]}
+          // pendingAnchor with null jsonPath — this is the briefing-wide
+          // chat path; deleting it would lose the primary assistant
+          // thread, so we hide the button (matches the same guard the
+          // cycler footer applies).
+          pendingAnchor={{ jsonPath: null, start: null, end: null }}
+          onDeleteChat={vi.fn()}
+        />,
+      )
+
+      captured_AskAiChatBody_onAnnotationIdReady?.('ann_minted_pagewide')
+
+      expect(
+        screen.queryByRole('button', { name: /delete chat/i }),
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type {
   Annotation,
   AnnotationAnchor,
@@ -117,6 +117,50 @@ export function BriefingAssistantSurface({
   // disabled so the user can't pull the annotation out from under an
   // in-flight stream / chat-create request.
   const [isStreaming, setIsStreaming] = useState(false)
+  // Track the freshly-minted chat id while we're still in pending-anchor
+  // (empty-state) mode. The empty-state `AskAiChatBody` fires
+  // `onAnnotationIdReady` the moment `createBriefingChat` resolves —
+  // which happens BEFORE the overlay swap (we defer `onChatCreated`
+  // until stream success to avoid mid-stream unmount). Without this,
+  // the Delete chat button only appears after the swap; users have
+  // observed the swap failing to fire reliably in production, so this
+  // also provides a fallback path: even if the swap never lands, the
+  // delete affordance is wired off the minted id directly.
+  const [emptyStateMintedId, setEmptyStateMintedId] = useState<string | null>(
+    null,
+  )
+  // Reset when the sheet closes or the overlay swaps away from the
+  // pending-anchor preempt — at that point the cycler-driven `current`
+  // takes over as the delete target.
+  useEffect(() => {
+    if (!pendingAnchor && emptyStateMintedId !== null) {
+      setEmptyStateMintedId(null)
+    }
+  }, [pendingAnchor, emptyStateMintedId])
+  // Synthesize a minimal annotation for the footer to render Delete
+  // chat against while the cycler still has empty items. We have the
+  // id (from the AskAiChatBody callback) and the anchor (from
+  // pendingAnchor); the other fields aren't read by DeleteAnnotation-
+  // Button or isPageWideChat, but typing them avoids a wider relaxation
+  // of the prop type. The button is disabled via `isStreaming` until
+  // the stream completes — see footer below.
+  const mintedAnnotation: EnrichedAnnotation | null =
+    emptyStateMintedId && pendingAnchor
+      ? {
+          id: emptyStateMintedId,
+          kind: 'chat',
+          resourceType: 'briefing',
+          resourceId: '',
+          authorUserId: 0,
+          jsonPath: pendingAnchor.jsonPath,
+          start: pendingAnchor.start,
+          end: pendingAnchor.end,
+          createdAt: '',
+          updatedAt: '',
+          docOrderIndex: 0,
+          highlightedText: null,
+        }
+      : null
   return (
     <AnnotationSurfaceSheet
       open={open}
@@ -135,14 +179,19 @@ export function BriefingAssistantSurface({
           briefingItems={briefingItems}
         />
       )}
-      footer={(current) =>
+      footer={(current) => {
+        // Prefer the cycler's `current` once it lands; fall back to the
+        // synthetic minted annotation while we're still in pending-
+        // anchor empty-state mode (overlay swap hasn't happened yet,
+        // but the row exists on the server).
+        const target = current ?? mintedAnnotation
         // Hide Delete chat for the page-wide (unanchored) AI chat — that
         // conversation is the briefing's primary assistant thread and
         // deleting it from the cycler would lose context with no recovery
         // path. Anchored chats remain deletable.
-        current && !isPageWideChat(current) ? (
+        return target && !isPageWideChat(target) ? (
           <DeleteAnnotationButton
-            current={current}
+            current={target}
             label="Delete chat"
             title="Delete this chat?"
             description="The conversation and all its messages will be permanently removed. You can't undo this."
@@ -150,7 +199,7 @@ export function BriefingAssistantSurface({
             disabled={isStreaming}
           />
         ) : null
-      }
+      }}
       emptyState={
         <AskAiChatBody
           meetingDate={meetingDate}
@@ -160,6 +209,12 @@ export function BriefingAssistantSurface({
           composerVariant="block"
           active={open}
           onChatCreated={onChatCreated}
+          onAnnotationIdReady={setEmptyStateMintedId}
+          // Wire isStreaming for the empty-state body too — when the
+          // user fires the first send the row exists (Delete chat is
+          // visible) but the stream is still in flight; the button must
+          // stay disabled until the conversation is durable.
+          onSendingChange={setIsStreaming}
         />
       }
       initialAnnotationId={initialAnnotationId}

--- a/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
+++ b/app/dashboard/briefings/components/annotations/NoteAttachmentPicker.tsx
@@ -28,14 +28,6 @@ type Props = {
   disabled?: boolean
   /** Surfaced inline; the caller is expected to render rejection reasons too. */
   error?: string | null
-  /**
-   * `pill` (default): compact rounded-full chip the user discovers
-   *  alongside other inline actions (used inside AddNoteSheet's composer
-   *  cluster).
-   * `button`: full-width outline Button matching the surrounding
-   *  cycler-footer buttons (Edit Note, Delete note) in NotesSurface.
-   */
-  triggerVariant?: 'pill' | 'button'
 }
 
 const PHOTOS_ACCEPT = 'image/*'
@@ -47,17 +39,17 @@ const newId = (): string =>
     : `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 /**
- * "Add attachment" pill + the list of attachment thumbnails below it.
+ * Full-width "Add attachment" button + a vertical stack of attachment
+ * rows below it.
  *
- * On desktop the pill opens the native OS file dialog directly. On
- * mobile the pill opens a bottom drawer with three sources — Photos
- * (gallery), Camera (capture), and Document (native document picker) —
+ * On desktop the button opens the native OS file dialog directly. On
+ * mobile it opens a bottom drawer with three sources — Photos
+ * (gallery), Camera (capture), and Files (native document picker) —
  * matching the WhatsApp-style attachment menu.
  *
- * Each attachment renders as a small thumbnail tile (image preview for
- * image MIME types, file-icon for everything else). Clicking the
- * thumbnail opens the file in a new tab via the corresponding S3 URL.
- * The X overlay in the corner removes the attachment.
+ * Each attachment renders as a `AttachmentThumbnail` row (small thumb
+ * left, filename middle, optional X right). Clicking the row opens the
+ * file in a new tab via the corresponding S3 / blob URL.
  */
 export default function NoteAttachmentPicker({
   items,
@@ -65,7 +57,6 @@ export default function NoteAttachmentPicker({
   onRemove,
   disabled = false,
   error = null,
-  triggerVariant = 'pill',
 }: Props): React.JSX.Element {
   const isMobile = useIsMobile()
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -105,26 +96,22 @@ export default function NoteAttachmentPicker({
   }
 
   const triggerClassName =
-    triggerVariant === 'button'
-      ? 'inline-flex w-full items-center justify-center gap-2 rounded-full border border-input bg-background px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
-      : 'inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
+    'inline-flex w-full items-center justify-center gap-2 rounded-full border border-input bg-background px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60'
 
   return (
     <div className="flex flex-col gap-2">
-      <div>
-        <button
-          type="button"
-          onClick={openPicker}
-          disabled={disabled}
-          className={triggerClassName}
-        >
-          <Paperclip className="size-4" aria-hidden />
-          Add attachment
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={openPicker}
+        disabled={disabled}
+        className={triggerClassName}
+      >
+        <Paperclip className="size-4" aria-hidden />
+        Add attachment
+      </button>
 
       {items.length > 0 ? (
-        <ul className="flex list-none flex-wrap items-start gap-2">
+        <ul className="flex list-none flex-col gap-2">
           {items.map((it) => (
             <li key={it.id}>
               <AttachmentThumbnail

--- a/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
@@ -115,7 +115,9 @@ describe('NotesSurface', () => {
       const note: Annotation = {
         ...makeNote(),
         id: 'card-level-exec',
-        jsonPath: '/executive_summary',
+        // Canonical card jsonPath (camelCase) — matches what
+        // `ActiveCard.jsonPath` and the create flow store on the DB.
+        jsonPath: '/executiveSummary',
         start: null,
         end: null,
       }

--- a/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
@@ -106,6 +106,37 @@ describe('NotesSurface', () => {
     ).toBeInTheDocument()
   })
 
+  describe('Card-level section header', () => {
+    // Anchored notes already render the AnchoredQuote with a label. For
+    // card-level notes (jsonPath set, no quote/offsets), we still want
+    // the uppercase section label so the user can see which card the
+    // note is attached to as they cycle.
+    it('renders the section label for a card-level note on the executive summary (no highlightedText)', () => {
+      const note: Annotation = {
+        ...makeNote(),
+        id: 'card-level-exec',
+        jsonPath: '/executive_summary',
+        start: null,
+        end: null,
+      }
+      render(
+        <NotesSurface
+          open
+          onClose={vi.fn()}
+          annotations={[note]}
+          onSaveEdit={vi.fn(() => Promise.resolve())}
+          onUploadAttachment={vi.fn(() => Promise.resolve())}
+          onDeleteAttachment={vi.fn(() => Promise.resolve())}
+          onDeleteNote={vi.fn()}
+        />,
+      )
+
+      expect(screen.getByText('EXECUTIVE SUMMARY')).toBeInTheDocument()
+      // No anchored-quote glyph since there's no highlighted text.
+      expect(screen.queryByText(/“/)).not.toBeInTheDocument()
+    })
+  })
+
   describe('Delete confirmation', () => {
     it('opens a confirm dialog instead of deleting immediately when Delete is clicked', async () => {
       const onDeleteNote = vi.fn()

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -341,7 +341,6 @@ export function NotesSurface({
             {isEditingCurrent ? null : (
               <>
                 <NoteAttachmentPicker
-                  triggerVariant="button"
                   items={[]}
                   onAdd={(file) => {
                     setAttachmentError(null)

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -185,7 +185,7 @@ function NoteBody({
           </div>
         )}
         {!editing && attachmentItems.length > 0 ? (
-          <ul className="flex list-none flex-wrap items-start gap-2 pt-2">
+          <ul className="flex list-none flex-col gap-2 pt-2">
             {attachmentItems.map((att) => (
               <li key={att.id}>
                 <AttachmentThumbnail item={att} onRemove={onRemoveAttachment} />

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -109,6 +109,10 @@ function NoteBody({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+      {/* Anchored notes get the full AnchoredQuote (label + quoted text).
+          Card-level notes (no `highlightedText`) still get the uppercase
+          section label by itself so the viewer can see which card the
+          note belongs to — matches the parity behavior in AddNoteSheet. */}
       {item.highlightedText ? (
         <AnchoredQuote
           text={item.highlightedText}
@@ -116,6 +120,10 @@ function NoteBody({
           label={sectionLabel ?? undefined}
           filled
         />
+      ) : sectionLabel ? (
+        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {sectionLabel}
+        </span>
       ) : null}
       <div className="flex flex-col gap-2 rounded-md border border-border bg-card p-4 text-card-foreground">
         <div className="flex items-baseline gap-2 text-sm">

--- a/app/dashboard/briefings/components/annotations/sectionLabel.test.ts
+++ b/app/dashboard/briefings/components/annotations/sectionLabel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { Item } from '@shared/briefings/types'
+import { sectionLabelFromPath } from './sectionLabel'
+
+// Minimal `Item` factory — only `title` matters for the helper.
+function makeItem(title: string): Item {
+  return { title } as unknown as Item
+}
+
+describe('sectionLabelFromPath', () => {
+  it('returns null for a null jsonPath', () => {
+    expect(sectionLabelFromPath(null, undefined)).toBeNull()
+  })
+
+  it('returns "EXECUTIVE SUMMARY" for the canonical camelCase card path "/executiveSummary"', () => {
+    // This is the form `ActiveCard.jsonPath` produces in
+    // AnnotationsScope, and the form annotations save to the DB.
+    expect(sectionLabelFromPath('/executiveSummary', undefined)).toBe(
+      'EXECUTIVE SUMMARY',
+    )
+  })
+
+  it('also accepts the snake_case form (passage selectors like "/executive_summary/title")', () => {
+    expect(sectionLabelFromPath('/executive_summary/title', undefined)).toBe(
+      'EXECUTIVE SUMMARY',
+    )
+  })
+
+  it('returns the agenda item title (uppercased) for "/items/N" paths', () => {
+    const items = [
+      makeItem('Approval of agenda'),
+      makeItem('Public comment'),
+      makeItem('Rezoning vote'),
+    ]
+    expect(sectionLabelFromPath('/items/2', items)).toBe('REZONING VOTE')
+    expect(sectionLabelFromPath('/items/0/title', items)).toBe(
+      'APPROVAL OF AGENDA',
+    )
+  })
+
+  it('returns null when the items index is out of range', () => {
+    expect(sectionLabelFromPath('/items/42', [makeItem('only')])).toBeNull()
+  })
+
+  it('returns null for an unknown path shape', () => {
+    expect(sectionLabelFromPath('/something/else', undefined)).toBeNull()
+  })
+})

--- a/app/dashboard/briefings/components/annotations/sectionLabel.ts
+++ b/app/dashboard/briefings/components/annotations/sectionLabel.ts
@@ -4,7 +4,12 @@ import type { Item } from '@shared/briefings/types'
  * Derive an uppercase section label for an annotation's anchored quote
  * from its jsonPath:
  *  - `/items/N/...` → items[N].title
- *  - `/executive_summary/...` → "EXECUTIVE SUMMARY"
+ *  - `/executiveSummary[/...]` or `/executive_summary[/...]` → "EXECUTIVE SUMMARY"
+ *
+ * Both spellings are accepted because card-level annotations store the
+ * camelCase form (`/executiveSummary` per `ActiveCard.jsonPath`) while
+ * passage anchors land on snake_case field selectors inside the same
+ * section (`/executive_summary/title`, etc.).
  *
  * Returns null when the path doesn't match a known section or the index
  * is out of range — callers should hide the label in that case.
@@ -14,7 +19,7 @@ export function sectionLabelFromPath(
   items: readonly Item[] | undefined,
 ): string | null {
   if (!jsonPath) return null
-  if (/^\/executive_summary(?:\/|$)/.test(jsonPath)) {
+  if (/^\/(executive_summary|executiveSummary)(?:\/|$)/.test(jsonPath)) {
     return 'EXECUTIVE SUMMARY'
   }
   const match = jsonPath.match(/^\/items\/(\d+)(?:\/|$)/)

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
@@ -39,6 +39,21 @@ describe('<DetailHeaderActions>', () => {
     expect(openShareDrawer).toHaveBeenCalledTimes(1)
   })
 
+  it('renders an icon-only IconButton for mobile and a labelled Button for desktop, gated by width-aware Tailwind classes', () => {
+    // Mobile (icon-only) and desktop (icon + "Share" text) both live in
+    // the DOM under jsdom; visibility is controlled by Tailwind utility
+    // classes. Asserting the class gating here pins the responsive
+    // contract so a future refactor can't accidentally drop one side.
+    setShareScope()
+    render(<DetailHeaderActions />)
+
+    const mobileBtn = screen.getByRole('button', { name: /share briefing/i })
+    expect(mobileBtn).toHaveClass('lg:hidden')
+
+    const desktopBtn = screen.getByRole('button', { name: /^share$/i })
+    expect(desktopBtn).toHaveClass('hidden', 'lg:inline-flex')
+  })
+
   it('renders nothing when share scope reports !canShare', () => {
     // Rolling-deploy window: gp-webapp has the share-drawer code but
     // gp-api's response hasn't grown `briefing_id` yet. `canShare` is

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -1,23 +1,23 @@
 'use client'
 
-import { Button, Share2Icon } from '@styleguide'
+import { Button, ShareIcon } from '@styleguide'
 import { useShareScope } from './ShareScope'
 
 /**
- * Sticky header actions on desktop. Share opens the bottom drawer whose
- * Copy/Email/Message/Download buttons all point at the public PDF URL
- * served by `gp-api` via the `/api/v1/briefings/:uuid` Vercel rewrite —
- * the client-side react-pdf Download flow this surface used to host was
- * removed alongside that backend cutover.
+ * Sticky header actions on the briefing detail page. Renders at every
+ * breakpoint — mobile keeps the share affordance in the sub-header
+ * (matching desktop) instead of duplicating it in MobileBottomBar.
  *
- * "Add note" + "Briefing assistant" used to live here, but the desktop
- * action surface is now the sticky `DesktopBottomBar` at the bottom of
- * the page — matching the mobile layout and the Lovable design.
+ * Share opens the bottom drawer whose Copy/Email/Message/Download
+ * buttons all point at the public PDF URL served by `gp-api` via the
+ * `/api/v1/briefings/:uuid` Vercel rewrite — the client-side react-pdf
+ * Download flow this surface used to host was removed alongside that
+ * backend cutover.
  *
  * The actual `<ShareBriefingDrawer>` lives in `<ShareScope>` at the
  * layout level — this component just dispatches the open call. That
  * keeps a single Radix Sheet instance on the page so focus / portal
- * management doesn't race with the mirror in `MobileBottomBar`.
+ * management doesn't race with other consumers.
  */
 export default function DetailHeaderActions(): React.JSX.Element | null {
   const { canShare, openShareDrawer } = useShareScope()
@@ -25,9 +25,9 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
   if (!canShare) return null
 
   return (
-    <div className="hidden items-center gap-2 lg:flex">
+    <div className="flex items-center gap-2">
       <Button variant="outline" onClick={openShareDrawer}>
-        <Share2Icon className="size-4" aria-hidden />
+        <ShareIcon className="size-4" aria-hidden />
         Share
       </Button>
     </div>

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -1,12 +1,18 @@
 'use client'
 
-import { Button, ShareIcon } from '@styleguide'
+import { Button, IconButton, ShareIcon } from '@styleguide'
 import { useShareScope } from './ShareScope'
 
 /**
  * Sticky header actions on the briefing detail page. Renders at every
- * breakpoint — mobile keeps the share affordance in the sub-header
- * (matching desktop) instead of duplicating it in MobileBottomBar.
+ * breakpoint:
+ *  - mobile (< lg): an icon-only `IconButton` keeps the sub-header
+ *    compact next to the meeting title block.
+ *  - desktop (lg+): a labelled `Button` with the icon + "Share" text.
+ *
+ * Both call the same `openShareDrawer` and share the same `aria-label`,
+ * so screen readers see one share affordance per page regardless of
+ * width.
  *
  * Share opens the bottom drawer whose Copy/Email/Message/Download
  * buttons all point at the public PDF URL served by `gp-api` via the
@@ -26,7 +32,21 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
 
   return (
     <div className="flex items-center gap-2">
-      <Button variant="outline" onClick={openShareDrawer}>
+      <IconButton
+        type="button"
+        size="medium"
+        variant="outline"
+        aria-label="Share briefing"
+        onClick={openShareDrawer}
+        className="lg:hidden"
+      >
+        <ShareIcon className="size-5" aria-hidden />
+      </IconButton>
+      <Button
+        variant="outline"
+        onClick={openShareDrawer}
+        className="hidden lg:inline-flex"
+      >
         <ShareIcon className="size-4" aria-hidden />
         Share
       </Button>

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -5,13 +5,9 @@ import { render } from 'helpers/test-utils/render'
 import MobileBottomBar from './MobileBottomBar'
 import type { Item } from '@shared/briefings/types'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
-import { useShareScope } from './ShareScope'
 
 vi.mock('../annotations/AnnotationsScope', () => ({
   useAnnotationsCtx: vi.fn(),
-}))
-vi.mock('./ShareScope', () => ({
-  useShareScope: vi.fn(),
 }))
 
 vi.mock('next/navigation', async () => {
@@ -23,7 +19,6 @@ vi.mock('next/navigation', async () => {
 })
 
 const mockedUseAnnotationsCtx = vi.mocked(useAnnotationsCtx)
-const mockedUseShareScope = vi.mocked(useShareScope)
 
 type AnnotationsCtxValue = ReturnType<typeof useAnnotationsCtx>
 
@@ -60,14 +55,6 @@ function setCtx(overrides: Partial<AnnotationsCtxValue> = {}) {
   mockedUseAnnotationsCtx.mockReturnValue(ctx)
 }
 
-function setShareScope({
-  canShare = true,
-  openShareDrawer = vi.fn(),
-}: { canShare?: boolean; openShareDrawer?: () => void } = {}) {
-  mockedUseShareScope.mockReturnValue({ canShare, openShareDrawer })
-  return openShareDrawer
-}
-
 function makeItems(n: number): Item[] {
   return Array.from(
     { length: n },
@@ -87,12 +74,10 @@ function makeItems(n: number): Item[] {
 describe('<MobileBottomBar>', () => {
   beforeEach(() => {
     mockedUseAnnotationsCtx.mockReset()
-    mockedUseShareScope.mockReset()
   })
 
-  it('renders the page-selector pill, Share, Add note, and Ask AI in a single dock row', () => {
+  it('renders the page-selector pill, Add note, and Ask AI in a single dock row', () => {
     setCtx({ activeCard: ACTIVE_CARD })
-    setShareScope()
     render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(2)} />)
 
     // The selector pill and the Ask AI button both contain "Executive
@@ -102,23 +87,28 @@ describe('<MobileBottomBar>', () => {
     })
     const selector = selectorMatches[0]
     if (!selector) throw new Error('selector button not rendered')
-    const share = screen.getByRole('button', { name: /share briefing/i })
     const askAi = screen.getByRole('button', {
       name: /ask ai about executive summary/i,
     })
 
-    // All controls share a common ancestor (the dock row) so they render as
-    // a single horizontal group instead of being scattered.
+    // Selector + Ask AI share a common ancestor (the dock row).
     const row = selector.parentElement
     expect(row).not.toBeNull()
-    expect(row).toContainElement(share)
     expect(row).toContainElement(askAi)
+  })
+
+  it('does not render a share button — share lives in the sub-header now', () => {
+    setCtx({ activeCard: ACTIVE_CARD })
+    render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
+
+    expect(
+      screen.queryByRole('button', { name: /share briefing/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('calls openAddNoteTopLevel when the Add note button is tapped with an active card', async () => {
     const openAddNoteTopLevel = vi.fn()
     setCtx({ openAddNoteTopLevel, activeCard: ACTIVE_CARD })
-    setShareScope()
     render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
 
     await userEvent.click(
@@ -130,41 +120,11 @@ describe('<MobileBottomBar>', () => {
   it('calls openCardLevelChat when the Briefing assistant button is tapped with an active card', async () => {
     const openCardLevelChat = vi.fn()
     setCtx({ openCardLevelChat, activeCard: ACTIVE_CARD })
-    setShareScope()
     render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
 
     await userEvent.click(
       screen.getByRole('button', { name: /ask ai about executive summary/i }),
     )
     expect(openCardLevelChat).toHaveBeenCalledTimes(1)
-  })
-
-  it('asks the share scope to open the drawer when Share is clicked', async () => {
-    setCtx()
-    const openShareDrawer = setShareScope()
-    render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
-
-    await userEvent.click(
-      screen.getByRole('button', { name: /share briefing/i }),
-    )
-    expect(openShareDrawer).toHaveBeenCalledTimes(1)
-  })
-
-  it('hides the share icon when share scope reports !canShare', () => {
-    // During a rolling-deploy window where the briefing artifact lacks
-    // `briefing_id`, the dock must not render a Share button — clicking
-    // one would otherwise produce a broken `/api/v1/briefings/undefined`
-    // URL via the drawer.
-    setCtx({ activeCard: ACTIVE_CARD })
-    setShareScope({ canShare: false })
-    render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
-
-    expect(
-      screen.queryByRole('button', { name: /share briefing/i }),
-    ).not.toBeInTheDocument()
-    // Other dock controls still render so the rest of the toolbar works.
-    expect(
-      screen.getByRole('button', { name: /add a note to executive summary/i }),
-    ).toBeInTheDocument()
   })
 })

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -5,7 +5,6 @@ import { List, ChevronUp, MessageSquare, Sparkles } from 'lucide-react'
 import {
   Button,
   IconButton,
-  Share2Icon,
   Sheet,
   SheetContent,
   SheetHeader,
@@ -17,7 +16,6 @@ import {
 } from '@shared/briefings/routes'
 import type { Item } from '@shared/briefings/types'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
-import { useShareScope } from './ShareScope'
 
 type Props = {
   briefingSlug: string
@@ -35,7 +33,10 @@ type Entry = {
  *
  *  - Left pill: name of the section currently in view + chevron, opens a
  *    bottom Sheet listing every section.
- *  - Right FABs: Share (opens the share drawer), Add notes, and Ask AI.
+ *  - Right FABs: Add notes and Ask AI.
+ *
+ * Share lives in the sub-header (`DetailHeaderActions`) on every
+ * breakpoint, so it isn't duplicated here.
  *
  * Tapping an entry scrolls to that section on the same page; the Sheet
  * closes on tap.
@@ -47,10 +48,9 @@ export default function MobileBottomBar({
   const [open, setOpen] = useState(false)
   // `openAddNoteTopLevel` / `openCardLevelChat` replaced the older
   // `openNotesSurface` / `openChatsSurface` API on `develop` and now
-  // require an active card; the share drawer is independent of that.
+  // require an active card.
   const { openAddNoteTopLevel, openCardLevelChat, activeCard } =
     useAnnotationsCtx()
-  const { canShare, openShareDrawer } = useShareScope()
 
   const entries: Entry[] = useMemo(() => {
     const list: Entry[] = [
@@ -211,17 +211,6 @@ export default function MobileBottomBar({
           </SheetContent>
         </Sheet>
 
-        {canShare && (
-          <IconButton
-            type="button"
-            size="medium"
-            variant="outline"
-            aria-label="Share briefing"
-            onClick={openShareDrawer}
-          >
-            <Share2Icon className="size-5" aria-hidden />
-          </IconButton>
-        )}
         <IconButton
           type="button"
           size="medium"

--- a/styleguide/components/ui/icons.tsx
+++ b/styleguide/components/ui/icons.tsx
@@ -37,6 +37,7 @@ export {
   Search as SearchIcon,
   Send as SendIcon,
   Settings as SettingsIcon,
+  Share as ShareIcon,
   Share2 as Share2Icon,
   Square as SquareIcon,
   Star as StarIcon,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Ask AI lifecycle changes (deferred create, delayed callbacks, verification GET) affect chat creation and overlay handoff; otherwise mostly UI and annotation display with broad test coverage.
> 
> **Overview**
> This PR tightens briefing **notes**, **Ask AI chat**, **attachments**, and **share** UX based on stakeholder feedback.
> 
> **Notes** show a consistent uppercase **section label** for card-level notes (not only anchored quotes) in `AddNoteSheet` and `NotesSurface`, backed by `sectionLabelFromPath` accepting both `/executiveSummary` and `/executive_summary` paths. New notes display a **"New Note"** header instead of a misleading "Note N of M" counter.
> 
> **Ask AI** no longer creates a chat on sheet open: `AskAiChatBody` **defers** `createBriefingChat` until the first send, runs a post-create `listMessages` warm-up, shows **Thinking…** during the create gap, and delays **`onChatCreated`** until the first stream completes so the overlay does not unmount mid-response. `BriefingAssistantSurface` uses **`onAnnotationIdReady`** so **Delete chat** appears as soon as the row is minted; **`AnnotationsScope`** **closes** the chats surface after a successful soft-delete.
> 
> **Attachments** move from small inline tiles to **full-width stacked cards** with large previews (`AttachmentThumbnail`, `NoteAttachmentPicker`).
> 
> **Share** is consolidated in the sub-header: **`DetailHeaderActions`** shows share on mobile (icon) and desktop (labeled button); **`MobileBottomBar`** drops its duplicate share control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb6e61c0ce08fb0cc8f35925caf7f6cf21fc2fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->