### PR TITLE
test: add unit tests for 4 pure helpers

### DIFF
--- a/helpers/URLSearchParamsToObject.test.ts
+++ b/helpers/URLSearchParamsToObject.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { URLSearchParamsToObject } from './URLSearchParamsToObject'
+
+describe('URLSearchParamsToObject', () => {
+  it('returns an empty object for empty params', () => {
+    expect(URLSearchParamsToObject(new URLSearchParams())).toEqual({})
+  })
+
+  it('maps single-occurrence keys to string values', () => {
+    const params = new URLSearchParams('a=1&b=hello')
+    expect(URLSearchParamsToObject(params)).toEqual({ a: '1', b: 'hello' })
+  })
+
+  it('promotes a duplicated key to a string array', () => {
+    const params = new URLSearchParams('tag=foo&tag=bar')
+    expect(URLSearchParamsToObject(params)).toEqual({ tag: ['foo', 'bar'] })
+  })
+
+  it('appends to the existing array on third and later occurrences', () => {
+    const params = new URLSearchParams('tag=a&tag=b&tag=c&tag=d')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      tag: ['a', 'b', 'c', 'd'],
+    })
+  })
+
+  it('handles a mix of single-value and multi-value keys', () => {
+    const params = new URLSearchParams('id=42&tag=a&tag=b&q=hello')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      id: '42',
+      tag: ['a', 'b'],
+      q: 'hello',
+    })
+  })
+
+  it('preserves empty-string values', () => {
+    const params = new URLSearchParams('a=&b=value')
+    expect(URLSearchParamsToObject(params)).toEqual({ a: '', b: 'value' })
+  })
+
+  it('preserves insertion order of duplicated keys', () => {
+    const params = new URLSearchParams('first=a&second=b&first=c')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      first: ['a', 'c'],
+      second: 'b',
+    })
+  })
+})

--- a/helpers/extractApiErrorInfo.test.ts
+++ b/helpers/extractApiErrorInfo.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { extractApiErrorInfo } from './extractApiErrorInfo'
+
+describe('extractApiErrorInfo', () => {
+  it('returns empty object for null', () => {
+    expect(extractApiErrorInfo(null)).toEqual({})
+  })
+
+  it('returns empty object for undefined', () => {
+    expect(extractApiErrorInfo(undefined)).toEqual({})
+  })
+
+  it('returns empty object for non-object primitives', () => {
+    expect(extractApiErrorInfo('boom')).toEqual({})
+    expect(extractApiErrorInfo(42)).toEqual({})
+    expect(extractApiErrorInfo(false)).toEqual({})
+  })
+
+  it('extracts a string message', () => {
+    expect(extractApiErrorInfo({ message: 'Something failed' })).toEqual({
+      message: 'Something failed',
+      errorCode: undefined,
+    })
+  })
+
+  it('joins an array message into a comma-separated string', () => {
+    expect(
+      extractApiErrorInfo({
+        message: ['email is required', 'name is required'],
+      }),
+    ).toEqual({
+      message: 'email is required, name is required',
+      errorCode: undefined,
+    })
+  })
+
+  it('filters out non-string entries when joining an array message', () => {
+    expect(
+      extractApiErrorInfo({ message: ['valid', 42, null, 'also valid'] }),
+    ).toEqual({
+      message: 'valid, also valid',
+      errorCode: undefined,
+    })
+  })
+
+  it('returns undefined message when the message field is neither string nor array', () => {
+    expect(extractApiErrorInfo({ message: { nested: 'shape' } })).toEqual({
+      message: undefined,
+      errorCode: undefined,
+    })
+  })
+
+  it('extracts a string errorCode', () => {
+    expect(
+      extractApiErrorInfo({ message: 'oops', errorCode: 'EMAIL_TAKEN' }),
+    ).toEqual({
+      message: 'oops',
+      errorCode: 'EMAIL_TAKEN',
+    })
+  })
+
+  it('returns undefined errorCode when it is not a string', () => {
+    expect(extractApiErrorInfo({ message: 'oops', errorCode: 123 })).toEqual({
+      message: 'oops',
+      errorCode: undefined,
+    })
+  })
+
+  it('returns both fields undefined when neither key is present', () => {
+    expect(extractApiErrorInfo({})).toEqual({
+      message: undefined,
+      errorCode: undefined,
+    })
+  })
+})

--- a/helpers/resolvePostAuthRedirectPath.util.test.ts
+++ b/helpers/resolvePostAuthRedirectPath.util.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { resolvePostAuthRedirectPath } from './resolvePostAuthRedirectPath.util'
+
+describe('resolvePostAuthRedirectPath', () => {
+  it('routes a sales user to the sales add-campaign page', () => {
+    expect(
+      resolvePostAuthRedirectPath({ roles: ['sales', 'admin'] }, null),
+    ).toBe('/sales/add-campaign')
+  })
+
+  it('prefers the sales role over any campaign status', () => {
+    expect(
+      resolvePostAuthRedirectPath(
+        { roles: ['sales'] },
+        { status: 'candidate' },
+      ),
+    ).toBe('/sales/add-campaign')
+  })
+
+  it('routes a candidate to the dashboard', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: 'candidate' })).toBe(
+      '/dashboard',
+    )
+  })
+
+  it('routes an onboarding user to the slug + step path', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, {
+        status: 'onboarding',
+        slug: 'jane-doe',
+        step: 4,
+      }),
+    ).toBe('/onboarding/jane-doe/4')
+  })
+
+  it('defaults onboarding step to 1 when missing', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, {
+        status: 'onboarding',
+        slug: 'jane-doe',
+      }),
+    ).toBe('/onboarding/jane-doe/1')
+  })
+
+  it('falls through to /dashboard/profile when onboarding has no slug', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: 'onboarding' })).toBe(
+      '/dashboard/profile',
+    )
+  })
+
+  it('routes to office-selection when there is no campaign status', () => {
+    expect(resolvePostAuthRedirectPath(null, null)).toBe(
+      '/onboarding/office-selection',
+    )
+  })
+
+  it('routes to office-selection when campaign status is false', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: false })).toBe(
+      '/onboarding/office-selection',
+    )
+  })
+
+  it('routes a user with elected office and no campaign to the dashboard', () => {
+    expect(resolvePostAuthRedirectPath(null, null, true)).toBe('/dashboard')
+    expect(resolvePostAuthRedirectPath(null, { status: false }, true)).toBe(
+      '/dashboard',
+    )
+  })
+
+  it('falls back to /dashboard/profile for any other status', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, { status: 'something-else' }),
+    ).toBe('/dashboard/profile')
+  })
+
+  it('handles a user without roles', () => {
+    expect(resolvePostAuthRedirectPath({}, { status: 'candidate' })).toBe(
+      '/dashboard',
+    )
+  })
+})

--- a/helpers/validations.test.ts
+++ b/helpers/validations.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { isValidEmail } from './validations'
+
+describe('isValidEmail', () => {
+  it('accepts a standard email', () => {
+    expect(isValidEmail('user@example.com')).toBe(true)
+  })
+
+  it('accepts emails with dots, plus signs, and dashes in the local part', () => {
+    expect(isValidEmail('first.last+tag@example.co.uk')).toBe(true)
+    expect(isValidEmail('a-b_c@sub.example.org')).toBe(true)
+  })
+
+  it('accepts uppercase emails (lowercased internally)', () => {
+    expect(isValidEmail('USER@EXAMPLE.COM')).toBe(true)
+  })
+
+  it('accepts emails with IP-literal domains', () => {
+    expect(isValidEmail('user@[127.0.0.1]')).toBe(true)
+  })
+
+  it('rejects emails missing the @ sign', () => {
+    expect(isValidEmail('userexample.com')).toBe(false)
+  })
+
+  it('rejects emails missing a domain', () => {
+    expect(isValidEmail('user@')).toBe(false)
+  })
+
+  it('rejects emails missing a local part', () => {
+    expect(isValidEmail('@example.com')).toBe(false)
+  })
+
+  it('rejects domains without a top-level domain', () => {
+    expect(isValidEmail('user@example')).toBe(false)
+  })
+
+  it('rejects single-character TLDs', () => {
+    expect(isValidEmail('user@example.c')).toBe(false)
+  })
+
+  it('rejects whitespace inputs', () => {
+    expect(isValidEmail('')).toBe(false)
+    expect(isValidEmail('   ')).toBe(false)
+    expect(isValidEmail('user @example.com')).toBe(false)
+    expect(isValidEmail('user@ example.com')).toBe(false)
+  })
+
+  it('rejects unicode characters in the domain part', () => {
+    expect(isValidEmail('user@exämple.com')).toBe(false)
+  })
+
+  it('accepts unicode characters in the local part (negated-class regex)', () => {
+    expect(isValidEmail('üser@example.com')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `extractApiErrorInfo`, `validations` (`isValidEmail`), `resolvePostAuthRedirectPath`, and `URLSearchParamsToObject`.
- 40 total tests added (10 / 12 / 11 / 7).

## Motivation
`helpers/` has 51 modules and only 5 tests. These four helpers are pure, branchy, and widely used — easy wins that pin behavior and prevent regressions.

## Notes (surprising-but-real behavior, NOT fixed here)
- `resolvePostAuthRedirectPath` with `{ status: 'onboarding' }` and no `slug` falls through to `/dashboard/profile` (not `/onboarding/office-selection`). Tests pin the actual behavior.
- `isValidEmail` regex uses a negated character class for the local part, so unicode local parts (e.g. `üser@example.com`) are accepted while unicode domains (e.g. `user@exämple.com`) are rejected. Tests pin both.

## Test plan
- All new test files pass: `npx vitest run helpers/extractApiErrorInfo.test.ts helpers/validations.test.ts helpers/resolvePostAuthRedirectPath.util.test.ts helpers/URLSearchParamsToObject.test.ts`
- `npx eslint` and `npx prettier --check` pass on the four new test files.
- No source helpers were modified.
- Pre-existing lint/type errors in unrelated `app/dashboard/polls/**` and `app/polls/**` files are not caused by this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or helper logic modifications.
> 
> **Overview**
> Adds **Vitest coverage only** for four existing pure helpers under `helpers/` — no production code changes.
> 
> New suites pin behavior for **`URLSearchParamsToObject`** (single vs repeated keys, empty values, order), **`extractApiErrorInfo`** (null/primitives, string vs array messages, `errorCode` typing), **`resolvePostAuthRedirectPath`** (sales vs candidate/onboarding/elected-office routing and fallbacks), and **`isValidEmail`** (format edge cases including unicode local vs domain). Together that’s **40 tests** documenting current behavior, including quirks called out in the PR (onboarding without `slug` → `/dashboard/profile`; unicode in local part allowed, domain not).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d505ab76a6bf168d30c54ef3aa4a28658d2487d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->