### PR TITLE
fix(AddressAutocomplete): add dropdownClassName prop for scoped dropd…

### DIFF
--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
@@ -293,6 +293,7 @@ const TextingComplianceRegistrationForm = ({
             },
             placeholder: 'Filing Address *',
             variant: 'outlined',
+            dropdownClassName: 'texting-compliance-address-dropdown',
           }}
         />
         <TextField

--- a/app/globals.css
+++ b/app/globals.css
@@ -798,6 +798,13 @@ strong {
     margin-top: 4px;
   }
 
+  /* Scoped override (see AddressAutocomplete `dropdownClassName`): anchor the
+     dropdown under its input instead of viewport-fixed, which renders at the
+     bottom of the page on mobile. Only affects dropdowns tagged with this class. */
+  .pac-container.texting-compliance-address-dropdown {
+    position: absolute !important;
+  }
+
   .pac-item {
     padding: 8px !important;
     font-size: 14px !important;

--- a/app/globals.css
+++ b/app/globals.css
@@ -803,6 +803,9 @@ strong {
      bottom of the page on mobile. Only affects dropdowns tagged with this class. */
   .pac-container.texting-compliance-address-dropdown {
     position: absolute !important;
+    left: unset !important;
+    right: unset !important;
+    width: unset !important;
   }
 
   .pac-item {

--- a/app/shared/AddressAutocomplete.tsx
+++ b/app/shared/AddressAutocomplete.tsx
@@ -77,29 +77,32 @@ export default function AddressAutocomplete({
     return (): void => observer.disconnect()
   }, [])
 
-  // Google appends the `.pac-container` dropdown to <body>, so it can't be
-  // matched via this component's DOM subtree. Tag it only while this input is
-  // focused (the only time its dropdown is visible) so a caller-supplied
-  // `dropdownClassName` can't bleed into other AddressAutocomplete instances.
+  // Google appends the `.pac-container` dropdown to <body>, outside this
+  // component's subtree, so it can't be matched via a ref. We tag it only while
+  // this input is focused — the only time its dropdown is visible — and track
+  // exactly which containers we tagged so blur/unmount removes only our own
+  // additions, never stripping the class from another instance's dropdown.
   useEffect(() => {
     const inputEl = ref.current
     if (!inputEl || !dropdownClassName) return
+
+    const taggedContainers = new Set<HTMLElement>()
 
     const tagDropdown = (): void => {
       if (document.activeElement !== inputEl) return
       document.querySelectorAll('.pac-container').forEach((container) => {
         if (container instanceof HTMLElement) {
           container.classList.add(dropdownClassName)
+          taggedContainers.add(container)
         }
       })
     }
 
     const untagDropdown = (): void => {
-      document.querySelectorAll('.pac-container').forEach((container) => {
-        if (container instanceof HTMLElement) {
-          container.classList.remove(dropdownClassName)
-        }
+      taggedContainers.forEach((container) => {
+        container.classList.remove(dropdownClassName)
       })
+      taggedContainers.clear()
     }
 
     inputEl.addEventListener('focus', tagDropdown)

--- a/app/shared/AddressAutocomplete.tsx
+++ b/app/shared/AddressAutocomplete.tsx
@@ -19,12 +19,14 @@ interface AddressAutocompleteProps
   value?: string
   onChange?: (inputValue: string) => void
   onSelect?: (place: GooglePlace) => void
+  dropdownClassName?: string
 }
 
 export default function AddressAutocomplete({
   value,
   onChange = noop,
   onSelect = noop,
+  dropdownClassName,
   ...restProps
 }: AddressAutocompleteProps): React.JSX.Element {
   const [inputValue, setInputValue] = useState(value || '')
@@ -57,6 +59,9 @@ export default function AddressAutocomplete({
         if (container instanceof HTMLElement) {
           container.classList.add('needsclick')
           container.style.touchAction = 'manipulation'
+          if (dropdownClassName) {
+            container.classList.add(dropdownClassName)
+          }
         }
       })
     }
@@ -73,7 +78,7 @@ export default function AddressAutocomplete({
     addMobileClassToAutocomplete()
 
     return (): void => observer.disconnect()
-  }, [])
+  }, [dropdownClassName])
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const newValue = e.target.value

--- a/app/shared/AddressAutocomplete.tsx
+++ b/app/shared/AddressAutocomplete.tsx
@@ -31,7 +31,7 @@ export default function AddressAutocomplete({
 }: AddressAutocompleteProps): React.JSX.Element {
   const [inputValue, setInputValue] = useState(value || '')
 
-  const { ref } = usePlacesWidget({
+  const { ref } = usePlacesWidget<HTMLInputElement>({
     apiKey: MAPS_API_KEY,
     onPlaceSelected: (place: GooglePlace) => {
       if (place && place.formatted_address) {
@@ -59,9 +59,6 @@ export default function AddressAutocomplete({
         if (container instanceof HTMLElement) {
           container.classList.add('needsclick')
           container.style.touchAction = 'manipulation'
-          if (dropdownClassName) {
-            container.classList.add(dropdownClassName)
-          }
         }
       })
     }
@@ -78,7 +75,46 @@ export default function AddressAutocomplete({
     addMobileClassToAutocomplete()
 
     return (): void => observer.disconnect()
-  }, [dropdownClassName])
+  }, [])
+
+  // Google appends the `.pac-container` dropdown to <body>, so it can't be
+  // matched via this component's DOM subtree. Tag it only while this input is
+  // focused (the only time its dropdown is visible) so a caller-supplied
+  // `dropdownClassName` can't bleed into other AddressAutocomplete instances.
+  useEffect(() => {
+    const inputEl = ref.current
+    if (!inputEl || !dropdownClassName) return
+
+    const tagDropdown = (): void => {
+      if (document.activeElement !== inputEl) return
+      document.querySelectorAll('.pac-container').forEach((container) => {
+        if (container instanceof HTMLElement) {
+          container.classList.add(dropdownClassName)
+        }
+      })
+    }
+
+    const untagDropdown = (): void => {
+      document.querySelectorAll('.pac-container').forEach((container) => {
+        if (container instanceof HTMLElement) {
+          container.classList.remove(dropdownClassName)
+        }
+      })
+    }
+
+    inputEl.addEventListener('focus', tagDropdown)
+    inputEl.addEventListener('blur', untagDropdown)
+
+    const observer = new MutationObserver(tagDropdown)
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return (): void => {
+      inputEl.removeEventListener('focus', tagDropdown)
+      inputEl.removeEventListener('blur', untagDropdown)
+      observer.disconnect()
+      untagDropdown()
+    }
+  }, [dropdownClassName, ref])
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const newValue = e.target.value


### PR DESCRIPTION
…own styling

- Introduced dropdownClassName prop to AddressAutocomplete for custom dropdown styling.
- Updated TextingComplianceRegistrationForm to utilize the new dropdownClassName for improved dropdown positioning on mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only CSS and an optional prop; behavior changes only where the new class is passed.
> 
> **Overview**
> Adds an optional **`dropdownClassName`** on **`AddressAutocomplete`** so Google’s **`.pac-container`** can be tagged when it appears (via the existing mutation observer), and wires **`texting-compliance-address-dropdown`** on the texting compliance filing address field.
> 
> On viewports **≤768px**, global styles force address suggestion lists to **`position: fixed`**, which was pinning the dropdown at the bottom of the screen on that long form. A scoped rule sets **`.pac-container.texting-compliance-address-dropdown`** back to **`position: absolute`** so suggestions sit under the input; other **`AddressAutocomplete`** usages keep the fixed mobile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e650fc5c7042a9b2270782efb8602d03256b8c5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->