### PR TITLE
fix(election-result): redirect winners into briefings

### DIFF
--- a/app/dashboard/election-result/components/ElectionResultPage.tsx
+++ b/app/dashboard/election-result/components/ElectionResultPage.tsx
@@ -91,7 +91,7 @@ export default function ElectionResultPage(): React.JSX.Element {
 
       setSelectedSlug(newOrg.slug)
 
-      router.replace('/polls/welcome')
+      router.replace('/dashboard/briefings')
     },
   })
 

--- a/e2e-tests/tests/app/organizations/election-result-flow.spec.ts
+++ b/e2e-tests/tests/app/organizations/election-result-flow.spec.ts
@@ -34,7 +34,7 @@ test('"I won my race" creates an EO org and auto-selects it', async ({
     .getByRole('button', { name: 'I won my race' })
     .click({ timeout: 10_000 })
 
-  await page.waitForURL('**/polls/welcome', { timeout: 15_000 })
+  await page.waitForURL('**/dashboard/briefings', { timeout: 15_000 })
 
   await NavigationHelper.navigateToPage(page, '/dashboard/polls')
   await NavigationHelper.dismissOverlays(page)


### PR DESCRIPTION
When a candidate confirms they won their race, they were being sent to the polls welcome flow (`/polls/welcome`). For someone who has just become an officeholder, polls are no longer the relevant next step — their new elected-office workspace and briefings are.

This redirects post-win users straight into `/dashboard/briefings` after the elected office is created and the new org is selected. The loss path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single post-success navigation change with no auth, data, or API behavior changes.
> 
> **Overview**
> After a candidate confirms they **won** and the elected-office org is created, navigation now goes to **`/dashboard/briefings`** instead of **`/polls/welcome`**, so new officeholders land in the elected-office briefings workspace rather than the polls onboarding flow.
> 
> The **loss** path (`/dashboard/election-result/loss`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da59a29f2272bd19b8f6f2d86c8c5005463a3c02. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->