### PR TITLE
Restore email property on all frontend analytics events

### DIFF
--- a/app/shared/layouts/navigation/SegmentIdentify.test.tsx
+++ b/app/shared/layouts/navigation/SegmentIdentify.test.tsx
@@ -6,6 +6,7 @@ import {
   persistUtmsOnce,
   getPersistedUtms,
   extractClids,
+  setUserEmail,
 } from 'helpers/analyticsHelper'
 import { buildUserTraits } from 'helpers/buildUserTraits'
 
@@ -29,6 +30,7 @@ vi.mock('helpers/analyticsHelper', () => ({
   persistUtmsOnce: vi.fn(),
   getPersistedUtms: vi.fn(() => ({})),
   extractClids: vi.fn(() => ({})),
+  setUserEmail: vi.fn(),
 }))
 
 vi.mock('helpers/buildUserTraits', () => ({
@@ -65,6 +67,7 @@ beforeEach(() => {
   vi.mocked(getPersistedUtms).mockReset().mockReturnValue({})
   vi.mocked(extractClids).mockReset().mockReturnValue({})
   vi.mocked(buildUserTraits).mockReset().mockReturnValue(fullUserTraits)
+  vi.mocked(setUserEmail).mockReset()
 })
 
 describe('SegmentIdentify', () => {
@@ -110,6 +113,26 @@ describe('SegmentIdentify', () => {
         utm_source_first: 'twitter',
         gclid: 'abc123',
       })
+    })
+  })
+
+  it('sets the user email for event tracking when logged in', async () => {
+    mockUser = fullUser
+
+    render(<SegmentIdentify />)
+
+    await vi.waitFor(() => {
+      expect(setUserEmail).toHaveBeenCalledWith('jane@example.com')
+    })
+  })
+
+  it('clears the user email for event tracking when no user', async () => {
+    mockUser = null
+
+    render(<SegmentIdentify />)
+
+    await vi.waitFor(() => {
+      expect(setUserEmail).toHaveBeenCalledWith(undefined)
     })
   })
 

--- a/app/shared/layouts/navigation/SegmentIdentify.tsx
+++ b/app/shared/layouts/navigation/SegmentIdentify.tsx
@@ -8,6 +8,7 @@ import { extractClids } from 'helpers/analyticsHelper'
 import { useEffect } from 'react'
 import { identifyUser } from '@shared/utils/analytics'
 import { buildUserTraits } from 'helpers/buildUserTraits'
+import { setUserEmail } from 'helpers/analyticsHelper'
 import { User } from 'helpers/types'
 
 const identify = async (
@@ -15,6 +16,7 @@ const identify = async (
   searchParams: ReturnType<typeof useSearchParams>,
 ) => {
   persistUtmsOnce()
+  setUserEmail(user?.email)
 
   const traits = {
     ...getPersistedUtms(),

--- a/helpers/analyticsHelper.test.ts
+++ b/helpers/analyticsHelper.test.ts
@@ -8,12 +8,13 @@ vi.mock('app/shared/utils/analytics', () => ({
   getReadyAnalytics: vi.fn(),
 }))
 
-import { trackEvent, setImpersonating } from './analyticsHelper'
+import { trackEvent, setImpersonating, setUserEmail } from './analyticsHelper'
 import { segmentTrackEvent } from './segmentHelper'
 
 describe('trackEvent', () => {
   beforeEach(() => {
     setImpersonating(false)
+    setUserEmail(undefined)
     vi.clearAllMocks()
     sessionStorage.clear()
   })
@@ -53,6 +54,42 @@ describe('trackEvent', () => {
       'Test Event',
       expect.objectContaining({
         impersonation: true,
+      }),
+    )
+  })
+
+  it('does not include email when no user email is set', () => {
+    trackEvent('Test Event', { foo: 'bar' })
+
+    expect(segmentTrackEvent).toHaveBeenCalledWith(
+      'Test Event',
+      expect.not.objectContaining({ email: expect.anything() }),
+    )
+  })
+
+  it('includes email on every event once the user email is set', () => {
+    setUserEmail('jane@example.com')
+
+    trackEvent('Test Event', { foo: 'bar' })
+
+    expect(segmentTrackEvent).toHaveBeenCalledWith(
+      'Test Event',
+      expect.objectContaining({
+        foo: 'bar',
+        email: 'jane@example.com',
+      }),
+    )
+  })
+
+  it('caller-provided email overrides the persisted user email', () => {
+    setUserEmail('jane@example.com')
+
+    trackEvent('Test Event', { email: 'override@example.com' })
+
+    expect(segmentTrackEvent).toHaveBeenCalledWith(
+      'Test Event',
+      expect.objectContaining({
+        email: 'override@example.com',
       }),
     )
   })

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -8,6 +8,11 @@ export const setImpersonating = (value: boolean): void => {
   isImpersonating = value
 }
 
+let userEmail: string | undefined
+export const setUserEmail = (value: string | undefined): void => {
+  userEmail = value
+}
+
 const UTM_KEYS = [
   'utm_source',
   'utm_medium',
@@ -694,6 +699,7 @@ export const trackEvent = (
   try {
     const commonProperties = {
       ...getPersistedUtms(),
+      ...(userEmail ? { email: userEmail } : {}),
       ...properties,
       impersonation: isImpersonating,
     }


### PR DESCRIPTION
Every frontend Segment event used to carry an `email` property, which is what our HubSpot pipeline joins on. The Clerk auth migration removed the cookie-based user store that fed it: the old `trackEvent()` read `email` out of the user cookie (via `getUserProperties()`) and spread it into every event. That helper was deleted with the cookie and never rewired to the new Clerk-backed `UserProvider`, so events have been shipping without `email` since the migration. Identify traits still carry it, but event-level joins broke.

This restores the event-level property by mirroring the existing module-level `isImpersonating`/`setImpersonating` pattern: a `setUserEmail()` setter is driven from `SegmentIdentify` (which already re-runs on every user change and has the Clerk user in scope), and `trackEvent()` spreads it into every event's common properties. Caller-provided `email` still wins, matching the prior precedence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PII on every analytics event and relies on SegmentIdentify staying in sync with auth state; logic is narrow and well-tested.
> 
> **Overview**
> Restores **`email` on every frontend Segment `trackEvent` payload** so HubSpot-style event joins work again after the Clerk migration removed the old cookie-based source.
> 
> Adds module-level **`setUserEmail` / `userEmail`** (same pattern as impersonation). **`SegmentIdentify`** sets the email from the logged-in Clerk user on each identify run and clears it when there is no user. **`trackEvent`** merges that email into common properties; explicit **`email` in event properties** still overrides.
> 
> Tests cover logged-in vs logged-out wiring and `trackEvent` behavior (omit, include, override).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4075a7be930a6f2c37dd42e93641894c2a04f72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->