### PR TITLE
fix: stale-closure bug in CreatePoll useEvent analytics call

### DIFF
--- a/app/dashboard/polls/create/CreatePoll.tsx
+++ b/app/dashboard/polls/create/CreatePoll.tsx
@@ -1,6 +1,6 @@
 'use client'
 import DashboardLayout from '../../shared/DashboardLayout'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { StepIndicator } from '@shared/stepper'
 import { useRouter } from 'next/navigation'
@@ -125,8 +125,18 @@ const FormContent: React.FC<{
 )
 
 const useEvent = (event: string, props?: Record<string, any>) => {
+  // Mount-only by intent (these are page-view / completion events that should
+  // fire exactly once), but the effect runs after the first commit — by which
+  // point a re-render may have produced fresher props (e.g. async user data
+  // resolving). Read through refs so the effect captures the latest values
+  // at fire time without retriggering on every prop change.
+  const eventRef = useRef(event)
+  const propsRef = useRef(props)
+  eventRef.current = event
+  propsRef.current = props
+
   useEffect(() => {
-    trackEvent(event, props)
+    trackEvent(eventRef.current, propsRef.current)
   }, [])
 }
 


### PR DESCRIPTION
## Summary
- Fix `useEvent` in `app/dashboard/polls/create/CreatePoll.tsx` so the captured event name and props are not stale when the effect fires.
- Forward the latest `event` / `props` through refs and read them inside the mount-only `useEffect`, preserving "fire exactly once" semantics for the page-view / completion events.

## Motivation
`useEvent` ran `trackEvent` inside `useEffect(() => …, [])`, which captured the first render's `event` and `props` in its closure. When state changed before the effect committed — most notably `SuccessForm`'s `paymentCompleted` payload, which depends on async `useUser()` data — the analytics call silently used stale (often `'Unknown'`) values. Six other call sites pass no props so they were unaffected in practice, but the same closure bug was latent.

The fix keeps the mount-only firing semantics (these are view / completion events, they shouldn't re-fire on every render) and just guarantees the effect reads the freshest `event` / `props` at fire time.

## Test plan
- [x] `npx eslint app/dashboard/polls/create/CreatePoll.tsx` — clean
- [x] `npx prettier --check app/dashboard/polls/create/CreatePoll.tsx` — clean
- [x] `npm run lint` and `npm run types` show only the same pre-existing repo-wide errors as `develop` (unrelated `PageProps` issues in other `app/dashboard/polls/[id]/...` page files); no new errors introduced.
- [x] No `CreatePoll.test.tsx` exists, so no targeted test run.
- [ ] Manual: verify analytics payload for the create-poll success page now contains the real `email` / `hubspotId` once `useUser()` resolves.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized analytics fix with no auth, payment, or API behavior changes—only correctness of tracked event payloads.
> 
> **Overview**
> Fixes a **stale-closure bug** in the local `useEvent` helper in `CreatePoll.tsx`: the mount-only `useEffect` still runs once per mount, but it now reads the latest `event` and `props` via refs instead of values frozen from the first render.
> 
> That matters for **`SuccessForm`’s `paymentCompleted` analytics**, where props include `email` and `hubspotId` from async `useUser()`—those were often sent as `'Unknown'` before user data loaded. Other step “viewed” call sites are unchanged in behavior when they pass no props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832018966c2346a5b28ecb5d7483e57f3d016812. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->