### PR TITLE
fix(briefings): resolve meeting briefing UI bugs

### DIFF
--- a/app/dashboard/briefings/[slug]/page.tsx
+++ b/app/dashboard/briefings/[slug]/page.tsx
@@ -2,10 +2,6 @@ import { notFound } from 'next/navigation'
 import pageMetaData from 'helpers/metadataHelper'
 import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
 import {
-  renderBriefingForSpeech,
-  renderItemForSpeech,
-} from '@shared/briefings/renderForSpeech'
-import {
   BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
   briefingItemDomId,
 } from '@shared/briefings/routes'
@@ -49,12 +45,6 @@ export default async function Page({
   if (!result || !isFullBriefing(result)) notFound()
   const briefing = result
 
-  // Pre-render the briefing into a single plain-text blob for the speech
-  // service. Doing this here (rather than in the button) keeps the speech
-  // module a pure pipe: it accepts text and returns audio, with zero
-  // briefing-schema knowledge.
-  const speechText = renderBriefingForSpeech(briefing)
-
   return (
     <>
       <TrackBriefingViewed briefingId={slug} />
@@ -62,8 +52,6 @@ export default async function Page({
         summary={briefing.executive_summary}
         agendaItemIds={briefing.items.map((item) => item.id)}
         domId={BRIEFING_EXECUTIVE_SUMMARY_DOM_ID}
-        speechText={speechText}
-        analyticsLabel="briefing"
       />
 
       {briefing.items.map((item, index) => {
@@ -78,8 +66,6 @@ export default async function Page({
             meetingDate={slug}
             showFeedback={isFeatured}
             variant={isFeatured ? 'full' : 'whatToExpectOnly'}
-            speechText={isFeatured ? renderItemForSpeech(item) : undefined}
-            analyticsLabel={`briefing-item-${item.id}`}
           />
         )
       })}

--- a/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
@@ -159,7 +159,7 @@ const MARKER_ICON_FOR_KIND: Record<MarkerKind, string> = {
 
 const MARKER_ARIA_LABEL_FOR_KIND: Record<MarkerKind, string> = {
   note: 'Open note',
-  chat: 'Open AI chat',
+  chat: 'Open chat',
   bug_report: 'Open bug report',
 }
 

--- a/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
+++ b/app/dashboard/briefings/components/annotations/AskAiChatBody.tsx
@@ -886,7 +886,7 @@ export default function AskAiChatBody({
             onKeyDown={onComposerKeyDown}
             placeholder="Ask anything about this briefing..."
             disabled={sending || creating}
-            aria-label="Ask AI message"
+            aria-label="Ask a question"
           />
           <IconButton
             type="button"

--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.tsx
@@ -11,7 +11,6 @@ import {
   isPageWideChat,
   resolveQuoteFromAnchor,
 } from '@shared/briefings/anchorResolver'
-import { useIsMobile } from '@styleguide/hooks/use-mobile'
 import AskAiChatBody from './AskAiChatBody'
 import { AnnotationSurfaceSheet } from './AnnotationSurfaceSheet'
 import type { EnrichedAnnotation } from './enrichForCycler'
@@ -108,7 +107,6 @@ export function BriefingAssistantSurface({
   onChatCreated,
   onDeleteChat,
 }: Props) {
-  const isMobile = useIsMobile()
   const items = useEnrichedAnnotations(open, annotations, 'chat')
   // When the user is mid-selection-to-anchored-chat, preempt the cycler with
   // the empty-state composer carrying the live anchor. Otherwise the cycler
@@ -181,7 +179,7 @@ export function BriefingAssistantSurface({
     <AnnotationSurfaceSheet
       open={open}
       onClose={onClose}
-      title={isMobile ? null : 'Assistant highlight'}
+      title={null}
       accessibleTitle="Briefing assistant"
       subtitle="Ask anything about this section, or highlight some text to ask or get help about just that text."
       positionLabel="Chat"

--- a/app/dashboard/briefings/components/annotations/BugReportsSurface.test.tsx
+++ b/app/dashboard/briefings/components/annotations/BugReportsSurface.test.tsx
@@ -69,7 +69,7 @@ describe('<BugReportsSurface>', () => {
     // Confirm at least one is present.
     expect(
       screen.getAllByText(
-        /spot an error\? describe what's wrong and we'll fix it\./i,
+        /spot an error\? mark it in your briefing, and your bug report will help us improve\./i,
       ).length,
     ).toBeGreaterThan(0)
   })

--- a/app/dashboard/briefings/components/annotations/BugReportsSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/BugReportsSurface.tsx
@@ -45,9 +45,9 @@ export function BugReportsSurface({
     <AnnotationSurfaceSheet
       open={open}
       onClose={onClose}
-      title="Bug reports"
+      title={null}
       accessibleTitle="Bug reports"
-      subtitle="Spot an error? Describe what's wrong and we'll fix it."
+      subtitle="Spot an error? Mark it in your briefing, and your bug report will help us improve."
       positionLabel="Bug"
       items={items}
       renderItem={(item) => <BugReportBody item={item} />}

--- a/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
+++ b/app/dashboard/briefings/components/annotations/HighlightToolbar.tsx
@@ -61,7 +61,7 @@ export default function HighlightToolbar({
     >
       <Button type="button" size="small" onClick={onAskAi}>
         <Sparkles className="size-3.5" aria-hidden />
-        Ask AI
+        Ask
       </Button>
       <Button type="button" size="small" variant="outline" onClick={onAddNote}>
         <MessageSquare className="size-3.5" aria-hidden />

--- a/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.test.tsx
@@ -353,7 +353,7 @@ describe('NotesSurface', () => {
   })
 
   describe('Header', () => {
-    it('renders the "Note" panel title on desktop (matches Lovable design)', () => {
+    it('renders no visible panel title on desktop — only the sr-only "Notes" label', () => {
       render(
         <NotesSurface
           open
@@ -366,9 +366,11 @@ describe('NotesSurface', () => {
         />,
       )
 
-      // The visible big heading; sr-only DrawerTitle ("Notes") is separate.
-      const titles = screen.getAllByText(/^Note$/)
-      expect(titles.some((el) => !el.classList.contains('sr-only'))).toBe(true)
+      // The visible "Note" heading was removed to match the other annotation
+      // surfaces; the Radix DrawerTitle keeps the sr-only "Notes" label for
+      // a11y.
+      expect(screen.queryByText(/^Note$/)).not.toBeInTheDocument()
+      expect(screen.getByText(/^Notes$/)).toHaveClass('sr-only')
     })
 
     it('does not render a visible "Note" panel title on mobile (sr-only label only)', async () => {

--- a/app/dashboard/briefings/components/annotations/NotesSurface.tsx
+++ b/app/dashboard/briefings/components/annotations/NotesSurface.tsx
@@ -17,7 +17,6 @@ import { useDictationAppend } from '../../shared/useDictationAppend'
 import { DictationMicButton } from '../../shared/DictationMicButton'
 import { DictationFeedback } from '../../shared/DictationFeedback'
 import NoteAttachmentPicker from './NoteAttachmentPicker'
-import { useIsMobile } from '@styleguide/hooks/use-mobile'
 
 interface Props {
   open: boolean
@@ -217,7 +216,6 @@ export function NotesSurface({
   initialAnnotationId,
   briefingItems,
 }: Props) {
-  const isMobile = useIsMobile()
   const items = useEnrichedAnnotations(open, annotations, 'note')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draftBody, setDraftBody] = useState('')
@@ -278,7 +276,7 @@ export function NotesSurface({
     <AnnotationSurfaceSheet
       open={open}
       onClose={onClose}
-      title={isMobile ? null : 'Note'}
+      title={null}
       accessibleTitle="Notes"
       subtitle="Add a note to this agenda item or highlight any text to add a note for just that part."
       positionLabel="Note"

--- a/app/dashboard/briefings/components/annotations/ReportErrorSheet.test.tsx
+++ b/app/dashboard/briefings/components/annotations/ReportErrorSheet.test.tsx
@@ -196,7 +196,7 @@ describe('<ReportErrorSheet>', () => {
 
     expect(
       screen.getByText(
-        /spot an error\? describe what's wrong and we'll fix it\./i,
+        /spot an error\? mark it in your briefing, and your bug report will help us improve\./i,
       ),
     ).toBeInTheDocument()
   })

--- a/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
+++ b/app/dashboard/briefings/components/annotations/ReportErrorSheet.tsx
@@ -134,8 +134,11 @@ export default function ReportErrorSheet({
     >
       <DrawerContent className="flex flex-col gap-0 p-0 data-[vaul-drawer-direction=right]:sm:max-w-[480px]">
         <DrawerHeader className="gap-2 border-b border-border px-6 pb-4 pr-12 pt-6">
-          <DrawerTitle className="text-2xl font-semibold tracking-tight text-foreground">
-            Report or Correct an Error
+          {/* Heading is kept for screen readers only — visually omitted to
+              match the other annotation surfaces, which lead with the byline
+              rather than a left-aligned title. */}
+          <DrawerTitle className="sr-only">
+            Report or correct an error
           </DrawerTitle>
           {position ? (
             <div className="flex items-center justify-center gap-3">
@@ -145,7 +148,8 @@ export default function ReportErrorSheet({
             </div>
           ) : null}
           <p className="text-balance text-center text-sm leading-relaxed text-muted-foreground">
-            Spot an error? Describe what&apos;s wrong and we&apos;ll fix it.
+            Spot an error? Mark it in your briefing, and your bug report will
+            help us improve.
           </p>
         </DrawerHeader>
 

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest'
-import { screen } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
 import AgendaItemCard from './AgendaItemCard'
 import type { Item, Source } from '@shared/briefings/types'
@@ -13,15 +12,7 @@ vi.mock('../annotations/AnnotationsScope', () => ({
     activeCard: null,
     setActiveCard: vi.fn(),
     openEditNote: vi.fn(),
-  }),
-}))
-
-vi.mock('../../shared/useReadAloud', () => ({
-  useReadAloud: () => ({
-    status: 'idle',
-    error: null,
-    play: vi.fn(),
-    stop: vi.fn(),
+    openChatsSurface: vi.fn(),
   }),
 }))
 
@@ -43,58 +34,6 @@ function makeItem(overrides: Partial<Item> = {}): Item {
 const noSources: Source[] = []
 
 describe('<AgendaItemCard>', () => {
-  it('renders a read-aloud button when speechText is provided', () => {
-    render(
-      <AgendaItemCard
-        item={makeItem()}
-        itemIndex={0}
-        sources={noSources}
-        domId="briefing-item-item_1"
-        meetingDate="2026-05-18"
-        showFeedback={false}
-        speechText="The mayor or chair opens the meeting."
-      />,
-    )
-
-    expect(
-      screen.getByRole('button', { name: /read aloud/i }),
-    ).toBeInTheDocument()
-  })
-
-  it('does not render a read-aloud button when speechText is omitted', () => {
-    render(
-      <AgendaItemCard
-        item={makeItem()}
-        itemIndex={0}
-        sources={noSources}
-        domId="briefing-item-item_1"
-        meetingDate="2026-05-18"
-        showFeedback={false}
-      />,
-    )
-
-    expect(
-      screen.queryByRole('button', { name: /read aloud/i }),
-    ).not.toBeInTheDocument()
-  })
-
-  it('renders the read-aloud button as an icon-only control (no visible "Read aloud" text label)', () => {
-    render(
-      <AgendaItemCard
-        item={makeItem()}
-        itemIndex={0}
-        sources={noSources}
-        domId="briefing-item-item_1"
-        meetingDate="2026-05-18"
-        showFeedback={false}
-        speechText="The mayor or chair opens the meeting."
-      />,
-    )
-
-    const btn = screen.getByRole('button', { name: /read aloud/i })
-    expect(btn.textContent?.trim()).toBe('')
-  })
-
   it('renders sections in Lovable order: What to expect → Budget → Sentiment → News → Talking points', () => {
     const item = makeItem({
       title: 'Public Safety Camera Expansion',

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -18,7 +18,6 @@ import RecentNewsList from './RecentNewsList'
 import TalkingPointsList from './TalkingPointsList'
 import SourcesCollapsible from './SourcesCollapsible'
 import FeedbackRow from './FeedbackRow'
-import ReadAloudButton from './ReadAloudButton'
 import CardLevelNotesList from './CardLevelNotesList'
 
 type Variant = 'full' | 'whatToExpectOnly'
@@ -31,14 +30,6 @@ type Props = {
   meetingDate: string
   showFeedback: boolean
   variant?: Variant
-  /**
-   * Pre-rendered plain-text for the speech service. When provided, the
-   * card header renders a compact read-aloud control. Featured items on
-   * the overview pass this; non-featured items omit it.
-   */
-  speechText?: string
-  /** Optional label forwarded to analytics so usage can be sliced by surface. */
-  analyticsLabel?: string
 }
 
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
@@ -189,13 +180,18 @@ const AgendaItemCard = ({
   meetingDate,
   showFeedback,
   variant = 'full',
-  speechText,
-  analyticsLabel,
 }: Props): React.JSX.Element => {
   const base = briefingItemCardPath(itemIndex)
   const titlePath = briefingItemTitlePath(itemIndex)
-  const { activeCard, setActiveCard } = useAnnotationsCtx()
+  const { activeCard, setActiveCard, annotations, openChatsSurface } =
+    useAnnotationsCtx()
   const isActive = activeCard?.key === domId
+  // If the assistant already has a thread anchored to this item's title,
+  // clicking the title opens that thread directly rather than re-surfacing
+  // the selection toolbar.
+  const titleChat = annotations.find(
+    (a) => a.kind === 'chat' && a.jsonPath === titlePath,
+  )
   const activate = () =>
     setActiveCard({
       key: domId,
@@ -240,27 +236,26 @@ const AgendaItemCard = ({
     >
       <header className="flex items-start justify-between gap-3">
         <div className="flex min-w-0 flex-col gap-1">
-          {/* Clicking the title selects its full text so the
-              HighlightToolbar surfaces anchored to the title — the same
+          {/* With no chat yet, clicking the title selects its full text so
+              the HighlightToolbar surfaces anchored to the title — the same
               anchor openCardLevelChat uses — without the user having to
-              drag-highlight it by hand. */}
+              drag-highlight it by hand. With a chat already attached, it
+              opens that thread directly. */}
           <h3
             className="w-fit cursor-pointer text-lg font-semibold text-foreground"
             data-briefing-json-path={titlePath}
-            onClick={(e) => selectElementContents(e.currentTarget)}
+            onClick={(e) => {
+              if (titleChat) {
+                e.stopPropagation()
+                openChatsSurface(titleChat.id)
+              } else {
+                selectElementContents(e.currentTarget)
+              }
+            }}
           >
             {item.title}
           </h3>
         </div>
-        {speechText ? (
-          <div className="shrink-0">
-            <ReadAloudButton
-              text={speechText}
-              analyticsLabel={analyticsLabel}
-              compact
-            />
-          </div>
-        ) : null}
       </header>
 
       <section className="flex flex-col gap-2">

--- a/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
+++ b/app/dashboard/briefings/components/detail/CardLevelNotesList.tsx
@@ -82,7 +82,7 @@ export default function CardLevelNotesList({
                   raw CSS-var brackets — per CLAUDE.md (Design Tokens).
                   Sized to its content with a cap so a long note doesn't
                   span the whole card. */}
-              <span className="inline-flex max-w-[260px] items-center gap-1.5 rounded-sm bg-info-50 px-1.5 py-0.5 transition-colors group-hover:bg-info-100">
+              <span className="inline-flex max-w-[260px] items-center gap-1.5 rounded-sm bg-info-500/20 px-1.5 py-0.5 transition-colors group-hover:bg-info-500/30">
                 <span className="min-w-0 truncate">{preview}</span>
                 <MessageSquare
                   className="size-3.5 shrink-0 text-info-600"

--- a/app/dashboard/briefings/components/detail/DesktopBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/DesktopBottomBar.test.tsx
@@ -59,11 +59,13 @@ describe('<DesktopBottomBar>', () => {
     mockedUseAnnotationsCtx.mockReset()
   })
 
-  it('renders Notes and Ask AI buttons', () => {
+  it('renders Notes and Assistant buttons', () => {
     setCtx()
     render(<DesktopBottomBar />)
     expect(screen.getByRole('button', { name: /^notes$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /ask ai/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /assistant/i }),
+    ).toBeInTheDocument()
   })
 
   it('calls openAddNoteTopLevel when Notes is clicked with an active card', async () => {
@@ -74,11 +76,11 @@ describe('<DesktopBottomBar>', () => {
     expect(openAddNoteTopLevel).toHaveBeenCalledTimes(1)
   })
 
-  it('calls openCardLevelChat when Ask AI is clicked with an active card', async () => {
+  it('calls openCardLevelChat when Assistant is clicked with an active card', async () => {
     const openCardLevelChat = vi.fn()
     setCtx({ openCardLevelChat })
     render(<DesktopBottomBar />)
-    await userEvent.click(screen.getByRole('button', { name: /ask ai/i }))
+    await userEvent.click(screen.getByRole('button', { name: /assistant/i }))
     expect(openCardLevelChat).toHaveBeenCalledTimes(1)
   })
 
@@ -86,6 +88,6 @@ describe('<DesktopBottomBar>', () => {
     setCtx({ activeCard: null })
     render(<DesktopBottomBar />)
     expect(screen.getByRole('button', { name: /^notes$/i })).toBeDisabled()
-    expect(screen.getByRole('button', { name: /ask ai/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /assistant/i })).toBeDisabled()
   })
 })

--- a/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/DesktopBottomBar.tsx
@@ -42,13 +42,13 @@ export default function DesktopBottomBar(): React.JSX.Element {
           disabled={!activeCard}
           title={
             activeCard
-              ? `Ask AI about ${activeCard.title}`
+              ? `Ask about ${activeCard.title}`
               : 'Click a card to make it active first'
           }
           className="text-sm!"
         >
           <Sparkles className="size-4" aria-hidden />
-          Ask AI
+          Assistant
         </Button>
       </div>
     </div>

--- a/app/dashboard/briefings/components/detail/DetailHeader.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeader.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { ArrowLeftIcon } from '@styleguide'
 import { briefingsLandingHref } from '@shared/briefings/routes'
 import { formatBriefingMeetingDate } from '@shared/briefings/dateHelpers'
+import { renderBriefingForSpeech } from '@shared/briefings/renderForSpeech'
 import type { Briefing } from '@shared/briefings/types'
 import DetailHeaderActions from './DetailHeaderActions'
 
@@ -21,6 +22,7 @@ type Props = {
  */
 export default function DetailHeader({ briefing }: Props): React.JSX.Element {
   const formattedDate = formatBriefingMeetingDate(briefing.meeting_date)
+  const speechText = renderBriefingForSpeech(briefing)
   return (
     <div className="sticky top-0 z-20 border-b border-border bg-sidebar">
       {/* Match the body's content container (mx-auto max-w-[1120px] + same
@@ -43,7 +45,7 @@ export default function DetailHeader({ briefing }: Props): React.JSX.Element {
             <p className="text-sm text-muted-foreground">{briefing.location}</p>
           ) : null}
         </div>
-        <DetailHeaderActions />
+        <DetailHeaderActions speechText={speechText} />
       </div>
     </div>
   )

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.test.tsx
@@ -11,6 +11,8 @@ vi.mock('./ShareScope', () => ({
 
 const mockedUseShareScope = vi.mocked(useShareScope)
 
+const SPEECH = 'City Council. June 1, 2026. City Hall'
+
 function setShareScope({
   canShare = true,
   openShareDrawer = vi.fn(),
@@ -26,14 +28,14 @@ describe('<DetailHeaderActions>', () => {
 
   it('renders the Share button when share scope reports canShare', () => {
     setShareScope()
-    render(<DetailHeaderActions />)
+    render(<DetailHeaderActions speechText={SPEECH} />)
 
     expect(screen.getByRole('button', { name: /^share$/i })).toBeInTheDocument()
   })
 
   it('asks the share scope to open the drawer when Share is clicked', async () => {
     const openShareDrawer = setShareScope()
-    render(<DetailHeaderActions />)
+    render(<DetailHeaderActions speechText={SPEECH} />)
 
     await userEvent.click(screen.getByRole('button', { name: /^share$/i }))
     expect(openShareDrawer).toHaveBeenCalledTimes(1)
@@ -45,7 +47,7 @@ describe('<DetailHeaderActions>', () => {
     // classes. Asserting the class gating here pins the responsive
     // contract so a future refactor can't accidentally drop one side.
     setShareScope()
-    render(<DetailHeaderActions />)
+    render(<DetailHeaderActions speechText={SPEECH} />)
 
     const mobileBtn = screen.getByRole('button', { name: /share briefing/i })
     expect(mobileBtn).toHaveClass('lg:hidden')
@@ -54,15 +56,30 @@ describe('<DetailHeaderActions>', () => {
     expect(desktopBtn).toHaveClass('hidden', 'lg:inline-flex')
   })
 
-  it('renders nothing when share scope reports !canShare', () => {
+  it('renders the Read aloud control to the left of Share', () => {
+    setShareScope()
+    render(<DetailHeaderActions speechText={SPEECH} />)
+
+    // Two breakpoints' worth of read-aloud controls live in the DOM (icon
+    // on mobile, labelled on desktop); both carry the "Read aloud" label.
+    expect(
+      screen.getAllByRole('button', { name: /read aloud/i }).length,
+    ).toBeGreaterThan(0)
+  })
+
+  it('still renders Read aloud (but no Share) when share scope reports !canShare', () => {
     // Rolling-deploy window: gp-webapp has the share-drawer code but
     // gp-api's response hasn't grown `briefing_id` yet. `canShare` is
-    // false in that case and the header has no other actions left
-    // (Add note + Briefing assistant moved to `DesktopBottomBar`), so
-    // the component renders nothing.
+    // false in that case, so Share is hidden — but Read aloud is
+    // independent of share and stays.
     setShareScope({ canShare: false })
-    const { container } = render(<DetailHeaderActions />)
+    render(<DetailHeaderActions speechText={SPEECH} />)
 
-    expect(container).toBeEmptyDOMElement()
+    expect(
+      screen.queryByRole('button', { name: /^share$/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getAllByRole('button', { name: /read aloud/i }).length,
+    ).toBeGreaterThan(0)
   })
 })

--- a/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
+++ b/app/dashboard/briefings/components/detail/DetailHeaderActions.tsx
@@ -2,6 +2,16 @@
 
 import { Button, IconButton, ShareIcon } from '@styleguide'
 import { useShareScope } from './ShareScope'
+import ReadAloudButton from './ReadAloudButton'
+
+type Props = {
+  /**
+   * Pre-rendered plain-text of the whole briefing. The header Read aloud
+   * control reads this top to bottom — header line, executive summary, then
+   * every agenda item — so the user gets a hands-free read of the full page.
+   */
+  speechText: string
+}
 
 /**
  * Sticky header actions on the briefing detail page. Renders at every
@@ -25,31 +35,51 @@ import { useShareScope } from './ShareScope'
  * keeps a single Radix Sheet instance on the page so focus / portal
  * management doesn't race with other consumers.
  */
-export default function DetailHeaderActions(): React.JSX.Element | null {
+export default function DetailHeaderActions({
+  speechText,
+}: Props): React.JSX.Element | null {
   const { canShare, openShareDrawer } = useShareScope()
-
-  if (!canShare) return null
 
   return (
     <div className="flex items-center gap-2 self-center">
-      <IconButton
-        type="button"
-        size="medium"
-        variant="outline"
-        aria-label="Share briefing"
-        onClick={openShareDrawer}
-        className="lg:hidden"
-      >
-        <ShareIcon className="size-5" aria-hidden />
-      </IconButton>
-      <Button
-        variant="outline"
-        onClick={openShareDrawer}
-        className="hidden text-sm! lg:inline-flex"
-      >
-        <ShareIcon className="size-4" aria-hidden />
-        Share
-      </Button>
+      {/* Read aloud sits to the left of Share. Mirror Share's responsive
+          pattern: icon-only below lg, labelled at lg+. */}
+      {speechText ? (
+        <>
+          <span className="lg:hidden">
+            <ReadAloudButton
+              text={speechText}
+              analyticsLabel="briefing"
+              compact
+            />
+          </span>
+          <span className="hidden lg:inline-flex">
+            <ReadAloudButton text={speechText} analyticsLabel="briefing" />
+          </span>
+        </>
+      ) : null}
+      {canShare ? (
+        <>
+          <IconButton
+            type="button"
+            size="medium"
+            variant="outline"
+            aria-label="Share briefing"
+            onClick={openShareDrawer}
+            className="lg:hidden"
+          >
+            <ShareIcon className="size-5" aria-hidden />
+          </IconButton>
+          <Button
+            variant="outline"
+            onClick={openShareDrawer}
+            className="hidden text-sm! lg:inline-flex"
+          >
+            <ShareIcon className="size-4" aria-hidden />
+            Share
+          </Button>
+        </>
+      ) : null}
     </div>
   )
 }

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -9,7 +9,6 @@ import {
 import { selectElementContents } from '@shared/briefings/anchorResolver'
 import { useAnnotationsCtx } from '../annotations/AnnotationsScope'
 import CardLevelNotesList from './CardLevelNotesList'
-import ReadAloudButton from './ReadAloudButton'
 
 type Props = {
   summary: MeetingBriefingOutput['executive_summary']
@@ -21,14 +20,6 @@ type Props = {
    */
   agendaItemIds: string[]
   domId: string
-  /**
-   * Pre-rendered plain-text version of the briefing for the speech
-   * service. Built by the page via `renderBriefingForSpeech` and
-   * threaded down so the read-aloud control stays a thin UI shell.
-   */
-  speechText: string
-  /** Optional label forwarded to analytics so usage can be sliced by surface. */
-  analyticsLabel?: string
 }
 
 const onJump = (
@@ -54,11 +45,17 @@ export default function ExecutiveSummaryCard({
   summary,
   agendaItemIds,
   domId,
-  speechText,
-  analyticsLabel,
 }: Props): React.JSX.Element {
-  const { activeCard, setActiveCard } = useAnnotationsCtx()
+  const { activeCard, setActiveCard, annotations, openChatsSurface } =
+    useAnnotationsCtx()
   const isActive = activeCard?.key === domId
+  // If the assistant already has a thread anchored to this title, clicking
+  // the title opens that thread directly rather than re-surfacing the
+  // selection toolbar.
+  const titleChat = annotations.find(
+    (a) =>
+      a.kind === 'chat' && a.jsonPath === BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
+  )
   const activate = () =>
     setActiveCard({
       key: domId,
@@ -90,22 +87,24 @@ export default function ExecutiveSummaryCard({
           : 'border-border hover:border-foreground/20'
       }`}
     >
-      <div className="flex items-start justify-between gap-3">
-        {/* `data-briefing-json-path` makes the title resolvable as an
-            anchor target — card-level chats hang off this element. Clicking
-            the title selects its full text so the HighlightToolbar surfaces
-            anchored to the title, the same as highlighting it by hand. */}
-        <h2
-          className="min-w-0 cursor-pointer text-2xl font-semibold text-foreground"
-          data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
-          onClick={(e) => selectElementContents(e.currentTarget)}
-        >
-          Executive Summary
-        </h2>
-        <div className="shrink-0">
-          <ReadAloudButton text={speechText} analyticsLabel={analyticsLabel} />
-        </div>
-      </div>
+      {/* `data-briefing-json-path` makes the title resolvable as an anchor
+          target — card-level chats hang off this element. With no chat yet,
+          clicking selects its full text so the HighlightToolbar surfaces
+          anchored to the title; with a chat, it opens that thread. */}
+      <h2
+        className="min-w-0 cursor-pointer text-2xl font-semibold text-foreground"
+        data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
+        onClick={(e) => {
+          if (titleChat) {
+            e.stopPropagation()
+            openChatsSurface(titleChat.id)
+          } else {
+            selectElementContents(e.currentTarget)
+          }
+        }}
+      >
+        Executive Summary
+      </h2>
       <p
         className="text-sm text-muted-foreground"
         data-briefing-json-path="/executive_summary/lead_in"

--- a/app/dashboard/briefings/components/detail/FeedbackRow.test.tsx
+++ b/app/dashboard/briefings/components/detail/FeedbackRow.test.tsx
@@ -44,7 +44,8 @@ describe('<FeedbackRow> thumbs-up path', () => {
 
     await user.click(screen.getByRole('button', { name: /^yes$/i }))
 
-    expect(setFeedbackMock).toHaveBeenCalledWith(ITEM_ID, 'positive')
+    // A thumbs-up clears any prior thumbs-down note (null comment).
+    expect(setFeedbackMock).toHaveBeenCalledWith(ITEM_ID, 'positive', null)
     // Composer should never render for a positive vote.
     expect(
       screen.queryByPlaceholderText(/tell us what was off/i),

--- a/app/dashboard/briefings/components/detail/FeedbackRow.tsx
+++ b/app/dashboard/briefings/components/detail/FeedbackRow.tsx
@@ -59,7 +59,10 @@ export default function FeedbackRow({
       setComposerOpen(true)
       return
     }
-    setFeedback(itemId, target)
+    // Switching to a thumbs-up clears any note left on a prior thumbs-down —
+    // the "what was wrong" comment no longer applies once the rating flips
+    // positive. Passing `null` tells the API to drop the stored comment.
+    setFeedback(itemId, target, null)
     trackEvent(EVENTS.BriefingAssistant.FeedbackCompleted, {
       meetingDate,
       itemId,

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.test.tsx
@@ -80,7 +80,7 @@ describe('<MobileBottomBar>', () => {
     setCtx({ activeCard: ACTIVE_CARD })
     render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(2)} />)
 
-    // The selector pill and the Ask AI button both contain "Executive
+    // The selector pill and the assistant button both contain "Executive
     // Summary"; the pill is the first match (it's the leftmost element).
     const selectorMatches = screen.getAllByRole('button', {
       name: /executive summary/i,
@@ -88,7 +88,7 @@ describe('<MobileBottomBar>', () => {
     const selector = selectorMatches[0]
     if (!selector) throw new Error('selector button not rendered')
     const askAi = screen.getByRole('button', {
-      name: /ask ai about executive summary/i,
+      name: /ask about executive summary/i,
     })
 
     // Selector + Ask AI share a common ancestor (the dock row).
@@ -123,7 +123,7 @@ describe('<MobileBottomBar>', () => {
     render(<MobileBottomBar briefingSlug="town-hall" items={makeItems(1)} />)
 
     await userEvent.click(
-      screen.getByRole('button', { name: /ask ai about executive summary/i }),
+      screen.getByRole('button', { name: /ask about executive summary/i }),
     )
     expect(openCardLevelChat).toHaveBeenCalledTimes(1)
   })

--- a/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
+++ b/app/dashboard/briefings/components/detail/MobileBottomBar.tsx
@@ -230,7 +230,7 @@ export default function MobileBottomBar({
           size="medium"
           aria-label={
             activeCard
-              ? `Ask AI about ${activeCard.title}`
+              ? `Ask about ${activeCard.title}`
               : 'Click a card to make it active first'
           }
           onClick={openCardLevelChat}

--- a/app/shared/briefings/renderForSpeech.test.ts
+++ b/app/shared/briefings/renderForSpeech.test.ts
@@ -46,9 +46,19 @@ const featuredItem = (overrides: Record<string, unknown> = {}): Item =>
   } as unknown as Item)
 
 describe('renderBriefingForSpeech', () => {
-  it('joins title, executive summary, and featured items into a single text blob', () => {
+  it('reads the header, executive summary, and every item section in page order', () => {
     const text = renderBriefingForSpeech(
       baseBriefing({
+        executive_summary: {
+          lead_in: 'Three big items tonight.',
+          items: [
+            {
+              item_id: 'a-1',
+              title: 'Approve budget',
+              overview: 'Adopts FY27.',
+            },
+          ],
+        },
         items: [
           featuredItem({
             display: {
@@ -58,7 +68,7 @@ describe('renderBriefingForSpeech', () => {
                 detail: null,
                 district_note: null,
                 haystaq_column: 'fiscal_responsibility',
-                mean_score: 0.6,
+                mean_score: 60,
                 score_direction: 'positive',
                 voter_count: 1200,
                 haystaq_status: 'ok',
@@ -83,15 +93,28 @@ describe('renderBriefingForSpeech', () => {
       }),
     )
 
-    expect(text).toContain('City Council meeting briefing for June 1, 2026')
+    // Header line mirrors the detail header: name, date, location.
+    expect(text).toContain('City Council. June 1, 2026. City Hall')
+    expect(text).toContain('Executive Summary.')
     expect(text).toContain('Three big items tonight.')
-    expect(text).toContain('Agenda item: Approve budget.')
+    expect(text).toContain('Approve budget. Adopts FY27.')
+    expect(text).toContain('What to expect.')
     expect(text).toContain('Adopts the FY27 operating budget.')
-    expect(text).toContain('Constituent sentiment: Mostly favorable.')
-    expect(text).toContain('Budget impact: +$2M to capital reserves.')
+    expect(text).toContain('Budget impact.')
+    expect(text).toContain('+$2M to capital reserves.')
+    expect(text).toContain('Constituent sentiment.')
+    expect(text).toContain('60 percent support, 40 percent oppose.')
+    expect(text).toContain('Mostly favorable.')
     expect(text).toContain('Talking points.')
     expect(text).toContain('Lock in school funding.')
-    expect(text).toContain('Defer the new park.')
+
+    // Order: header before the executive summary before the agenda item.
+    const headerIdx = text.indexOf('City Council. June 1, 2026. City Hall')
+    const summaryIdx = text.indexOf('Executive Summary.')
+    const whatIdx = text.indexOf('What to expect.')
+    expect(headerIdx).toBeGreaterThanOrEqual(0)
+    expect(headerIdx).toBeLessThan(summaryIdx)
+    expect(summaryIdx).toBeLessThan(whatIdx)
   })
 
   it('strips markdown markers and link syntax that Polly would otherwise read literally', () => {
@@ -111,21 +134,11 @@ describe('renderBriefingForSpeech', () => {
     expect(text).toContain('Bold italic code and a link.')
   })
 
-  it('skips non-featured items and empty optional sections', () => {
+  it('reads non-featured items too (the page renders them as "What to expect")', () => {
     const text = renderBriefingForSpeech(
       baseBriefing({
         executive_summary: { items: [], lead_in: '' },
         items: [
-          featuredItem({
-            title: 'Quiet item',
-            display: {
-              summary: '',
-              constituent_sentiment: null,
-              recent_news: null,
-              budget_impact: null,
-              talking_points: null,
-            },
-          }),
           {
             id: 'q-1',
             item_number: '2',
@@ -139,7 +152,7 @@ describe('renderBriefingForSpeech', () => {
       }),
     )
     expect(text).toBe(
-      'City Council meeting briefing for June 1, 2026\n\nAgenda item: Quiet item.',
+      'City Council. June 1, 2026. City Hall\n\nExecutive Summary.\n\nProcedural matters. What to expect. Routine roll call.',
     )
   })
 })
@@ -163,7 +176,7 @@ const itemWithDisplay = (overrides: Record<string, unknown> = {}): Item =>
   } as unknown as Item)
 
 describe('renderItemForSpeech', () => {
-  it('joins title, summary, sentiment, budget, and talking points with single spaces', () => {
+  it('joins title, section headers, and bodies with single spaces in page order', () => {
     const item = {
       id: 'i-2',
       item_number: '3',
@@ -178,7 +191,7 @@ describe('renderItemForSpeech', () => {
           detail: null,
           district_note: null,
           haystaq_column: 'parks',
-          mean_score: 0.7,
+          mean_score: 70,
           score_direction: 'positive',
           voter_count: 800,
           haystaq_status: 'ok',
@@ -199,7 +212,7 @@ describe('renderItemForSpeech', () => {
     } as unknown as Item
 
     expect(renderItemForSpeech(item)).toBe(
-      'Agenda item: Approve new park funding. Council will vote on a 2 million dollar park proposal. Constituent sentiment: Strong support across the district. Budget impact: Adds 2 million to the capital budget. Talking points. Parks improve public health. Funding comes from reserves. Construction begins in spring.',
+      'Approve new park funding. What to expect. Council will vote on a 2 million dollar park proposal. Budget impact. Adds 2 million to the capital budget. Constituent sentiment. 70 percent support, 30 percent oppose. Strong support across the district. Talking points. Parks improve public health. Funding comes from reserves. Construction begins in spring.',
     )
   })
 
@@ -213,7 +226,7 @@ describe('renderItemForSpeech', () => {
 
     expect(output).not.toMatch(/[*_`#>~]/)
     expect(output).toBe(
-      'Agenda item: Ordinance review. bold italic code heading quote strike',
+      'Ordinance review. What to expect. bold italic code heading quote strike',
     )
   })
 
@@ -229,11 +242,11 @@ describe('renderItemForSpeech', () => {
     expect(output).not.toMatch(/\t/)
     expect(output).not.toMatch(/ {2,}/)
     expect(output).toBe(
-      'Agenda item: Zoning update. First line. Second line. Third line.',
+      'Zoning update. What to expect. First line. Second line. Third line.',
     )
   })
 
-  it('omits optional section labels when sentiment, budget, and talking points are missing', () => {
+  it('omits optional section headers when sentiment, budget, and talking points are missing', () => {
     const item = itemWithDisplay({
       summary: 'Procedural items only.',
     })
@@ -241,11 +254,11 @@ describe('renderItemForSpeech', () => {
 
     const output = renderItemForSpeech(item)
 
-    expect(output).not.toContain('Constituent sentiment:')
-    expect(output).not.toContain('Budget impact:')
+    expect(output).not.toContain('Constituent sentiment.')
+    expect(output).not.toContain('Budget impact.')
     expect(output).not.toContain('Talking points.')
     expect(output).toBe(
-      'Agenda item: Routine consent agenda. Procedural items only.',
+      'Routine consent agenda. What to expect. Procedural items only.',
     )
   })
 })

--- a/app/shared/briefings/renderForSpeech.test.ts
+++ b/app/shared/briefings/renderForSpeech.test.ts
@@ -151,8 +151,10 @@ describe('renderBriefingForSpeech', () => {
         ],
       }),
     )
+    // No lead-in and no summary items, so the "Executive Summary." heading
+    // is omitted — it would otherwise announce a header into the next item.
     expect(text).toBe(
-      'City Council. June 1, 2026. City Hall\n\nExecutive Summary.\n\nProcedural matters. What to expect. Routine roll call.',
+      'City Council. June 1, 2026. City Hall\n\nProcedural matters. What to expect. Routine roll call.',
     )
   })
 })

--- a/app/shared/briefings/renderForSpeech.ts
+++ b/app/shared/briefings/renderForSpeech.ts
@@ -1,8 +1,15 @@
 import type { Briefing, Item } from './types'
+import { formatBriefingMeetingDate } from './dateHelpers'
 
 /**
  * Render a briefing into a single, sentence-friendly plain-text blob
  * suitable for the speech service to synthesize.
+ *
+ * The goal is a hands-free read of the whole page: we walk the briefing
+ * top to bottom in the same order the detail page renders it — the
+ * meeting header line, the executive summary, then every agenda item with
+ * its section headers ("What to expect", "Budget impact", etc.) — so the
+ * audio matches what the reader sees on screen.
  *
  * Why this lives in the frontend, not the speech module:
  *   The speech module is a pure pipe (text → audio). Each caller owns the
@@ -17,13 +24,31 @@ import type { Briefing, Item } from './types'
  */
 export const renderBriefingForSpeech = (briefing: Briefing): string => {
   const sections: string[] = []
-  sections.push(briefing.title)
+
+  // Meeting header line — name, date, location — read in the same order
+  // the detail header shows them.
+  const header = [
+    briefing.meeting_name,
+    formatBriefingMeetingDate(briefing.meeting_date),
+    briefing.location,
+  ]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join('. ')
+  if (header) sections.push(header)
+
+  // Executive summary: heading, lead-in, then each summary item.
+  sections.push('Executive Summary.')
   if (briefing.executive_summary.lead_in)
     sections.push(briefing.executive_summary.lead_in)
+  for (const summaryItem of briefing.executive_summary.items) {
+    sections.push(`${summaryItem.title}. ${summaryItem.overview}`)
+  }
+
+  // Every agenda item, in page order.
   for (const item of briefing.items) {
-    if (item.tier !== 'featured') continue
     sections.push(renderItem(item))
   }
+
   return sections
     .map(normalize)
     .filter((section) => section.length > 0)
@@ -34,24 +59,57 @@ export const renderItemForSpeech = (item: Item): string =>
   normalize(renderItem(item))
 
 const renderItem = (item: Item): string => {
-  const parts: string[] = []
-  parts.push(`Agenda item: ${item.title}.`)
-  if (item.display.summary) parts.push(item.display.summary)
-  if (item.display.constituent_sentiment?.summary) {
-    parts.push(
-      `Constituent sentiment: ${item.display.constituent_sentiment.summary}`,
-    )
+  const display = item.display
+  const parts: string[] = [`${item.title}.`]
+
+  if (display.summary) {
+    parts.push('What to expect.')
+    parts.push(display.summary)
   }
-  if (item.display.budget_impact?.summary) {
-    parts.push(`Budget impact: ${item.display.budget_impact.summary}`)
-  }
-  const talkingPoints = item.display.talking_points ?? []
-  if (talkingPoints.length > 0) {
-    parts.push('Talking points.')
-    for (const point of talkingPoints) {
-      parts.push(point)
+
+  // Featured items render their full section stack on the page; non-featured
+  // items render the "What to expect" summary only. Mirror that here so the
+  // read-aloud matches the page. Section order matches AgendaItemCard:
+  // budget impact, constituent sentiment, recent news, talking points.
+  if (item.tier === 'featured') {
+    if (display.budget_impact?.summary) {
+      parts.push('Budget impact.')
+      parts.push(display.budget_impact.summary)
+    }
+
+    const sentiment = display.constituent_sentiment
+    if (sentiment) {
+      parts.push('Constituent sentiment.')
+      if (
+        sentiment.haystaq_status === 'ok' &&
+        typeof sentiment.mean_score === 'number'
+      ) {
+        const support = Math.round(sentiment.mean_score)
+        parts.push(
+          `${support} percent support, ${100 - support} percent oppose.`,
+        )
+      }
+      if (sentiment.summary) parts.push(sentiment.summary)
+      if (sentiment.detail) parts.push(sentiment.detail)
+    }
+
+    const news = display.recent_news ?? []
+    if (news.length > 0) {
+      parts.push('Recent news.')
+      for (const entry of news) {
+        if (entry.headline) parts.push(entry.headline)
+      }
+    }
+
+    const talkingPoints = display.talking_points ?? []
+    if (talkingPoints.length > 0) {
+      parts.push('Talking points.')
+      for (const point of talkingPoints) {
+        parts.push(point)
+      }
     }
   }
+
   return parts.filter((part) => part.length > 0).join(' ')
 }
 

--- a/app/shared/briefings/renderForSpeech.ts
+++ b/app/shared/briefings/renderForSpeech.ts
@@ -36,12 +36,18 @@ export const renderBriefingForSpeech = (briefing: Briefing): string => {
     .join('. ')
   if (header) sections.push(header)
 
-  // Executive summary: heading, lead-in, then each summary item.
-  sections.push('Executive Summary.')
+  // Executive summary: heading, lead-in, then each summary item. Only emit
+  // the heading when the section actually has content — otherwise the audio
+  // announces "Executive Summary." straight into the first agenda item.
+  const execSummary: string[] = []
   if (briefing.executive_summary.lead_in)
-    sections.push(briefing.executive_summary.lead_in)
+    execSummary.push(briefing.executive_summary.lead_in)
   for (const summaryItem of briefing.executive_summary.items) {
-    sections.push(`${summaryItem.title}. ${summaryItem.overview}`)
+    execSummary.push(`${summaryItem.title}. ${summaryItem.overview}`)
+  }
+  if (execSummary.length > 0) {
+    sections.push('Executive Summary.')
+    sections.push(...execSummary)
   }
 
   // Every agenda item, in page order.

--- a/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
+++ b/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
@@ -56,8 +56,10 @@ test.describe('Mobile Navigation', () => {
 
     await NavigationHelper.openMobileMenu(page)
     await page.getByRole('link', { name: 'AI Assistant' }).click()
+    // The mobile header renders the page title as a heading in addition to the
+    // page's own heading, so scope to the first match to avoid strict mode.
     await expect(
-      page.getByRole('heading', { name: 'AI Assistant' }),
+      page.getByRole('heading', { name: 'AI Assistant' }).first(),
     ).toBeVisible({ timeout: 5000 })
     await expect(page).toHaveURL(/\/dashboard\/campaign-assistant$/)
 
@@ -71,8 +73,10 @@ test.describe('Mobile Navigation', () => {
 
     await NavigationHelper.openMobileMenu(page)
     await page.locator('#my-content-dashboard').click()
+    // The mobile header renders the page title as a heading in addition to the
+    // page's own heading, so scope to the first match to avoid strict mode.
     await expect(
-      page.getByRole('heading', { name: 'Content Builder' }),
+      page.getByRole('heading', { name: 'Content Builder' }).first(),
     ).toBeVisible({ timeout: 5000 })
     await expect(page).toHaveURL(/\/dashboard\/content$/)
 

--- a/e2e-tests/tests/app/polls/polls-onboarding.spec.ts
+++ b/e2e-tests/tests/app/polls/polls-onboarding.spec.ts
@@ -328,6 +328,9 @@ test.describe.serial('poll onboarding', () => {
     sharedUser = user
     await NavigationHelper.dismissOverlays(page)
 
+    // Elected office users now land on /dashboard/briefings after winning their
+    // race, so navigate to the polls welcome screen before onboarding.
+    await page.goto('/polls/welcome')
     await page.getByRole('button', { name: "Let's get started" }).click()
 
     // Confirm constituent count.


### PR DESCRIPTION
A batch of QA-reported bugs on the meeting briefing detail page. Grouped by the behavior they were getting in the way of.

### Read aloud
The read-aloud control lived on the Executive Summary card and only read a thin, mislabeled subset of the page (it skipped the location and section headers, and jumped straight into the first agenda item). That made a feature meant to be a simple "read me the whole page" confusing. Read aloud now lives in the header next to Share, and the speech script walks the page in the same order it renders so the audio matches what's on screen. The per-card speakers are gone so there's one obvious control.

### Chat vs. selection toolbar
Clicking an agenda item that already had a chat attached re-opened the selection toolbar instead of the conversation, which is a dead end for a thread that already exists. Clicking a title with a chat now opens that thread directly; titles without one keep the selection behavior.

### Removing AI framing
Lovable dropped explicit "AI" language from this surface but it never made it into the prototype. Updated the user-facing copy to match (Assistant, Ask, chat labels) so the product language is consistent.

### Drawer header consistency
The note, assistant, and bug surfaces had inconsistent visible headings (some desktop-only, the bug sheet on both breakpoints). Removed the visible headings so the surfaces read the same way; accessible labels are preserved. The bug-report byline also promised "we'll fix it," which overstates what happens, so it now frames the report as feedback that helps us improve.

### Note highlight color
The full-section note highlight used a different blue than the inline note highlight, so the same concept looked like two things. They now use the same token.

### Feedback rating
Switching a rating from thumbs-down to thumbs-up left the old "what was wrong" note attached, which no longer applies once the rating flips positive. Thumbs-up now clears it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI copy, layout, and client-side speech/feedback behavior; feedback comment clearing is a small API-facing change but scoped to briefing ratings.
> 
> **Overview**
> This PR tightens meeting briefing detail UX from QA: one **Read aloud** in the sticky header (next to Share), a fuller speech script, and several annotation/feedback fixes.
> 
> **Read aloud** moves from per-card controls to `DetailHeader` / `DetailHeaderActions`, with `renderBriefingForSpeech` rewritten to follow on-screen order (meeting header, executive summary, all items with section labels). Share can be hidden when `canShare` is false; read aloud still shows.
> 
> **Assistant / copy** renames user-facing “AI” strings to **Assistant**, **Ask**, and neutral chat labels across toolbars, bottom bars, and sheets. Note/assistant/bug **drawers** drop visible titles (sr-only titles kept) and soften bug-report byline copy.
> 
> **Title clicks** on executive summary and agenda cards open an existing title-anchored chat via `openChatsSurface` instead of re-opening the selection toolbar.
> 
> **Other:** card-level note pills use `bg-info-500/20` to match inline highlights; thumbs-up clears prior thumbs-down feedback comments (`setFeedback(..., null)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bb3644358fe75b534d06eaaf75de02637ed573. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->