### PR TITLE
Feature/briefing button font size

### DIFF
--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -871,7 +871,7 @@ export default function AskAiChatBody({
             loading={sending || creating}
             icon={<Sparkles className="size-4" aria-hidden />}
             iconPosition="left"
-            className="w-full text-sm"
+            className="w-full text-sm!"
           >
             Ask Assistant
           </Button>

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -864,7 +864,6 @@ export default function AskAiChatBody({
           </div>
           <Button
             type="button"
-            size="small"
             onClick={() => {
               void onSend()
             }}
@@ -872,7 +871,7 @@ export default function AskAiChatBody({
             loading={sending || creating}
             icon={<Sparkles className="size-4" aria-hidden />}
             iconPosition="left"
-            className="w-full"
+            className="w-full text-sm"
           >
             Ask Assistant
           </Button>

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -864,6 +864,7 @@ export default function AskAiChatBody({
           </div>
           <Button
             type="button"
+            size="small"
             onClick={() => {
               void onSend()
             }}

--- a/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
+++ b/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
@@ -74,7 +74,7 @@ export function DeleteAnnotationButton({
     <>
       <Button
         variant="outline"
-        size="large"
+        size="small"
         onClick={() => {
           setErrorMessage(null)
           setPendingDelete(current)

--- a/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
+++ b/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
@@ -80,7 +80,7 @@ export function DeleteAnnotationButton({
           setPendingDelete(current)
         }}
         disabled={disabled}
-        className="w-full gap-2 border-transparent bg-transparent text-sm text-destructive hover:bg-destructive/10 hover:text-destructive"
+        className="w-full gap-2 border-transparent bg-transparent text-sm! text-destructive hover:bg-destructive/10 hover:text-destructive"
       >
         <Trash2Icon className="size-4" aria-hidden="true" />
         {label}

--- a/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
+++ b/app/dashboard/briefings/components/annotations/DeleteAnnotationButton.tsx
@@ -74,13 +74,13 @@ export function DeleteAnnotationButton({
     <>
       <Button
         variant="outline"
-        size="small"
+        size="large"
         onClick={() => {
           setErrorMessage(null)
           setPendingDelete(current)
         }}
         disabled={disabled}
-        className="w-full gap-2 border-transparent bg-transparent text-destructive hover:bg-destructive/10 hover:text-destructive"
+        className="w-full gap-2 border-transparent bg-transparent text-sm text-destructive hover:bg-destructive/10 hover:text-destructive"
       >
         <Trash2Icon className="size-4" aria-hidden="true" />
         {label}

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -405,7 +405,7 @@ export function NotesSurface({
                 />
                 <Button
                   onClick={() => startEdit(current)}
-                  className="w-full gap-2 text-sm"
+                  className="w-full gap-2 text-sm!"
                 >
                   <PencilIcon className="size-4" aria-hidden="true" />
                   Edit Note

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -404,9 +404,8 @@ export function NotesSurface({
                   error={attachmentError}
                 />
                 <Button
-                  size="small"
                   onClick={() => startEdit(current)}
-                  className="w-full gap-2"
+                  className="w-full gap-2 text-sm"
                 >
                   <PencilIcon className="size-4" aria-hidden="true" />
                   Edit Note

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -404,6 +404,7 @@ export function NotesSurface({
                   error={attachmentError}
                 />
                 <Button
+                  size="small"
                   onClick={() => startEdit(current)}
                   className="w-full gap-2"
                 >

--- a/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
@@ -25,7 +25,6 @@ export default function DesktopBottomBar(): React.JSX.Element {
       <div className="mx-auto flex w-full max-w-[1120px] items-center justify-end gap-2 px-8 py-3">
         <Button
           variant="outline"
-          size="small"
           onClick={openAddNoteTopLevel}
           disabled={!activeCard}
           title={
@@ -33,12 +32,12 @@ export default function DesktopBottomBar(): React.JSX.Element {
               ? `Add a note to ${activeCard.title}`
               : 'Click a card to make it active first'
           }
+          className="text-sm"
         >
           <MessageSquare className="size-4" aria-hidden />
           Notes
         </Button>
         <Button
-          size="small"
           onClick={openCardLevelChat}
           disabled={!activeCard}
           title={
@@ -46,6 +45,7 @@ export default function DesktopBottomBar(): React.JSX.Element {
               ? `Ask AI about ${activeCard.title}`
               : 'Click a card to make it active first'
           }
+          className="text-sm"
         >
           <Sparkles className="size-4" aria-hidden />
           Ask AI

--- a/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
@@ -32,7 +32,7 @@ export default function DesktopBottomBar(): React.JSX.Element {
               ? `Add a note to ${activeCard.title}`
               : 'Click a card to make it active first'
           }
-          className="text-sm"
+          className="text-sm!"
         >
           <MessageSquare className="size-4" aria-hidden />
           Notes
@@ -45,7 +45,7 @@ export default function DesktopBottomBar(): React.JSX.Element {
               ? `Ask AI about ${activeCard.title}`
               : 'Click a card to make it active first'
           }
-          className="text-sm"
+          className="text-sm!"
         >
           <Sparkles className="size-4" aria-hidden />
           Ask AI

--- a/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
@@ -25,6 +25,7 @@ export default function DesktopBottomBar(): React.JSX.Element {
       <div className="mx-auto flex w-full max-w-[1120px] items-center justify-end gap-2 px-8 py-3">
         <Button
           variant="outline"
+          size="small"
           onClick={openAddNoteTopLevel}
           disabled={!activeCard}
           title={
@@ -37,6 +38,7 @@ export default function DesktopBottomBar(): React.JSX.Element {
           Notes
         </Button>
         <Button
+          size="small"
           onClick={openCardLevelChat}
           disabled={!activeCard}
           title={

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -45,7 +45,7 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
       <Button
         variant="outline"
         onClick={openShareDrawer}
-        className="hidden text-sm lg:inline-flex"
+        className="hidden text-sm! lg:inline-flex"
       >
         <ShareIcon className="size-4" aria-hidden />
         Share

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -44,9 +44,8 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
       </IconButton>
       <Button
         variant="outline"
-        size="small"
         onClick={openShareDrawer}
-        className="hidden lg:inline-flex"
+        className="hidden text-sm lg:inline-flex"
       >
         <ShareIcon className="size-4" aria-hidden />
         Share

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -44,6 +44,7 @@ export default function DetailHeaderActions(): React.JSX.Element | null {
       </IconButton>
       <Button
         variant="outline"
+        size="small"
         onClick={openShareDrawer}
         className="hidden lg:inline-flex"
       >

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -76,6 +76,7 @@ export default function ReadAloudButton({
   return (
     <Button
       variant="outline"
+      size="small"
       aria-label={ariaLabel}
       aria-busy={status === 'loading'}
       disabled={status === 'loading'}

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -79,7 +79,7 @@ export default function ReadAloudButton({
       aria-label={ariaLabel}
       aria-busy={status === 'loading'}
       disabled={status === 'loading'}
-      className="text-sm"
+      className="text-sm!"
       onClick={onClick}
     >
       {status === 'error' ? (

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -76,10 +76,10 @@ export default function ReadAloudButton({
   return (
     <Button
       variant="outline"
-      size="small"
       aria-label={ariaLabel}
       aria-busy={status === 'loading'}
       disabled={status === 'loading'}
+      className="text-sm"
       onClick={onClick}
     >
       {status === 'error' ? (


### PR DESCRIPTION
Before:
<img width="1423" height="663" alt="Screenshot 2026-05-28 at 3 57 05 PM" src="https://github.com/user-attachments/assets/5f6808f2-b86c-4475-88b3-47f48d8dd3b4" />

After:
<img width="1424" height="662" alt="Screenshot 2026-05-28 at 3 58 25 PM" src="https://github.com/user-attachments/assets/446d9882-3810-4954-a6dd-268c058c14c6" />



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only label sizing on briefing UI buttons; no logic, API, or data changes.
> 
> **Overview**
> Briefing **Button** labels are forced to **`text-sm`** across annotation sheets, the desktop bottom bar, detail header, and read-aloud control by appending the Tailwind **`text-sm!`** utility to existing `className` values (no behavior or layout logic changes).
> 
> Touched surfaces include **Ask Assistant**, **Delete note**, **Edit Note**, **Notes** / **Ask AI** in `DesktopBottomBar`, desktop **Share**, and **Read aloud**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0e9e50357e1015b12d5283e940c3feab83c5f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->