### PR TITLE
Prod <- QA

### DIFF
--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -233,6 +233,55 @@ describe('<ChatProvider>', () => {
     expect(screen.getByTestId('should-type')).toHaveTextContent('true')
   })
 
+  it('handleRegenerate replaces the last assistant message via the update endpoint', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [
+            { role: 'user', content: 'first question' },
+            { role: 'assistant', content: 'original reply' },
+          ],
+        }),
+      ),
+      http.put(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          message: { role: 'assistant', content: 'regenerated reply' },
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+    await screen.findByText('original reply')
+
+    await user.click(screen.getByRole('button', { name: 'regen' }))
+
+    expect(await screen.findByText('regenerated reply')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('first question')
+    expect(messages[1]).toHaveTextContent('regenerated reply')
+    expect(screen.queryByText('original reply')).not.toBeInTheDocument()
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('handleRegenerate is a no-op when there is no active threadId', async () => {
+    const user = userEvent.setup()
+    // No msw handlers registered: a real PUT would 500 (unhandled) and
+    // the test would fail. The provider must short-circuit before the
+    // network call.
+    renderProvider()
+
+    await user.click(screen.getByRole('button', { name: 'regen' }))
+
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+  })
+
   it('finishTyping flips shouldType back to false', async () => {
     const user = userEvent.setup()
     mswServer.use(

--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -1,0 +1,222 @@
+import { useContext } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { render } from 'helpers/test-utils/render'
+import { mswServer } from 'helpers/test-utils/api-mocking'
+import { ChatContext, ChatProvider } from './ChatProvider'
+
+vi.mock('helpers/analyticsHelper', async () => {
+  const actual = await vi.importActual<object>('helpers/analyticsHelper')
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  }
+})
+
+const CHAT_LIST_URL = '/api/v1/campaigns/ai/chat'
+const CHAT_THREAD_URL = '/api/v1/campaigns/ai/chat/:threadId'
+
+const Consumer = () => {
+  const ctx = useContext(ChatContext)
+  return (
+    <div>
+      <div data-testid="thread-id">
+        {ctx.threadId === null
+          ? 'null'
+          : ctx.threadId === ''
+          ? 'empty'
+          : ctx.threadId}
+      </div>
+      <div data-testid="loading">{String(ctx.loading)}</div>
+      <div data-testid="should-type">{String(ctx.shouldType)}</div>
+      <div data-testid="chats-count">{ctx.chats.length}</div>
+      <ul data-testid="chat-messages">
+        {ctx.chat.map((m, i) => (
+          <li key={i} data-role={m.role}>
+            {m.content}
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => void ctx.loadInitialChats()}>load</button>
+      <button onClick={() => void ctx.handleNewInput('hello world')}>
+        send
+      </button>
+      <button onClick={() => void ctx.loadChatByThreadId('thread-2')}>
+        switch
+      </button>
+      <button onClick={() => void ctx.handleRegenerate()}>regen</button>
+      <button onClick={() => ctx.finishTyping()}>finish</button>
+    </div>
+  )
+}
+
+const renderProvider = () =>
+  render(
+    <ChatProvider>
+      <Consumer />
+    </ChatProvider>,
+  )
+
+describe('<ChatProvider>', () => {
+  beforeEach(() => {
+    // jsdom doesn't implement scrollTo; the provider scrolls a ref that we
+    // never attach, but the implementation still calls .scrollTo on null
+    // checks. Be defensive.
+    Element.prototype.scrollTo = vi.fn()
+  })
+
+  it('exposes default context values before any action runs', () => {
+    renderProvider()
+
+    // The provider initializes threadId to an empty string (not null) and
+    // flips to null only after a hydrate that returns no threads.
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('empty')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('false')
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('0')
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+  })
+
+  it('loadInitialChats fetches the chat list and hydrates the first thread', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          chats: [
+            {
+              threadId: 'thread-1',
+              name: 'First chat',
+              updatedAt: '2026-05-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ),
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-1',
+          chat: [
+            { role: 'user', content: 'hi there' },
+            { role: 'assistant', content: 'hello back' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'load' }))
+
+    expect(await screen.findByText('thread-1')).toBeInTheDocument()
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('1')
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('hi there')
+    expect(messages[1]).toHaveTextContent('hello back')
+  })
+
+  it('loadInitialChats resets state when the API returns no chats', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_LIST_URL, () => HttpResponse.json({ chats: [] })),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'load' }))
+
+    // The empty-list response resets threadId to null (distinct from the
+    // initial empty-string state).
+    await screen.findByText('null')
+    expect(screen.getByTestId('chats-count')).toHaveTextContent('0')
+    expect(screen.getByTestId('chat-messages').children).toHaveLength(0)
+  })
+
+  it('handleNewInput creates a new thread on the first message', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.post(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-new',
+          chat: [
+            { role: 'user', content: 'hello world' },
+            { role: 'assistant', content: 'glad to help' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    expect(await screen.findByText('thread-new')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(2)
+    expect(messages[0]).toHaveTextContent('hello world')
+    expect(messages[1]).toHaveTextContent('glad to help')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+  })
+
+  it('handleNewInput keeps the optimistic user message and clears loading when the create call fails at the network layer', async () => {
+    const user = userEvent.setup()
+    // `HttpResponse.error()` simulates a network error so that the
+    // `ajaxActions` try/catch path triggers and `createInitialChat`
+    // returns `false`. Returning a 5xx JSON body would NOT trip the
+    // catch (clientFetch swallows non-2xx) and the provider would crash
+    // trying to destructure `result.chat` — that's a separate latent bug
+    // worth tracking, not exercised here.
+    mswServer.use(http.post(CHAT_LIST_URL, () => HttpResponse.error()))
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    await screen.findByText('hello world')
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toHaveTextContent('hello world')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    // threadId remains the initial empty string when no new thread was returned.
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('empty')
+  })
+
+  it('loadChatByThreadId swaps the active thread and replaces messages', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [{ role: 'assistant', content: 'switched thread reply' }],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+
+    expect(await screen.findByText('thread-2')).toBeInTheDocument()
+    expect(await screen.findByText('switched thread reply')).toBeInTheDocument()
+  })
+
+  it('finishTyping flips shouldType back to false', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.post(CHAT_LIST_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-new',
+          chat: [
+            { role: 'user', content: 'hello world' },
+            { role: 'assistant', content: 'glad to help' },
+          ],
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'send' }))
+    await screen.findByText('glad to help')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+
+    await user.click(screen.getByRole('button', { name: 'finish' }))
+    expect(screen.getByTestId('should-type')).toHaveTextContent('false')
+  })
+})

--- a/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatProvider.test.tsx
@@ -197,6 +197,42 @@ describe('<ChatProvider>', () => {
     expect(await screen.findByText('switched thread reply')).toBeInTheDocument()
   })
 
+  it('handleNewInput updates an existing thread on follow-up messages', async () => {
+    const user = userEvent.setup()
+    mswServer.use(
+      http.get(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          threadId: 'thread-2',
+          chat: [{ role: 'assistant', content: 'switched thread reply' }],
+        }),
+      ),
+      http.put(CHAT_THREAD_URL, () =>
+        HttpResponse.json({
+          message: { role: 'assistant', content: 'follow-up reply' },
+        }),
+      ),
+    )
+
+    renderProvider()
+    await user.click(screen.getByRole('button', { name: 'switch' }))
+    expect(await screen.findByText('thread-2')).toBeInTheDocument()
+    await screen.findByText('switched thread reply')
+
+    // threadId is now 'thread-2' and chat has one assistant message, so the
+    // !threadId || chat.length === 0 branch routes to updateChat (PUT), not
+    // createInitialChat.
+    await user.click(screen.getByRole('button', { name: 'send' }))
+
+    expect(await screen.findByText('follow-up reply')).toBeInTheDocument()
+    const messages = screen.getByTestId('chat-messages').children
+    expect(messages).toHaveLength(3)
+    expect(messages[0]).toHaveTextContent('switched thread reply')
+    expect(messages[1]).toHaveTextContent('hello world')
+    expect(messages[2]).toHaveTextContent('follow-up reply')
+    expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    expect(screen.getByTestId('should-type')).toHaveTextContent('true')
+  })
+
   it('finishTyping flips shouldType back to false', async () => {
     const user = userEvent.setup()
     mswServer.use(

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -5,7 +5,7 @@ import { render } from 'helpers/test-utils/render'
 import ContactsTable from './ContactsTable'
 import { useContactsTable } from '../hooks/ContactsTableProvider'
 import { useShowContactProModal } from '../hooks/ContactProModal'
-import type { Person } from './shared/contacts-types'
+import { makePerson } from './shared/test-fixtures'
 
 vi.mock('../hooks/ContactsTableProvider', () => ({
   useContactsTable: vi.fn(),
@@ -19,45 +19,6 @@ const mockedUseContactsTable = vi.mocked(useContactsTable)
 const mockedUseShowContactProModal = vi.mocked(useShowContactProModal)
 
 type ContextValue = ReturnType<typeof useContactsTable>
-
-function makePerson(overrides: Partial<Person> = {}): Person {
-  return {
-    id: 'p_1',
-    lalVoterId: 'lal_1',
-    firstName: 'Jane',
-    middleName: null,
-    lastName: 'Doe',
-    nameSuffix: null,
-    age: 42,
-    state: 'CA',
-    address: {
-      line1: '123 Main St',
-      line2: null,
-      city: 'Townsville',
-      state: 'CA',
-      zip: '90210',
-      zipPlus4: null,
-      latitude: null,
-      longitude: null,
-    },
-    cellPhone: '555-0100',
-    landline: '555-0101',
-    gender: 'Female',
-    politicalParty: 'Independent',
-    registeredVoter: 'Yes',
-    estimatedIncomeAmount: null,
-    voterStatus: null,
-    maritalStatus: null,
-    hasChildrenUnder18: null,
-    veteranStatus: null,
-    homeowner: null,
-    businessOwner: null,
-    levelOfEducation: null,
-    ethnicityGroup: null,
-    language: 'English',
-    ...overrides,
-  }
-}
 
 function setContext(overrides: Partial<ContextValue> = {}) {
   const ctx: ContextValue = {

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import ContactsTable from './ContactsTable'
+import { useContactsTable } from '../hooks/ContactsTableProvider'
+import { useShowContactProModal } from '../hooks/ContactProModal'
+import type { Person } from './shared/contacts-types'
+
+vi.mock('../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('../hooks/ContactProModal', () => ({
+  useShowContactProModal: vi.fn(),
+}))
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseShowContactProModal = vi.mocked(useShowContactProModal)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: null,
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}
+
+function setContext(overrides: Partial<ContextValue> = {}) {
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: null,
+    currentlySelectedPerson: {
+      person: null,
+      isLoadingPerson: false,
+      isErrorPerson: false,
+      issues: [],
+      isLoadingIssues: false,
+      isErrorIssues: false,
+      issuesHasNextPage: false,
+      issuesFetchNextPage: vi.fn(),
+      isFetchingNextIssues: false,
+      activities: [],
+      isLoadingActivities: false,
+      isErrorActivities: false,
+      activitiesHasNextPage: false,
+      activitiesFetchNextPage: vi.fn(),
+      isFetchingNextActivities: false,
+    },
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: {
+      totalResults: 0,
+      currentPage: 1,
+      pageSize: 20,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial: false,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson: vi.fn(),
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+describe('<ContactsTable>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseShowContactProModal.mockReset()
+    mockedUseShowContactProModal.mockReturnValue(vi.fn())
+  })
+
+  it('renders the column headers', () => {
+    setContext({ filteredContacts: [makePerson()] })
+    render(<ContactsTable />)
+
+    // Columns are non-sortable so headers render as plain text, not buttons.
+    for (const label of [
+      'Name',
+      'Gender',
+      'Age',
+      'Address',
+      'Cell Phone',
+      'Landline',
+    ]) {
+      expect(
+        screen.getByRole('columnheader', { name: label }),
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('renders one row per contact with formatted name', () => {
+    setContext({
+      filteredContacts: [
+        makePerson({ id: '1', firstName: 'Jane', lastName: 'Doe' }),
+        makePerson({ id: '2', firstName: 'John', lastName: 'Smith' }),
+      ],
+    })
+    render(<ContactsTable />)
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
+    expect(screen.getByText('John Smith')).toBeInTheDocument()
+  })
+
+  it('renders skeleton cells when isLoading is true', () => {
+    setContext({ isLoading: true })
+    const { container } = render(<ContactsTable />)
+
+    // 6 skeleton columns x 20 rows (default page size) = 120 placeholders.
+    // We just assert the skeleton class shows up and the real data cells
+    // (e.g. "Jane Doe") do not.
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(
+      0,
+    )
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument()
+  })
+
+  it('calls selectPerson when a pro user clicks a row', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    setContext({
+      filteredContacts: [makePerson({ id: 'pid_42' })],
+      canUseProFeatures: true,
+      selectPerson,
+    })
+    render(<ContactsTable />)
+
+    await user.click(screen.getByText('Jane Doe'))
+
+    expect(selectPerson).toHaveBeenCalledWith('pid_42')
+  })
+
+  it('opens the pro upgrade modal instead of selecting when the user is not pro', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    const showProModal = vi.fn()
+    mockedUseShowContactProModal.mockReturnValue(showProModal)
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: false,
+      selectPerson,
+    })
+    render(<ContactsTable />)
+
+    await user.click(screen.getByText('Jane Doe'))
+
+    expect(showProModal).toHaveBeenCalledWith(true)
+    expect(selectPerson).not.toHaveBeenCalled()
+  })
+
+  it('blurs sensitive cells for non-pro users', () => {
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: false,
+    })
+    const { container } = render(<ContactsTable />)
+
+    // Cell phone, landline, and address are wrapped in a blurred span for
+    // non-pro users. Match by class to keep the assertion structural.
+    const blurredEls = container.querySelectorAll('.blur-\\[6px\\]')
+    expect(blurredEls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('does not blur sensitive cells for pro users', () => {
+    setContext({
+      filteredContacts: [makePerson()],
+      canUseProFeatures: true,
+    })
+    const { container } = render(<ContactsTable />)
+
+    expect(container.querySelectorAll('.blur-\\[6px\\]')).toHaveLength(0)
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/ContactsTable.test.tsx
@@ -205,9 +205,10 @@ describe('<ContactsTable>', () => {
     const { container } = render(<ContactsTable />)
 
     // Cell phone, landline, and address are wrapped in a blurred span for
-    // non-pro users. Match by class to keep the assertion structural.
+    // non-pro users. Exactly three fields blur per row — assert the exact
+    // count so accidentally blurring more cells fails the test.
     const blurredEls = container.querySelectorAll('.blur-\\[6px\\]')
-    expect(blurredEls.length).toBeGreaterThanOrEqual(3)
+    expect(blurredEls).toHaveLength(3)
   })
 
   it('does not blur sensitive cells for pro users', () => {

--- a/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
@@ -5,8 +5,8 @@ import { render } from 'helpers/test-utils/render'
 import PersonOverlay from './PersonOverlay'
 import { useContactsTable } from '../../hooks/ContactsTableProvider'
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import { makePerson } from '../shared/test-fixtures'
 import type {
-  Person,
   ConstituentIssue,
   ConstituentActivity,
 } from '../shared/contacts-types'
@@ -31,45 +31,6 @@ const mockedUseFlagOn = vi.mocked(useFlagOn)
 
 type ContextValue = ReturnType<typeof useContactsTable>
 type SelectedPerson = ContextValue['currentlySelectedPerson']
-
-function makePerson(overrides: Partial<Person> = {}): Person {
-  return {
-    id: 'p_1',
-    lalVoterId: 'lal_1',
-    firstName: 'Jane',
-    middleName: null,
-    lastName: 'Doe',
-    nameSuffix: null,
-    age: 42,
-    state: 'CA',
-    address: {
-      line1: '123 Main St',
-      line2: null,
-      city: 'Townsville',
-      state: 'CA',
-      zip: '90210',
-      zipPlus4: null,
-      latitude: null,
-      longitude: null,
-    },
-    cellPhone: '555-0100',
-    landline: '555-0101',
-    gender: 'Female',
-    politicalParty: 'Independent',
-    registeredVoter: 'Yes',
-    estimatedIncomeAmount: null,
-    voterStatus: 'Likely',
-    maritalStatus: null,
-    hasChildrenUnder18: null,
-    veteranStatus: null,
-    homeowner: null,
-    businessOwner: null,
-    levelOfEducation: null,
-    ethnicityGroup: null,
-    language: 'English',
-    ...overrides,
-  }
-}
 
 function setContext({
   selectedPersonId = 'p_1',

--- a/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/person/PersonOverlay.test.tsx
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import PersonOverlay from './PersonOverlay'
+import { useContactsTable } from '../../hooks/ContactsTableProvider'
+import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import type {
+  Person,
+  ConstituentIssue,
+  ConstituentActivity,
+} from '../shared/contacts-types'
+
+vi.mock('../../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('@shared/experiments/FeatureFlagsProvider', () => ({
+  useFlagOn: vi.fn(),
+}))
+
+// Google Maps would otherwise try to attach a Script tag and reference
+// `window.google`. Stub it with a marker we can assert on.
+vi.mock('@shared/utils/Map', () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-map" />,
+}))
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseFlagOn = vi.mocked(useFlagOn)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+type SelectedPerson = ContextValue['currentlySelectedPerson']
+
+function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: 'Likely',
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}
+
+function setContext({
+  selectedPersonId = 'p_1',
+  selectedPerson,
+  isElectedOfficial = false,
+  selectPerson = vi.fn(),
+}: {
+  selectedPersonId?: string | null
+  selectedPerson?: Partial<SelectedPerson>
+  isElectedOfficial?: boolean
+  selectPerson?: ContextValue['selectPerson']
+} = {}) {
+  const currentlySelectedPerson: SelectedPerson = {
+    person: makePerson(),
+    isLoadingPerson: false,
+    isErrorPerson: false,
+    issues: [],
+    isLoadingIssues: false,
+    isErrorIssues: false,
+    issuesHasNextPage: false,
+    issuesFetchNextPage: vi.fn(),
+    isFetchingNextIssues: false,
+    activities: [],
+    isLoadingActivities: false,
+    isErrorActivities: false,
+    activitiesHasNextPage: false,
+    activitiesFetchNextPage: vi.fn(),
+    isFetchingNextActivities: false,
+    ...selectedPerson,
+  }
+
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: selectedPersonId,
+    currentlySelectedPerson,
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: null,
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson,
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+describe('<PersonOverlay>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseFlagOn.mockReset()
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: false })
+  })
+
+  it('does not open the overlay when no person is selected', () => {
+    setContext({ selectedPersonId: null })
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the loading skeleton while the person query is loading', () => {
+    setContext({
+      selectedPerson: { person: null, isLoadingPerson: true },
+    })
+
+    render(<PersonOverlay />)
+
+    // Sheet content renders inside a Radix Portal, so query the document
+    // instead of the render container.
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+    // No real card section headings while loading.
+    expect(
+      screen.queryByRole('heading', { name: /contact information/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the person details and the standard info sections', () => {
+    setContext()
+
+    render(<PersonOverlay />)
+
+    // Person name renders as a real <h2>; the card titles render as styled
+    // <div>s (CardTitle), so query them by text content.
+    expect(
+      screen.getByRole('heading', { name: /jane doe/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/female, 42 years old/i)).toBeInTheDocument()
+    // CardTitle is a styled <div>; scope to data-slot to avoid colliding
+    // with the sr-only SheetTitle that uses the same copy.
+    const cardTitles = document.querySelectorAll('[data-slot="card-title"]')
+    const titles = Array.from(cardTitles).map((el) => el.textContent?.trim())
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        'Contact Information',
+        'Voter Demographics',
+        'Demographic Information',
+      ]),
+    )
+  })
+
+  it('renders an error message and lets the user close the overlay when the person fetch fails', async () => {
+    const user = userEvent.setup()
+    const selectPerson = vi.fn()
+    setContext({
+      selectPerson,
+      selectedPerson: { person: null, isErrorPerson: true },
+    })
+
+    render(<PersonOverlay />)
+
+    const errorHeading = screen.getByRole('heading', {
+      name: /error loading contact/i,
+    })
+    const errorBlock = errorHeading.parentElement
+    if (!errorBlock) throw new Error('error block not rendered')
+
+    // The error UI's Close button is a raw <button> next to the heading;
+    // the Sheet renders its own (svg-icon) close button at the top right.
+    await user.click(within(errorBlock).getByRole('button', { name: /close/i }))
+    expect(selectPerson).toHaveBeenCalledWith(null)
+  })
+
+  it('hides the Political Party field for elected officials', () => {
+    setContext({ isElectedOfficial: true })
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByText(/^political party$/i)).not.toBeInTheDocument()
+  })
+
+  it('hides Top Issues and Activity Feed when the feature flag is off', () => {
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: false })
+    setContext()
+
+    render(<PersonOverlay />)
+
+    expect(screen.queryByText('Top Issues')).not.toBeInTheDocument()
+    expect(screen.queryByText('Activity Feed')).not.toBeInTheDocument()
+  })
+
+  it('shows Top Issues and Activity Feed (with seeded data) when the feature flag is on', () => {
+    mockedUseFlagOn.mockReturnValue({ ready: true, on: true })
+    const issues: ConstituentIssue[] = [
+      {
+        issueTitle: 'Better Bike Lanes',
+        issueSummary: 'Constituent supports bike-lane expansion',
+        pollTitle: 'Transit',
+        pollId: 'poll_1',
+        date: '2026-05-01',
+      },
+    ]
+    const activities: ConstituentActivity[] = [
+      {
+        type: 'poll',
+        date: '2026-05-02',
+        data: {
+          pollId: 'poll_1',
+          pollTitle: 'Transit Survey',
+          events: [{ type: 'SENT', date: '2026-05-02T00:00:00.000Z' }],
+        },
+      },
+    ]
+    setContext({
+      selectedPerson: { issues, activities },
+    })
+
+    render(<PersonOverlay />)
+
+    expect(screen.getByText('Top Issues')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /better bike lanes/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Activity Feed')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /transit survey/i }),
+    ).toBeInTheDocument()
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
@@ -1,0 +1,318 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import FiltersSheet from './FiltersSheet'
+import { useContactsTable } from '../../hooks/ContactsTableProvider'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { SHEET_MODES } from '../shared/constants'
+import type { SegmentResponse } from '../shared/contacts-types'
+
+vi.mock('../../hooks/ContactsTableProvider', () => ({
+  useContactsTable: vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: vi.fn(),
+}))
+
+vi.mock('helpers/analyticsHelper', async () => {
+  const actual = await vi.importActual<object>('helpers/analyticsHelper')
+  return {
+    ...actual,
+    trackEvent: vi.fn(),
+  }
+})
+
+const mockedUseContactsTable = vi.mocked(useContactsTable)
+const mockedUseSnackbar = vi.mocked(useSnackbar)
+
+type ContextValue = ReturnType<typeof useContactsTable>
+
+function setContext(overrides: Partial<ContextValue> = {}) {
+  const ctx: ContextValue = {
+    filteredContacts: [],
+    currentlySelectedPersonId: null,
+    currentlySelectedPerson: {
+      person: null,
+      isLoadingPerson: false,
+      isErrorPerson: false,
+      issues: [],
+      isLoadingIssues: false,
+      isErrorIssues: false,
+      issuesHasNextPage: false,
+      issuesFetchNextPage: vi.fn(),
+      isFetchingNextIssues: false,
+      activities: [],
+      isLoadingActivities: false,
+      isErrorActivities: false,
+      activitiesHasNextPage: false,
+      activitiesFetchNextPage: vi.fn(),
+      isFetchingNextActivities: false,
+    },
+    segments: [],
+    customSegments: [],
+    currentSegment: 'all',
+    searchTerm: '',
+    urlQueryParams: new URLSearchParams(),
+    pagination: null,
+    isLoading: false,
+    isCustomSegment: false,
+    totalSegmentContacts: 0,
+    canUseProFeatures: true,
+    isElectedOfficial: false,
+    pageUp: vi.fn(),
+    pageDown: vi.fn(),
+    goToPage: vi.fn(),
+    setPageSize: vi.fn(),
+    selectPerson: vi.fn(),
+    selectSegment: vi.fn(),
+    searchContacts: vi.fn(),
+    refreshCustomSegments: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+  mockedUseContactsTable.mockReturnValue(ctx)
+  return ctx
+}
+
+function setSnackbar() {
+  const successSnackbar = vi.fn()
+  const errorSnackbar = vi.fn()
+  const displaySnackbar = vi.fn()
+  mockedUseSnackbar.mockReturnValue({
+    successSnackbar,
+    errorSnackbar,
+    displaySnackbar,
+  })
+  return { successSnackbar, errorSnackbar }
+}
+
+const editableSegment = (
+  overrides: Partial<SegmentResponse> = {},
+): SegmentResponse => ({
+  id: 42,
+  name: 'My Saved Segment',
+  genderMale: true,
+  ...overrides,
+})
+
+/**
+ * The filter checkboxes don't use a real <label htmlFor>; the option name
+ * is rendered as a sibling div. Find the option row by its label text,
+ * then return its inner checkbox.
+ */
+function checkboxForOption(label: string): HTMLElement {
+  const labelNode = screen.getByText(new RegExp(`^${label}$`, 'i'))
+  const row = labelNode.parentElement
+  if (!row) throw new Error(`row for ${label} not found`)
+  const checkbox = within(row).getByRole('checkbox')
+  return checkbox
+}
+
+describe('<FiltersSheet>', () => {
+  beforeEach(() => {
+    mockedUseContactsTable.mockReset()
+    mockedUseSnackbar.mockReset()
+  })
+
+  it('renders the filter sheet with section titles in create mode', () => {
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /general information/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /create segment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('auto-generates a default segment name in create mode using the number of existing custom segments', () => {
+    setContext({
+      customSegments: [editableSegment({ id: 1 }), editableSegment({ id: 2 })],
+    })
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /custom segment 3/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps the Create button disabled until a filter is selected, then triggers afterSave with the new segment id on success', async () => {
+    const user = userEvent.setup()
+    const afterSave = vi.fn()
+    const handleClose = vi.fn()
+    setContext()
+    const { successSnackbar } = setSnackbar()
+    api.mock('POST /v1/voters/voter-file/filter', {
+      status: 200,
+      data: { id: 7, name: 'Custom Segment 1' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={afterSave}
+      />,
+    )
+
+    const create = screen.getByRole('button', { name: /create segment/i })
+    expect(create).toBeDisabled()
+
+    await user.click(checkboxForOption('Male'))
+    expect(create).toBeEnabled()
+
+    await user.click(create)
+
+    await vi.waitFor(() => {
+      expect(afterSave).toHaveBeenCalledWith(7)
+    })
+    expect(successSnackbar).toHaveBeenCalledWith('Segment created successfully')
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('shows an error snackbar when the create API fails', async () => {
+    const user = userEvent.setup()
+    const afterSave = vi.fn()
+    setContext()
+    const { errorSnackbar } = setSnackbar()
+    api.mock('POST /v1/voters/voter-file/filter', {
+      status: 500,
+      data: { message: 'server exploded' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={afterSave}
+      />,
+    )
+
+    await user.click(checkboxForOption('Female'))
+    await user.click(screen.getByRole('button', { name: /create segment/i }))
+
+    await vi.waitFor(() => {
+      expect(errorSnackbar).toHaveBeenCalledWith('Failed to create segment')
+    })
+    expect(afterSave).not.toHaveBeenCalled()
+  })
+
+  it('renders the existing name and an Update Segment button in edit mode', () => {
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole('heading', { name: /my saved segment/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /update segment/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Political Party section for elected officials', () => {
+    setContext({ isElectedOfficial: true })
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // The General Information section still renders, but its Political
+    // Party field is filtered out.
+    expect(
+      screen.getByRole('heading', { name: /general information/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: /political party/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Select All toggles every option within a filter field on at once', async () => {
+    const user = userEvent.setup()
+    setContext()
+    setSnackbar()
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={vi.fn()}
+        mode={SHEET_MODES.CREATE}
+        editSegment={null}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // Scope all queries to the Gender field container (heading parent's
+    // parent) — "Unknown" repeats across other filter sections.
+    const genderHeading = screen.getByRole('heading', { name: /^gender$/i })
+    const headerRow = genderHeading.parentElement
+    const fieldContainer = headerRow?.parentElement
+    if (!fieldContainer) throw new Error('gender field container not rendered')
+
+    const selectAll = within(headerRow!).getByText(/select all/i)
+    await user.click(selectAll)
+
+    const checkboxes = within(fieldContainer).getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(3)
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toHaveAttribute('aria-checked', 'true')
+    }
+  })
+})

--- a/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
+++ b/app/dashboard/contacts/[[...attr]]/components/segments/FiltersSheet.test.tsx
@@ -256,6 +256,76 @@ describe('<FiltersSheet>', () => {
     ).toBeInTheDocument()
   })
 
+  it('PUTs the segment, selects it, and closes the sheet when Update Segment succeeds in edit mode', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    const selectSegment = vi.fn()
+    const refreshCustomSegments = vi.fn().mockResolvedValue(undefined)
+    setContext({ selectSegment, refreshCustomSegments })
+    const { successSnackbar } = setSnackbar()
+    api.mock('PUT /v1/voters/voter-file/filter/:id', {
+      status: 200,
+      data: { id: 42, name: 'My Saved Segment' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    // editableSegment seeds genderMale=true, so Update is enabled
+    // immediately without needing a checkbox click.
+    await user.click(screen.getByRole('button', { name: /update segment/i }))
+
+    await vi.waitFor(() => {
+      expect(successSnackbar).toHaveBeenCalledWith(
+        'Segment updated successfully',
+      )
+    })
+    expect(refreshCustomSegments).toHaveBeenCalled()
+    expect(selectSegment).toHaveBeenCalledWith('42')
+    expect(handleClose).toHaveBeenCalled()
+  })
+
+  it('shows an error snackbar and keeps the sheet open when the update API fails in edit mode', async () => {
+    const user = userEvent.setup()
+    const handleClose = vi.fn()
+    const selectSegment = vi.fn()
+    setContext({ selectSegment })
+    const { errorSnackbar } = setSnackbar()
+    api.mock('PUT /v1/voters/voter-file/filter/:id', {
+      status: 500,
+      data: { message: 'server exploded' },
+    })
+
+    render(
+      <FiltersSheet
+        open
+        handleClose={handleClose}
+        mode={SHEET_MODES.EDIT}
+        editSegment={editableSegment()}
+        handleOpenChange={vi.fn()}
+        resetSelect={vi.fn()}
+        afterSave={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /update segment/i }))
+
+    await vi.waitFor(() => {
+      expect(errorSnackbar).toHaveBeenCalledWith('Failed to update segment')
+    })
+    expect(selectSegment).not.toHaveBeenCalled()
+    expect(handleClose).not.toHaveBeenCalled()
+  })
+
   it('hides the Political Party section for elected officials', () => {
     setContext({ isElectedOfficial: true })
     setSnackbar()

--- a/app/dashboard/contacts/[[...attr]]/components/shared/test-fixtures.ts
+++ b/app/dashboard/contacts/[[...attr]]/components/shared/test-fixtures.ts
@@ -1,0 +1,48 @@
+import type { Person } from './contacts-types'
+
+/**
+ * Canonical Person factory for contacts unit tests. Defaults to a
+ * `voterStatus` of `null` (the most common state in production data);
+ * tests that need a specific status should pass it via `overrides`.
+ *
+ * This file is imported only from `*.test.tsx` files and is not used
+ * in production code.
+ */
+export function makePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: 'p_1',
+    lalVoterId: 'lal_1',
+    firstName: 'Jane',
+    middleName: null,
+    lastName: 'Doe',
+    nameSuffix: null,
+    age: 42,
+    state: 'CA',
+    address: {
+      line1: '123 Main St',
+      line2: null,
+      city: 'Townsville',
+      state: 'CA',
+      zip: '90210',
+      zipPlus4: null,
+      latitude: null,
+      longitude: null,
+    },
+    cellPhone: '555-0100',
+    landline: '555-0101',
+    gender: 'Female',
+    politicalParty: 'Independent',
+    registeredVoter: 'Yes',
+    estimatedIncomeAmount: null,
+    voterStatus: null,
+    maritalStatus: null,
+    hasChildrenUnder18: null,
+    veteranStatus: null,
+    homeowner: null,
+    businessOwner: null,
+    levelOfEducation: null,
+    ethnicityGroup: null,
+    language: 'English',
+    ...overrides,
+  }
+}

--- a/app/dashboard/election-result/components/ElectionResultPage.tsx
+++ b/app/dashboard/election-result/components/ElectionResultPage.tsx
@@ -91,7 +91,7 @@ export default function ElectionResultPage(): React.JSX.Element {
 
       setSelectedSlug(newOrg.slug)
 
-      router.replace('/polls/welcome')
+      router.replace('/dashboard/briefings')
     },
   })
 

--- a/app/dashboard/polls/create/CreatePoll.tsx
+++ b/app/dashboard/polls/create/CreatePoll.tsx
@@ -1,6 +1,6 @@
 'use client'
 import DashboardLayout from '../../shared/DashboardLayout'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { StepIndicator } from '@shared/stepper'
 import { useRouter } from 'next/navigation'
@@ -125,8 +125,18 @@ const FormContent: React.FC<{
 )
 
 const useEvent = (event: string, props?: Record<string, any>) => {
+  // Mount-only by intent (these are page-view / completion events that should
+  // fire exactly once), but the effect runs after the first commit — by which
+  // point a re-render may have produced fresher props (e.g. async user data
+  // resolving). Read through refs so the effect captures the latest values
+  // at fire time without retriggering on every prop change.
+  const eventRef = useRef(event)
+  const propsRef = useRef(props)
+  eventRef.current = event
+  propsRef.current = props
+
   useEffect(() => {
-    trackEvent(event, props)
+    trackEvent(eventRef.current, propsRef.current)
   }, [])
 }
 

--- a/e2e-tests/tests/app/organizations/election-result-flow.spec.ts
+++ b/e2e-tests/tests/app/organizations/election-result-flow.spec.ts
@@ -34,7 +34,7 @@ test('"I won my race" creates an EO org and auto-selects it', async ({
     .getByRole('button', { name: 'I won my race' })
     .click({ timeout: 10_000 })
 
-  await page.waitForURL('**/polls/welcome', { timeout: 15_000 })
+  await page.waitForURL('**/dashboard/briefings', { timeout: 15_000 })
 
   await NavigationHelper.navigateToPage(page, '/dashboard/polls')
   await NavigationHelper.dismissOverlays(page)

--- a/helpers/URLSearchParamsToObject.test.ts
+++ b/helpers/URLSearchParamsToObject.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { URLSearchParamsToObject } from './URLSearchParamsToObject'
+
+describe('URLSearchParamsToObject', () => {
+  it('returns an empty object for empty params', () => {
+    expect(URLSearchParamsToObject(new URLSearchParams())).toEqual({})
+  })
+
+  it('maps single-occurrence keys to string values', () => {
+    const params = new URLSearchParams('a=1&b=hello')
+    expect(URLSearchParamsToObject(params)).toEqual({ a: '1', b: 'hello' })
+  })
+
+  it('promotes a duplicated key to a string array', () => {
+    const params = new URLSearchParams('tag=foo&tag=bar')
+    expect(URLSearchParamsToObject(params)).toEqual({ tag: ['foo', 'bar'] })
+  })
+
+  it('appends to the existing array on third and later occurrences', () => {
+    const params = new URLSearchParams('tag=a&tag=b&tag=c&tag=d')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      tag: ['a', 'b', 'c', 'd'],
+    })
+  })
+
+  it('handles a mix of single-value and multi-value keys', () => {
+    const params = new URLSearchParams('id=42&tag=a&tag=b&q=hello')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      id: '42',
+      tag: ['a', 'b'],
+      q: 'hello',
+    })
+  })
+
+  it('preserves empty-string values', () => {
+    const params = new URLSearchParams('a=&b=value')
+    expect(URLSearchParamsToObject(params)).toEqual({ a: '', b: 'value' })
+  })
+
+  it('preserves insertion order of duplicated keys', () => {
+    const params = new URLSearchParams('first=a&second=b&first=c')
+    expect(URLSearchParamsToObject(params)).toEqual({
+      first: ['a', 'c'],
+      second: 'b',
+    })
+  })
+})

--- a/helpers/extractApiErrorInfo.test.ts
+++ b/helpers/extractApiErrorInfo.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { extractApiErrorInfo } from './extractApiErrorInfo'
+
+describe('extractApiErrorInfo', () => {
+  it('returns empty object for null', () => {
+    expect(extractApiErrorInfo(null)).toEqual({})
+  })
+
+  it('returns empty object for undefined', () => {
+    expect(extractApiErrorInfo(undefined)).toEqual({})
+  })
+
+  it('returns empty object for non-object primitives', () => {
+    expect(extractApiErrorInfo('boom')).toEqual({})
+    expect(extractApiErrorInfo(42)).toEqual({})
+    expect(extractApiErrorInfo(false)).toEqual({})
+  })
+
+  it('extracts a string message', () => {
+    expect(extractApiErrorInfo({ message: 'Something failed' })).toEqual({
+      message: 'Something failed',
+      errorCode: undefined,
+    })
+  })
+
+  it('joins an array message into a comma-separated string', () => {
+    expect(
+      extractApiErrorInfo({
+        message: ['email is required', 'name is required'],
+      }),
+    ).toEqual({
+      message: 'email is required, name is required',
+      errorCode: undefined,
+    })
+  })
+
+  it('filters out non-string entries when joining an array message', () => {
+    expect(
+      extractApiErrorInfo({ message: ['valid', 42, null, 'also valid'] }),
+    ).toEqual({
+      message: 'valid, also valid',
+      errorCode: undefined,
+    })
+  })
+
+  it('returns undefined message when the message field is neither string nor array', () => {
+    expect(extractApiErrorInfo({ message: { nested: 'shape' } })).toEqual({
+      message: undefined,
+      errorCode: undefined,
+    })
+  })
+
+  it('extracts a string errorCode', () => {
+    expect(
+      extractApiErrorInfo({ message: 'oops', errorCode: 'EMAIL_TAKEN' }),
+    ).toEqual({
+      message: 'oops',
+      errorCode: 'EMAIL_TAKEN',
+    })
+  })
+
+  it('returns undefined errorCode when it is not a string', () => {
+    expect(extractApiErrorInfo({ message: 'oops', errorCode: 123 })).toEqual({
+      message: 'oops',
+      errorCode: undefined,
+    })
+  })
+
+  it('returns both fields undefined when neither key is present', () => {
+    expect(extractApiErrorInfo({})).toEqual({
+      message: undefined,
+      errorCode: undefined,
+    })
+  })
+})

--- a/helpers/resolvePostAuthRedirectPath.util.test.ts
+++ b/helpers/resolvePostAuthRedirectPath.util.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { resolvePostAuthRedirectPath } from './resolvePostAuthRedirectPath.util'
+
+describe('resolvePostAuthRedirectPath', () => {
+  it('routes a sales user to the sales add-campaign page', () => {
+    expect(
+      resolvePostAuthRedirectPath({ roles: ['sales', 'admin'] }, null),
+    ).toBe('/sales/add-campaign')
+  })
+
+  it('prefers the sales role over any campaign status', () => {
+    expect(
+      resolvePostAuthRedirectPath(
+        { roles: ['sales'] },
+        { status: 'candidate' },
+      ),
+    ).toBe('/sales/add-campaign')
+  })
+
+  it('routes a candidate to the dashboard', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: 'candidate' })).toBe(
+      '/dashboard',
+    )
+  })
+
+  it('routes an onboarding user to the slug + step path', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, {
+        status: 'onboarding',
+        slug: 'jane-doe',
+        step: 4,
+      }),
+    ).toBe('/onboarding/jane-doe/4')
+  })
+
+  it('defaults onboarding step to 1 when missing', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, {
+        status: 'onboarding',
+        slug: 'jane-doe',
+      }),
+    ).toBe('/onboarding/jane-doe/1')
+  })
+
+  it('falls through to /dashboard/profile when onboarding has no slug', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: 'onboarding' })).toBe(
+      '/dashboard/profile',
+    )
+  })
+
+  it('routes to office-selection when there is no campaign status', () => {
+    expect(resolvePostAuthRedirectPath(null, null)).toBe(
+      '/onboarding/office-selection',
+    )
+  })
+
+  it('routes to office-selection when campaign status is false', () => {
+    expect(resolvePostAuthRedirectPath(null, { status: false })).toBe(
+      '/onboarding/office-selection',
+    )
+  })
+
+  it('routes a user with elected office and no campaign to the dashboard', () => {
+    expect(resolvePostAuthRedirectPath(null, null, true)).toBe('/dashboard')
+    expect(resolvePostAuthRedirectPath(null, { status: false }, true)).toBe(
+      '/dashboard',
+    )
+  })
+
+  it('falls back to /dashboard/profile for any other status', () => {
+    expect(
+      resolvePostAuthRedirectPath(null, { status: 'something-else' }),
+    ).toBe('/dashboard/profile')
+  })
+
+  it('handles a user without roles', () => {
+    expect(resolvePostAuthRedirectPath({}, { status: 'candidate' })).toBe(
+      '/dashboard',
+    )
+  })
+})

--- a/helpers/validations.test.ts
+++ b/helpers/validations.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { isValidEmail } from './validations'
+
+describe('isValidEmail', () => {
+  it('accepts a standard email', () => {
+    expect(isValidEmail('user@example.com')).toBe(true)
+  })
+
+  it('accepts emails with dots, plus signs, and dashes in the local part', () => {
+    expect(isValidEmail('first.last+tag@example.co.uk')).toBe(true)
+    expect(isValidEmail('a-b_c@sub.example.org')).toBe(true)
+  })
+
+  it('accepts uppercase emails (lowercased internally)', () => {
+    expect(isValidEmail('USER@EXAMPLE.COM')).toBe(true)
+  })
+
+  it('accepts emails with IP-literal domains', () => {
+    expect(isValidEmail('user@[127.0.0.1]')).toBe(true)
+  })
+
+  it('rejects emails missing the @ sign', () => {
+    expect(isValidEmail('userexample.com')).toBe(false)
+  })
+
+  it('rejects emails missing a domain', () => {
+    expect(isValidEmail('user@')).toBe(false)
+  })
+
+  it('rejects emails missing a local part', () => {
+    expect(isValidEmail('@example.com')).toBe(false)
+  })
+
+  it('rejects domains without a top-level domain', () => {
+    expect(isValidEmail('user@example')).toBe(false)
+  })
+
+  it('rejects single-character TLDs', () => {
+    expect(isValidEmail('user@example.c')).toBe(false)
+  })
+
+  it('rejects whitespace inputs', () => {
+    expect(isValidEmail('')).toBe(false)
+    expect(isValidEmail('   ')).toBe(false)
+    expect(isValidEmail('user @example.com')).toBe(false)
+    expect(isValidEmail('user@ example.com')).toBe(false)
+  })
+
+  it('rejects unicode characters in the domain part', () => {
+    expect(isValidEmail('user@exämple.com')).toBe(false)
+  })
+
+  it('accepts unicode characters in the local part (negated-class regex)', () => {
+    expect(isValidEmail('üser@example.com')).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The post-win redirect changes a core onboarding path for elected users; the rest is mostly tests plus a low-impact analytics timing fix in CreatePoll.
> 
> **Overview**
> Adds broad **Vitest** coverage for campaign assistant chat (`ChatProvider`), contacts UI (`ContactsTable`, `PersonOverlay`, `FiltersSheet`), and shared helpers (`URLSearchParamsToObject`, `extractApiErrorInfo`, `resolvePostAuthRedirectPath`, `isValidEmail`), plus a contacts-only `makePerson` test factory.
> 
> **Product/behavior tweaks:** after winning an election, `ElectionResultPage` and the Playwright election-result spec now navigate to **`/dashboard/briefings`** instead of `/polls/welcome`. In poll creation, mount-once analytics in `useEvent` now reads **latest** `event`/`props` via refs so one-shot `trackEvent` calls aren’t stuck with stale values from the first render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74eb2aa344c49663b741ffe1200852ac0867f58c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->