### PR TITLE
refactor: update campaign primaryResult handling

### DIFF
--- a/app/dashboard/components/PrimaryResultModal.test.tsx
+++ b/app/dashboard/components/PrimaryResultModal.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import PrimaryResultModal from './PrimaryResultModal'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn().mockResolvedValue({ id: 1 }),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  EVENTS: { Candidacy: { CampaignCompleted: 'campaign_completed' } },
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn() }),
+}))
+
+vi.mock('@shared/animations/PartyAnimation', () => ({
+  default: () => null,
+}))
+
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+
+const optionLabel = { won: 'I won my race', lost: 'I did not win my race' }
+
+describe('PrimaryResultModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(['won', 'lost'] as const)(
+    'submits the selection with the top-level primaryResult key (%s)',
+    async (result) => {
+      render(
+        <PrimaryResultModal
+          open
+          officeName="Mayor"
+          electionDate="2026-11-03"
+          onClose={vi.fn()}
+        />,
+      )
+
+      fireEvent.click(screen.getByText(optionLabel[result]))
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateCampaign).toHaveBeenCalledWith([
+          { key: 'primaryResult', value: result },
+        ])
+      })
+    },
+  )
+})

--- a/app/dashboard/components/PrimaryResultModal.tsx
+++ b/app/dashboard/components/PrimaryResultModal.tsx
@@ -91,7 +91,7 @@ export default function PrimaryResultModal({
 
     try {
       const updatedCampaign = await updateCampaign([
-        { key: 'details.primaryResult', value: primaryResult },
+        { key: 'primaryResult', value: primaryResult },
       ])
       if (updatedCampaign) {
         queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updatedCampaign)

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -26,10 +26,10 @@ const setCampaign = (overrides: {
   mockUseCampaign.mockReturnValue([
     {
       id: 'campaign-1',
+      primaryResult: overrides.primaryResult ?? null,
       details: {
         electionDate: overrides.electionDate,
         primaryElectionDate: overrides.primaryElectionDate,
-        primaryResult: overrides.primaryResult ?? null,
       },
       goals: overrides.goalsElectionDate
         ? { electionDate: overrides.goalsElectionDate }

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -40,9 +40,7 @@ export function usePostElectionState(): PostElectionState {
   // are always respected after they load — local state only tracks the
   // current session's modal interaction.
   const primaryResult =
-    primaryResultState.overrideResult ??
-    campaign?.details?.primaryResult ??
-    null
+    primaryResultState.overrideResult ?? campaign?.primaryResult ?? null
   const { modalDismissed } = primaryResultState
 
   const weeksUntil = weeksTill(resolvedDate)

--- a/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
+++ b/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
@@ -72,7 +72,7 @@ test.describe('Mobile Navigation', () => {
     await WaitHelper.waitForPageReady(page)
 
     await NavigationHelper.openMobileMenu(page)
-    await page.locator('#my-content-dashboard').click()
+    await page.getByRole('link', { name: 'Content Builder' }).click()
     // The mobile header renders the page title as a heading in addition to the
     // page's own heading, so scope to the first match to avoid strict mode.
     await expect(

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -110,7 +110,6 @@ export interface CampaignDetails {
   ballotLevel?: string
   electionDate?: string
   primaryElectionDate?: string
-  primaryResult?: 'won' | 'lost' | null
   zip?: string
   knowRun?: 'yes' | null
   runForOffice?: 'yes' | 'no' | null
@@ -377,6 +376,7 @@ export interface Campaign {
   isPro?: boolean | null
   isDemo: boolean
   didWin?: boolean | null
+  primaryResult?: 'won' | 'lost' | null
   dateVerified?: Date | string | null
   tier?: CampaignTier | null
   formattedAddress?: string | null


### PR DESCRIPTION
- Changed the key for updating the campaign's primary result in PrimaryResultModal from 'details.primaryResult' to 'primaryResult'.
- Updated related test to reflect the change in structure.
- Adjusted usePostElectionState to access primaryResult directly from the campaign object.
- Removed the primaryResult field from CampaignDetails interface and added it to the Campaign interface for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how primary election outcomes are saved and read; a mismatch with the API would break persistence or post-primary dashboard behavior until aligned.
> 
> **Overview**
> Moves **`primaryResult`** from **`campaign.details`** to a **top-level** field on **`Campaign`**, so dashboard reads and writes match the API/DB shape.
> 
> **`PrimaryResultModal`** now persists via `updateCampaign` with key **`primaryResult`** (was **`details.primaryResult`**). **`usePostElectionState`** reads **`campaign?.primaryResult`** for modal gating and persisted outcomes; tests mock the campaign object the same way. **`CampaignDetails`** no longer declares this field; **`helpers/types`** adds it on **`Campaign`** next to fields like **`didWin`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df60a7681eb4ac6118698c09bbc1088f6c07fd79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->