### PR TITLE
feat(campaign-details): enhance layout with Card components and condi…

### DIFF
--- a/app/dashboard/campaign-details/components/CampaignSection.tsx
+++ b/app/dashboard/campaign-details/components/CampaignSection.tsx
@@ -30,6 +30,9 @@ interface FieldConfig {
 
 interface CampaignSectionProps {
   campaign?: Campaign
+  // When rendered inside a Card (pro path), the card supplies the surrounding
+  // spacing, so the section drops its own bottom margin.
+  carded?: boolean
 }
 
 interface FieldState {
@@ -88,7 +91,7 @@ export default function CampaignSection(
   }
   const [state, setState] = useState<FieldState>(initialState)
   const [saving, setSaving] = useState(false)
-  const { campaign } = props
+  const { campaign, carded = false } = props
 
   useEffect(() => {
     if (campaign?.details) {
@@ -178,7 +181,7 @@ export default function CampaignSection(
           )
         })}
       </div>
-      <div className="flex justify-end mb-6">
+      <div className={`flex justify-end ${carded ? '' : 'mb-6'}`}>
         {saving ? (
           <PrimaryButton disabled>
             <div className="px-3">

--- a/app/dashboard/campaign-details/components/DetailsPage.tsx
+++ b/app/dashboard/campaign-details/components/DetailsPage.tsx
@@ -13,6 +13,7 @@ import PolicyPrioritiesSection from './PolicyPrioritiesSection'
 import { CandidatePositionsProvider } from 'app/dashboard/campaign-details/components/issues/CandidatePositionsProvider'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { Campaign, User, CandidatePosition } from 'helpers/types'
+import { Card } from '@styleguide'
 
 interface TopIssue {
   id: number
@@ -39,23 +40,33 @@ export default function DetailsPage(
   return (
     <DashboardLayout {...props}>
       <CandidatePositionsProvider candidatePositions={props.candidatePositions}>
-        <div className="max-w-[940px] mx-auto bg-gray-50 rounded-xl px-6 py-5">
-          {campaign && <CampaignSection {...campaignProps} />}
-          <OfficeSection campaign={campaign ?? undefined} />
-          {useNewSections ? (
-            <>
+        {useNewSections ? (
+          <div className="max-w-[940px] mx-auto flex flex-col gap-4 py-5">
+            {campaign && (
+              <Card className="p-6">
+                <CampaignSection {...campaignProps} carded />
+              </Card>
+            )}
+            <Card className="p-6">
+              <OfficeSection campaign={campaign ?? undefined} carded />
+            </Card>
+            <Card className="p-6">
               <WhyRunningSection />
+            </Card>
+            <Card className="p-6">
               <PolicyPrioritiesSection />
-            </>
-          ) : (
-            <>
-              {campaign && <RunningAgainstSection {...campaignProps} />}
-              {campaign && <WhySection {...campaignProps} />}
-              {campaign && <FunFactSection {...campaignProps} />}
-              {campaign && <IssuesSection {...campaignProps} />}
-            </>
-          )}
-        </div>
+            </Card>
+          </div>
+        ) : (
+          <div className="max-w-[940px] mx-auto bg-gray-50 rounded-xl px-6 py-5">
+            {campaign && <CampaignSection {...campaignProps} />}
+            <OfficeSection campaign={campaign ?? undefined} />
+            {campaign && <RunningAgainstSection {...campaignProps} />}
+            {campaign && <WhySection {...campaignProps} />}
+            {campaign && <FunFactSection {...campaignProps} />}
+            {campaign && <IssuesSection {...campaignProps} />}
+          </div>
+        )}
       </CandidatePositionsProvider>
     </DashboardLayout>
   )

--- a/app/dashboard/campaign-details/components/OfficeSection.tsx
+++ b/app/dashboard/campaign-details/components/OfficeSection.tsx
@@ -18,9 +18,13 @@ import { useQueryClient } from '@tanstack/react-query'
 
 interface OfficeSectionProps {
   campaign?: Campaign
+  // When rendered inside a Card (pro path), the card supplies the section
+  // separation, so the top divider and bottom margin are dropped.
+  carded?: boolean
 }
 
 const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
+  const { carded = false } = props
   const organization = useOrganization()
   const positionName = usePositionName()
   const queryClient = useQueryClient()
@@ -81,7 +85,11 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
   return (
     <section
       className={
-        organization?.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
+        carded
+          ? ''
+          : organization?.electedOfficeId
+          ? 'pt-6'
+          : 'border-t pt-6 border-gray-600'
       }
     >
       <H3 className="pb-6">Office Details</H3>
@@ -96,7 +104,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
           }
         />
       </div>
-      <div className="flex justify-end mb-6 mt-2">
+      <div className={`flex justify-end mt-2 ${carded ? '' : 'mb-6'}`}>
         <PrimaryButton onClick={handleEdit}>Edit Office Details</PrimaryButton>
       </div>
       <CampaignOfficeSelectionModal

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -56,7 +56,7 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
   }
 
   return (
-    <section className="border-t pt-6 border-gray-600">
+    <section>
       <H3>Your policy priorities</H3>
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters about the policy priorities you&apos;ll focus on.
@@ -66,7 +66,7 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
         onChange={setIssues}
         disabled={saving}
       />
-      <div className="flex justify-end mt-6 mb-6">
+      <div className="flex justify-end mt-6">
         <PrimaryButton
           loading={saving}
           disabled={!canSave}

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -77,7 +77,7 @@ export default function WhyRunningSection(): React.JSX.Element {
   }
 
   return (
-    <section className="border-t pt-6 border-gray-600">
+    <section>
       <H3>Why are you running?</H3>
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters why you&apos;re running for office.
@@ -93,7 +93,7 @@ export default function WhyRunningSection(): React.JSX.Element {
         <span>{MIN_BIO_LENGTH} character minimum</span>
         <span>{bioPlainLength}</span>
       </div>
-      <div className="flex justify-end mt-6 mb-6">
+      <div className="flex justify-end mt-6">
         <PrimaryButton
           loading={saving}
           disabled={!canSave}


### PR DESCRIPTION
…tional margins

- Updated CampaignSection and OfficeSection to accept a `carded` prop, allowing for conditional styling when rendered inside a Card.
- Adjusted DetailsPage to wrap sections in Card components when `useNewSections` is true, improving visual separation.
- Removed unnecessary bottom margins in sections when rendered within a Card to maintain consistent spacing.
- Cleaned up PolicyPrioritiesSection and WhyRunningSection by removing redundant margin classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes behind the existing pro upgrade flag; save flows and section logic are untouched.
> 
> **Overview**
> When the **pro upgrade** flag is on, campaign details no longer use one gray panel with stacked sections; each block is wrapped in a shared **`Card`** with vertical **`gap-4`** between cards.
> 
> **`CampaignSection`** and **`OfficeSection`** gain an optional **`carded`** prop so they skip extra bottom margin and (for office) the top border/divider that duplicated the card’s separation. Legacy layout is unchanged when the flag is off.
> 
> **`WhyRunningSection`** and **`PolicyPrioritiesSection`** drop section top borders and trailing bottom margins so spacing comes from the parent cards in the pro layout only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61346b5738cbd1612a232f24bcc5a5b20bb6888. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->