### PR TITLE
feat: ENG-10269 ENG-10271

### DIFF
--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type { Website } from 'helpers/types'
+import PolicyPrioritiesSection from './PolicyPrioritiesSection'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWithIssues = (count: number): Website =>
+  ({
+    content: {
+      about: {
+        bio: '',
+        issues: Array.from({ length: count }, (_, i) => ({
+          title: `Priority ${i + 1}`,
+          description: `Description ${i + 1}`,
+        })),
+      },
+    },
+  } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('PolicyPrioritiesSection — save validation messaging', () => {
+  it('keeps the Save button enabled when there are no priorities', async () => {
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    render(<PolicyPrioritiesSection />)
+    expect(await screen.findByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('surfaces the missing-priority error and does not save when there are none', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    render(<PolicyPrioritiesSection />)
+
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+  })
+
+  it('saves when at least one policy priority exists', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(1))
+    saveAboutFields.mockResolvedValue(true)
+    render(<PolicyPrioritiesSection />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith({
+      issues: [{ title: 'Priority 1', description: 'Description 1' }],
+    })
+    expect(
+      screen.queryByText('Please add at least one policy priority'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import type { Website } from 'helpers/types'
+import { MIN_POLICY_FOCUS_LENGTH } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import PolicyPrioritiesSection from './PolicyPrioritiesSection'
 
 vi.mock('app/shared/utils/RichEditor', async () => ({
@@ -74,6 +75,60 @@ describe('PolicyPrioritiesSection — save validation messaging', () => {
     expect(saveAboutFields).toHaveBeenCalledWith({
       issues: [{ title: 'Priority 1', description: 'Description 1' }],
     })
+    expect(
+      screen.queryByText('Please add at least one policy priority'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not re-show the error on a later invalid edit after a successful save', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    saveAboutFields.mockResolvedValue(true)
+    render(<PolicyPrioritiesSection />)
+
+    await screen.findByRole('button', { name: 'Add a policy priority' })
+
+    // Trigger the error state.
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+
+    // Add a valid priority through the modal.
+    await user.click(
+      screen.getByRole('button', { name: 'Add a policy priority' }),
+    )
+    const addDialog = await screen.findByRole('dialog')
+    await user.type(
+      within(addDialog).getByLabelText('Policy title'),
+      'Education',
+    )
+    fireEvent.change(within(addDialog).getByTestId('rich-editor'), {
+      target: { value: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH) },
+    })
+    await user.click(within(addDialog).getByRole('button', { name: 'Save' }))
+
+    // Save the section successfully (resets the attempted-save flag).
+    await screen.findByRole('button', { name: 'Edit Education' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled(),
+    )
+
+    // Remove the only priority to return to an invalid state.
+    await user.click(screen.getByRole('button', { name: 'Edit Education' }))
+    const editDialog = await screen.findByRole('dialog')
+    await user.click(within(editDialog).getByRole('button', { name: 'Delete' }))
+    await screen.findByText('Delete policy priority')
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    // The error must NOT reappear until the user attempts to save again.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Edit Education' }),
+      ).toBeNull(),
+    )
     expect(
       screen.queryByText('Please add at least one policy priority'),
     ).not.toBeInTheDocument()

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -61,6 +61,9 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
     }
     await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
     successSnackbar('Policy priorities saved')
+    // Clear the attempted-save flag so a later edit back to an invalid state
+    // doesn't re-show the error before the user tries to save again.
+    setAttemptedSave(false)
     setSaving(false)
   }
 

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -3,6 +3,7 @@
 import H3 from '@shared/typography/H3'
 import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
+import { Alert, AlertDescription, CircleAlertIcon } from '@styleguide'
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -14,7 +15,7 @@ import { useSnackbar } from 'helpers/useSnackbar'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { Website, WebsiteIssue } from 'helpers/types'
 import {
-  MIN_POLICY_PRIORITIES,
+  getPolicyPrioritiesError,
   normalizeIssues,
 } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import PolicyPriorities from 'app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities'
@@ -29,6 +30,10 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
 
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [saving, setSaving] = useState(false)
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error rather than a silently-disabled button. The error only
+  // surfaces once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
   const seededRef = useRef(false)
 
   const websiteIssues = website?.content?.about?.issues
@@ -38,10 +43,14 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
     seededRef.current = true
   }, [website, websiteIssues])
 
-  const canSave = issues.length >= MIN_POLICY_PRIORITIES && !saving
+  const prioritiesError = getPolicyPrioritiesError(issues.length)
 
   const handleSave = async () => {
-    if (!canSave) return
+    if (saving) return
+    if (prioritiesError) {
+      setAttemptedSave(true)
+      return
+    }
     trackEvent(EVENTS.Profile.PolicyPriorities.ClickSave)
     setSaving(true)
     const ok = await saveAboutFields({ issues })
@@ -61,17 +70,22 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters about the policy priorities you&apos;ll focus on.
       </Body1>
+      {attemptedSave && prioritiesError && (
+        <Alert
+          variant="destructive"
+          icon={<CircleAlertIcon />}
+          className="mb-4"
+        >
+          <AlertDescription>{prioritiesError}</AlertDescription>
+        </Alert>
+      )}
       <PolicyPriorities
         issues={issues}
         onChange={setIssues}
         disabled={saving}
       />
       <div className="flex justify-end mt-6">
-        <PrimaryButton
-          loading={saving}
-          disabled={!canSave}
-          onClick={handleSave}
-        >
+        <PrimaryButton loading={saving} disabled={saving} onClick={handleSave}>
           {saving ? 'Saving...' : 'Save'}
         </PrimaryButton>
       </div>

--- a/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import type { Website } from 'helpers/types'
@@ -66,6 +66,33 @@ describe('WhyRunningSection — save validation messaging', () => {
 
     await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
     expect(saveAboutFields).toHaveBeenCalledWith({ bio: validBio })
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+
+  it('does not re-show the error on a later invalid edit after a successful save', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    saveAboutFields.mockResolvedValue(true)
+    render(<WhyRunningSection />)
+
+    const editor = await screen.findByTestId('rich-editor')
+
+    // Trigger the error state.
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+
+    // Fix the content and save successfully.
+    fireEvent.change(editor, { target: { value: 'a'.repeat(MIN_BIO_LENGTH) } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    // Save settled (button re-enabled), so attemptedSave has been reset.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled(),
+    )
+
+    // Editing back to an invalid state must NOT re-show the error until the
+    // user attempts to save again.
+    fireEvent.change(editor, { target: { value: '' } })
     expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
   })
 })

--- a/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type { Website } from 'helpers/types'
+import { MIN_BIO_LENGTH } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+import WhyRunningSection from './WhyRunningSection'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWithBio = (bio: string): Website =>
+  ({ content: { about: { bio, issues: [] } } } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('WhyRunningSection — save validation messaging', () => {
+  it('keeps the Save button enabled when the bio is incomplete', async () => {
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    render(<WhyRunningSection />)
+    expect(await screen.findByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('surfaces the bio error and does not save when the bio is empty', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    render(<WhyRunningSection />)
+
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves the bio when it meets the minimum length', async () => {
+    const user = userEvent.setup()
+    const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+    getUserWebsite.mockResolvedValue(websiteWithBio(validBio))
+    saveAboutFields.mockResolvedValue(true)
+    render(<WhyRunningSection />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith({ bio: validBio })
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -83,6 +83,9 @@ export default function WhyRunningSection(): React.JSX.Element {
     }
     await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
     successSnackbar('Bio saved')
+    // Clear the attempted-save flag so a later edit back to an invalid state
+    // doesn't re-show the error before the user tries to save again.
+    setAttemptedSave(false)
     setSaving(false)
   }
 

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -3,6 +3,7 @@
 import H3 from '@shared/typography/H3'
 import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
+import { Alert, AlertDescription, CircleAlertIcon } from '@styleguide'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -16,6 +17,7 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { Website } from 'helpers/types'
 import {
   MIN_BIO_LENGTH,
+  getBioError,
   getBioPlainLength,
 } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 
@@ -46,6 +48,10 @@ export default function WhyRunningSection(): React.JSX.Element {
   // refetch. `null` means "not seeded yet" so we can defer mounting the
   // editor until we have the real value.
   const [initialBio, setInitialBio] = useState<string | null>(null)
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error rather than a silently-disabled button. The error (alert +
+  // red bio border) only surfaces once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -59,10 +65,14 @@ export default function WhyRunningSection(): React.JSX.Element {
     seededRef.current = true
   }, [website])
 
-  const canSave = bioPlainLength >= MIN_BIO_LENGTH && !saving
+  const bioError = getBioError(bioPlainLength)
 
   const handleSave = async () => {
-    if (!canSave) return
+    if (saving) return
+    if (bioError) {
+      setAttemptedSave(true)
+      return
+    }
     trackEvent(EVENTS.Profile.WhyRunning.ClickSave)
     setSaving(true)
     const ok = await saveAboutFields({ bio })
@@ -82,11 +92,21 @@ export default function WhyRunningSection(): React.JSX.Element {
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters why you&apos;re running for office.
       </Body1>
+      {attemptedSave && bioError && (
+        <Alert
+          variant="destructive"
+          icon={<CircleAlertIcon />}
+          className="mb-4"
+        >
+          <AlertDescription>{bioError}</AlertDescription>
+        </Alert>
+      )}
       {initialBio !== null && (
         <RichEditor
           initialText={initialBio}
           onChangeCallback={setBio}
           onTextLengthChange={setBioPlainLength}
+          error={attemptedSave && !!bioError}
         />
       )}
       <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
@@ -94,11 +114,7 @@ export default function WhyRunningSection(): React.JSX.Element {
         <span>{bioPlainLength}</span>
       </div>
       <div className="flex justify-end mt-6">
-        <PrimaryButton
-          loading={saving}
-          disabled={!canSave}
-          onClick={handleSave}
-        >
+        <PrimaryButton loading={saving} disabled={saving} onClick={handleSave}>
           {saving ? 'Saving...' : 'Save'}
         </PrimaryButton>
       </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
@@ -69,6 +69,15 @@ describe('getPolicyFormValidation', () => {
     expect(result.focusInvalid).toBe(true)
   })
 
+  it('surfaces both problems when the title is missing and the focus is present but too short', () => {
+    const result = getPolicyFormValidation(0, MIN_POLICY_FOCUS_LENGTH - 1)
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(true)
+    // Both fields render red, so the message must explain both.
+    expect(result.message).toContain('Policy title')
+    expect(result.message).toContain('Policy focus')
+  })
+
   it('returns no message when both fields satisfy their requirements', () => {
     const result = getPolicyFormValidation(5, MIN_POLICY_FOCUS_LENGTH)
     expect(result.message).toBeNull()

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MIN_BIO_LENGTH,
+  MIN_POLICY_FOCUS_LENGTH,
+  getBioError,
+  getPolicyPrioritiesError,
+  getPolicyFormValidation,
+} from './candidateProfile.utils'
+
+describe('getBioError', () => {
+  it('asks the user to add a bio when it is empty', () => {
+    expect(getBioError(0)).toBe('Please add your bio')
+  })
+
+  it('reports the character requirement when the bio is too short', () => {
+    expect(getBioError(MIN_BIO_LENGTH - 1)).toBe(
+      `Your bio requires ${MIN_BIO_LENGTH} characters`,
+    )
+  })
+
+  it('returns null once the bio meets the minimum length', () => {
+    expect(getBioError(MIN_BIO_LENGTH)).toBeNull()
+  })
+})
+
+describe('getPolicyPrioritiesError', () => {
+  it('asks for at least one priority when there are none', () => {
+    expect(getPolicyPrioritiesError(0)).toBe(
+      'Please add at least one policy priority',
+    )
+  })
+
+  it('returns null once at least one priority exists', () => {
+    expect(getPolicyPrioritiesError(1)).toBeNull()
+  })
+})
+
+describe('getPolicyFormValidation', () => {
+  it('asks to add both fields when both are empty (matches Figma)', () => {
+    const result = getPolicyFormValidation(0, 0)
+    expect(result.message).toBe('Please add a Policy title and Policy focus')
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('reports the focus length requirement when the title is set but focus is too short (matches Figma)', () => {
+    const result = getPolicyFormValidation(
+      'Education'.length,
+      MIN_POLICY_FOCUS_LENGTH - 1,
+    )
+    expect(result.message).toBe(
+      `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`,
+    )
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('asks to add the title alone when only the title is missing', () => {
+    const result = getPolicyFormValidation(0, MIN_POLICY_FOCUS_LENGTH)
+    expect(result.message).toBe('Please add a Policy title')
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(false)
+  })
+
+  it('asks to add the focus alone when only the focus is empty', () => {
+    const result = getPolicyFormValidation(5, 0)
+    expect(result.message).toBe('Please add a Policy focus')
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('returns no message when both fields satisfy their requirements', () => {
+    const result = getPolicyFormValidation(5, MIN_POLICY_FOCUS_LENGTH)
+    expect(result.message).toBeNull()
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(false)
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -56,6 +56,10 @@ export const getPolicyFormValidation = (
   let message: string | null = null
   if (missing.length === 2) {
     message = 'Please add a Policy title and Policy focus'
+  } else if (titleInvalid && focusInvalid && focusPlainLength > 0) {
+    // Title is empty AND the focus has content but is too short: both fields
+    // render red, so the message must explain both, not just the empty title.
+    message = `Please add a Policy title. Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`
   } else if (missing.length === 1) {
     message = `Please add a ${missing[0]}`
   } else if (focusInvalid) {

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -8,6 +8,63 @@ export const MIN_POLICY_PRIORITIES = 1
 export const getBioPlainLength = (rawBio: string | undefined | null): number =>
   rawBio ? stripHtml(rawBio).result.trim().length : 0
 
+/**
+ * Error message for the bio ("Why are you running?") field, or null when the
+ * bio meets the minimum length. Consumed by every surface that gates a
+ * Submit/Save on the bio so the copy stays consistent.
+ */
+export const getBioError = (bioPlainLength: number): string | null => {
+  if (bioPlainLength === 0) return 'Please add your bio'
+  if (bioPlainLength < MIN_BIO_LENGTH) {
+    return `Your bio requires ${MIN_BIO_LENGTH} characters`
+  }
+  return null
+}
+
+/**
+ * Error message for the policy-priorities requirement, or null when at least
+ * the minimum number of priorities exist.
+ */
+export const getPolicyPrioritiesError = (count: number): string | null =>
+  count < MIN_POLICY_PRIORITIES
+    ? 'Please add at least one policy priority'
+    : null
+
+export interface PolicyFormValidation {
+  titleInvalid: boolean
+  focusInvalid: boolean
+  message: string | null
+}
+
+/**
+ * Validation state for the policy-priority form (title + focus). `message`
+ * mirrors the Figma error states: missing fields are surfaced as "Please add
+ * a ..." and a present-but-too-short focus as "Policy focus requires N
+ * characters". `titleInvalid` / `focusInvalid` drive the red field borders.
+ */
+export const getPolicyFormValidation = (
+  trimmedTitleLength: number,
+  focusPlainLength: number,
+): PolicyFormValidation => {
+  const titleInvalid = trimmedTitleLength === 0
+  const focusInvalid = focusPlainLength < MIN_POLICY_FOCUS_LENGTH
+
+  const missing: string[] = []
+  if (titleInvalid) missing.push('Policy title')
+  if (focusPlainLength === 0) missing.push('Policy focus')
+
+  let message: string | null = null
+  if (missing.length === 2) {
+    message = 'Please add a Policy title and Policy focus'
+  } else if (missing.length === 1) {
+    message = `Please add a ${missing[0]}`
+  } else if (focusInvalid) {
+    message = `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`
+  }
+
+  return { titleInvalid, focusInvalid, message }
+}
+
 export const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import type { Website } from 'helpers/types'
+import { MIN_BIO_LENGTH } from '../candidateProfile.utils'
+import CandidateProfile from './CandidateProfile'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWith = (bio: string, issueCount: number): Website =>
+  ({
+    content: {
+      about: {
+        bio,
+        issues: Array.from({ length: issueCount }, (_, i) => ({
+          title: `Priority ${i + 1}`,
+          description: 'y'.repeat(MIN_BIO_LENGTH),
+        })),
+      },
+    },
+  } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CandidateProfile — submit validation messaging', () => {
+  it('keeps the Submit button enabled when the profile is incomplete', async () => {
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+    expect(await screen.findByRole('button', { name: /submit/i })).toBeEnabled()
+  })
+
+  it('surfaces bio and policy-priority errors and does not save an incomplete profile', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+
+    await user.click(await screen.findByRole('button', { name: /submit/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves and navigates when the bio and a policy priority are present', async () => {
+    const user = userEvent.setup()
+    const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+    getUserWebsite.mockResolvedValue(websiteWith(validBio, 1))
+    saveAboutFields.mockResolvedValue(true)
+    render(<CandidateProfile />)
+
+    // Wait for the seeded bio to reach the minimum length (editor mounted).
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+
+    await user.click(await screen.findByRole('button', { name: /submit/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bio: validBio,
+        issues: expect.arrayContaining([
+          expect.objectContaining({ title: 'Priority 1' }),
+        ]),
+      }),
+    )
+    await waitFor(() =>
+      expect(router.push).toHaveBeenCalledWith('/dashboard/profile'),
+    )
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -45,17 +45,19 @@ beforeEach(() => {
 
 describe('CandidateProfile — submit validation messaging', () => {
   it('keeps the Submit button enabled when the profile is incomplete', async () => {
-    getUserWebsite.mockResolvedValue(null)
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
     render(<CandidateProfile />)
     expect(await screen.findByRole('button', { name: /submit/i })).toBeEnabled()
   })
 
   it('surfaces bio and policy-priority errors and does not save an incomplete profile', async () => {
     const user = userEvent.setup()
-    getUserWebsite.mockResolvedValue(null)
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
     render(<CandidateProfile />)
 
-    await user.click(await screen.findByRole('button', { name: /submit/i }))
+    // Wait for the editor to mount (profile seeded) before submitting.
+    await screen.findByTestId('rich-editor')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
 
     expect(saveAboutFields).not.toHaveBeenCalled()
     expect(screen.getByText('Please add your bio')).toBeInTheDocument()

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -49,6 +49,13 @@ export default function CandidateProfile(): React.JSX.Element {
   // get a guiding error rather than a silently-disabled button. Errors (alert
   // + red bio border) only surface once they've tried to submit.
   const [attemptedSubmit, setAttemptedSubmit] = useState(false)
+  // `initialBio` must be captured exactly once and never change afterward.
+  // RichEditor re-pastes its content whenever `initialText` changes by value,
+  // so deriving it live from the query would clobber the user's in-progress
+  // edits whenever a refetch lands (e.g. the post-submit `invalidateQueries`
+  // or a window-focus refetch). `null` means "not seeded yet" so we defer
+  // mounting the editor until we have the real value.
+  const [initialBio, setInitialBio] = useState<string | null>(null)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -58,11 +65,10 @@ export default function CandidateProfile(): React.JSX.Element {
     // Seed length up-front so Submit doesn't show a false "add your bio" error
     // before the dynamically-imported editor emits its first onTextLengthChange.
     setBioPlainLength(getBioPlainLength(initialBioValue))
+    setInitialBio(initialBioValue)
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])
-
-  const initialBio = website?.content?.about?.bio ?? ''
 
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)
@@ -115,12 +121,14 @@ export default function CandidateProfile(): React.JSX.Element {
           <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
           </div>
-          <RichEditor
-            initialText={initialBio}
-            onChangeCallback={setBio}
-            onTextLengthChange={setBioPlainLength}
-            error={attemptedSubmit && !!bioError}
-          />
+          {initialBio !== null && (
+            <RichEditor
+              initialText={initialBio}
+              onChangeCallback={setBio}
+              onTextLengthChange={setBioPlainLength}
+              error={attemptedSubmit && !!bioError}
+            />
+          )}
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
             <span>{bioPlainLength}</span>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -17,6 +17,7 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
   getBioError,
+  getBioPlainLength,
   getPolicyPrioritiesError,
   normalizeIssues,
 } from '../candidateProfile.utils'
@@ -52,7 +53,11 @@ export default function CandidateProfile(): React.JSX.Element {
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(website.content?.about?.bio ?? '')
+    const initialBioValue = website.content?.about?.bio ?? ''
+    setBio(initialBioValue)
+    // Seed length up-front so Submit doesn't show a false "add your bio" error
+    // before the dynamically-imported editor emits its first onTextLengthChange.
+    setBioPlainLength(getBioPlainLength(initialBioValue))
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Button } from '@styleguide'
+import { Alert, AlertDescription, Button, CircleAlertIcon } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
@@ -16,7 +16,8 @@ import { Website, WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
-  MIN_POLICY_PRIORITIES,
+  getBioError,
+  getPolicyPrioritiesError,
   normalizeIssues,
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
@@ -43,6 +44,10 @@ export default function CandidateProfile(): React.JSX.Element {
   const [bioPlainLength, setBioPlainLength] = useState(0)
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
+  // The Submit button is always enabled so the user can attempt to submit and
+  // get a guiding error rather than a silently-disabled button. Errors (alert
+  // + red bio border) only surface once they've tried to submit.
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -54,13 +59,15 @@ export default function CandidateProfile(): React.JSX.Element {
 
   const initialBio = website?.content?.about?.bio ?? ''
 
-  const canSubmit =
-    bioPlainLength >= MIN_BIO_LENGTH &&
-    issues.length >= MIN_POLICY_PRIORITIES &&
-    !submitting
+  const bioError = getBioError(bioPlainLength)
+  const prioritiesError = getPolicyPrioritiesError(issues.length)
 
   const handleSubmit = async () => {
-    if (!canSubmit) return
+    if (submitting) return
+    if (bioError || prioritiesError) {
+      setAttemptedSubmit(true)
+      return
+    }
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
     const ok = await saveAboutFields({ bio, issues })
@@ -86,6 +93,19 @@ export default function CandidateProfile(): React.JSX.Element {
           <div>&nbsp;</div>
         </div>
 
+        {attemptedSubmit && (bioError || prioritiesError) && (
+          <Alert
+            variant="destructive"
+            icon={<CircleAlertIcon />}
+            className="mt-6"
+          >
+            <AlertDescription>
+              {bioError && <p>{bioError}</p>}
+              {prioritiesError && <p>{prioritiesError}</p>}
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="mt-10">
           <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
@@ -94,6 +114,7 @@ export default function CandidateProfile(): React.JSX.Element {
             initialText={initialBio}
             onChangeCallback={setBio}
             onTextLengthChange={setBioPlainLength}
+            error={attemptedSubmit && !!bioError}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
@@ -118,7 +139,6 @@ export default function CandidateProfile(): React.JSX.Element {
           variant="secondary"
           type="button"
           onClick={handleSubmit}
-          disabled={!canSubmit}
           loading={submitting}
           loadingText="Submitting"
         >

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
@@ -86,4 +86,30 @@ describe('PolicyForm — validation messaging', () => {
     })
     expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
   })
+
+  it('saves an existing policy without re-typing, before the editor reports a length', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const existing = {
+      title: 'Education',
+      description: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH),
+    }
+    render(
+      <PolicyForm
+        initial={existing}
+        showDelete
+        onSave={onSave}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    // No typing: the description length must be seeded from `initial` so a
+    // valid existing policy isn't falsely blocked before the dynamic editor
+    // fires its first onTextLengthChange.
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith(existing)
+    expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
+  })
 })

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+import PolicyForm from './PolicyForm'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const typeFocus = (length: number) => {
+  fireEvent.change(screen.getByTestId('rich-editor'), {
+    target: { value: 'x'.repeat(length) },
+  })
+}
+
+describe('PolicyForm — validation messaging', () => {
+  it('keeps the Save button enabled even when the form is empty', () => {
+    render(
+      <PolicyForm showDelete={false} onSave={vi.fn()} onDelete={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('shows the combined add-fields message and flags both fields when empty', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please add a Policy title and Policy focus'),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Policy title')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    )
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('reports the focus length requirement when the title is set but focus is too short', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Policy title'), 'Education')
+    typeFocus(MIN_POLICY_FOCUS_LENGTH - 1)
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`,
+      ),
+    ).toBeInTheDocument()
+    // Title is valid now, so only the focus field is flagged.
+    expect(screen.getByLabelText('Policy title')).toHaveAttribute(
+      'aria-invalid',
+      'false',
+    )
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves the trimmed title and description once the form is valid', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Policy title'), '  Education  ')
+    typeFocus(MIN_POLICY_FOCUS_LENGTH)
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({
+      title: 'Education',
+      description: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH),
+    })
+    expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,9 +1,18 @@
 'use client'
-import { Button, Input } from '@styleguide'
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  CircleAlertIcon,
+  Input,
+} from '@styleguide'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
-import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+import {
+  MIN_POLICY_FOCUS_LENGTH,
+  getPolicyFormValidation,
+} from '../candidateProfile.utils'
 
 const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
   ssr: false,
@@ -31,14 +40,34 @@ export default function PolicyForm({
   const [description, setDescription] = useState(initial?.description ?? '')
   const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
   const [initialDescription] = useState(initial?.description ?? '')
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error instead of a silently-disabled button. Errors (alert +
+  // red field borders) only surface once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
 
   const trimmedTitle = title.trim()
-  const canSave =
-    trimmedTitle.length > 0 && descriptionPlainLength >= MIN_POLICY_FOCUS_LENGTH
+  const { titleInvalid, focusInvalid, message } = getPolicyFormValidation(
+    trimmedTitle.length,
+    descriptionPlainLength,
+  )
+
+  const handleSave = () => {
+    if (message) {
+      setAttemptedSave(true)
+      return
+    }
+    onSave({ title: trimmedTitle, description })
+  }
 
   return (
     <div className="flex flex-col gap-4 p-6">
       <h2 className="text-lg font-semibold">Policy priority</h2>
+
+      {attemptedSave && message && (
+        <Alert variant="destructive" icon={<CircleAlertIcon />}>
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+      )}
 
       <div className="flex flex-col gap-2">
         <label htmlFor="policy-title" className="text-sm font-medium">
@@ -48,6 +77,7 @@ export default function PolicyForm({
           id="policy-title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
+          aria-invalid={attemptedSave && titleInvalid}
           autoFocus
         />
       </div>
@@ -58,6 +88,7 @@ export default function PolicyForm({
           initialText={initialDescription}
           onChangeCallback={setDescription}
           onTextLengthChange={setDescriptionPlainLength}
+          error={attemptedSave && focusInvalid}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
@@ -78,12 +109,7 @@ export default function PolicyForm({
         ) : (
           <span />
         )}
-        <Button
-          type="button"
-          size="medium"
-          disabled={!canSave}
-          onClick={() => onSave({ title: trimmedTitle, description })}
-        >
+        <Button type="button" size="medium" onClick={handleSave}>
           Save
         </Button>
       </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
 import {
   MIN_POLICY_FOCUS_LENGTH,
+  getBioPlainLength,
   getPolicyFormValidation,
 } from '../candidateProfile.utils'
 
@@ -38,7 +39,12 @@ export default function PolicyForm({
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
-  const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
+  // Seed the length from the existing description so Save isn't falsely
+  // blocked before the dynamically-loaded editor fires its first
+  // onTextLengthChange when editing an existing policy.
+  const [descriptionPlainLength, setDescriptionPlainLength] = useState(() =>
+    getBioPlainLength(initial?.description),
+  )
   const [initialDescription] = useState(initial?.description ?? '')
   // The Save button is always enabled so the user can attempt to save and get
   // a guiding error instead of a silently-disabled button. Errors (alert +

--- a/app/shared/utils/RichEditor.tsx
+++ b/app/shared/utils/RichEditor.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from 'react'
 import { useQuill } from 'react-quilljs'
 import 'quill/dist/quill.bubble.css'
+import { cn } from '@styleguide'
 import { noop } from './noop'
 
 interface RichEditorProps {
@@ -9,12 +10,15 @@ interface RichEditorProps {
   onChangeCallback?: (value: string, flag?: number) => void
   onTextLengthChange?: (length: number) => void
   useOnChange?: boolean
+  // Renders the editor with a destructive border to flag a validation error.
+  error?: boolean
 }
 
 const RichEditor = ({
   initialText = '',
   onChangeCallback = noop,
   onTextLengthChange,
+  error = false,
 }: RichEditorProps): React.JSX.Element => {
   const { quill, quillRef } = useQuill({
     theme: 'bubble',
@@ -57,7 +61,12 @@ const RichEditor = ({
   }, [quill, onChangeCallback, onTextLengthChange])
 
   return (
-    <div className="p-3 border rounded-lg border-gray-200 [&>.quill>.ql-container]:text-base [&_.ql-editor]:wrap-anywhere">
+    <div
+      className={cn(
+        'p-3 border rounded-lg [&>.quill>.ql-container]:text-base [&_.ql-editor]:wrap-anywhere',
+        error ? 'border-destructive' : 'border-gray-200',
+      )}
+    >
       <div ref={quillRef} />
     </div>
   )

--- a/helpers/test-utils/RichEditorMock.tsx
+++ b/helpers/test-utils/RichEditorMock.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+
+interface RichEditorMockProps {
+  initialText?: string
+  onChangeCallback?: (value: string, flag?: number) => void
+  onTextLengthChange?: (length: number) => void
+  error?: boolean
+}
+
+/**
+ * Test stand-in for `app/shared/utils/RichEditor`.
+ *
+ * The real editor wraps Quill, which needs browser APIs jsdom does not
+ * implement, so component tests mock it with this controllable textarea.
+ * Typing into it drives the same `onChangeCallback` / `onTextLengthChange`
+ * callbacks the real editor fires (length is the trimmed plain-text length),
+ * letting tests exercise the consumer's validation behavior. The `error` prop
+ * is reflected onto `data-error` so tests can assert the red-border wiring
+ * without rendering real Quill.
+ *
+ * Use via:
+ *   vi.mock('app/shared/utils/RichEditor', async () => ({
+ *     default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+ *   }))
+ */
+export const RichEditorMock = ({
+  initialText = '',
+  onChangeCallback,
+  onTextLengthChange,
+  error = false,
+}: RichEditorMockProps): React.JSX.Element => {
+  useEffect(() => {
+    if (initialText) {
+      onTextLengthChange?.(initialText.trim().length)
+    }
+    // Mirror the real editor, which re-seeds its length whenever `initialText`
+    // changes by value (e.g. after an async data fetch resolves).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialText])
+
+  return (
+    <textarea
+      data-testid="rich-editor"
+      data-error={error}
+      defaultValue={initialText}
+      onChange={(e) => {
+        const value = e.target.value
+        onChangeCallback?.(value)
+        onTextLengthChange?.(value.trim().length)
+      }}
+    />
+  )
+}

--- a/helpers/test-utils/RichEditorMock.tsx
+++ b/helpers/test-utils/RichEditorMock.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 interface RichEditorMockProps {
   initialText?: string
   onChangeCallback?: (value: string, flag?: number) => void
@@ -18,6 +16,13 @@ interface RichEditorMockProps {
  * is reflected onto `data-error` so tests can assert the red-border wiring
  * without rendering real Quill.
  *
+ * It intentionally does NOT report a length on mount from `initialText`. The
+ * real editor is dynamically imported and only emits its first
+ * `onTextLengthChange` once Quill has initialized, so there is a window where
+ * server-provided content exists but no length has been reported. Consumers
+ * that gate a Submit/Save on the length must seed it themselves from the
+ * server value; this mock holds them to that.
+ *
  * Use via:
  *   vi.mock('app/shared/utils/RichEditor', async () => ({
  *     default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
@@ -29,15 +34,6 @@ export const RichEditorMock = ({
   onTextLengthChange,
   error = false,
 }: RichEditorMockProps): React.JSX.Element => {
-  useEffect(() => {
-    if (initialText) {
-      onTextLengthChange?.(initialText.trim().length)
-    }
-    // Mirror the real editor, which re-seeds its length whenever `initialText`
-    // changes by value (e.g. after an async data fetch resolves).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialText])
-
   return (
     <textarea
       data-testid="rich-editor"

--- a/styleguide/components/ui/icons.tsx
+++ b/styleguide/components/ui/icons.tsx
@@ -13,6 +13,7 @@ export {
   ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon,
   ChevronsUpDown as ChevronsUpDownIcon,
+  CircleAlert as CircleAlertIcon,
   CircleUserRound as CircleUserRoundIcon,
   ClipboardList as ClipboardListIcon,
   Copy as CopyIcon,


### PR DESCRIPTION
enhance form validation with error handling for bio and policy priorities

- Added error handling for the bio and policy priorities sections, providing user feedback when validation fails.
- Introduced guiding error messages that surface after an attempt to save, improving user experience.
- Updated the PolicyForm component to include validation for title and focus fields, ensuring consistent error messaging.
- Integrated alert components to display validation errors across relevant sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and client-side validation only; save paths still gate on the same rules before calling `saveAboutFields`, with broad test coverage and no API or auth changes.
> 
> **Overview**
> Campaign profile and campaign-details forms no longer **disable Save/Submit** when bio, policy priorities, or policy title/focus are invalid. Users can click through; validation runs on attempt and shows **destructive alerts** with shared copy from new helpers (`getBioError`, `getPolicyPrioritiesError`, `getPolicyFormValidation` in `candidateProfile.utils`).
> 
> **Why running**, **policy priorities**, **candidate profile submit**, and **policy priority modal** (`PolicyForm`) all follow the same pattern: `attemptedSave` / `attemptedSubmit` gates messaging, blocks `saveAboutFields` until valid, and flags fields (`RichEditor` `error` prop → red border; policy title `aria-invalid`). `RichEditor` gains an optional `error` border; `CircleAlertIcon` is exported from the styleguide.
> 
> Component tests use a new **`RichEditorMock`** so validation behavior is covered without Quill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa883b47c16da9fe844f19640a0e25a70d20081. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->