### PR TITLE
test: add coverage for campaign-assistant ChatProvider and contacts CRM components

### DIFF
--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -233,6 +233,55 @@ describe('<ChatProvider>', () => {
     expect(screen.getByTestId('should-type')).toHaveTextContent('true')
   })
 
+  it('handleRegenerate replaces the last assistant message via the update endpoint', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [
+            { role: 'user', content: 'first question' },
+            { role: 'assistant', content: 'original reply' },
+          ],
+        }),
+      ),
+      http.put(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          message: { role: 'assistant', content: 'regenerated reply' },
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+    await screen.findByText('original reply')
+
+    await user.click(screen.getByRole('button', { name: 'regen' }))
+
+    expect(await screen.findByText('regenerated reply')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('first question')
+    expect(messages[1]).toHaveTextContent('regenerated reply')
+    expect(screen.queryByText('original reply')).not.toBeInTheDocument()
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('handleRegenerate is a no-op when there is no active threadId', async () => {
+    const user = userEvent.setup()
+    // No msw handlers registered: a real PUT would 500 (unhandled) and
+    // the test would fail. The provider must short-circuit before the
+    // network call.
+    renderProvider()
+
+    await user.click(screen.getByRole('button', { name: 'regen' }))
+
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+  })
+
   it('finishTyping flips shouldType back to false', async () => {
     const user = userEvent.setup()
     mswServer.use(

--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -1,0 +1,222 @@
+import { useContext } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { render } from 'helpers/test-utils/render'
+import { mswServer } from 'helpers/test-utils/api-mocking'
+import { ChatContext, ChatProvider } from './ChatProvider'
+
+vi.mock('helpers/analyticsHelper', async () => {
+  const actual = await vi.importActual<object>('helpers/analyticsHelper')
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  }
+})
+
+const CHAT_LIST_URL = '/api/v1/campaigns/ai/chat'
+const CHAT_THREAD_URL = '/api/v1/campaigns/ai/chat/:threadId'
+
+const Consumer = () => {
+  const ctx = useContext(ChatContext)
+  return (
+    <div>
+      <div data-testid="thread-id">
+        {ctx.threadId === null
+          ? 'null'
+          : ctx.threadId === ''
+          ? 'empty'
+          : ctx.threadId}
+      </div>
+      <div data-testid="loading">{String(ctx.loading)}</div>
+      <div data-testid="should-type">{String(ctx.shouldType)}</div>
+      <div data-testid="chats-count">{ctx.chats.length}</div>
+      <ul data-testid="chat-messages">
+        {ctx.chat.map((m, i) => (
+          <li key={i} data-role={m.role}>
+            {m.content}
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => void ctx.loadInitialChats()}>load</button>
+      <button onClick={() => void ctx.handleNewInput('hello world')}>
+        send
+      </button>
+      <button onClick={() => void ctx.loadChatByThreadId('thread-2')}>
+        switch
+      </button>
+      <button onClick={() => void ctx.handleRegenerate()}>regen</button>
+      <button onClick={() => ctx.finishTyping()}>finish</button>
+    </div>
+  )
+}
+
+const renderProvider = () =>
+  render(
+    <ChatProvider>
+      <Consumer />
+    </ChatProvider>,
+  )
+
+describe('<ChatProvider>', () => {
+  beforeEach(() => {
+    // jsdom doesn't implement scrollTo; the provider scrolls a ref that we
+    // never attach, but the implementation still calls .scrollTo on null
+    // checks. Be defensive.
+    Element.prototype.scrollTo = vi.fn()
+  })
+
+  it('exposes default context values before any action runs', () => {
+    renderProvider()
+
+    // The provider initializes threadId to an empty string (not null) and
+    // flips to null only after a hydrate that returns no threads.
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('empty')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('false')
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('0')
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+  })
+
+  it('loadInitialChats fetches the chat list and hydrates the first thread', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          chats: [
+            {
+              threadId: 'thread-1',
+              name: 'First chat',
+              updatedAt: '2026-05-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ),
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-1',
+          chat: [
+            { role: 'user', content: 'hi there' },
+            { role: 'assistant', content: 'hello back' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'load' }))
+
+    expect(await screen.findByText('thread-1')).toBeInTheDocument()
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('1')
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('hi there')
+    expect(messages[1]).toHaveTextContent('hello back')
+  })
+
+  it('loadInitialChats resets state when the API returns no chats', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_LIST_URL, () => HttpResponse.json({ chats: [] })),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'load' }))
+
+    // The empty-list response resets threadId to null (distinct from the
+    // initial empty-string state).
+    await screen.findByText('null')
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('0')
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+  })
+
+  it('handleNewInput creates a new thread on the first message', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.post(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-new',
+          chat: [
+            { role: 'user', content: 'hello world' },
+            { role: 'assistant', content: 'glad to help' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    expect(await screen.findByText('thread-new')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('hello world')
+    expect(messages[1]).toHaveTextContent('glad to help')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('handleNewInput keeps the optimistic user message and clears loading when the create call fails at the network layer', async () => {
+    const user = userEvent.setup()
+    // `HttpResponse.error()` simulates a network error so that the
+    // `ajaxActions` try/catch path triggers and `createInitialChat`
+    // returns `false`. Returning a 5xx JSON body would NOT trip the
+    // catch (clientFetch swallows non-2xx) and the provider would crash
+    // trying to destructure `result.chat` — that's a separate latent bug
+    // worth tracking, not exercised here.
+    mswServer.use(http.post(CHAT_LIST_URL, () => HttpResponse.error()))
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    await screen.findByText('hello world')
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toHaveTextContent('hello world')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    // threadId remains the initial empty string when no new thread was returned.
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('empty')
+  })
+
+  it('loadChatByThreadId swaps the active thread and replaces messages', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [{ role: 'assistant', content: 'switched thread reply' }],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+
+    expect(await screen.findByText('thread-2')).toBeInTheDocument()
+    expect(await screen.findByText('switched thread reply')).toBeInTheDocument()
+  })
+
+  it('finishTyping flips shouldType back to false', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.post(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-new',
+          chat: [
+            { role: 'user', content: 'hello world' },
+            { role: 'assistant', content: 'glad to help' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+    await screen.findByText('glad to help')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+
+    await user.click(screen.getByRole('button', { name: 'finish' }))
+    expect(screen.getByTestId('should-type')).toHaveTextContent('false')
+  })
+})

--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -197,6 +197,42 @@ describe('<ChatProvider>', () => {
     expect(await screen.findByText('switched thread reply')).toBeInTheDocument()
   })
 
+  it('handleNewInput updates an existing thread on follow-up messages', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [{ role: 'assistant', content: 'switched thread reply' }],
+        }),
+      ),
+      http.put(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          message: { role: 'assistant', content: 'follow-up reply' },
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+    expect(await screen.findByText('thread-2')).toBeInTheDocument()
+    await screen.findByText('switched thread reply')
+
+    // threadId is now 'thread-2' and chat has one assistant message, so the
+    // !threadId || chat.length === 0 branch routes to updateChat (PUT), not
+    // createInitialChat.
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    expect(await screen.findByText('follow-up reply')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(3)
+    expect(messages[0]).toHaveTextContent('switched thread reply')
+    expect(messages[1]).toHaveTextContent('hello world')
+    expect(messages[2]).toHaveTextContent('follow-up reply')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+  })
+
   it('finishTyping flips shouldType back to false', async () => {
     const user = userEvent.setup()
     mswServer.use(

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'helpers/test-utils/render'
 import ContactsTable from './ContactsTable'
 import { useContactsTable } from '../hooks/ContactsTableProvider'
 import { useShowContactProModal } from '../hooks/ContactProModal'
-import type { Person } from './shared/contacts-types'
+import { makePerson } from './shared/test-fixtures'
 
 vi.mock('../hooks/ContactsTableProvider', () => ({
   useContactsTable: vi.fn(),
@@ -19,45 +19,6 @@ const mockedUseContactsTable = vi.mocked(useContactsTable)
 const mockedUseShowContactProModal = vi.mocked(useShowContactProModal)
 
 type ContextValue = ReturnType<typeof useContactsTable>
-
-function makePerson(overrides: Partial<Person> = {}): Person {
-  return {
-    id: 'p_1',
-    lalVoterId: 'lal_1',
-    firstName: 'Jane',
-    middleName: null,
-    lastName: 'Doe',
-    nameSuffix: null,
-    age: 42,
-    state: 'CA',
-    address: {
-      line1: '123 Main St',
-      line2: null,
-      city: 'Townsville',
-      state: 'CA',
-      zip: '90210',
-      zipPlus4: null,
-      latitude: null,
-      longitude: null,
-    },
-    cellPhone: '555-0100',
-    landline: '555-0101',
-    gender: 'Female',
-    politicalParty: 'Independent',
-    registeredVoter: 'Yes',
-    estimatedIncomeAmount: null,
-    voterStatus: null,
-    maritalStatus: null,
-    hasChildrenUnder18: null,
-    veteranStatus: null,
-    homeowner: null,
-    businessOwner: null,
-    levelOfEducation: null,
-    ethnicityGroup: null,
-    language: 'English',
-    ...overrides,
-  }
-}
 
 function setContext(overrides: Partial<ContextValue> = {}) {
   const ctx: ContextValue = {

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import ContactsTable from './ContactsTable'
+import { useContactsTable } from '../hooks/ContactsTableProvider'
+import { useShowContactProModal } from '../hooks/ContactProModal'
+import type { Person } from './shared/contacts-types'
+
+vi.mock('../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('../hooks/ContactProModal', () => ({
+  useShowContactProModal: vi.fn(),
+}))
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseShowContactProModal = vi.mocked(useShowContactProModal)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: null,
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}
+
+function setContext(overrides: Partial<ContextValue> = {}) {
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: null,
+    currentlySelectedPerson: {
+      person: null,
+      isLoadingPerson: false,
+      isErrorPerson: false,
+      issues: [],
+      isLoadingIssues: false,
+      isErrorIssues: false,
+      issuesHasNextPage: false,
+      issuesFetchNextPage: vi.fn(),
+      isFetchingNextIssues: false,
+      activities: [],
+      isLoadingActivities: false,
+      isErrorActivities: false,
+      activitiesHasNextPage: false,
+      activitiesFetchNextPage: vi.fn(),
+      isFetchingNextActivities: false,
+    },
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: {
+      totalResults: 0,
+      currentPage: 1,
+      pageSize: 20,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial: false,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson: vi.fn(),
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+describe('<ContactsTable>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseShowContactProModal.mockReset()
+    mockedUseShowContactProModal.mockReturnValue(vi.fn())
+  })
+
+  it('renders the column headers', () => {
+    setContext({ filteredContacts: [makePerson()] })
+    render(<ContactsTable />)
+
+    // Columns are non-sortable so headers render as plain text, not buttons.
+    for (const label of [
+      'Name',
+      'Gender',
+      'Age',
+      'Address',
+      'Cell Phone',
+      'Landline',
+    ]) {
+      expect(
+        screen.getByRole('columnheader', { name: label }),
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('renders one row per contact with formatted name', () => {
+    setContext({
+      filteredContacts: [
+        makePerson({ id: '1', firstName: 'Jane', lastName: 'Doe' }),
+        makePerson({ id: '2', firstName: 'John', lastName: 'Smith' }),
+      ],
+    })
+    render(<ContactsTable />)
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('John Smith')).toBeInTheDocument()
+  })
+
+  it('renders skeleton cells when isLoading is true', () => {
+    setContext({ isLoading: true })
+    const { container } = render(<ContactsTable />)
+
+    // 6 skeleton columns x 20 rows (default page size) = 120 placeholders.
+    // We just assert the skeleton class shows up and the real data cells
+    // (e.g. "Jane Doe") do not.
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+      0,
+    )
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+  })
+
+  it('calls selectPerson when a pro user clicks a row', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    setContext({
+      filteredContacts: [makePerson({ id: 'pid_42' })],
+      canUseProFeatures: true,
+      selectPerson,
+    })
+    render(<ContactsTable />)
+
+    await user.click(screen.getByText('Jane Doe'))
+
+    expect(selectPerson).toHaveBeenCalledWith('pid_42')
+  })
+
+  it('opens the pro upgrade modal instead of selecting when the user is not pro', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    const showProModal = vi.fn()
+    mockedUseShowContactProModal.mockReturnValue(showProModal)
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: false,
+      selectPerson,
+    })
+    render(<ContactsTable />)
+
+    await user.click(screen.getByText('Jane Doe'))
+
+    expect(showProModal).toHaveBeenCalledWith(true)
+    expect(selectPerson).not.toHaveBeenCalled()
+  })
+
+  it('blurs sensitive cells for non-pro users', () => {
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: false,
+    })
+    const { container } = render(<ContactsTable />)
+
+    // Cell phone, landline, and address are wrapped in a blurred span for
+    // non-pro users. Match by class to keep the assertion structural.
+    const blurredEls = container.querySelectorAll('.blur-\\[6px\\]')
+    expect(blurredEls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('does not blur sensitive cells for pro users', () => {
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: true,
+    })
+    const { container } = render(<ContactsTable />)
+
+    expect(container.querySelectorAll('.blur-\\[6px\\]')).toHaveLength(0)
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -205,9 +205,10 @@ describe('<ContactsTable>', () => {
     const { container } = render(<ContactsTable />)
 
     // Cell phone, landline, and address are wrapped in a blurred span for
-    // non-pro users. Match by class to keep the assertion structural.
+    // non-pro users. Exactly three fields blur per row — assert the exact
+    // count so accidentally blurring more cells fails the test.
     const blurredEls = container.querySelectorAll('.blur-\\[6px\\]')
-    expect(blurredEls.length).toBeGreaterThanOrEqual(3)
+    expect(blurredEls).toHaveLength(3)
   })
 
   it('does not blur sensitive cells for pro users', () => {

--- a/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
@@ -5,8 +5,8 @@ import { render } from 'helpers/test-utils/render'
 import PersonOverlay from './PersonOverlay'
 import { useContactsTable } from '../../hooks/ContactsTableProvider'
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import { makePerson } from '../shared/test-fixtures'
 import type {
-  Person,
   ConstituentIssue,
   ConstituentActivity,
 } from '../shared/contacts-types'
@@ -31,45 +31,6 @@ const mockedUseFlagOn = vi.mocked(useFlagOn)
 
 type ContextValue = ReturnType<typeof useContactsTable>
 type SelectedPerson = ContextValue['currentlySelectedPerson']
-
-function makePerson(overrides: Partial<Person> = {}): Person {
-  return {
-    id: 'p_1',
-    lalVoterId: 'lal_1',
-    firstName: 'Jane',
-    middleName: null,
-    lastName: 'Doe',
-    nameSuffix: null,
-    age: 42,
-    state: 'CA',
-    address: {
-      line1: '123 Main St',
-      line2: null,
-      city: 'Townsville',
-      state: 'CA',
-      zip: '90210',
-      zipPlus4: null,
-      latitude: null,
-      longitude: null,
-    },
-    cellPhone: '555-0100',
-    landline: '555-0101',
-    gender: 'Female',
-    politicalParty: 'Independent',
-    registeredVoter: 'Yes',
-    estimatedIncomeAmount: null,
-    voterStatus: 'Likely',
-    maritalStatus: null,
-    hasChildrenUnder18: null,
-    veteranStatus: null,
-    homeowner: null,
-    businessOwner: null,
-    levelOfEducation: null,
-    ethnicityGroup: null,
-    language: 'English',
-    ...overrides,
-  }
-}
 
 function setContext({
   selectedPersonId = 'p_1',

--- a/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import PersonOverlay from './PersonOverlay'
+import { useContactsTable } from '../../hooks/ContactsTableProvider'
+import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import type {
+  Person,
+  ConstituentIssue,
+  ConstituentActivity,
+} from '../shared/contacts-types'
+
+vi.mock('../../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('@shared/experiments/FeatureFlagsProvider', () => ({
+  useFlagOn: vi.fn(),
+}))
+
+// Google Maps would otherwise try to attach a Script tag and reference
+// `window.google`. Stub it with a marker we can assert on.
+vi.mock('@shared/utils/Map', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-map" />,
+}))
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseFlagOn = vi.mocked(useFlagOn)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+type SelectedPerson = ContextValue['currentlySelectedPerson']
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: 'Likely',
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}
+
+function setContext({
+  selectedPersonId = 'p_1',
+  selectedPerson,
+  isElectedOfficial = false,
+  selectPerson = vi.fn(),
+}: {
+  selectedPersonId?: string | null
+  selectedPerson?: Partial<SelectedPerson>
+  isElectedOfficial?: boolean
+  selectPerson?: ContextValue['selectPerson']
+} = {}) {
+  const currentlySelectedPerson: SelectedPerson = {
+    person: makePerson(),
+    isLoadingPerson: false,
+    isErrorPerson: false,
+    issues: [],
+    isLoadingIssues: false,
+    isErrorIssues: false,
+    issuesHasNextPage: false,
+    issuesFetchNextPage: vi.fn(),
+    isFetchingNextIssues: false,
+    activities: [],
+    isLoadingActivities: false,
+    isErrorActivities: false,
+    activitiesHasNextPage: false,
+    activitiesFetchNextPage: vi.fn(),
+    isFetchingNextActivities: false,
+    ...selectedPerson,
+  }
+
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: selectedPersonId,
+    currentlySelectedPerson,
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: null,
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson,
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+describe('<PersonOverlay>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseFlagOn.mockReset()
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: false })
+  })
+
+  it('does not open the overlay when no person is selected', () => {
+    setContext({ selectedPersonId: null })
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the loading skeleton while the person query is loading', () => {
+    setContext({
+      selectedPerson: { person: null, isLoadingPerson: true },
+    })
+
+    render(<PersonOverlay />)
+
+    // Sheet content renders inside a Radix Portal, so query the document
+    // instead of the render container.
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+    // No real card section headings while loading.
+    expect(
+      screen.queryByRole('heading', { name: /contact information/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the person details and the standard info sections', () => {
+    setContext()
+
+    render(<PersonOverlay />)
+
+    // Person name renders as a real <h2>; the card titles render as styled
+    // <div>s (CardTitle), so query them by text content.
+    expect(
+      screen.getByRole('heading', { name: /jane doe/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/female, 42 years old/i)).toBeInTheDocument()
+    // CardTitle is a styled <div>; scope to data-slot to avoid colliding
+    // with the sr-only SheetTitle that uses the same copy.
+    const cardTitles = document.querySelectorAll('[data-slot="card-title"]')
+    const titles = Array.from(cardTitles).map((el) => el.textContent?.trim())
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        'Contact Information',
+        'Voter Demographics',
+        'Demographic Information',
+      ]),
+    )
+  })
+
+  it('renders an error message and lets the user close the overlay when the person fetch fails', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    setContext({
+      selectPerson,
+      selectedPerson: { person: null, isErrorPerson: true },
+    })
+
+    render(<PersonOverlay />)
+
+    const errorHeading = screen.getByRole('heading', {
+      name: /error loading contact/i,
+    })
+    const errorBlock = errorHeading.parentElement
+    if (!errorBlock) throw new Error('error block not rendered')
+
+    // The error UI's Close button is a raw <button> next to the heading;
+    // the Sheet renders its own (svg-icon) close button at the top right.
+    await user.click(within(errorBlock).getByRole('button', { name: /close/i }))
+    expect(selectPerson).toHaveBeenCalledWith(null)
+  })
+
+  it('hides the Political Party field for elected officials', () => {
+    setContext({ isElectedOfficial: true })
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByText(/^political party$/i)).not.toBeInTheDocument()
+  })
+
+  it('hides Top Issues and Activity Feed when the feature flag is off', () => {
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: false })
+    setContext()
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByText('Top Issues')).not.toBeInTheDocument()
+    expect(screen.queryByText('Activity Feed')).not.toBeInTheDocument()
+  })
+
+  it('shows Top Issues and Activity Feed (with seeded data) when the feature flag is on', () => {
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: true })
+    const issues: ConstituentIssue[] = [
+      {
+        issueTitle: 'Better Bike Lanes',
+        issueSummary: 'Constituent supports bike-lane expansion',
+        pollTitle: 'Transit',
+        pollId: 'poll_1',
+        date: '2026-05-01',
+      },
+    ]
+    const activities: ConstituentActivity[] = [
+      {
+        type: 'poll',
+        date: '2026-05-02',
+        data: {
+          pollId: 'poll_1',
+          pollTitle: 'Transit Survey',
+          events: [{ type: 'SENT', date: '2026-05-02T00:00:00.000Z' }],
+        },
+      },
+    ]
+    setContext({
+      selectedPerson: { issues, activities },
+    })
+
+    render(<PersonOverlay />)
+
+    expect(screen.getByText('Top Issues')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /better bike lanes/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Activity Feed')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /transit survey/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
@@ -1,0 +1,318 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import FiltersSheet from './FiltersSheet'
+import { useContactsTable } from '../../hooks/ContactsTableProvider'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { SHEET_MODES } from '../shared/constants'
+import type { SegmentResponse } from '../shared/contacts-types'
+
+vi.mock('../../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: vi.fn(),
+}))
+
+vi.mock('helpers/analyticsHelper', async () => {
+  const actual = await vi.importActual<object>('helpers/analyticsHelper')
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  }
+})
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseSnackbar = vi.mocked(useSnackbar)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+
+function setContext(overrides: Partial<ContextValue> = {}) {
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: null,
+    currentlySelectedPerson: {
+      person: null,
+      isLoadingPerson: false,
+      isErrorPerson: false,
+      issues: [],
+      isLoadingIssues: false,
+      isErrorIssues: false,
+      issuesHasNextPage: false,
+      issuesFetchNextPage: vi.fn(),
+      isFetchingNextIssues: false,
+      activities: [],
+      isLoadingActivities: false,
+      isErrorActivities: false,
+      activitiesHasNextPage: false,
+      activitiesFetchNextPage: vi.fn(),
+      isFetchingNextActivities: false,
+    },
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: null,
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial: false,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson: vi.fn(),
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+function setSnackbar() {
+  const successSnackbar = vi.fn()
+  const errorSnackbar = vi.fn()
+  const displaySnackbar = vi.fn()
+  mockedUseSnackbar.mockReturnValue({
+    successSnackbar,
+    errorSnackbar,
+    displaySnackbar,
+  })
+  return { successSnackbar, errorSnackbar }
+}
+
+const editableSegment = (
+  overrides: Partial<SegmentResponse> = {},
+): SegmentResponse => ({
+  id: 42,
+  name: 'My Saved Segment',
+  genderMale: true,
+  ...overrides,
+})
+
+/**
+ * The filter checkboxes don't use a real <label htmlFor>; the option name
+ * is rendered as a sibling div. Find the option row by its label text,
+ * then return its inner checkbox.
+ */
+function checkboxForOption(label: string): HTMLElement {
+  const labelNode = screen.getByText(new RegExp(`^${label}$`, 'i'))
+  const row = labelNode.parentElement
+  if (!row) throw new Error(`row for ${label} not found`)
+  const checkbox = within(row).getByRole('checkbox')
+  return checkbox
+}
+
+describe('<FiltersSheet>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseSnackbar.mockReset()
+  })
+
+  it('renders the filter sheet with section titles in create mode', () => {
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /general information/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /create segment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('auto-generates a default segment name in create mode using the number of existing custom segments', () => {
+    setContext({
+      customSegments: [editableSegment({ id: 1 }), editableSegment({ id: 2 })],
+    })
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /custom segment 3/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the Create button disabled until a filter is selected, then triggers afterSave with the new segment id on success', async () => {
+    const user = userEvent.setup()
+    const afterSave = vi.fn()
+    const handleClose = vi.fn()
+    setContext()
+    const { successSnackbar } = setSnackbar()
+    api.mock('POST /v1/voters/voter-file/filter', {
+      status: 200,
+      data: { id: 7, name: 'Custom Segment 1' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={afterSave}
+      />,
+    )
+
+    const create = screen.getByRole('button', { name: /create segment/i })
+    expect(create).toBeDisabled()
+
+    await user.click(checkboxForOption('Male'))
+    expect(create).toBeEnabled()
+
+    await user.click(create)
+
+    await vi.waitFor(() => {
+      expect(afterSave).toHaveBeenCalledWith(7)
+    })
+    expect(successSnackbar).toHaveBeenCalledWith('Segment created successfully')
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('shows an error snackbar when the create API fails', async () => {
+    const user = userEvent.setup()
+    const afterSave = vi.fn()
+    setContext()
+    const { errorSnackbar } = setSnackbar()
+    api.mock('POST /v1/voters/voter-file/filter', {
+      status: 500,
+      data: { message: 'server exploded' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={afterSave}
+      />,
+    )
+
+    await user.click(checkboxForOption('Female'))
+    await user.click(screen.getByRole('button', { name: /create segment/i }))
+
+    await vi.waitFor(() => {
+      expect(errorSnackbar).toHaveBeenCalledWith('Failed to create segment')
+    })
+    expect(afterSave).not.toHaveBeenCalled()
+  })
+
+  it('renders the existing name and an Update Segment button in edit mode', () => {
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /my saved segment/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /update segment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Political Party section for elected officials', () => {
+    setContext({ isElectedOfficial: true })
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // The General Information section still renders, but its Political
+    // Party field is filtered out.
+    expect(
+      screen.getByRole('heading', { name: /general information/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /political party/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Select All toggles every option within a filter field on at once', async () => {
+    const user = userEvent.setup()
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // Scope all queries to the Gender field container (heading parent's
+    // parent) — "Unknown" repeats across other filter sections.
+    const genderHeading = screen.getByRole('heading', { name: /^gender$/i })
+    const headerRow = genderHeading.parentElement
+    const fieldContainer = headerRow?.parentElement
+    if (!fieldContainer) throw new Error('gender field container not rendered')
+
+    const selectAll = within(headerRow!).getByText(/select all/i)
+    await user.click(selectAll)
+
+    const checkboxes = within(fieldContainer).getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(3)
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toHaveAttribute('aria-checked', 'true')
+    }
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
@@ -256,6 +256,76 @@ describe('<FiltersSheet>', () => {
     ).toBeInTheDocument()
   })
 
+  it('PUTs the segment, selects it, and closes the sheet when Update Segment succeeds in edit mode', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    const selectSegment = vi.fn()
+    const refreshCustomSegments = vi.fn().mockResolvedValue(undefined)
+    setContext({ selectSegment, refreshCustomSegments })
+    const { successSnackbar } = setSnackbar()
+    api.mock('PUT /v1/voters/voter-file/filter/:id', {
+      status: 200,
+      data: { id: 42, name: 'My Saved Segment' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // editableSegment seeds genderMale=true, so Update is enabled
+    // immediately without needing a checkbox click.
+    await user.click(screen.getByRole('button', { name: /update segment/i }))
+
+    await vi.waitFor(() => {
+      expect(successSnackbar).toHaveBeenCalledWith(
+        'Segment updated successfully',
+      )
+    })
+    expect(refreshCustomSegments).toHaveBeenCalled()
+    expect(selectSegment).toHaveBeenCalledWith('42')
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('shows an error snackbar and keeps the sheet open when the update API fails in edit mode', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    const selectSegment = vi.fn()
+    setContext({ selectSegment })
+    const { errorSnackbar } = setSnackbar()
+    api.mock('PUT /v1/voters/voter-file/filter/:id', {
+      status: 500,
+      data: { message: 'server exploded' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /update segment/i }))
+
+    await vi.waitFor(() => {
+      expect(errorSnackbar).toHaveBeenCalledWith('Failed to update segment')
+    })
+    expect(selectSegment).not.toHaveBeenCalled()
+    expect(handleClose).not.toHaveBeenCalled()
+  })
+
   it('hides the Political Party section for elected officials', () => {
     setContext({ isElectedOfficial: true })
     setSnackbar()

--- a/app/dashboard/contacts/[[...attr]]/components/shared/test-fixtures.ts
+++ b/app/dashboard/contacts/[[...attr]]/components/shared/test-fixtures.ts
@@ -1,0 +1,48 @@
+import type { Person } from './contacts-types'
+
+/**
+ * Canonical Person factory for contacts unit tests. Defaults to a
+ * `voterStatus` of `null` (the most common state in production data);
+ * tests that need a specific status should pass it via `overrides`.
+ *
+ * This file is imported only from `*.test.tsx` files and is not used
+ * in production code.
+ */
+export function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: null,
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ChatProvider.test.tsx` covering provider state + API integration with mocked endpoints (7 tests).
- Add tests for `ContactsTable` (7), `FiltersSheet` (7), and `PersonOverlay` (7).
- 28 new tests total across two previously uncovered feature areas.

## Motivation
Both `app/dashboard/campaign-assistant/` (ChatProvider, the heart of
the assistant) and `app/dashboard/contacts/` (the CRM table, person
overlay, and segment filter sheet) had **zero test coverage**. This
PR seeds the pattern for future expansion across both feature dirs.

## How API mocking is handled
- Contacts components use the typed `clientRequest` layer, so the
  one place a real network call is mocked (FiltersSheet create
  segment) uses `api.mock('POST /v1/voters/voter-file/filter', ...)`
  from `helpers/test-utils/api-mocking`.
- ChatProvider goes through the legacy `clientFetch` against routes
  that are not yet keyed in `APIEndpoints`, so its tests use the
  exported `mswServer.use(http.X(...))` directly. Still MSW, just
  the untyped door — moved to `api.mock` if/when the routes get
  added to `gpApi/api-endpoints.ts`.

## Out of scope (noted, not acted on)
- `handleNewInput` in `ChatProvider.tsx` crashes if the API
  responds with a non-2xx JSON body that isn't `{chat, threadId}` —
  the network-layer error path is covered, the malformed-body case
  is not. Filed as a comment in the test file rather than fixed
  here.
- `ConstituentActivity['data']['events']` is typed as required but
  `PersonOverlay.tsx` already guards with `events?.length` — the
  type vs. runtime mismatch is left as-is.

## Test plan
- [x] All 4 new test files pass (`npx vitest run` on each)
- [x] `npm run lint` — no new errors (10 pre-existing errors on
      `develop`, all in unrelated `app/dashboard/polls/[id]/expand*`
      pages and `app/polls/onboarding/success/page.tsx`)
- [x] `npm run types` — no new errors (6 pre-existing TS errors on
      `develop` in the same files; `PageProps` typing predates this
      branch)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with mocked providers and APIs; no runtime behavior or deployment surface changes.
> 
> **Overview**
> Adds **28 Vitest + Testing Library tests** across four new files, with **no production code changes**.
> 
> **Campaign assistant:** `ChatProvider.test.tsx` exercises default context, list/thread hydration via **MSW** (`mswServer.use` on `/api/v1/campaigns/ai/chat`), first-message thread creation, optimistic send on network failure, thread switching, and `finishTyping`—with analytics stubbed and `scrollTo` patched for jsdom.
> 
> **Contacts CRM:** Three component suites mock `useContactsTable` (and related hooks): **`ContactsTable`** (headers, rows, loading skeletons, pro vs non-pro row click / blur), **`PersonOverlay`** (open/close, loading/error, elected-official and feature-flag sections, stubbed map), and **`FiltersSheet`** (create/edit UI, default naming, create success/failure via **`api.mock`** on `POST /v1/voters/voter-file/filter`, political-party hiding, Select All).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b484191a684895253135ca89509a8c754484930d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->