### PR TITLE
fix(briefings): selection toolbar on full-passage highlights + detail UI polish

### DIFF
--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.pendingAnchor.test.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.pendingAnchor.test.tsx
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { screen } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
-import type { Annotation } from '@shared/briefings/types'
+import type { Annotation, Item } from '@shared/briefings/types'
 import { BriefingAssistantSurface } from './BriefingAssistantSurface'
 
 vi.mock('./AskAiChatBody', () => ({
@@ -48,6 +48,12 @@ describe('<BriefingAssistantSurface> — pendingAnchor takes precedence', () => 
     Element.prototype.scrollIntoView = vi.fn()
   })
 
+  afterEach(() => {
+    document
+      .querySelectorAll('[data-briefing-json-path]')
+      .forEach((el) => el.remove())
+  })
+
   it('preempts the cycler with a fresh anchored composer when pendingAnchor is set, even if other chats exist', () => {
     render(
       <BriefingAssistantSurface
@@ -92,6 +98,36 @@ describe('<BriefingAssistantSurface> — pendingAnchor takes precedence', () => 
     const body = screen.getByTestId('chat-body')
     expect(body.getAttribute('data-json-path')).toBe('/items/3/title')
     expect(body.getAttribute('data-annotation-id')).toBe('none')
+  })
+
+  it('shows the section label and quoted text above the empty-state composer when starting from a selection', () => {
+    // resolveQuoteFromAnchor rebuilds the quote from the live DOM, so the
+    // anchored passage must exist in the document for the quote to resolve.
+    const passage = document.createElement('p')
+    passage.setAttribute('data-briefing-json-path', '/items/0/display/summary')
+    passage.textContent = 'The council will vote on the budget.'
+    document.body.appendChild(passage)
+
+    render(
+      <BriefingAssistantSurface
+        open
+        onClose={vi.fn()}
+        meetingDate="2026-05-14"
+        briefingItems={[{ title: 'Budget Vote' }] as unknown as Item[]}
+        annotations={[]}
+        onDeleteChat={vi.fn()}
+        pendingAnchor={{
+          jsonPath: '/items/0/display/summary',
+          start: 4,
+          end: 11,
+        }}
+      />,
+    )
+
+    // start=4,end=11 of "The council will vote..." → "council", rendered as
+    // the anchored quote (distinct from the source passage in the document).
+    expect(screen.getByText(/“council”/)).toBeInTheDocument()
+    expect(screen.getByText('BUDGET VOTE')).toBeInTheDocument()
   })
 
   it('falls back to the cycler view when pendingAnchor is undefined and chats exist', () => {

--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
@@ -6,7 +6,11 @@ import type {
   AnnotationAnchor,
   Item,
 } from '@shared/briefings/types'
-import { EMPTY_ANCHOR, isPageWideChat } from '@shared/briefings/anchorResolver'
+import {
+  EMPTY_ANCHOR,
+  isPageWideChat,
+  resolveQuoteFromAnchor,
+} from '@shared/briefings/anchorResolver'
 import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import AskAiChatBody from './AskAiChatBody'
 import { AnnotationSurfaceSheet } from './AnnotationSurfaceSheet'
@@ -161,6 +165,18 @@ export function BriefingAssistantSurface({
           highlightedText: null,
         }
       : null
+  // Section label + quoted text for the empty-state composer when the chat is
+  // being started from a selection. The pending anchor carries only
+  // jsonPath/start/end, so rebuild the quote from the live DOM the same way
+  // existing anchored chats and notes do.
+  const pendingSectionLabel = sectionLabelFromPath(
+    pendingAnchor?.jsonPath ?? null,
+    briefingItems,
+  )
+  const pendingQuote =
+    pendingAnchor && pendingAnchor.jsonPath !== null
+      ? resolveQuoteFromAnchor(pendingAnchor)
+      : null
   return (
     <AnnotationSurfaceSheet
       open={open}
@@ -201,21 +217,31 @@ export function BriefingAssistantSurface({
         ) : null
       }}
       emptyState={
-        <AskAiChatBody
-          meetingDate={meetingDate}
-          anchor={pendingAnchor ?? EMPTY_ANCHOR}
-          showInlineHeader={false}
-          bodyClassName="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
-          composerVariant="block"
-          active={open}
-          onChatCreated={onChatCreated}
-          onAnnotationIdReady={setEmptyStateMintedId}
-          // Wire isStreaming for the empty-state body too — when the
-          // user fires the first send the row exists (Delete chat is
-          // visible) but the stream is still in flight; the button must
-          // stay disabled until the conversation is durable.
-          onSendingChange={setIsStreaming}
-        />
+        <div className="flex h-full min-h-0 flex-col gap-3">
+          {pendingQuote ? (
+            <AnchoredQuote
+              text={pendingQuote}
+              variant="primary"
+              showLabel={pendingSectionLabel !== null}
+              label={pendingSectionLabel ?? undefined}
+            />
+          ) : null}
+          <AskAiChatBody
+            meetingDate={meetingDate}
+            anchor={pendingAnchor ?? EMPTY_ANCHOR}
+            showInlineHeader={false}
+            bodyClassName="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto"
+            composerVariant="block"
+            active={open}
+            onChatCreated={onChatCreated}
+            onAnnotationIdReady={setEmptyStateMintedId}
+            // Wire isStreaming for the empty-state body too — when the
+            // user fires the first send the row exists (Delete chat is
+            // visible) but the stream is still in flight; the button must
+            // stay disabled until the conversation is durable.
+            onSendingChange={setIsStreaming}
+          />
+        </div>
       }
       initialAnnotationId={initialAnnotationId}
     />

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -344,7 +344,13 @@ const AgendaItemCard = ({
               />
             </section>
           ) : null}
+        </>
+      )}
 
+      <CardLevelNotesList cardPath={base} />
+
+      {isWhatToExpectOnly ? null : (
+        <>
           {itemSources.length > 0 ? (
             <div className="border-y border-border py-2">
               <SourcesCollapsible sources={itemSources} />
@@ -355,7 +361,6 @@ const AgendaItemCard = ({
           ) : null}
         </>
       )}
-      <CardLevelNotesList cardPath={base} />
     </article>
   )
 }

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -12,6 +12,7 @@ import {
   briefingItemCardPath,
   briefingItemTitlePath,
 } from '@shared/briefings/routes'
+import { selectElementContents } from '@shared/briefings/anchorResolver'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
@@ -239,13 +240,14 @@ const AgendaItemCard = ({
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
-          {/* `select-none` reserves the title as the card-level chat
-              anchor — see openCardLevelChat. Users don't need (and we
-              don't want) to highlight it themselves. Body text inside
-              the card remains selectable. */}
+          {/* Clicking the title selects its full text so the
+              HighlightToolbar surfaces anchored to the title — the same
+              anchor openCardLevelChat uses — without the user having to
+              drag-highlight it by hand. */}
           <h3
-            className="select-none text-lg font-semibold text-foreground"
+            className="w-fit cursor-pointer text-lg font-semibold text-foreground"
             data-briefing-json-path={titlePath}
+            onClick={(e) => selectElementContents(e.currentTarget)}
           >
             {item.title}
           </h3>

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -239,7 +239,7 @@ const AgendaItemCard = ({
       }`}
     >
       <header className="flex items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
+        <div className="flex min-w-0 flex-col gap-1">
           {/* Clicking the title selects its full text so the
               HighlightToolbar surfaces anchored to the title — the same
               anchor openCardLevelChat uses — without the user having to
@@ -253,11 +253,13 @@ const AgendaItemCard = ({
           </h3>
         </div>
         {speechText ? (
-          <ReadAloudButton
-            text={speechText}
-            analyticsLabel={analyticsLabel}
-            compact
-          />
+          <div className="shrink-0">
+            <ReadAloudButton
+              text={speechText}
+              analyticsLabel={analyticsLabel}
+              compact
+            />
+          </div>
         ) : null}
       </header>
 

--- a/app/dashboard/briefings/components/detail/DetailHeader.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeader.tsx
@@ -23,7 +23,10 @@ export default function DetailHeader({ briefing }: Props): React.JSX.Element {
   const formattedDate = formatBriefingMeetingDate(briefing.meeting_date)
   return (
     <div className="sticky top-0 z-20 border-b border-border bg-sidebar">
-      <div className="flex w-full items-start gap-3 px-4 py-4 lg:px-8">
+      {/* Match the body's content container (mx-auto max-w-[1120px] + same
+          padding) so the back arrow and Share button line up with the cards
+          below instead of sitting against the viewport edges. */}
+      <div className="mx-auto flex w-full max-w-[1120px] items-start gap-3 px-4 py-4 lg:px-8">
         <Link
           href={briefingsLandingHref()}
           aria-label="Back to meetings"

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -31,7 +31,7 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
   if (!canShare) return null
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 self-center">
       <IconButton
         type="button"
         size="medium"

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -96,12 +96,14 @@ export default function ExecutiveSummaryCard({
             doesn't need to highlight it themselves; the "Briefing
             assistant" button anchors here automatically. */}
         <h2
-          className="select-none text-2xl font-semibold text-foreground"
+          className="min-w-0 select-none text-2xl font-semibold text-foreground"
           data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
         >
           Executive Summary
         </h2>
-        <ReadAloudButton text={speechText} analyticsLabel={analyticsLabel} />
+        <div className="shrink-0">
+          <ReadAloudButton text={speechText} analyticsLabel={analyticsLabel} />
+        </div>
       </div>
       <p
         className="text-sm text-muted-foreground"

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -6,6 +6,7 @@ import {
   BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
   briefingItemDomId,
 } from '@shared/briefings/routes'
+import { selectElementContents } from '@shared/briefings/anchorResolver'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 import CardLevelNotesList from './CardLevelNotesList'
 import ReadAloudButton from './ReadAloudButton'
@@ -91,13 +92,13 @@ export default function ExecutiveSummaryCard({
     >
       <div className="flex items-start justify-between gap-3">
         {/* `data-briefing-json-path` makes the title resolvable as an
-            anchor target — card-level chats hang off this element.
-            `select-none` reserves the title for that role: the user
-            doesn't need to highlight it themselves; the "Briefing
-            assistant" button anchors here automatically. */}
+            anchor target — card-level chats hang off this element. Clicking
+            the title selects its full text so the HighlightToolbar surfaces
+            anchored to the title, the same as highlighting it by hand. */}
         <h2
-          className="min-w-0 select-none text-2xl font-semibold text-foreground"
+          className="min-w-0 cursor-pointer text-2xl font-semibold text-foreground"
           data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
+          onClick={(e) => selectElementContents(e.currentTarget)}
         >
           Executive Summary
         </h2>

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -190,7 +190,7 @@ export default function MobileBottomBar({
                     <a
                       href={`#${e.domId}`}
                       onClick={(ev) => onJump(ev, e)}
-                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 ${
+                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 no-underline hover:no-underline ${
                         isActive
                           ? 'bg-muted font-semibold text-foreground'
                           : 'text-foreground hover:bg-muted/60'

--- a/app/dashboard/briefings/shared/DictationMicButton.test.tsx
+++ b/app/dashboard/briefings/shared/DictationMicButton.test.tsx
@@ -47,6 +47,21 @@ describe('<DictationMicButton>', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders a red, blinking stop icon while recording', () => {
+    render(
+      <DictationMicButton
+        dictation={makeDictation({ status: 'recording', active: true })}
+        idleLabel="Dictate note"
+        recordingLabel="Stop dictation"
+      />,
+    )
+    const icon = screen
+      .getByRole('button', { name: /stop dictation/i })
+      .querySelector('svg')
+    expect(icon?.getAttribute('class')).toMatch(/text-red-500/)
+    expect(icon?.getAttribute('class')).toMatch(/animate-pulse/)
+  })
+
   it('invokes toggle when clicked', async () => {
     const user = userEvent.setup()
     const toggle = vi.fn(async () => undefined)

--- a/app/dashboard/briefings/shared/DictationMicButton.tsx
+++ b/app/dashboard/briefings/shared/DictationMicButton.tsx
@@ -39,7 +39,7 @@ export function DictationMicButton({
       {dictation.busy ? (
         <Loader2Icon className="size-4 animate-spin" aria-hidden />
       ) : isRecording ? (
-        <SquareIcon className="size-4" aria-hidden />
+        <SquareIcon className="size-4 animate-pulse text-red-500" aria-hidden />
       ) : (
         <MicIcon className="size-4" aria-hidden />
       )}

--- a/app/shared/briefings/anchorResolver.test.ts
+++ b/app/shared/briefings/anchorResolver.test.ts
@@ -114,6 +114,36 @@ describe('resolveSelection', () => {
     })
   })
 
+  it('resolves via endContainer when startContainer has no anchor ancestor', () => {
+    // Selection begins in non-anchored chrome and ends inside a passage. The
+    // start is necessarily before the passage in document order, so clamping
+    // start to 0 captures exactly the in-passage slice (not wrong text).
+    document.body.innerHTML =
+      '<div>' +
+      '<span>preamble </span>' +
+      '<p data-briefing-json-path="/items/2/body">hello world</p>' +
+      '</div>'
+    const preamble = document.querySelector('span')?.firstChild as Node
+    const bodyText = document.querySelector('p')?.firstChild as Node
+    const anchor = resolveSelection(
+      asSelection(rangeBetween([preamble, 0], [bodyText, 5])),
+    )
+    expect(anchor).toMatchObject({
+      jsonPath: '/items/2/body',
+      start: 0,
+      end: 5,
+      quote: 'hello',
+    })
+  })
+
+  it('returns null when neither startContainer nor endContainer has an anchor ancestor', () => {
+    document.body.innerHTML = '<span>no anchor here</span>'
+    const text = document.querySelector('span')?.firstChild as Node
+    expect(
+      resolveSelection(asSelection(rangeBetween([text, 0], [text, 8]))),
+    ).toBeNull()
+  })
+
   it('returns null for a collapsed selection', () => {
     document.body.innerHTML = '<li data-briefing-json-path="/x">hello</li>'
     const text = document.querySelector('li')?.firstChild as Node

--- a/app/shared/briefings/anchorResolver.test.ts
+++ b/app/shared/briefings/anchorResolver.test.ts
@@ -3,7 +3,29 @@ import {
   EMPTY_ANCHOR,
   resolveSelection,
   scrollAnchorIntoView,
+  selectElementContents,
 } from './anchorResolver'
+
+describe('selectElementContents', () => {
+  it('makes the element’s full text the document selection', () => {
+    document.body.innerHTML =
+      '<h3 data-briefing-json-path="/items/0/title">My Title</h3>'
+    const h3 = document.querySelector('h3') as HTMLElement
+    const removeAllRanges = vi.fn()
+    const addRange = vi.fn()
+    const spy = vi
+      .spyOn(window, 'getSelection')
+      .mockReturnValue({ removeAllRanges, addRange } as unknown as Selection)
+
+    selectElementContents(h3)
+
+    expect(removeAllRanges).toHaveBeenCalledOnce()
+    expect(addRange).toHaveBeenCalledOnce()
+    const range = addRange.mock.calls[0]?.[0] as Range
+    expect(range.toString()).toBe('My Title')
+    spy.mockRestore()
+  })
+})
 
 describe('resolveSelection', () => {
   beforeEach(() => {

--- a/app/shared/briefings/anchorResolver.test.ts
+++ b/app/shared/briefings/anchorResolver.test.ts
@@ -1,5 +1,105 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { EMPTY_ANCHOR, scrollAnchorIntoView } from './anchorResolver'
+import {
+  EMPTY_ANCHOR,
+  resolveSelection,
+  scrollAnchorIntoView,
+} from './anchorResolver'
+
+describe('resolveSelection', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // resolveSelection only reads isCollapsed / rangeCount / getRangeAt, so a
+  // real jsdom Range wrapped in this stub exercises the offset math without
+  // depending on jsdom's partial window.getSelection() implementation.
+  const asSelection = (range: Range): Selection =>
+    ({
+      isCollapsed: range.collapsed,
+      rangeCount: 1,
+      getRangeAt: () => range,
+    } as unknown as Selection)
+
+  const rangeBetween = (start: [Node, number], end: [Node, number]): Range => {
+    const range = document.createRange()
+    range.setStart(start[0], start[1])
+    range.setEnd(end[0], end[1])
+    // jsdom Range has no layout; resolveSelection only stores the rect.
+    range.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect)
+    return range
+  }
+
+  it('resolves a text-node selection (drag / double-click word)', () => {
+    document.body.innerHTML =
+      '<ul><li data-briefing-json-path="/items/0/talking_points/0">hello world</li></ul>'
+    const text = document.querySelector('li')?.firstChild as Node
+    const anchor = resolveSelection(
+      asSelection(rangeBetween([text, 0], [text, 11])),
+    )
+    expect(anchor).toMatchObject({
+      jsonPath: '/items/0/talking_points/0',
+      start: 0,
+      end: 11,
+      quote: 'hello world',
+    })
+  })
+
+  it('resolves a block selection whose boundary is the element node (triple-click / full-highlight)', () => {
+    document.body.innerHTML =
+      '<ul><li data-briefing-json-path="/items/0/talking_points/0">hello world</li></ul>'
+    const li = document.querySelector('li') as HTMLElement
+    // Block selections set the boundary on the element itself (child index),
+    // not a text node: start before child 0, end after child 0.
+    const anchor = resolveSelection(asSelection(rangeBetween([li, 0], [li, 1])))
+    expect(anchor).toMatchObject({
+      jsonPath: '/items/0/talking_points/0',
+      start: 0,
+      end: 11,
+    })
+  })
+
+  it('clamps to the start passage when the end boundary spills past it (full-passage highlight)', () => {
+    // Mirrors the real DOM: a passage <p> inside a card root, followed by a
+    // trailing sibling. Selecting to the end of the passage lands the end
+    // boundary on that sibling, whose nearest anchor is the card — not the
+    // passage. We must still resolve against the passage.
+    document.body.innerHTML =
+      '<article data-briefing-json-path="/items/1">' +
+      '<p data-briefing-json-path="/items/1/display/summary">hello world</p>' +
+      '<span>source</span>' +
+      '</article>'
+    const summaryText = document.querySelector('p')?.firstChild as Node
+    const trailing = document.querySelector('span')?.firstChild as Node
+    const anchor = resolveSelection(
+      asSelection(rangeBetween([summaryText, 0], [trailing, 3])),
+    )
+    expect(anchor).toMatchObject({
+      jsonPath: '/items/1/display/summary',
+      start: 0,
+      end: 11,
+      quote: 'hello world',
+    })
+  })
+
+  it('returns null for a collapsed selection', () => {
+    document.body.innerHTML = '<li data-briefing-json-path="/x">hello</li>'
+    const text = document.querySelector('li')?.firstChild as Node
+    expect(
+      resolveSelection(asSelection(rangeBetween([text, 2], [text, 2]))),
+    ).toBeNull()
+  })
+})
 
 describe('EMPTY_ANCHOR', () => {
   it('is frozen so consumers cannot mutate the shared sentinel', () => {

--- a/app/shared/briefings/anchorResolver.ts
+++ b/app/shared/briefings/anchorResolver.ts
@@ -99,6 +99,22 @@ export function resolveSelection(
 }
 
 /**
+ * Make an element's full text the live document selection. Used so clicking a
+ * card title highlights the whole title and surfaces the HighlightToolbar —
+ * the selection flows through useSelection → resolveSelection exactly as a
+ * manual drag would, anchoring to the title's jsonPath.
+ */
+export function selectElementContents(el: HTMLElement): void {
+  if (typeof window === 'undefined') return
+  const selection = window.getSelection()
+  if (!selection) return
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  selection.removeAllRanges()
+  selection.addRange(range)
+}
+
+/**
  * Locate the text-bearing element for a given jsonPath in the current DOM.
  */
 export function findAnchorEl(jsonPath: string): HTMLElement | null {

--- a/app/shared/briefings/anchorResolver.ts
+++ b/app/shared/briefings/anchorResolver.ts
@@ -39,20 +39,26 @@ function nearestAnchorEl(node: Node | null): HTMLElement | null {
 }
 
 /**
- * Character offset of the first character of `node` within
- * `container.textContent`. Returns -1 if `node` is not inside `container`.
+ * Character offset of a selection boundary within `container`'s plain text.
+ * Returns -1 if `node` is not inside `container`.
+ *
+ * `node`/`nodeOffset` is a DOM boundary point. For a text node it's an offset
+ * into the character data; for an element node it's a child index. Block-level
+ * selections (triple-click, "select the whole line") set the boundary on the
+ * element itself rather than a text node, so we measure with a Range — from
+ * the container's start to the boundary — instead of walking text nodes (which
+ * never match an element boundary and would return -1, dropping the toolbar).
  */
 function textOffsetIn(container: Node, node: Node, nodeOffset: number): number {
-  if (!container.contains(node)) return -1
-  let offset = 0
-  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
-  let cur: Node | null = walker.nextNode()
-  while (cur) {
-    if (cur === node) return offset + nodeOffset
-    offset += cur.textContent?.length ?? 0
-    cur = walker.nextNode()
+  if (node !== container && !container.contains(node)) return -1
+  const range = document.createRange()
+  range.setStart(container, 0)
+  try {
+    range.setEnd(node, nodeOffset)
+  } catch {
+    return -1
   }
-  return -1
+  return range.toString().length
 }
 
 export function resolveSelection(
@@ -61,19 +67,33 @@ export function resolveSelection(
   if (!selection || selection.isCollapsed || selection.rangeCount === 0)
     return null
   const range = selection.getRangeAt(0)
-  const quote = range.toString()
-  if (quote.trim().length === 0) return null
+  if (range.toString().trim().length === 0) return null
 
-  const startEl = nearestAnchorEl(range.startContainer)
-  const endEl = nearestAnchorEl(range.endContainer)
-  if (!startEl || startEl !== endEl) return null // selection crosses sections; skip
+  // Anchor to the passage the selection STARTS in. Selecting to (or through)
+  // the end of a paragraph routinely places the end boundary just past that
+  // passage — on the enclosing card root or a trailing sibling node — so the
+  // end's nearest anchor element differs from the start's. Rejecting on that
+  // mismatch dropped every full-passage highlight (the toolbar only showed for
+  // mid-passage selections). Instead, resolve against the start passage and
+  // clamp the offsets to it.
+  const anchorEl =
+    nearestAnchorEl(range.startContainer) ?? nearestAnchorEl(range.endContainer)
+  if (!anchorEl) return null
 
-  const jsonPath = startEl.getAttribute(ANCHOR_ATTR)
+  const jsonPath = anchorEl.getAttribute(ANCHOR_ATTR)
   if (!jsonPath) return null
 
-  const start = textOffsetIn(startEl, range.startContainer, range.startOffset)
-  const end = textOffsetIn(startEl, range.endContainer, range.endOffset)
+  const fullText = anchorEl.textContent ?? ''
+  const start = anchorEl.contains(range.startContainer)
+    ? textOffsetIn(anchorEl, range.startContainer, range.startOffset)
+    : 0
+  const end = anchorEl.contains(range.endContainer)
+    ? textOffsetIn(anchorEl, range.endContainer, range.endOffset)
+    : fullText.length
   if (start < 0 || end <= start) return null
+
+  const quote = fullText.slice(start, end)
+  if (quote.trim().length === 0) return null
 
   return { jsonPath, start, end, quote, rect: range.getBoundingClientRect() }
 }


### PR DESCRIPTION
Four briefing detail-page fixes, all surfaced from testing.

**Selection toolbar never appeared on a full-passage highlight.** This was the main one. Highlighting a passage all the way to the end of a paragraph places the selection's end boundary just past the passage element (on the card root or a trailing sibling node), so the end's nearest annotation anchor differed from the start's and `resolveSelection` discarded the selection as a cross-section span. Only selections that stayed entirely inside one passage — e.g. a double-clicked word — ever produced an anchor, which is why it looked intermittent. We now anchor to the passage the selection starts in and clamp the end to it, and we also handle element-node range boundaries (block / triple-click selections) in the offset math. Console instrumentation pinned the exact boundary mismatch before the fix; it's been removed.

**Read-aloud button squished on mobile** in the Executive Summary header — the long title was starving the button of width. The title now shrinks/wraps and the button keeps its intrinsic size.

**Sticky underline on the mobile "Jump to section" list** — tapping an entry left it underlined via the global `a:hover` rule on touch. Suppressed.

**Card-level notes were rendering at the very bottom of each card**, below the sources. Moved them below the card content and above the sources so they read as part of the card.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side selection math and presentation-only layout/CSS changes; no auth, API, or data persistence impact.
> 
> **Overview**
> Fixes **briefing text selection** so the annotation toolbar appears on full-passage and block-level highlights, not only partial in-passage selections. `resolveSelection` now anchors to the passage where the selection **starts**, clamps offsets when the end boundary spills onto a card root or sibling, and measures boundaries with a **Range** so element-node edges (e.g. triple-click) resolve correctly. New unit tests cover those cases.
> 
> **Detail UI:** card-level notes on agenda items sit **above** sources/feedback instead of at the card bottom; the executive summary header lets the title wrap (`min-w-0`) while the read-aloud control stays full size; mobile “Jump to section” links drop persistent underline from global anchor hover styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915fe844d68eaec45c0e3f73b5764866b9c245fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->