### PR TITLE
test(e2e): fix setupElectedOfficeUser redirect wait

### DIFF
--- a/e2e-tests/src/helpers/organizations.ts
+++ b/e2e-tests/src/helpers/organizations.ts
@@ -31,7 +31,7 @@ export const setupElectedOfficeUser = async (
   await page
     .getByRole('button', { name: 'I won my race' })
     .click({ timeout: 10000 })
-  await page.waitForURL('**/polls/welcome', { timeout: 15000 })
+  await page.waitForURL('**/dashboard/briefings', { timeout: 15000 })
 
   const electedOfficeOrgSlug = await eventually(
     { that: 'an elected office organization is created' },


### PR DESCRIPTION
Follow-up to #1902. That PR moved the won-race redirect from `/polls/welcome` to `/dashboard/briefings` and updated the dedicated election-result spec, but the shared `setupElectedOfficeUser` helper in `e2e-tests/src/helpers/organizations.ts` was missed.

That helper drives the contacts e2e suites (`contacts.spec.ts`, `contacts-filters.spec.ts`, `contacts-org-scoping.spec.ts`), all of which were left waiting 15s for a URL that no longer appears. This points the helper at the new destination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a shared helper URL assertion; no production code.
> 
> **Overview**
> Aligns the shared **`setupElectedOfficeUser`** e2e helper with the post–#1902 “I won my race” flow: after clicking **I won my race**, it now waits for **`/dashboard/briefings`** instead of **`/polls/welcome`**.
> 
> That helper backs the contacts-related suites (`contacts.spec.ts`, `contacts-filters.spec.ts`, `contacts-org-scoping.spec.ts`), which were timing out on the old URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe4ed8e26e22a7422d86e2c9008d4263695ea1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->