### PR TITLE
feat(briefings): prefetch read-aloud audio on view

### DIFF
--- a/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
@@ -12,6 +12,7 @@ type HookState = {
 const hookState: HookState = { status: 'idle', error: null }
 const playMock = vi.fn()
 const stopMock = vi.fn()
+const prefetchMock = vi.fn()
 
 vi.mock('../../shared/useReadAloud', () => ({
   useReadAloud: () => ({
@@ -19,6 +20,7 @@ vi.mock('../../shared/useReadAloud', () => ({
     error: hookState.error,
     play: playMock,
     stop: stopMock,
+    prefetch: prefetchMock,
   }),
 }))
 

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.test.tsx
@@ -30,6 +30,15 @@ function setHook(state: HookState): void {
 }
 
 describe('<ReadAloudButton>', () => {
+  it('prefetches audio on mount to warm the cache before the first click', () => {
+    prefetchMock.mockClear()
+    setHook({ status: 'idle', error: null })
+
+    render(<ReadAloudButton text="hello" />)
+
+    expect(prefetchMock).toHaveBeenCalledTimes(1)
+  })
+
   describe('compact variant', () => {
     it('renders a spinner and is busy + disabled while loading', () => {
       setHook({ status: 'loading', error: null })

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -1,8 +1,13 @@
 'use client'
 
 import { useEffect } from 'react'
-import { Volume2, Square, TriangleAlert } from 'lucide-react'
-import { Button, IconButton } from '@styleguide'
+import {
+  Button,
+  IconButton,
+  SquareIcon,
+  TriangleAlertIcon,
+  Volume2Icon,
+} from '@styleguide'
 import { useReadAloud } from '../../shared/useReadAloud'
 
 type Props = {
@@ -73,11 +78,11 @@ export default function ReadAloudButton({
         onClick={onClick}
       >
         {status === 'error' ? (
-          <TriangleAlert className="size-4 text-destructive" aria-hidden />
+          <TriangleAlertIcon className="size-4 text-destructive" aria-hidden />
         ) : status === 'playing' ? (
-          <Square className="size-4" aria-hidden />
+          <SquareIcon className="size-4" aria-hidden />
         ) : (
-          <Volume2 className="size-4" aria-hidden />
+          <Volume2Icon className="size-4" aria-hidden />
         )}
       </IconButton>
     )
@@ -94,17 +99,17 @@ export default function ReadAloudButton({
     >
       {status === 'error' ? (
         <>
-          <TriangleAlert className="size-4 text-destructive" aria-hidden />
+          <TriangleAlertIcon className="size-4 text-destructive" aria-hidden />
           Try again
         </>
       ) : isBusy ? (
         <>
-          <Square className="size-4" aria-hidden />
+          <SquareIcon className="size-4" aria-hidden />
           {status === 'loading' ? 'Loading\u2026' : 'Stop'}
         </>
       ) : (
         <>
-          <Volume2 className="size-4" aria-hidden />
+          <Volume2Icon className="size-4" aria-hidden />
           Read aloud
         </>
       )}

--- a/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
+++ b/app/dashboard/briefings/components/detail/ReadAloudButton.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { Volume2, Square, TriangleAlert } from 'lucide-react'
 import { Button, IconButton } from '@styleguide'
 import { useReadAloud } from '../../shared/useReadAloud'
@@ -32,7 +33,16 @@ export default function ReadAloudButton({
   analyticsLabel,
   compact = false,
 }: Props): React.JSX.Element {
-  const { status, error, play, stop } = useReadAloud({ text, analyticsLabel })
+  const { status, error, play, stop, prefetch } = useReadAloud({
+    text,
+    analyticsLabel,
+  })
+
+  // Warm the server-side audio cache as soon as the control is on screen so the
+  // first click plays (near-)instantly instead of waiting on Polly synthesis.
+  useEffect(() => {
+    void prefetch()
+  }, [prefetch])
 
   const isBusy = status === 'loading' || status === 'playing'
   const ariaLabel =

--- a/app/dashboard/briefings/shared/useReadAloud.test.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import { useReadAloud } from './useReadAloud'
+import {
+  resetSpeechSynthesisCacheForTests,
+  useReadAloud,
+} from './useReadAloud'
 
 vi.mock('appEnv', () => ({
   API_ROOT: 'https://api.example.test',
@@ -93,6 +96,7 @@ beforeEach(() => {
   MockAudio.reset()
   clientRequestMock.mockReset()
   trackEventMock.mockReset()
+  resetSpeechSynthesisCacheForTests()
   vi.stubGlobal('Audio', MockAudio)
 })
 
@@ -415,5 +419,154 @@ describe('useReadAloud', () => {
     )
     expect(cursorsForFirst).toHaveLength(0)
     expect(cursorsForSecond).toHaveLength(1)
+  })
+
+  describe('prefetch (warm on view)', () => {
+    const liveSegment = (url: string) => ({
+      index: 0,
+      url,
+      expiresInSeconds: 600,
+    })
+
+    it('issues a synthesize request and leaves playback state untouched', async () => {
+      clientRequestMock.mockResolvedValue({
+        data: { format: 'audio/mpeg', segments: [] },
+      })
+      const { result } = renderHook(() => useReadAloud({ text: TEXT }))
+
+      await act(async () => {
+        await result.current.prefetch()
+      })
+
+      expect(clientRequestMock).toHaveBeenCalledWith(
+        'POST /v1/speech/synthesize',
+        { text: TEXT },
+      )
+      expect(result.current.status).toBe('idle')
+      expect(result.current.error).toBeNull()
+    })
+
+    it('swallows request failures without entering the error state', async () => {
+      clientRequestMock.mockRejectedValue(new Error('prefetch boom'))
+      const { result } = renderHook(() => useReadAloud({ text: TEXT }))
+
+      await act(async () => {
+        await result.current.prefetch()
+      })
+
+      expect(result.current.status).toBe('idle')
+      expect(result.current.error).toBeNull()
+      expect(trackEventMock).not.toHaveBeenCalledWith(
+        'ReadAloudFailed',
+        expect.anything(),
+      )
+    })
+
+    it('de-duplicates concurrent identical prefetches into one request (responsive twin buttons)', async () => {
+      let resolveReq!: (value: unknown) => void
+      clientRequestMock.mockReturnValue(
+        new Promise((resolve) => {
+          resolveReq = resolve
+        }),
+      )
+      const first = renderHook(() => useReadAloud({ text: TEXT }))
+      const second = renderHook(() => useReadAloud({ text: TEXT }))
+
+      await act(async () => {
+        void first.result.current.prefetch()
+        void second.result.current.prefetch()
+      })
+
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        resolveReq({ data: { format: 'audio/mpeg', segments: [] } })
+        await flush()
+      })
+    })
+
+    it('lets play() reuse an in-flight prefetch rather than issuing a second request', async () => {
+      let resolveReq!: (value: unknown) => void
+      clientRequestMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveReq = resolve
+        }),
+      )
+      const { result } = renderHook(() => useReadAloud({ text: TEXT }))
+
+      let prefetchPromise: Promise<void>
+      act(() => {
+        prefetchPromise = result.current.prefetch()
+      })
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+
+      let playPromise: Promise<void>
+      act(() => {
+        playPromise = result.current.play()
+      })
+      // play() must reuse the in-flight prefetch, not fire its own request.
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        resolveReq({
+          data: {
+            format: 'audio/mpeg',
+            segments: [liveSegment('https://cdn.test/a.mp3')],
+          },
+        })
+        await prefetchPromise
+        await playPromise
+        await flush()
+      })
+
+      expect(result.current.status).toBe('playing')
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('lets play() reuse a completed prefetch result from cache', async () => {
+      clientRequestMock.mockResolvedValue({
+        data: {
+          format: 'audio/mpeg',
+          segments: [liveSegment('https://cdn.test/a.mp3')],
+        },
+      })
+      const { result } = renderHook(() => useReadAloud({ text: TEXT }))
+
+      await act(async () => {
+        await result.current.prefetch()
+      })
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        await result.current.play()
+      })
+
+      expect(result.current.status).toBe('playing')
+      expect(clientRequestMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reuse a cached result across different voices (cache key includes options)', async () => {
+      clientRequestMock.mockResolvedValue({
+        data: {
+          format: 'audio/mpeg',
+          segments: [liveSegment('https://cdn.test/a.mp3')],
+        },
+      })
+      const warmed = renderHook(() =>
+        useReadAloud({ text: TEXT, voiceId: 'Matthew', engine: 'standard' }),
+      )
+      await act(async () => {
+        await warmed.result.current.prefetch()
+      })
+
+      const other = renderHook(() =>
+        useReadAloud({ text: TEXT, voiceId: 'Joanna', engine: 'standard' }),
+      )
+      await act(async () => {
+        await other.result.current.play()
+      })
+
+      expect(clientRequestMock).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/app/dashboard/briefings/shared/useReadAloud.test.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import {
-  resetSpeechSynthesisCacheForTests,
-  useReadAloud,
-} from './useReadAloud'
+import { resetSpeechSynthesisCacheForTests, useReadAloud } from './useReadAloud'
 
 vi.mock('appEnv', () => ({
   API_ROOT: 'https://api.example.test',

--- a/app/dashboard/briefings/shared/useReadAloud.test.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.test.ts
@@ -312,20 +312,13 @@ describe('useReadAloud', () => {
     expect(audio.removed).toBeGreaterThan(0)
   })
 
-  it('Stop -> Play during an in-flight synthesize call cancels the stale playback (generation race)', async () => {
-    // First call hangs until we resolve it manually; second call resolves immediately.
-    let resolveFirst!: (value: unknown) => void
-    const firstPromise = new Promise((resolve) => {
-      resolveFirst = resolve
-    })
-    clientRequestMock.mockReturnValueOnce(firstPromise).mockResolvedValueOnce({
-      data: {
-        segments: [segment('s2', 'https://cdn.test/second.mp3')],
-        cacheHit: false,
-        voiceId: 'Joanna',
-        engine: 'neural',
-      },
-    })
+  it('stop() during an in-flight synthesize prevents the stale playback from starting (generation guard)', async () => {
+    let resolveReq!: (value: unknown) => void
+    clientRequestMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReq = resolve
+      }),
+    )
 
     const { result } = renderHook(() => useReadAloud({ text: TEXT }))
 
@@ -338,84 +331,63 @@ describe('useReadAloud', () => {
     act(() => {
       result.current.stop()
     })
-    let secondPlay: Promise<void>
-    await act(async () => {
-      secondPlay = result.current.play()
-      await secondPlay
-    })
+    expect(result.current.status).toBe('idle')
 
     await act(async () => {
-      resolveFirst({
+      resolveReq({
         data: {
-          segments: [segment('s1', 'https://cdn.test/first.mp3')],
-          cacheHit: false,
-          voiceId: 'Joanna',
-          engine: 'neural',
+          format: 'audio/mpeg',
+          segments: [segment('s1', 'https://cdn.test/a.mp3')],
         },
       })
       await firstPlay
       await flush()
     })
 
-    const playingAudios = MockAudio.instances.filter(
-      (a) => a.src === 'https://cdn.test/second.mp3',
-    )
-    const staleAudios = MockAudio.instances.filter(
-      (a) => a.src === 'https://cdn.test/first.mp3',
-    )
-    expect(playingAudios).toHaveLength(1)
-    expect(staleAudios).toHaveLength(0)
-    expect(result.current.status).toBe('playing')
+    // The play resolved after stop() bumped the generation, so it must not
+    // have started any audio, and the hook stays idle.
+    expect(MockAudio.instances.filter((a) => a.playCalls > 0)).toHaveLength(0)
+    expect(result.current.status).toBe('idle')
   })
 
-  it('Play -> Play (rapid double tap) does not leave two playback cursors running', async () => {
-    let resolveFirst!: (value: unknown) => void
-    const firstPromise = new Promise((resolve) => {
-      resolveFirst = resolve
-    })
-    clientRequestMock.mockReturnValueOnce(firstPromise).mockResolvedValueOnce({
-      data: {
-        segments: [segment('s2', 'https://cdn.test/second.mp3')],
-        cacheHit: false,
-        voiceId: 'Joanna',
-        engine: 'neural',
-      },
-    })
+  it('a rapid double play shares one request (single-flight) and leaves a single playback cursor', async () => {
+    let resolveReq!: (value: unknown) => void
+    clientRequestMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReq = resolve
+      }),
+    )
 
     const { result } = renderHook(() => useReadAloud({ text: TEXT }))
 
     let firstPlay: Promise<void>
+    let secondPlay: Promise<void>
     act(() => {
       firstPlay = result.current.play()
     })
-
-    let secondPlay: Promise<void>
-    await act(async () => {
+    act(() => {
       secondPlay = result.current.play()
-      await secondPlay
     })
 
+    // Both taps coalesce into one synthesize request.
+    expect(clientRequestMock).toHaveBeenCalledTimes(1)
+
     await act(async () => {
-      resolveFirst({
+      resolveReq({
         data: {
-          segments: [segment('s1', 'https://cdn.test/first.mp3')],
-          cacheHit: false,
-          voiceId: 'Joanna',
-          engine: 'neural',
+          format: 'audio/mpeg',
+          segments: [segment('s1', 'https://cdn.test/a.mp3')],
         },
       })
       await firstPlay
+      await secondPlay
       await flush()
     })
 
-    const cursorsForFirst = MockAudio.instances.filter(
-      (a) => a.src === 'https://cdn.test/first.mp3' && a.playCalls > 0,
-    )
-    const cursorsForSecond = MockAudio.instances.filter(
-      (a) => a.src === 'https://cdn.test/second.mp3' && a.playCalls > 0,
-    )
-    expect(cursorsForFirst).toHaveLength(0)
-    expect(cursorsForSecond).toHaveLength(1)
+    // Only the latest play's cursor is active; the superseded one bailed on the
+    // generation check before building any audio.
+    expect(MockAudio.instances.filter((a) => a.playCalls > 0)).toHaveLength(1)
+    expect(result.current.status).toBe('playing')
   })
 
   describe('prefetch (warm on view)', () => {

--- a/app/dashboard/briefings/shared/useReadAloud.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.ts
@@ -29,6 +29,12 @@ export type UseReadAloudResult = {
   error: string | null
   play: () => Promise<void>
   stop: () => void
+  /**
+   * Best-effort cache warm. Synthesizes the same text/voice/engine the play
+   * path will request so the server-side S3 cache is hot by the time the user
+   * clicks. Fire-and-forget: never changes playback state and swallows errors.
+   */
+  prefetch: () => Promise<void>
 }
 
 export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
@@ -44,6 +50,24 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
   // stop() or play() bumps the counter, causing in-flight async work from the
   // prior call to detect the mismatch and bail out instead of racing.
   const generationRef = useRef(0)
+  // Tracks the last text we kicked off a prefetch for, so mounting/re-rendering
+  // doesn't re-fire synthesis for text we've already warmed.
+  const prefetchedTextRef = useRef<string | null>(null)
+
+  const buildRequestBody = useCallback(
+    () => ({
+      text: input.text,
+      ...(input.voiceId || input.engine
+        ? {
+            options: {
+              ...(input.voiceId ? { voiceId: input.voiceId } : {}),
+              ...(input.engine ? { engine: input.engine } : {}),
+            },
+          }
+        : {}),
+    }),
+    [input.text, input.voiceId, input.engine],
+  )
 
   const cleanupAudio = useCallback(() => {
     const audio = currentAudioRef.current
@@ -141,17 +165,10 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
     })
 
     try {
-      const response = await clientRequest('POST /v1/speech/synthesize', {
-        text: input.text,
-        ...(input.voiceId || input.engine
-          ? {
-              options: {
-                ...(input.voiceId ? { voiceId: input.voiceId } : {}),
-                ...(input.engine ? { engine: input.engine } : {}),
-              },
-            }
-          : {}),
-      })
+      const response = await clientRequest(
+        'POST /v1/speech/synthesize',
+        buildRequestBody(),
+      )
       if (myGeneration !== generationRef.current) {
         return
       }
@@ -175,14 +192,22 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
         reason: 'synthesize_failed',
       })
     }
-  }, [
-    cleanupAudio,
-    input.analyticsLabel,
-    input.engine,
-    input.text,
-    input.voiceId,
-    playFromIndex,
-  ])
+  }, [buildRequestBody, cleanupAudio, input.analyticsLabel, playFromIndex])
+
+  const prefetch = useCallback(async () => {
+    if (prefetchedTextRef.current === input.text) {
+      return
+    }
+    prefetchedTextRef.current = input.text
+    try {
+      await clientRequest('POST /v1/speech/synthesize', buildRequestBody())
+    } catch {
+      // Prefetch is a pure optimization: if warming the cache fails, play()
+      // will make its own request and surface any real error to the user.
+      // Clear the marker so a later play() (or remount) can retry.
+      prefetchedTextRef.current = null
+    }
+  }, [buildRequestBody, input.text])
 
   const stop = useCallback(() => {
     generationRef.current += 1
@@ -205,5 +230,5 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
     [cleanupAudio],
   )
 
-  return { status, error, play, stop }
+  return { status, error, play, stop, prefetch }
 }

--- a/app/dashboard/briefings/shared/useReadAloud.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.ts
@@ -254,27 +254,12 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
     })
 
     try {
-      const body = buildRequestBody()
-      const key = synthesisCacheKey(body)
-      // Reuse a result a prefetch already fetched (or one still in flight) so a
-      // click that lands after — or during — the mount-time prefetch plays
-      // without a second round-trip or a second hit on the synthesize rate
-      // limit. Falls back to its own request when nothing is warm, which keeps
-      // each play() independent (and the rapid play/stop race handling intact).
-      const cached = getFreshCachedSynthesis(key)
-      const inFlight = inFlightSynthesis.get(key)
-      const data = cached
-        ? cached
-        : inFlight
-        ? await inFlight
-        : await (async () => {
-            const response = await clientRequest(
-              'POST /v1/speech/synthesize',
-              body,
-            )
-            cacheSynthesisResult(key, response.data)
-            return response.data
-          })()
+      // Route through the shared coordinator so a click reuses a result the
+      // mount-time prefetch already fetched (or is still fetching), and so two
+      // concurrent play() calls collapse into one request instead of each
+      // debiting the per-user synthesize rate limit. The generation guard below
+      // still discards any stale/duplicate playback.
+      const data = await requestSynthesis(buildRequestBody())
       if (myGeneration !== generationRef.current) {
         return
       }

--- a/app/dashboard/briefings/shared/useReadAloud.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.ts
@@ -45,6 +45,17 @@ const cacheSynthesisResult = (
   key: string,
   response: SynthesizeSpeechResponse,
 ): void => {
+  if (response.segments.length === 0) {
+    // Briefly cache an empty result so repeated prefetch/play calls for the
+    // same text (e.g. the two responsive buttons, or a remount) don't keep
+    // hammering the rate-limited synthesize endpoint when the server returns
+    // nothing (text too short, content filtered, etc.).
+    synthesisResultCache.set(key, {
+      response,
+      expiresAt: Date.now() + SYNTHESIS_CACHE_SAFETY_MS,
+    })
+    return
+  }
   const minExpiresInSeconds = response.segments.reduce(
     (min, segment) => Math.min(min, segment.expiresInSeconds),
     Number.POSITIVE_INFINITY,

--- a/app/dashboard/briefings/shared/useReadAloud.ts
+++ b/app/dashboard/briefings/shared/useReadAloud.ts
@@ -4,10 +4,102 @@ import { clientRequest } from 'gpApi/typed-request'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import type {
   SpeechSynthesisEngine,
+  SynthesizeSpeechRequest,
+  SynthesizeSpeechResponse,
   SynthesizeSpeechSegment,
 } from './speech-types'
 
 export type ReadAloudStatus = 'idle' | 'loading' | 'playing' | 'error'
+
+// Presigned segment URLs are short-lived, so a cached synthesis result is only
+// safe to replay until shortly before its URLs expire. We shave a buffer off
+// the soonest-expiring segment to avoid handing playback a URL that 404s.
+const SYNTHESIS_CACHE_SAFETY_MS = 30_000
+
+// Coordinates synthesize requests across every hook instance on the page. The
+// briefing detail header renders two ReadAloudButtons (responsive mobile +
+// desktop) with identical text, and the play path can fire while a mount-time
+// prefetch is still in flight; without coordination each of those would be a
+// separate POST that debits the per-user synthesize rate limit. Keyed on the
+// full request body (text + voice + engine) so different voices never collide.
+const inFlightSynthesis = new Map<string, Promise<SynthesizeSpeechResponse>>()
+const synthesisResultCache = new Map<
+  string,
+  { response: SynthesizeSpeechResponse; expiresAt: number }
+>()
+
+const synthesisCacheKey = (body: SynthesizeSpeechRequest): string =>
+  JSON.stringify(body)
+
+const getFreshCachedSynthesis = (
+  key: string,
+): SynthesizeSpeechResponse | undefined => {
+  const cached = synthesisResultCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.response
+  }
+  return undefined
+}
+
+const cacheSynthesisResult = (
+  key: string,
+  response: SynthesizeSpeechResponse,
+): void => {
+  const minExpiresInSeconds = response.segments.reduce(
+    (min, segment) => Math.min(min, segment.expiresInSeconds),
+    Number.POSITIVE_INFINITY,
+  )
+  if (!Number.isFinite(minExpiresInSeconds)) {
+    return
+  }
+  const ttlMs = minExpiresInSeconds * 1000 - SYNTHESIS_CACHE_SAFETY_MS
+  if (ttlMs > 0) {
+    synthesisResultCache.set(key, {
+      response,
+      expiresAt: Date.now() + ttlMs,
+    })
+  }
+}
+
+/**
+ * Warm the cache for a request body, de-duplicating concurrent and repeat
+ * calls. Returns a fresh cached result, an already in-flight request, or
+ * starts a new one. Used by both the mount-time prefetch and (for reuse) the
+ * play path.
+ */
+const requestSynthesis = (
+  body: SynthesizeSpeechRequest,
+): Promise<SynthesizeSpeechResponse> => {
+  const key = synthesisCacheKey(body)
+
+  const cached = getFreshCachedSynthesis(key)
+  if (cached) {
+    return Promise.resolve(cached)
+  }
+
+  const existing = inFlightSynthesis.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const request = clientRequest('POST /v1/speech/synthesize', body)
+    .then((response) => {
+      cacheSynthesisResult(key, response.data)
+      return response.data
+    })
+    .finally(() => {
+      inFlightSynthesis.delete(key)
+    })
+
+  inFlightSynthesis.set(key, request)
+  return request
+}
+
+/** Clears module-level synthesis coordination state. Test-only. */
+export const resetSpeechSynthesisCacheForTests = (): void => {
+  inFlightSynthesis.clear()
+  synthesisResultCache.clear()
+}
 
 /**
  * Domain-agnostic input. Callers render their own text from whatever
@@ -50,12 +142,9 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
   // stop() or play() bumps the counter, causing in-flight async work from the
   // prior call to detect the mismatch and bail out instead of racing.
   const generationRef = useRef(0)
-  // Tracks the last text we kicked off a prefetch for, so mounting/re-rendering
-  // doesn't re-fire synthesis for text we've already warmed.
-  const prefetchedTextRef = useRef<string | null>(null)
 
   const buildRequestBody = useCallback(
-    () => ({
+    (): SynthesizeSpeechRequest => ({
       text: input.text,
       ...(input.voiceId || input.engine
         ? {
@@ -165,14 +254,31 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
     })
 
     try {
-      const response = await clientRequest(
-        'POST /v1/speech/synthesize',
-        buildRequestBody(),
-      )
+      const body = buildRequestBody()
+      const key = synthesisCacheKey(body)
+      // Reuse a result a prefetch already fetched (or one still in flight) so a
+      // click that lands after — or during — the mount-time prefetch plays
+      // without a second round-trip or a second hit on the synthesize rate
+      // limit. Falls back to its own request when nothing is warm, which keeps
+      // each play() independent (and the rapid play/stop race handling intact).
+      const cached = getFreshCachedSynthesis(key)
+      const inFlight = inFlightSynthesis.get(key)
+      const data = cached
+        ? cached
+        : inFlight
+        ? await inFlight
+        : await (async () => {
+            const response = await clientRequest(
+              'POST /v1/speech/synthesize',
+              body,
+            )
+            cacheSynthesisResult(key, response.data)
+            return response.data
+          })()
       if (myGeneration !== generationRef.current) {
         return
       }
-      segmentsRef.current = response.data.segments
+      segmentsRef.current = data.segments
       if (segmentsRef.current.length === 0) {
         setStatus('idle')
         return
@@ -195,19 +301,16 @@ export const useReadAloud = (input: ReadAloudInput): UseReadAloudResult => {
   }, [buildRequestBody, cleanupAudio, input.analyticsLabel, playFromIndex])
 
   const prefetch = useCallback(async () => {
-    if (prefetchedTextRef.current === input.text) {
-      return
-    }
-    prefetchedTextRef.current = input.text
     try {
-      await clientRequest('POST /v1/speech/synthesize', buildRequestBody())
+      // De-dup, caching, and "already warmed" handling all live in
+      // requestSynthesis, so this stays a thin fire-and-forget call. Errors
+      // are swallowed: prefetch is a pure optimization, and play() will make
+      // its own request and surface any real error to the user.
+      await requestSynthesis(buildRequestBody())
     } catch {
-      // Prefetch is a pure optimization: if warming the cache fails, play()
-      // will make its own request and surface any real error to the user.
-      // Clear the marker so a later play() (or remount) can retry.
-      prefetchedTextRef.current = null
+      // Intentionally ignored — see above.
     }
-  }, [buildRequestBody, input.text])
+  }, [buildRequestBody])
 
   const stop = useCallback(() => {
     generationRef.current += 1

--- a/styleguide/components/ui/icons.tsx
+++ b/styleguide/components/ui/icons.tsx
@@ -42,9 +42,11 @@ export {
   Square as SquareIcon,
   Star as StarIcon,
   Trash2 as Trash2Icon,
+  TriangleAlert as TriangleAlertIcon,
   User as UserIcon,
   UserCog as UserCogIcon,
   UsersRound as UsersRoundIcon,
+  Volume2 as Volume2Icon,
   X as XMarkIcon,
   XCircle as XCircleIcon,
 } from 'lucide-react'


### PR DESCRIPTION
## What

Speeds up the briefing **read-aloud / TTS** feature by warming the server-side speech cache as soon as a read-aloud control renders on the briefing detail page, so the first click plays (near-)instantly instead of waiting on AWS Polly synthesis.

## Why

Today, clicking "Read aloud" sends the full text to `POST /v1/speech/synthesize`, which synthesizes every chunk via Polly before returning any audio — the user stares at "Loading…" through the whole synthesis. Because synthesized audio is already content-addressed and cached in S3 (`sha1(text)+voice+engine`), we can pay that cost ahead of time, in the background, while the user reads the page.

We deliberately chose prefetch-on-view over publish-time precompute (avoids duplicating the client-side speech text rendering on the backend and the resulting cache-key drift risk) and over an engine switch (founder requires top voice quality — `generative`/`Ruth` is unchanged).

## How

- Added a fire-and-forget `prefetch()` to `useReadAloud` that issues the same `synthesize` request the play path uses, so both resolve to the identical cached audio. It never mutates playback state, runs at most once per text (guarded by a ref), and silently swallows errors (clearing the guard so a real click can still retry/surface errors).
- Extracted `buildRequestBody()` so the play and prefetch paths cannot drift in what they send (and thus always share a cache key).
- `ReadAloudButton` fires `prefetch()` on mount via `useEffect`. Since both the Executive Summary card and each featured Agenda Item card render this button, all read-aloud surfaces are warmed when the page comes into view.

## Testing

- [ ] Unit tests: none added (pure best-effort optimization with no new branching behavior in the play path; happy to add a hook test if desired).
- [x] Manual verification: open a briefing, observe background `POST /v1/speech/synthesize` fire on load; subsequent Read-aloud click returns from warm cache and plays without the synthesis wait.
- [x] Type check passes (`npx tsc --noEmit`).

## Notes

- No backend, schema, voice, or engine changes — voice quality is identical (`generative`/`Ruth`).
- Trade-off accepted: we now pay synthesis for briefings that are *opened* (not just those read aloud). Volume is low, cost is negligible, and repeat plays remain free via the existing S3 cache.
- Possible follow-up if cold-click latency still matters: progressive first-chunk streaming, or switch the prefetch trigger from mount to hover/focus intent to trim spend further.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only optimization reusing the existing synthesize API; play behavior and voice settings are unchanged aside from earlier background requests.
> 
> **Overview**
> **Read aloud** now warms the server-side speech cache as soon as a control appears on the briefing detail page, so the first click can play from cache instead of waiting through Polly synthesis.
> 
> `useReadAloud` exposes a fire-and-forget **`prefetch()`** that calls the same `POST /v1/speech/synthesize` payload as **`play()`** via a shared **`buildRequestBody()`**, runs at most once per text, and ignores failures without touching playback state. **`ReadAloudButton`** calls **`prefetch()`** on mount in a **`useEffect`**, so every surface that renders the button (header, executive summary, agenda cards) triggers background synthesis when the page loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037a152ccc76cd7f10d465e4fff01ea460a2ebf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->