### PR TITLE
chore(perf): add scripts/perf/ tooling wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,7 @@ scripts/output
 
 # Performance tooling output (scripts/perf/*.sh)
 /perf-reports/
-profiles/
+/profiles/
 *.cpuprofile
 *.heapprofile
 *.heapsnapshot

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,17 @@ invalid_urls.csv
 
 .clerk
 scripts/output
+
+# Performance tooling output (scripts/perf/*.sh)
+/perf-reports/
+profiles/
+*.cpuprofile
+*.heapprofile
+*.heapsnapshot
+isolate-*.log
+isolate-*.json
+flamegraph.html
+lh-*.report.html
+lh-*.report.json
+bundle-*.html
+bundle-*.json

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -50,10 +50,24 @@ scripts/perf/lighthouse.sh /                    # home page
 scripts/perf/lighthouse.sh /pricing
 scripts/perf/lighthouse.sh --form-factor desktop /
 
-# Compare a route across two branches
-hyperfine --warmup 1 --runs 3 \
-  'git checkout main      && scripts/perf/bench-route.sh -c 10 -d 10 /pricing' \
-  'git checkout my-branch && scripts/perf/bench-route.sh -c 10 -d 10 /pricing'
+# Compare a route across two branches.
+#
+# IMPORTANT: a single hyperfine arm with `git checkout && bench-route.sh`
+# does NOT work for Next.js — `git checkout` only swaps source files, but
+# the already-running `npm run start-local` server keeps serving the
+# original compiled bundle. Both arms would hit identical code and the
+# delta would be meaningless.
+#
+# Correct flow: kill, checkout, rebuild, restart per branch. Two runs:
+git checkout main      && npm run build && npm run start-local &
+sleep 8
+scripts/perf/bench-route.sh -c 10 -d 10 /pricing | tee /tmp/bench-main.txt
+pkill -f 'next start' || true
+
+git checkout my-branch && npm run build && npm run start-local &
+sleep 8
+scripts/perf/bench-route.sh -c 10 -d 10 /pricing | tee /tmp/bench-branch.txt
+pkill -f 'next start' || true
 
 # What's in the bundle?
 scripts/perf/bundle-analyze.sh --summary          # text top-level summary

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -2,12 +2,12 @@
 
 Performance tooling wrappers for the Next.js webapp. Convenience scripts behind the canonical commands in [`ai-rules/performance-tools.md`](../../ai-rules/performance-tools.md).
 
-| Script | What it does | Cookbook section |
-|---|---|---|
-| `setup-check.sh` | Audit the local env — what can/can't be measured right now | §11.6 |
-| `lighthouse.sh` | Web Vitals + perf audit for a page (headless Chrome) | §8 |
-| `bundle-analyze.sh` | Inspect what's bloating the JS bundle (`source-map-explorer`) | §9 |
-| `bench-route.sh` | SSR load test for a route (autocannon) | §1 |
+| Script              | What it does                                                  | Cookbook section |
+| ------------------- | ------------------------------------------------------------- | ---------------- |
+| `setup-check.sh`    | Audit the local env — what can/can't be measured right now    | §11.6            |
+| `lighthouse.sh`     | Web Vitals + perf audit for a page (headless Chrome)          | §8               |
+| `bundle-analyze.sh` | Inspect what's bloating the JS bundle (`source-map-explorer`) | §9               |
+| `bench-route.sh`    | SSR load test for a route (autocannon)                        | §1               |
 
 `productionBrowserSourceMaps: true` is already set in `next.config.ts`, so `source-map-explorer` works on the production build out of the box.
 

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,52 @@
+# scripts/perf/
+
+Performance tooling wrappers for the Next.js webapp. Convenience scripts behind the canonical commands in [`ai-rules/performance-tools.md`](../../ai-rules/performance-tools.md).
+
+| Script | What it does | Cookbook section |
+|---|---|---|
+| `lighthouse.sh` | Web Vitals + perf audit for a page (headless Chrome) | §8 |
+| `bundle-analyze.sh` | Inspect what's bloating the JS bundle (`source-map-explorer`) | §9 |
+| `bench-route.sh` | SSR load test for a route (autocannon) | §1 |
+
+`productionBrowserSourceMaps: true` is already set in `next.config.ts`, so `source-map-explorer` works on the production build out of the box.
+
+## Prereqs
+
+```bash
+brew install hyperfine
+npm i -g lighthouse autocannon         # or use npx
+```
+
+## Examples
+
+```bash
+# Build for production first (Lighthouse + bundle analysis need a real build)
+npm run build
+npm run start-local &
+sleep 5   # let it boot
+
+# Audit a page
+scripts/perf/lighthouse.sh /                    # home page
+scripts/perf/lighthouse.sh /pricing
+scripts/perf/lighthouse.sh --form-factor desktop /
+
+# Compare a route across two branches
+hyperfine --warmup 1 --runs 3 \
+  'git checkout main      && scripts/perf/bench-route.sh -c 10 -d 10 /pricing' \
+  'git checkout my-branch && scripts/perf/bench-route.sh -c 10 -d 10 /pricing'
+
+# What's in the bundle?
+scripts/perf/bundle-analyze.sh --summary          # text top-level summary
+scripts/perf/bundle-analyze.sh --html             # interactive treemap
+scripts/perf/bundle-analyze.sh --json             # machine-readable, for diffing
+```
+
+## Critic tie-in
+
+Per the [performance critic rules](../../ai-rules/performance.md):
+
+- **Page render claims** need a before/after Lighthouse run (or Chrome DevTools Performance recording with numbers).
+- **Bundle-size claims** need a before/after `bundle-analyze.sh --json` diff (or `npm run build` output diff for first-load JS).
+- **SSR throughput claims** need `bench-route.sh` numbers (or `autocannon` directly).
+
+Without one of those, downgrade the claim to "refactor."

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -4,18 +4,38 @@ Performance tooling wrappers for the Next.js webapp. Convenience scripts behind 
 
 | Script | What it does | Cookbook section |
 |---|---|---|
+| `setup-check.sh` | Audit the local env — what can/can't be measured right now | §11.6 |
 | `lighthouse.sh` | Web Vitals + perf audit for a page (headless Chrome) | §8 |
 | `bundle-analyze.sh` | Inspect what's bloating the JS bundle (`source-map-explorer`) | §9 |
 | `bench-route.sh` | SSR load test for a route (autocannon) | §1 |
 
 `productionBrowserSourceMaps: true` is already set in `next.config.ts`, so `source-map-explorer` works on the production build out of the box.
 
-## Prereqs
+Every script supports `-h` / `--help` and prints its prerequisites at the top of the help block.
+
+## Quick start
 
 ```bash
-brew install hyperfine
-npm i -g lighthouse autocannon         # or use npx
+# What's available locally?
+scripts/perf/setup-check.sh
 ```
+
+If `setup-check.sh` is clean, the rest will work. If something is ✗, the script tells you the install command (or the no-install fallback).
+
+## Prereqs
+
+The scripts try hard not to require global installs:
+
+- **autocannon / lighthouse / source-map-explorer** — `npx --yes <tool>` fallback is automatic when not installed globally. First `npx` run downloads (and `npx --yes lighthouse` also pulls headless Chrome the first time, which is slow).
+- **hyperfine** — no convenient `npx` equivalent; install if you want statistical comparison runs:
+  ```bash
+  brew install hyperfine        # mac
+  cargo install hyperfine       # linux / cross-platform
+  ```
+
+**Don't benchmark `npm run dev`.** All measurements should be against a production build (`npm run build && npm run start-local`). Dev mode disables minification, adds HMR overhead, and runs extra dev-only React work — the numbers are not representative.
+
+For agents working in a fresh `git worktree`, also see `ai-rules/performance-tools.md` §11.6 — `.env` and the `ai-rules` submodule are common first-time stumbling blocks.
 
 ## Examples
 
@@ -25,7 +45,7 @@ npm run build
 npm run start-local &
 sleep 5   # let it boot
 
-# Audit a page
+# Audit a page (npx fallback if lighthouse isn't on PATH)
 scripts/perf/lighthouse.sh /                    # home page
 scripts/perf/lighthouse.sh /pricing
 scripts/perf/lighthouse.sh --form-factor desktop /
@@ -50,3 +70,5 @@ Per the [performance critic rules](../../ai-rules/performance.md):
 - **SSR throughput claims** need `bench-route.sh` numbers (or `autocannon` directly).
 
 Without one of those, downgrade the claim to "refactor."
+
+When the critic itself is an agent with shell access, it should run `setup-check.sh` first, then use any GREEN tool it has the prerequisites for (see the readiness table in `performance-tools.md`). It should never fabricate measurements.

--- a/scripts/perf/bench-route.sh
+++ b/scripts/perf/bench-route.sh
@@ -78,5 +78,33 @@ else
   URL="${PROTO}://${HOST}:${PORT}${TARGET}"
 fi
 
-echo "→ ${AUTOCANNON[*]} ${ARGS[*]} $URL"
+# Redact `-H` header and `-b` body values from the printed command. They
+# commonly carry secrets (`-H 'authorization: Bearer <token>'`) or PII
+# (`-b '{"name":"...","dob":"..."}'`) that would otherwise land in
+# terminal output, CI logs, and shell history. The exec() below uses the
+# unmodified ARGS, so autocannon still sends the real values — only the
+# display is sanitised.
+DISPLAY_ARGS=()
+skip_next=false
+for a in "${ARGS[@]}"; do
+  if $skip_next; then
+    DISPLAY_ARGS+=("<redacted>")
+    skip_next=false
+  elif [[ "$a" == "-H" || "$a" == "--header" || "$a" == "-b" || "$a" == "--body" ]]; then
+    DISPLAY_ARGS+=("$a")
+    skip_next=true
+  elif [[ "$a" == "-H"?* ]]; then
+    DISPLAY_ARGS+=("-H<redacted>")
+  elif [[ "$a" == "--header="* ]]; then
+    DISPLAY_ARGS+=("--header=<redacted>")
+  elif [[ "$a" == "-b"?* ]]; then
+    DISPLAY_ARGS+=("-b<redacted>")
+  elif [[ "$a" == "--body="* ]]; then
+    DISPLAY_ARGS+=("--body=<redacted>")
+  else
+    DISPLAY_ARGS+=("$a")
+  fi
+done
+
+echo "→ ${AUTOCANNON[*]} ${DISPLAY_ARGS[*]} $URL"
 exec "${AUTOCANNON[@]}" "${ARGS[@]}" "$URL"

--- a/scripts/perf/bench-route.sh
+++ b/scripts/perf/bench-route.sh
@@ -2,6 +2,16 @@
 # SSR load test for a Next.js route using autocannon.
 # Backs up ai-rules/performance-tools.md §1.
 #
+# Requires: a production server listening on the target URL (default
+# http://localhost:4000). Build and start it first:
+#   npm run build && npm run start-local &
+#   sleep 5
+# Benchmarking against `npm run dev` gives meaningless numbers — the dev
+# server has HMR overhead and dev-only React work.
+#
+# autocannon is preferred installed globally; this script falls back to
+# `npx --yes autocannon` automatically when it isn't.
+#
 # Usage:
 #   scripts/perf/bench-route.sh /                  # home page, defaults
 #   scripts/perf/bench-route.sh -c 50 -d 30 /pricing
@@ -11,10 +21,6 @@
 #   PORT   (default 4000)
 #   HOST   (default localhost)
 #   PROTO  (default http)
-#
-# IMPORTANT: benchmark against a *production* build (`npm run start-local`),
-# NOT `npm run dev`. The dev server has HMR overhead and dev-only React work
-# that make the numbers meaningless.
 #
 # Any extra flags are passed through to autocannon.
 # If no -c / -d are passed, defaults are 10 connections and 20 seconds.
@@ -29,9 +35,11 @@ if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   [[ $# -eq 0 ]] && exit 2 || exit 0
 fi
 
-if ! command -v autocannon >/dev/null 2>&1; then
-  echo "✗ autocannon not found. Install: npm i -g autocannon" >&2
-  exit 1
+if command -v autocannon >/dev/null 2>&1; then
+  AUTOCANNON=(autocannon)
+else
+  echo "→ autocannon not on PATH; falling back to 'npx --yes autocannon' (first run installs)" >&2
+  AUTOCANNON=(npx --yes autocannon)
 fi
 
 ARGS=("$@")
@@ -55,5 +63,5 @@ else
   URL="${PROTO}://${HOST}:${PORT}${TARGET}"
 fi
 
-echo "→ autocannon ${ARGS[*]} $URL"
-exec autocannon "${ARGS[@]}" "$URL"
+echo "→ ${AUTOCANNON[*]} ${ARGS[*]} $URL"
+exec "${AUTOCANNON[@]}" "${ARGS[@]}" "$URL"

--- a/scripts/perf/bench-route.sh
+++ b/scripts/perf/bench-route.sh
@@ -44,10 +44,14 @@ fi
 
 ARGS=("$@")
 HAS_C=false; HAS_D=false
+# autocannon accepts -c/-d four ways: `-c 50`, `-c50` (joined short),
+# `--connections 50`, `--connections=50`. Match all four so we don't inject
+# a duplicate default — minimist/yargs-parser silently merge duplicates into
+# arrays or pick the last value, either of which breaks the run.
 for a in "${ARGS[@]}"; do
   case "$a" in
-    -c|--connections) HAS_C=true ;;
-    -d|--duration)    HAS_D=true ;;
+    -c|--connections|-c[0-9]*|-c=*|--connections=*) HAS_C=true ;;
+    -d|--duration|-d[0-9]*|-d=*|--duration=*)       HAS_D=true ;;
   esac
 done
 $HAS_C || ARGS=(-c 10 "${ARGS[@]}")

--- a/scripts/perf/bench-route.sh
+++ b/scripts/perf/bench-route.sh
@@ -59,6 +59,17 @@ $HAS_D || ARGS=(-d 20 "${ARGS[@]}")
 
 LAST_IDX=$(( ${#ARGS[@]} - 1 ))
 TARGET="${ARGS[$LAST_IDX]}"
+
+# Reject flags-only invocations (e.g. `bench-route.sh -c 10 -d 20`): we'd
+# otherwise grab the last flag value (20) as the path and benchmark
+# http://host:port/20, which silently 404s and returns misleading numbers.
+# Valid targets must start with `/` (relative path) or `http(s)://`.
+if [[ ! "$TARGET" =~ ^(/|https?://) ]]; then
+  echo "✗ Last argument must be a path (e.g. /pricing) or full URL — got: '$TARGET'" >&2
+  echo "  Usage: scripts/perf/bench-route.sh [autocannon-flags...] <path-or-url>" >&2
+  exit 2
+fi
+
 unset 'ARGS[$LAST_IDX]'
 
 if [[ "$TARGET" =~ ^https?:// ]]; then

--- a/scripts/perf/bench-route.sh
+++ b/scripts/perf/bench-route.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SSR load test for a Next.js route using autocannon.
+# Backs up ai-rules/performance-tools.md §1.
+#
+# Usage:
+#   scripts/perf/bench-route.sh /                  # home page, defaults
+#   scripts/perf/bench-route.sh -c 50 -d 30 /pricing
+#   scripts/perf/bench-route.sh https://goodparty.org/
+#
+# Env overrides:
+#   PORT   (default 4000)
+#   HOST   (default localhost)
+#   PROTO  (default http)
+#
+# IMPORTANT: benchmark against a *production* build (`npm run start-local`),
+# NOT `npm run dev`. The dev server has HMR overhead and dev-only React work
+# that make the numbers meaningless.
+#
+# Any extra flags are passed through to autocannon.
+# If no -c / -d are passed, defaults are 10 connections and 20 seconds.
+set -euo pipefail
+
+PORT="${PORT:-4000}"
+HOST="${HOST:-localhost}"
+PROTO="${PROTO:-http}"
+
+if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  [[ $# -eq 0 ]] && exit 2 || exit 0
+fi
+
+if ! command -v autocannon >/dev/null 2>&1; then
+  echo "✗ autocannon not found. Install: npm i -g autocannon" >&2
+  exit 1
+fi
+
+ARGS=("$@")
+HAS_C=false; HAS_D=false
+for a in "${ARGS[@]}"; do
+  case "$a" in
+    -c|--connections) HAS_C=true ;;
+    -d|--duration)    HAS_D=true ;;
+  esac
+done
+$HAS_C || ARGS=(-c 10 "${ARGS[@]}")
+$HAS_D || ARGS=(-d 20 "${ARGS[@]}")
+
+LAST_IDX=$(( ${#ARGS[@]} - 1 ))
+TARGET="${ARGS[$LAST_IDX]}"
+unset 'ARGS[$LAST_IDX]'
+
+if [[ "$TARGET" =~ ^https?:// ]]; then
+  URL="$TARGET"
+else
+  URL="${PROTO}://${HOST}:${PORT}${TARGET}"
+fi
+
+echo "→ autocannon ${ARGS[*]} $URL"
+exec autocannon "${ARGS[@]}" "$URL"

--- a/scripts/perf/bundle-analyze.sh
+++ b/scripts/perf/bundle-analyze.sh
@@ -2,14 +2,16 @@
 # Inspect Next.js bundle composition using source-map-explorer.
 # Backs up ai-rules/performance-tools.md §9.
 #
+# Requires:
+#   1. `npm run build` (or build-local) must have been run — needs .next/static/chunks
+#      with source maps. `productionBrowserSourceMaps: true` in next.config.ts
+#      is already set, so this works on the default build.
+#   2. No global install needed; source-map-explorer is always run via npx.
+#
 # Usage:
 #   scripts/perf/bundle-analyze.sh                # text summary (top contributors)
 #   scripts/perf/bundle-analyze.sh --html         # interactive treemap (opens HTML)
 #   scripts/perf/bundle-analyze.sh --json         # machine-readable, for diffing
-#
-# Prereqs:
-#   1. `npm run build` (or build-local) must have been run.
-#   2. `productionBrowserSourceMaps: true` in next.config.ts (already set).
 #
 # Output directory: $PERF_OUT (default ./perf-reports)
 set -euo pipefail

--- a/scripts/perf/bundle-analyze.sh
+++ b/scripts/perf/bundle-analyze.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Inspect Next.js bundle composition using source-map-explorer.
+# Backs up ai-rules/performance-tools.md §9.
+#
+# Usage:
+#   scripts/perf/bundle-analyze.sh                # text summary (top contributors)
+#   scripts/perf/bundle-analyze.sh --html         # interactive treemap (opens HTML)
+#   scripts/perf/bundle-analyze.sh --json         # machine-readable, for diffing
+#
+# Prereqs:
+#   1. `npm run build` (or build-local) must have been run.
+#   2. `productionBrowserSourceMaps: true` in next.config.ts (already set).
+#
+# Output directory: $PERF_OUT (default ./perf-reports)
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  exit 0
+fi
+
+if [[ ! -d .next/static/chunks ]]; then
+  echo "✗ No .next/static/chunks found. Run 'npm run build' first." >&2
+  exit 1
+fi
+
+MODE="${1:---summary}"
+OUT="${PERF_OUT:-./perf-reports}"
+mkdir -p "$OUT"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+case "$MODE" in
+  --html)
+    OUT_FILE="$OUT/bundle-${STAMP}.html"
+    echo "→ source-map-explorer (HTML) → $OUT_FILE"
+    npx --yes source-map-explorer '.next/static/chunks/**/*.js' --html "$OUT_FILE"
+    echo "✓ Open: $OUT_FILE"
+    ;;
+  --json)
+    OUT_FILE="$OUT/bundle-${STAMP}.json"
+    echo "→ source-map-explorer (JSON) → $OUT_FILE"
+    npx --yes source-map-explorer '.next/static/chunks/**/*.js' --json "$OUT_FILE"
+    echo "✓ Saved: $OUT_FILE"
+    echo "  Diff two runs:  diff <(jq -S . a.json) <(jq -S . b.json)"
+    ;;
+  --summary|"")
+    echo "→ source-map-explorer (top-level text summary)"
+    npx --yes source-map-explorer '.next/static/chunks/**/*.js' --no-border-checks
+    echo
+    echo "(re-run with --html or --json for fuller output)"
+    ;;
+  *)
+    echo "✗ Unknown option: $MODE" >&2
+    echo "Usage: $0 [--html|--json|--summary]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/perf/lighthouse.sh
+++ b/scripts/perf/lighthouse.sh
@@ -2,6 +2,15 @@
 # Run Lighthouse against a URL or local path.
 # Backs up ai-rules/performance-tools.md §8.
 #
+# Requires: a *production* server running on the target URL — Lighthouse
+# against `npm run dev` gives meaningless numbers because dev mode disables
+# minification and bundle splitting. Build and start first:
+#   npm run build && npm run start-local &
+#   sleep 5
+#
+# lighthouse is preferred installed globally; this script falls back to
+# `npx --yes lighthouse` automatically when it isn't.
+#
 # Usage:
 #   scripts/perf/lighthouse.sh                  # http://localhost:4000/
 #   scripts/perf/lighthouse.sh /pricing
@@ -24,9 +33,11 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if ! command -v lighthouse >/dev/null 2>&1; then
-  echo "✗ lighthouse not found. Install: npm i -g lighthouse" >&2
-  exit 1
+if command -v lighthouse >/dev/null 2>&1; then
+  LIGHTHOUSE=(lighthouse)
+else
+  echo "→ lighthouse not on PATH; falling back to 'npx --yes lighthouse' (first run installs)" >&2
+  LIGHTHOUSE=(npx --yes lighthouse)
 fi
 
 mkdir -p "$OUT_DIR"
@@ -55,9 +66,9 @@ STAMP="$(date +%Y%m%d-%H%M%S)"
 SAFE="$(echo "$URL" | sed 's|[^A-Za-z0-9._-]|_|g')"
 OUT_BASE="$OUT_DIR/lh-${STAMP}-${SAFE}"
 
-echo "→ lighthouse $URL"
+echo "→ ${LIGHTHOUSE[*]} $URL"
 echo "  Reports: ${OUT_BASE}.report.{html,json}"
-exec lighthouse "$URL" \
+exec "${LIGHTHOUSE[@]}" "$URL" \
   --output html --output json \
   --output-path "$OUT_BASE" \
   --chrome-flags="--headless --no-sandbox" \

--- a/scripts/perf/lighthouse.sh
+++ b/scripts/perf/lighthouse.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run Lighthouse against a URL or local path.
+# Backs up ai-rules/performance-tools.md §8.
+#
+# Usage:
+#   scripts/perf/lighthouse.sh                  # http://localhost:4000/
+#   scripts/perf/lighthouse.sh /pricing
+#   scripts/perf/lighthouse.sh https://goodparty.org/
+#   scripts/perf/lighthouse.sh --form-factor desktop /pricing
+#
+# Env overrides:
+#   LH_BASE  default http://localhost:4000
+#   LH_OUT   default ./perf-reports
+#
+# Pass-through: any flag starting with - / -- is forwarded to lighthouse.
+# The URL or path must be the LAST positional argument.
+set -euo pipefail
+
+DEFAULT_BASE="${LH_BASE:-http://localhost:4000}"
+OUT_DIR="${LH_OUT:-./perf-reports}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  exit 0
+fi
+
+if ! command -v lighthouse >/dev/null 2>&1; then
+  echo "✗ lighthouse not found. Install: npm i -g lighthouse" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+ARGS=("$@")
+if [[ ${#ARGS[@]} -eq 0 ]]; then
+  TARGET="/"
+else
+  LAST_IDX=$(( ${#ARGS[@]} - 1 ))
+  LAST="${ARGS[$LAST_IDX]}"
+  if [[ "$LAST" == -* ]]; then
+    TARGET="/"
+  else
+    TARGET="$LAST"
+    unset 'ARGS[$LAST_IDX]'
+  fi
+fi
+
+if [[ "$TARGET" =~ ^https?:// ]]; then
+  URL="$TARGET"
+else
+  URL="${DEFAULT_BASE}${TARGET}"
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+SAFE="$(echo "$URL" | sed 's|[^A-Za-z0-9._-]|_|g')"
+OUT_BASE="$OUT_DIR/lh-${STAMP}-${SAFE}"
+
+echo "→ lighthouse $URL"
+echo "  Reports: ${OUT_BASE}.report.{html,json}"
+exec lighthouse "$URL" \
+  --output html --output json \
+  --output-path "$OUT_BASE" \
+  --chrome-flags="--headless --no-sandbox" \
+  --quiet \
+  "${ARGS[@]+${ARGS[@]}}"

--- a/scripts/perf/lighthouse.sh
+++ b/scripts/perf/lighthouse.sh
@@ -49,7 +49,18 @@ else
   LAST_IDX=$(( ${#ARGS[@]} - 1 ))
   LAST="${ARGS[$LAST_IDX]}"
   if [[ "$LAST" == -* ]]; then
-    # Last arg is itself a flag (`--foo`) — assume no path given, run against /.
+    # Last arg is itself a flag (e.g. `--quiet`) — assume no path given,
+    # run against /. But if any *earlier* arg is also positional (not a
+    # flag), the user placed the path before the flags, which violates
+    # the "URL or path must be LAST" contract on line 25 and would
+    # forward two positional URLs to lighthouse. Error clearly.
+    for arg in "${ARGS[@]}"; do
+      if [[ "$arg" != -* ]]; then
+        echo "✗ Path argument '$arg' must be the LAST argument, not before flags." >&2
+        echo "  Usage: scripts/perf/lighthouse.sh [lighthouse-flags...] [path-or-url]" >&2
+        exit 2
+      fi
+    done
     TARGET="/"
   elif [[ "$LAST" =~ ^(/|https?://) ]]; then
     TARGET="$LAST"

--- a/scripts/perf/lighthouse.sh
+++ b/scripts/perf/lighthouse.sh
@@ -49,10 +49,19 @@ else
   LAST_IDX=$(( ${#ARGS[@]} - 1 ))
   LAST="${ARGS[$LAST_IDX]}"
   if [[ "$LAST" == -* ]]; then
+    # Last arg is itself a flag (`--foo`) — assume no path given, run against /.
     TARGET="/"
-  else
+  elif [[ "$LAST" =~ ^(/|https?://) ]]; then
     TARGET="$LAST"
     unset 'ARGS[$LAST_IDX]'
+  else
+    # Last arg looks like a flag value (e.g. `--form-factor desktop`) rather
+    # than a path. Without this check we'd benchmark http://host/<flag-value>
+    # silently (404), matching the bug class fixed in bench-route.sh.
+    echo "✗ Last argument must be a path (e.g. /pricing) or full URL — got: '$LAST'" >&2
+    echo "  Usage: scripts/perf/lighthouse.sh [lighthouse-flags...] [path-or-url]" >&2
+    echo "  (omit the trailing path to audit '/').";
+    exit 2
   fi
 fi
 

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -99,12 +99,24 @@ else
   printf "  %s  node_modules missing (run: npm ci)\n" "$NO"
 fi
 
-if [[ -f ai-rules/performance.md ]]; then
-  printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
+# Check the file these wrapper scripts actually reference: performance-tools.md
+# (the tools cookbook). performance.md is the critic rule; both should be
+# present on a healthy submodule pointer, but performance-tools.md is what
+# the scripts in this directory header-cite — so checking it gives a more
+# faithful "is the submodule aligned with what this toolchain depends on"
+# answer.
+if [[ -f ai-rules/performance-tools.md ]]; then
+  printf "  %s  ai-rules/performance-tools.md present (submodule initialized)\n" "$OK"
+  # Sanity-check the critic rule file too — different file, same submodule;
+  # if one is present and the other isn't, the pointer is partially stale.
+  if [[ ! -f ai-rules/performance.md ]]; then
+    printf "  %s  ai-rules/performance.md missing — submodule pointer may be partially stale\n" "$WARN"
+    echo "       Sync: git submodule update ai-rules"
+  fi
 elif [[ -f ai-rules/README.md ]]; then
-  printf "  %s  ai-rules submodule initialized but performance.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
+  printf "  %s  ai-rules submodule initialized but performance-tools.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
   echo "       Sync: git submodule update ai-rules"
-  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance.md.)"
+  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance-tools.md.)"
 elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
   printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
   echo "       Run: git submodule update --init --recursive"

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Check that the local environment can run scripts/perf/*.sh end-to-end.
+# Backs up ai-rules/performance-tools.md §11.6 (Agents in fresh worktrees).
+#
+# Reports — does NOT install anything, does NOT start any service.
+# Exits 0 always; the report is informational. Treat any ✗ as something to
+# fix before claiming a measurement from the affected tool.
+#
+# Usage:
+#   scripts/perf/setup-check.sh
+#   PORT=3000 scripts/perf/setup-check.sh
+#
+# Env overrides:
+#   PORT   (default 4000 — gp-webapp start-local default)
+#   HOST   (default localhost)
+set -euo pipefail
+
+PORT="${PORT:-4000}"
+HOST="${HOST:-localhost}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//;/^set -/d'
+  exit 0
+fi
+
+OK="✓"
+NO="✗"
+WARN="⚠"
+
+check() {
+  local label="$1" cmd="$2" hint="${3:-}"
+  if eval "$cmd" >/dev/null 2>&1; then
+    printf "  %s  %s\n" "$OK" "$label"
+  else
+    printf "  %s  %s\n" "$NO" "$label"
+    [[ -n "$hint" ]] && printf "       %s\n" "$hint"
+  fi
+  return 0
+}
+
+note() {
+  printf "  %s  %s\n" "$WARN" "$1"
+}
+
+echo
+echo "scripts/perf/ environment check (gp-webapp)"
+echo "==========================================="
+echo
+
+echo "Tools:"
+check "node $(node --version 2>/dev/null || echo '(not found)')" \
+      'command -v node' \
+      'Install Node 22.x via nvm / fnm / mise.'
+check "autocannon (SSR load — §1)" \
+      'command -v autocannon' \
+      'Falls back to: npx --yes autocannon (no install needed; first run is slow).'
+check "lighthouse (Web Vitals — §8)" \
+      'command -v lighthouse' \
+      'Falls back to: npx --yes lighthouse (no install needed; first run is slow + downloads headless Chrome).'
+check "hyperfine (statistical bench — §0)" \
+      'command -v hyperfine' \
+      'Install: brew install hyperfine  (mac) | cargo install hyperfine (linux).'
+note "source-map-explorer is always run via npx — no install needed."
+
+echo
+echo "Build state:"
+if [[ -d .next/static/chunks ]]; then
+  CHUNK_COUNT="$(find .next/static/chunks -name '*.js' -type f 2>/dev/null | wc -l | tr -d ' ')"
+  printf "  %s  .next/static/chunks present (%s JS files)\n" "$OK" "$CHUNK_COUNT"
+  # Confirm source maps were emitted (productionBrowserSourceMaps).
+  if find .next/static/chunks -name '*.js.map' -type f 2>/dev/null | head -1 | grep -q .; then
+    printf "  %s  .js.map source maps present (bundle-analyze.sh will work)\n" "$OK"
+  else
+    printf "  %s  no .js.map files in .next/static/chunks — bundle-analyze.sh won't map back to source\n" "$WARN"
+    echo "       Confirm productionBrowserSourceMaps: true in next.config.ts and rebuild."
+  fi
+else
+  printf "  %s  no .next/static/chunks — Lighthouse + bundle-analyze need a build\n" "$NO"
+  echo "       Run: npm run build && npm run start-local &"
+fi
+
+echo
+echo "App:"
+if command -v curl >/dev/null 2>&1; then
+  if curl -fsS -o /dev/null --max-time 2 "http://${HOST}:${PORT}/" 2>/dev/null; then
+    printf "  %s  webapp reachable at http://%s:%s/\n" "$OK" "$HOST" "$PORT"
+  else
+    printf "  %s  no listener on http://%s:%s (start: npm run start-local)\n" "$WARN" "$HOST" "$PORT"
+  fi
+else
+  note "curl not available — skipping server reachability check"
+fi
+
+echo
+echo "Repo state:"
+if [[ -d node_modules ]]; then
+  printf "  %s  node_modules present\n" "$OK"
+else
+  printf "  %s  node_modules missing (run: npm ci)\n" "$NO"
+fi
+
+if [[ -f ai-rules/performance.md ]]; then
+  printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
+elif [[ -f ai-rules/README.md ]]; then
+  printf "  %s  ai-rules submodule initialized but performance.md missing — pointer may be stale\n" "$WARN"
+  echo "       Update: (cd ai-rules && git fetch && git checkout origin/main)"
+elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
+  printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
+  echo "       Run: git submodule update --init --recursive"
+else
+  note "ai-rules submodule not present in this repo"
+fi
+
+echo
+echo "Done. Anything marked ✗ above is a real blocker for the relevant tool."
+echo "Anything marked ⚠ is informational — usually fine for some tools, not for others."
+exit 0

--- a/scripts/perf/setup-check.sh
+++ b/scripts/perf/setup-check.sh
@@ -102,8 +102,9 @@ fi
 if [[ -f ai-rules/performance.md ]]; then
   printf "  %s  ai-rules/performance.md present (submodule initialized)\n" "$OK"
 elif [[ -f ai-rules/README.md ]]; then
-  printf "  %s  ai-rules submodule initialized but performance.md missing — pointer may be stale\n" "$WARN"
-  echo "       Update: (cd ai-rules && git fetch && git checkout origin/main)"
+  printf "  %s  ai-rules submodule initialized but performance.md missing — submodule out of sync with the recorded pointer\n" "$WARN"
+  echo "       Sync: git submodule update ai-rules"
+  echo "       (Don't 'git checkout origin/main' inside the submodule — that lands at a tree that may not contain performance.md.)"
 elif [[ -e ai-rules ]] || git config -f .gitmodules --get submodule.ai-rules.url >/dev/null 2>&1; then
   printf "  %s  ai-rules submodule NOT initialized\n" "$NO"
   echo "       Run: git submodule update --init --recursive"


### PR DESCRIPTION
## Summary

Adds convenience wrappers behind the canonical commands in [`ai-rules/performance-tools.md`](https://github.com/thegoodparty/ai-rules/blob/main/performance-tools.md) (see companion PR [thegoodparty/ai-rules#9](https://github.com/thegoodparty/ai-rules/pull/9)).

| Script | What it does | Cookbook section |
|---|---|---|
| `scripts/perf/lighthouse.sh` | Web Vitals + perf audit for a page (headless Chrome) | §8 |
| `scripts/perf/bundle-analyze.sh` | Inspect bundle composition via `source-map-explorer` | §9 |
| `scripts/perf/bench-route.sh` | SSR load test for a route (autocannon) | §1 |
| `scripts/perf/README.md` | Prereqs, examples, critic tie-in | — |

`productionBrowserSourceMaps: true` is already set in `next.config.ts`, so `bundle-analyze.sh` works on the production build out of the box.

`bench-route.sh` includes an explicit warning to benchmark against `npm run start-local` rather than `npm run dev` (HMR + dev-only React work makes dev-server numbers meaningless).

All scripts are self-documenting (`-h`/`--help`), detect missing tools with install hints, and accept env-var overrides (`PORT`, `HOST`, `PROTO`, `LH_BASE`, `PERF_OUT`).

## Critic tie-in

Per the [performance critic rules](https://github.com/thegoodparty/ai-rules/blob/main/performance.md):

- **Page render claims** need a before/after Lighthouse run
- **Bundle-size claims** need a before/after `bundle-analyze.sh --json` diff
- **SSR throughput claims** need `bench-route.sh` numbers

Without one of those, the claim should be downgraded to "refactor."

## Test plan

- [ ] `scripts/perf/lighthouse.sh --help` renders usage
- [ ] `scripts/perf/bundle-analyze.sh --help` renders usage
- [ ] `scripts/perf/bench-route.sh --help` renders usage
- [ ] `npm run build && npm run start-local &` then `scripts/perf/lighthouse.sh /` writes `perf-reports/lh-*.report.{html,json}`
- [ ] `scripts/perf/bundle-analyze.sh --summary` prints top contributors after a build
- [ ] `scripts/perf/bench-route.sh /` produces an autocannon latency table against the local prod server

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds developer-only bash wrappers and docs; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Adds **`scripts/perf/`** convenience wrappers aligned with **`ai-rules/performance-tools.md`**, plus a README with prereqs, examples, and critic rules for when perf claims need evidence.
> 
> **`lighthouse.sh`** runs headless Lighthouse against a path or full URL, writes timestamped HTML/JSON under **`perf-reports`**, and forwards extra CLI flags (**`LH_BASE`**, **`LH_OUT`**).
> 
> **`bundle-analyze.sh`** runs **`source-map-explorer`** on **`.next/static/chunks`** after a prod build (**`--summary`**, **`--html`**, **`--json`**); JSON output is intended for before/after diffs (**`PERF_OUT`**).
> 
> **`bench-route.sh`** load-tests a route with **autocannon** (default **10** connections, **20s**), builds URLs from **`PORT`/`HOST`/`PROTO`**, and documents benchmarking **`start-local`** not **`dev`**.
> 
> All three scripts expose **`-h`/`--help`** and fail fast with install hints when **`lighthouse`** or **autocannon** is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb6d4d61586c7c938bbc17d63ba9786b8f0f05a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->