### PR TITLE
chore: remove website link from menu

### DIFF
--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -251,7 +251,8 @@ export default function DashboardMenu({
   const { data: electedOffice } = useElectedOffice()
   const { ready: _flagsReady, on: serveAccessEnabled } =
     useFlagOn('serve-access')
-  const { enabled: proUpgradeEnabled } = useProUpgradeFlag()
+  const { ready: proUpgradeReady, enabled: proUpgradeEnabled } =
+    useProUpgradeFlag()
 
   const menuItems = useMemo(() => {
     const items = getDashboardMenuItems(
@@ -264,10 +265,17 @@ export default function DashboardMenu({
       items.push(ECANVASSER_MENU_ITEM)
     }
 
-    return proUpgradeEnabled
+    return proUpgradeReady && proUpgradeEnabled
       ? items.filter((item) => item !== WEBSITE_MENU_ITEM)
       : items
-  }, [campaign, serveAccessEnabled, ecanvasser, electedOffice, proUpgradeEnabled])
+  }, [
+    campaign,
+    serveAccessEnabled,
+    ecanvasser,
+    electedOffice,
+    proUpgradeReady,
+    proUpgradeEnabled,
+  ])
 
   useEffect(() => {
     if (campaign && ecanvasser) {

--- a/app/dashboard/shared/DashboardMenu.tsx
+++ b/app/dashboard/shared/DashboardMenu.tsx
@@ -64,6 +64,7 @@ import {
   useOrganization,
 } from '@shared/organization-picker'
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 
 interface MenuItem {
   id: string
@@ -91,6 +92,16 @@ const VOTER_DATA_UPGRADE_ITEM: MenuItem = {
   id: 'upgrade-pro-dashboard',
 }
 
+const WEBSITE_MENU_ITEM: MenuItem = {
+  label: 'Website',
+  icon: <MdWeb />,
+  v2Icon: Globe,
+  v2Category: 'campaign',
+  link: '/dashboard/website',
+  id: 'website-dashboard',
+  onClick: () => trackEvent(EVENTS.Navigation.Dashboard.ClickWebsite),
+}
+
 const DEFAULT_MENU_ITEMS: MenuItem[] = [
   {
     label: 'Dashboard',
@@ -111,15 +122,7 @@ const DEFAULT_MENU_ITEMS: MenuItem[] = [
     onClick: () => trackEvent(EVENTS.Navigation.Dashboard.ClickVoterOutreach),
   },
   VOTER_DATA_UPGRADE_ITEM,
-  {
-    label: 'Website',
-    icon: <MdWeb />,
-    v2Icon: Globe,
-    v2Category: 'campaign',
-    link: '/dashboard/website',
-    id: 'website-dashboard',
-    onClick: () => trackEvent(EVENTS.Navigation.Dashboard.ClickWebsite),
-  },
+  WEBSITE_MENU_ITEM,
   {
     label: 'My Profile',
     icon: <MdAccountCircle />,
@@ -248,6 +251,7 @@ export default function DashboardMenu({
   const { data: electedOffice } = useElectedOffice()
   const { ready: _flagsReady, on: serveAccessEnabled } =
     useFlagOn('serve-access')
+  const { enabled: proUpgradeEnabled } = useProUpgradeFlag()
 
   const menuItems = useMemo(() => {
     const items = getDashboardMenuItems(
@@ -260,8 +264,10 @@ export default function DashboardMenu({
       items.push(ECANVASSER_MENU_ITEM)
     }
 
-    return items
-  }, [campaign, serveAccessEnabled, ecanvasser, electedOffice])
+    return proUpgradeEnabled
+      ? items.filter((item) => item !== WEBSITE_MENU_ITEM)
+      : items
+  }, [campaign, serveAccessEnabled, ecanvasser, electedOffice, proUpgradeEnabled])
 
   useEffect(() => {
     if (campaign && ecanvasser) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Navigation-only change gated by an existing experiment flag; no auth or data path changes.
> 
> **Overview**
> When the **`pro-upgrade1`** experiment is on (`useProUpgradeFlag`), the dashboard sidebar no longer shows the **Website** entry.
> 
> The Website nav item is pulled into a shared **`WEBSITE_MENU_ITEM`** constant so it can be removed from the computed menu via reference equality, without changing other menu-building logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c4ff0dc6a929f4434f78adcd9068841d5521fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->