### PR TITLE
fix(auth): make /dashboard/briefings deep links work for logged-out and wrong-org users

### DIFF
--- a/app/dashboard/shared/serveAccess.test.ts
+++ b/app/dashboard/shared/serveAccess.test.ts
@@ -61,10 +61,12 @@ const setCookieSlug = (slug?: string) =>
     name === 'organization-slug' && slug ? { value: slug } : undefined,
   )
 
-const setPathname = (pathname: string) =>
-  mockHeadersGet.mockImplementation((name: string) =>
-    name === 'x-pathname' ? pathname : null,
-  )
+const setPathname = (pathname: string, search = '') =>
+  mockHeadersGet.mockImplementation((name: string) => {
+    if (name === 'x-pathname') return pathname
+    if (name === 'x-search') return search
+    return null
+  })
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -113,6 +115,22 @@ describe('serveAccess', () => {
 
     expect(mockRedirect).toHaveBeenCalledWith(
       '/post-auth-redirect?next=%2Fdashboard%2Fpolls%2F42',
+    )
+  })
+
+  it('preserves query parameters on serve routes as next', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/polls', '?tab=open')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fpolls%3Ftab%3Dopen',
     )
   })
 

--- a/app/dashboard/shared/serveAccess.test.ts
+++ b/app/dashboard/shared/serveAccess.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Organization } from 'gpApi/api-endpoints'
+import serveAccess from './serveAccess'
+
+const {
+  mockServerFetch,
+  mockGetCurrentUserOrganizations,
+  mockCookiesGet,
+  mockHeadersGet,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockServerFetch: vi.fn(),
+  mockGetCurrentUserOrganizations: vi.fn(),
+  mockCookiesGet: vi.fn(),
+  mockHeadersGet: vi.fn(),
+  mockRedirect: vi.fn(),
+}))
+
+vi.mock('gpApi/serverFetch', () => ({
+  serverFetch: (...args: unknown[]) => mockServerFetch(...args),
+}))
+
+vi.mock('helpers/getCurrentUserOrganizations', () => ({
+  getCurrentUserOrganizations: () => mockGetCurrentUserOrganizations(),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => mockCookiesGet(name),
+    }),
+  headers: () =>
+    Promise.resolve({
+      get: (name: string) => mockHeadersGet(name),
+    }),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => mockRedirect(url),
+}))
+
+const campaignOrg: Organization = {
+  slug: 'campaign-1',
+  name: '2026 Campaign',
+  positionName: null,
+  position: null,
+  district: null,
+  electedOfficeId: null,
+  campaignId: 1,
+}
+
+const electedOfficeOrg: Organization = {
+  ...campaignOrg,
+  slug: 'serve-org',
+  name: 'Serve Org',
+  electedOfficeId: 'eo-123',
+}
+
+const setCookieSlug = (slug?: string) =>
+  mockCookiesGet.mockImplementation((name: string) =>
+    name === 'organization-slug' && slug ? { value: slug } : undefined,
+  )
+
+const setPathname = (pathname: string) =>
+  mockHeadersGet.mockImplementation((name: string) =>
+    name === 'x-pathname' ? pathname : null,
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRedirect.mockImplementation(() => undefined as never)
+  mockGetCurrentUserOrganizations.mockResolvedValue([campaignOrg])
+  setCookieSlug(undefined)
+  setPathname('/dashboard/briefings')
+})
+
+describe('serveAccess', () => {
+  it('returns without redirecting when the elected-office lookup succeeds', async () => {
+    mockServerFetch.mockResolvedValue({ ok: true, data: { id: 'eo-123' } })
+
+    await serveAccess()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+    expect(mockGetCurrentUserOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('switches org via post-auth-redirect when an elected-office org is not selected', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/briefings')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fbriefings',
+    )
+  })
+
+  it('preserves the requested serve path (polls / specific briefing) as next', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/polls/42')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fpolls%2F42',
+    )
+  })
+
+  it('falls back to /dashboard (no loop) when the elected-office org is already selected', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([electedOfficeOrg])
+    setCookieSlug('serve-org')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('bounces to /dashboard when the user has no elected-office org', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([campaignOrg])
+    setCookieSlug('campaign-1')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard')
+  })
+})

--- a/app/dashboard/shared/serveAccess.ts
+++ b/app/dashboard/shared/serveAccess.ts
@@ -1,10 +1,36 @@
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
+import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
+import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 
 export default async function serveAccess(): Promise<void> {
   const resp = await serverFetch(apiRoutes.electedOffice.current)
-  if (!resp?.ok || !resp?.data) {
-    return redirect('/dashboard')
+  if (resp?.ok && resp?.data) {
+    return
   }
+
+  // The elected-office (and meetings) endpoints resolve by the selected org's
+  // slug, so the lookup above fails whenever the user lands here with a
+  // different org selected — e.g. a logged-in user opening a /dashboard/briefings
+  // deep link from a marketing email while their campaign org is active. If the
+  // user owns an elected-office org that isn't the one currently selected,
+  // route through /post-auth-redirect to switch the org slug cookie and come
+  // back, rather than incorrectly bouncing them to /dashboard.
+  const [organizations, cookieStore] = await Promise.all([
+    getCurrentUserOrganizations(),
+    cookies(),
+  ])
+  const currentSlug = cookieStore.get(ORG_SLUG_COOKIE)?.value
+  const electedOfficeOrg = organizations.find((org) => org.electedOfficeId)
+
+  // Only redirect when switching to a *different* org could actually help.
+  // If the elected-office org is already selected (or none exists), fall back
+  // to /dashboard so we can't loop back here through post-auth-redirect.
+  if (electedOfficeOrg && electedOfficeOrg.slug !== currentSlug) {
+    return redirect('/post-auth-redirect?next=/dashboard/briefings')
+  }
+
+  return redirect('/dashboard')
 }

--- a/app/dashboard/shared/serveAccess.ts
+++ b/app/dashboard/shared/serveAccess.ts
@@ -32,11 +32,15 @@ export default async function serveAccess(): Promise<void> {
   // to /dashboard so we can't loop back here through post-auth-redirect.
   if (electedOfficeOrg && electedOfficeOrg.slug !== currentSlug) {
     // Preserve the page the user actually asked for (set by the middleware on
-    // the `x-pathname` header) so we return them to e.g. a specific briefing or
-    // a polls route — not always the briefings landing page. Fall back to the
-    // briefings landing only when the pathname is missing or isn't a serve route.
+    // the `x-pathname` / `x-search` headers) so we return them to e.g. a
+    // specific briefing or a polls route with its query intact — not always the
+    // briefings landing page. Fall back to the briefings landing only when the
+    // pathname is missing or isn't a serve route.
     const pathname = headerStore.get('x-pathname') ?? ''
-    const next = isServeRoutePath(pathname) ? pathname : '/dashboard/briefings'
+    const search = headerStore.get('x-search') ?? ''
+    const next = isServeRoutePath(pathname)
+      ? `${pathname}${search}`
+      : '/dashboard/briefings'
     return redirect(`/post-auth-redirect?next=${encodeURIComponent(next)}`)
   }
 

--- a/app/dashboard/shared/serveAccess.ts
+++ b/app/dashboard/shared/serveAccess.ts
@@ -1,9 +1,10 @@
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
 import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
 import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
+import { isServeRoutePath } from './serveRoutes'
 
 export default async function serveAccess(): Promise<void> {
   const resp = await serverFetch(apiRoutes.electedOffice.current)
@@ -18,9 +19,10 @@ export default async function serveAccess(): Promise<void> {
   // user owns an elected-office org that isn't the one currently selected,
   // route through /post-auth-redirect to switch the org slug cookie and come
   // back, rather than incorrectly bouncing them to /dashboard.
-  const [organizations, cookieStore] = await Promise.all([
+  const [organizations, cookieStore, headerStore] = await Promise.all([
     getCurrentUserOrganizations(),
     cookies(),
+    headers(),
   ])
   const currentSlug = cookieStore.get(ORG_SLUG_COOKIE)?.value
   const electedOfficeOrg = organizations.find((org) => org.electedOfficeId)
@@ -29,7 +31,13 @@ export default async function serveAccess(): Promise<void> {
   // If the elected-office org is already selected (or none exists), fall back
   // to /dashboard so we can't loop back here through post-auth-redirect.
   if (electedOfficeOrg && electedOfficeOrg.slug !== currentSlug) {
-    return redirect('/post-auth-redirect?next=/dashboard/briefings')
+    // Preserve the page the user actually asked for (set by the middleware on
+    // the `x-pathname` header) so we return them to e.g. a specific briefing or
+    // a polls route — not always the briefings landing page. Fall back to the
+    // briefings landing only when the pathname is missing or isn't a serve route.
+    const pathname = headerStore.get('x-pathname') ?? ''
+    const next = isServeRoutePath(pathname) ? pathname : '/dashboard/briefings'
+    return redirect(`/post-auth-redirect?next=${encodeURIComponent(next)}`)
   }
 
   return redirect('/dashboard')

--- a/app/dashboard/shared/serveRoutes.test.ts
+++ b/app/dashboard/shared/serveRoutes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { isServeRoutePath } from './serveRoutes'
+
+describe('isServeRoutePath', () => {
+  it('matches serve route prefixes and their sub-paths', () => {
+    expect(isServeRoutePath('/dashboard/briefings')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings/2026-01-15')).toBe(true)
+    expect(isServeRoutePath('/dashboard/polls')).toBe(true)
+    expect(isServeRoutePath('/dashboard/polls/42/expand')).toBe(true)
+  })
+
+  it('ignores query strings and hashes when matching', () => {
+    expect(isServeRoutePath('/dashboard/polls?tab=open')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings#section')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings/2026-01-15?x=1#y')).toBe(true)
+  })
+
+  it('does not match non-serve routes or prefix look-alikes', () => {
+    expect(isServeRoutePath('/dashboard')).toBe(false)
+    expect(isServeRoutePath('/dashboard/profile')).toBe(false)
+    expect(isServeRoutePath('/dashboard/briefings-archive')).toBe(false)
+    expect(isServeRoutePath('/dashboard/pollsters')).toBe(false)
+  })
+})

--- a/app/dashboard/shared/serveRoutes.ts
+++ b/app/dashboard/shared/serveRoutes.ts
@@ -1,0 +1,15 @@
+/**
+ * Route prefixes that make up the elected-official "serve" experience. These
+ * pages are gated by `serveAccess` and are scoped to the org that owns the
+ * user's elected office, so the post-auth flow must select that org (not the
+ * default first org) when landing a user on any of them.
+ */
+export const SERVE_ROUTE_PREFIXES = [
+  '/dashboard/briefings',
+  '/dashboard/polls',
+] as const
+
+export const isServeRoutePath = (path: string): boolean =>
+  SERVE_ROUTE_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  )

--- a/app/dashboard/shared/serveRoutes.ts
+++ b/app/dashboard/shared/serveRoutes.ts
@@ -9,7 +9,11 @@ export const SERVE_ROUTE_PREFIXES = [
   '/dashboard/polls',
 ] as const
 
-export const isServeRoutePath = (path: string): boolean =>
-  SERVE_ROUTE_PREFIXES.some(
-    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+export const isServeRoutePath = (path: string): boolean => {
+  // Match on the pathname only — callers may pass a value that still carries a
+  // query string or hash (e.g. `/dashboard/polls?tab=open`).
+  const pathname = path.split(/[?#]/)[0] ?? path
+  return SERVE_ROUTE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
   )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -29,9 +29,15 @@ export default async function LoginPage({
     : null
 
   if (userId) {
-    // Already signed in: honor an explicit deep link if present, otherwise fall
-    // back to the role-aware post-auth resolver.
-    redirect(redirectUrl ?? (await getPostAuthRedirectPath()))
+    // Already signed in: honor an explicit deep link if present, routing it
+    // through /post-auth-redirect (same as the unauthenticated path) so the
+    // org slug cookie is established before landing on org-scoped pages.
+    // Otherwise fall back to the role-aware post-auth resolver.
+    redirect(
+      redirectUrl
+        ? `/post-auth-redirect?next=${encodeURIComponent(redirectUrl)}`
+        : await getPostAuthRedirectPath(),
+    )
   }
 
   // We can't send the user straight to the deep link after sign-in:

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,15 +11,43 @@ const meta = pageMetaData({
 })
 export const metadata = meta
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: PageProps<any>): Promise<React.JSX.Element> {
   const { userId } = await auth()
   if (userId) {
     redirect(await getPostAuthRedirectPath())
   }
 
+  // When the middleware bounces an unauthenticated deep link (e.g.
+  // /dashboard/briefings from a marketing email) through here, it preserves
+  // the original path in `redirect_url`. We can't send the user straight there
+  // after sign-in: `/post-auth-redirect` is what resolves the user's org and
+  // sets the ORG_SLUG_COOKIE that server requests need, so skipping it leaves
+  // pages like briefings without org context (blank render / server-side
+  // bounce to /dashboard). Instead, always route through `/post-auth-redirect`
+  // and forward the requested path as `next` so it can land the user there
+  // once setup is done. Only same-origin relative paths are honored so the
+  // param can't be abused as an open redirect.
+  const { redirect_url: redirectUrlParam } = await searchParams
+  const redirectUrl =
+    typeof redirectUrlParam === 'string' &&
+    redirectUrlParam.startsWith('/') &&
+    !redirectUrlParam.startsWith('//')
+      ? redirectUrlParam
+      : null
+  const forceRedirectUrl = redirectUrl
+    ? `/post-auth-redirect?next=${encodeURIComponent(redirectUrl)}`
+    : null
+
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-64px)] py-8">
-      <SignIn fallbackRedirectUrl="/post-auth-redirect" routing="hash" />
+      <SignIn
+        {...(forceRedirectUrl
+          ? { forceRedirectUrl }
+          : { fallbackRedirectUrl: '/post-auth-redirect' })}
+        routing="hash"
+      />
     </div>
   )
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server'
 import { redirect } from 'next/navigation'
 import { SignIn } from '@clerk/nextjs'
 import { getPostAuthRedirectPath } from 'app/dashboard/shared/candidateAccess'
+import { isSafeInternalPath } from 'helpers/isSafeInternalPath'
 import pageMetaData from 'helpers/metadataHelper'
 
 const meta = pageMetaData({
@@ -14,28 +15,31 @@ export const metadata = meta
 export default async function LoginPage({
   searchParams,
 }: PageProps<any>): Promise<React.JSX.Element> {
-  const { userId } = await auth()
-  if (userId) {
-    redirect(await getPostAuthRedirectPath())
-  }
+  const [{ userId }, { redirect_url: redirectUrlParam }] = await Promise.all([
+    auth(),
+    searchParams,
+  ])
 
   // When the middleware bounces an unauthenticated deep link (e.g.
   // /dashboard/briefings from a marketing email) through here, it preserves
-  // the original path in `redirect_url`. We can't send the user straight there
-  // after sign-in: `/post-auth-redirect` is what resolves the user's org and
-  // sets the ORG_SLUG_COOKIE that server requests need, so skipping it leaves
-  // pages like briefings without org context (blank render / server-side
-  // bounce to /dashboard). Instead, always route through `/post-auth-redirect`
-  // and forward the requested path as `next` so it can land the user there
-  // once setup is done. Only same-origin relative paths are honored so the
-  // param can't be abused as an open redirect.
-  const { redirect_url: redirectUrlParam } = await searchParams
-  const redirectUrl =
-    typeof redirectUrlParam === 'string' &&
-    redirectUrlParam.startsWith('/') &&
-    !redirectUrlParam.startsWith('//')
-      ? redirectUrlParam
-      : null
+  // the original path in `redirect_url`. Only same-origin relative paths are
+  // honored so the param can't be abused as an open redirect.
+  const redirectUrl = isSafeInternalPath(redirectUrlParam)
+    ? redirectUrlParam
+    : null
+
+  if (userId) {
+    // Already signed in: honor an explicit deep link if present, otherwise fall
+    // back to the role-aware post-auth resolver.
+    redirect(redirectUrl ?? (await getPostAuthRedirectPath()))
+  }
+
+  // We can't send the user straight to the deep link after sign-in:
+  // `/post-auth-redirect` is what resolves the user's org and sets the
+  // ORG_SLUG_COOKIE that server requests need, so skipping it leaves pages like
+  // briefings without org context (blank render / server-side bounce to
+  // /dashboard). Route through `/post-auth-redirect` and forward the requested
+  // path as `next` so it can land the user there once setup is done.
   const forceRedirectUrl = redirectUrl
     ? `/post-auth-redirect?next=${encodeURIComponent(redirectUrl)}`
     : null

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -45,19 +45,23 @@ export default async function LoginPage({
   // ORG_SLUG_COOKIE that server requests need, so skipping it leaves pages like
   // briefings without org context (blank render / server-side bounce to
   // /dashboard). Route through `/post-auth-redirect` and forward the requested
-  // path as `next` so it can land the user there once setup is done.
-  const forceRedirectUrl = redirectUrl
-    ? `/post-auth-redirect?next=${encodeURIComponent(redirectUrl)}`
+  // path as `next` so it can land the user there once setup is done. Set both
+  // sign-in and sign-up redirect props since the embedded "create account" flow
+  // on this page uses the sign-up props; the sign-up variant also carries the
+  // `source=signup` hint so registration tracking still fires.
+  const nextQuery = redirectUrl
+    ? `next=${encodeURIComponent(redirectUrl)}`
     : null
+  const redirectProps = nextQuery
+    ? {
+        forceRedirectUrl: `/post-auth-redirect?${nextQuery}`,
+        signUpForceRedirectUrl: `/post-auth-redirect?${nextQuery}&source=signup`,
+      }
+    : { fallbackRedirectUrl: '/post-auth-redirect' }
 
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-64px)] py-8">
-      <SignIn
-        {...(forceRedirectUrl
-          ? { forceRedirectUrl }
-          : { fallbackRedirectUrl: '/post-auth-redirect' })}
-        routing="hash"
-      />
+      <SignIn {...redirectProps} routing="hash" />
     </div>
   )
 }

--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -254,7 +254,7 @@ describe('PostAuthRedirectPage', () => {
     })
     api.mock('GET /v1/elected-office/current', {
       status: 200,
-      data: { id: 'eo-123' },
+      data: { id: 'eo-123', swornInDate: '2026-01-01' } as any,
     })
 
     render(<PostAuthRedirectPage />)

--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -209,6 +209,86 @@ describe('PostAuthRedirectPage', () => {
     expect(mockTrackRegistration).not.toHaveBeenCalled()
   })
 
+  it('next param: honors a same-origin deep link over the resolved path', async () => {
+    setLocation('?next=%2Fdashboard%2Fbriefings')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() =>
+      expect(replaceSpy).toHaveBeenCalledWith('/dashboard/briefings'),
+    )
+    // Org context is still established before navigating to the deep link.
+    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
+  })
+
+  it('next param: selects the elected-office org for a briefings deep link', async () => {
+    setLocation('?next=%2Fdashboard%2Fbriefings')
+    const electedOfficeOrg = {
+      ...orgFixture,
+      slug: 'serve-org',
+      name: 'Serve Org',
+      electedOfficeId: 'eo-123',
+    }
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      // Campaign org first (resolveSlug would otherwise pick this one).
+      data: { organizations: [orgFixture, electedOfficeOrg] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 200,
+      data: { id: 'eo-123' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() =>
+      expect(mockSetCookie).toHaveBeenCalledWith(
+        'organization-slug',
+        'serve-org',
+      ),
+    )
+    expect(replaceSpy).toHaveBeenCalledWith('/dashboard/briefings')
+  })
+
+  it('next param: ignores protocol-relative/open-redirect values', async () => {
+    setLocation('?next=%2F%2Fevil.com')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+  })
+
   it('login (no source param): does not fire trackRegistrationCompleted', async () => {
     api.mock('GET /v1/organizations', {
       status: 200,

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -138,10 +138,19 @@ const PostAuthRedirectPage = () => {
           hasElectedOffice,
         )
         // Honor the explicit deep-link destination now that the org slug cookie
-        // is set and the session is established.
+        // is set and the session is established. Re-derive a same-origin
+        // relative path before navigating: `safeNext` is already validated, but
+        // rebuilding from `URL().pathname` strips any host an attacker could
+        // smuggle in, keeping the redirect provably same-origin.
+        const destination = new URL(
+          safeNext ?? resolvedPath,
+          window.location.origin,
+        )
         // Hard nav so the destination renders with fresh auth'd server
         // state (PageWrapper re-runs with isAuthed=true and real orgs).
-        window.location.replace(safeNext ?? resolvedPath)
+        window.location.replace(
+          `${destination.pathname}${destination.search}${destination.hash}`,
+        )
       } catch (e) {
         console.error('post-auth-redirect error', e)
         // Don't strand new users on a blank /dashboard if the resolver

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -30,6 +30,18 @@ const PostAuthRedirectPage = () => {
     ranRef.current = true
     ;(async () => {
       try {
+        // An explicit deep-link destination forwarded by the login flow when
+        // the middleware bounced an unauthenticated deep link (e.g.
+        // /dashboard/briefings from a marketing email). Only same-origin
+        // relative paths are honored so this can't be an open redirect.
+        const nextParam = new URLSearchParams(window.location.search).get(
+          'next',
+        )
+        const safeNext =
+          nextParam && nextParam.startsWith('/') && !nextParam.startsWith('//')
+            ? nextParam
+            : null
+
         // First authenticated call after a fresh sign-up may race the gp-api
         // JIT-provisioning of the local user record. Retry once on failure
         // before falling back to an empty list.
@@ -51,7 +63,19 @@ const PostAuthRedirectPage = () => {
           if (retry.ok) organizations = retry.data.organizations
         }
 
-        const slug = resolveSlug(organizations)
+        // The briefings / "serve" experience is scoped to the org that owns the
+        // user's elected office (the gp-api elected-office + meetings endpoints
+        // resolve by the X-Organization-Slug header). When the deep link points
+        // there, select that org explicitly — otherwise `resolveSlug` falls
+        // back to the first org and the briefings page can't find the elected
+        // office, bouncing the user to /dashboard.
+        const electedOrg = organizations.find((o) => o.electedOfficeId)
+        const wantsServe =
+          !!safeNext && safeNext.startsWith('/dashboard/briefings')
+        const slug =
+          wantsServe && electedOrg
+            ? electedOrg.slug
+            : resolveSlug(organizations)
         if (slug) {
           setCookie(ORG_SLUG_COOKIE, slug)
         }
@@ -110,14 +134,16 @@ const PostAuthRedirectPage = () => {
           }
         }
 
-        const path = resolvePostAuthRedirectPath(
+        const resolvedPath = resolvePostAuthRedirectPath(
           user,
           campaignStatus,
           hasElectedOffice,
         )
+        // Honor the explicit deep-link destination now that the org slug cookie
+        // is set and the session is established.
         // Hard nav so the destination renders with fresh auth'd server
         // state (PageWrapper re-runs with isAuthed=true and real orgs).
-        window.location.replace(path)
+        window.location.replace(safeNext ?? resolvedPath)
       } catch (e) {
         console.error('post-auth-redirect error', e)
         // Don't strand new users on a blank /dashboard if the resolver

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -13,6 +13,8 @@ import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { resolveSlug } from '@shared/hooks/useSelectedOrgSlug'
 import { trackRegistrationCompleted } from 'helpers/analyticsHelper'
 import { getReadyAnalytics } from '@shared/utils/analytics'
+import { isSafeInternalPath } from 'helpers/isSafeInternalPath'
+import { isServeRoutePath } from 'app/dashboard/shared/serveRoutes'
 import { LoaderCircle } from 'lucide-react'
 
 const PostAuthRedirectPage = () => {
@@ -37,10 +39,7 @@ const PostAuthRedirectPage = () => {
         const nextParam = new URLSearchParams(window.location.search).get(
           'next',
         )
-        const safeNext =
-          nextParam && nextParam.startsWith('/') && !nextParam.startsWith('//')
-            ? nextParam
-            : null
+        const safeNext = isSafeInternalPath(nextParam) ? nextParam : null
 
         // First authenticated call after a fresh sign-up may race the gp-api
         // JIT-provisioning of the local user record. Retry once on failure
@@ -63,15 +62,14 @@ const PostAuthRedirectPage = () => {
           if (retry.ok) organizations = retry.data.organizations
         }
 
-        // The briefings / "serve" experience is scoped to the org that owns the
-        // user's elected office (the gp-api elected-office + meetings endpoints
-        // resolve by the X-Organization-Slug header). When the deep link points
-        // there, select that org explicitly — otherwise `resolveSlug` falls
-        // back to the first org and the briefings page can't find the elected
-        // office, bouncing the user to /dashboard.
+        // The "serve" experience (briefings, polls) is scoped to the org that
+        // owns the user's elected office (the gp-api elected-office + meetings
+        // endpoints resolve by the X-Organization-Slug header). When the deep
+        // link points there, select that org explicitly — otherwise
+        // `resolveSlug` falls back to the first org and those pages can't find
+        // the elected office, bouncing the user to /dashboard.
         const electedOrg = organizations.find((o) => o.electedOfficeId)
-        const wantsServe =
-          !!safeNext && safeNext.startsWith('/dashboard/briefings')
+        const wantsServe = !!safeNext && isServeRoutePath(safeNext)
         const slug =
           wantsServe && electedOrg
             ? electedOrg.slug

--- a/helpers/isSafeInternalPath.test.ts
+++ b/helpers/isSafeInternalPath.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeInternalPath } from './isSafeInternalPath'
+
+describe('isSafeInternalPath', () => {
+  it('accepts root-relative paths', () => {
+    expect(isSafeInternalPath('/dashboard/briefings')).toBe(true)
+    expect(isSafeInternalPath('/dashboard/briefings/2026-01-15')).toBe(true)
+    expect(isSafeInternalPath('/dashboard/polls?tab=open')).toBe(true)
+    expect(isSafeInternalPath('/')).toBe(true)
+  })
+
+  it('rejects non-string values', () => {
+    expect(isSafeInternalPath(null)).toBe(false)
+    expect(isSafeInternalPath(undefined)).toBe(false)
+    expect(isSafeInternalPath(42)).toBe(false)
+  })
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(isSafeInternalPath('//evil.com')).toBe(false)
+    expect(isSafeInternalPath('https://evil.com')).toBe(false)
+    expect(isSafeInternalPath('http://evil.com/path')).toBe(false)
+    expect(isSafeInternalPath('evil.com')).toBe(false)
+  })
+
+  it('rejects backslash open-redirect bypasses', () => {
+    expect(isSafeInternalPath('/\\evil.com')).toBe(false)
+    expect(isSafeInternalPath('/\\/evil.com')).toBe(false)
+    expect(isSafeInternalPath('\\\\evil.com')).toBe(false)
+  })
+
+  it('rejects embedded whitespace/control characters', () => {
+    expect(isSafeInternalPath('/\tdashboard')).toBe(false)
+    expect(isSafeInternalPath('/dash board')).toBe(false)
+    expect(isSafeInternalPath('/foo\n//evil.com')).toBe(false)
+  })
+})

--- a/helpers/isSafeInternalPath.ts
+++ b/helpers/isSafeInternalPath.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns true only for a root-relative, same-origin path that is safe to use
+ * as a post-auth redirect target.
+ *
+ * Guards against open-redirect payloads that browsers normalize into an
+ * authority/host: protocol-relative URLs (`//evil.com`), their backslash
+ * variants (`/\evil.com`, which WHATWG/browsers fold into `//evil.com`),
+ * absolute URLs (`https://evil.com`), and any embedded whitespace/control
+ * characters. The `new URL()` origin check is a belt-and-suspenders backstop
+ * in case a novel normalization slips past the explicit string checks.
+ */
+export const isSafeInternalPath = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false
+  if (!value.startsWith('/')) return false
+  if (value.startsWith('//')) return false
+  // Reject backslashes and whitespace anywhere — browsers treat `\` like `/`
+  // and strip tabs/newlines, both of which can smuggle in a host segment.
+  if (/[\\\s]/.test(value)) return false
+  try {
+    const base = 'https://internal.invalid'
+    return new URL(value, base).origin === base
+  } catch {
+    return false
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,10 +12,14 @@ const isPublicRoute = createRouteMatcher([
 ])
 
 export default clerkMiddleware(async (auth, req: NextRequest) => {
-  const { pathname } = req.nextUrl
-  // This is a workaround to pass the pathname to SSR pages
+  const { pathname, search } = req.nextUrl
+  // This is a workaround to pass the pathname to SSR pages. `x-search` carries
+  // the query string separately so server components (e.g. serveAccess) can
+  // reconstruct the full requested URL without changing the `x-pathname`
+  // semantics other consumers rely on.
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set('x-pathname', pathname)
+  requestHeaders.set('x-search', search)
 
   // Handle API request rewrites
   const apiRewriteRequest = pathname.startsWith(`/api${API_VERSION_PREFIX}`)

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,7 +31,22 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   }
 
   if (!isPublicRoute(req)) {
-    await auth.protect()
+    const { userId } = await auth()
+    if (!userId) {
+      // Redirect unauthenticated users to the sign-in page explicitly instead
+      // of relying on `auth.protect()`. When Clerk can't resolve the sign-in
+      // URL on the server it responds with a 404 rather than redirecting (see
+      // clerk/javascript#8302), which breaks deep links like
+      // `/dashboard/briefings` shared in marketing emails. Preserving the
+      // original path in `redirect_url` lets `<SignIn>` route the user back to
+      // the requested page after they log in.
+      const signInUrl = new URL('/login', req.url)
+      signInUrl.searchParams.set(
+        'redirect_url',
+        `${req.nextUrl.pathname}${req.nextUrl.search}`,
+      )
+      return NextResponse.redirect(signInUrl)
+    }
   }
 
   return NextResponse.next({


### PR DESCRIPTION
## Summary

Marketing-email links to `http://goodparty.org/dashboard/briefings` were 404'ing for logged-out recipients and bouncing logged-in recipients to `/dashboard` (with a "get pro" popup). This fixes the full deep-link flow so recipients land on briefings after signing in.

Two root causes:

1. **404 when logged out** — Clerk's `auth.protect()` returns a 404 instead of redirecting to sign-in when it can't resolve the sign-in URL server-side ([clerk/javascript#8302](https://github.com/clerk/javascript/issues/8302)). The middleware now redirects unauthenticated users to `/login` explicitly, preserving the original path in `redirect_url`.

2. **Bounced to `/dashboard` after sign-in** — the briefings/"serve" experience is **org-scoped**: gp-api resolves the elected office and meetings by the `X-Organization-Slug` header (see `UseElectedOffice.guard.ts`). The post-auth flow was selecting the user's first org (usually their campaign org), so the elected-office lookup 404'd. Now:
   - The login page forwards deep links through `/post-auth-redirect?next=…` so org context is always established (this page sets `ORG_SLUG_COOKIE`).
   - `/post-auth-redirect` selects the org that actually owns the user's elected office when the destination is briefings.
   - `serveAccess()` self-heals already-logged-in users on the wrong org by switching to their elected-office org (guarded against redirect loops) instead of bouncing to `/dashboard`.

## Changes
- `middleware.ts` — explicit unauthenticated redirect to `/login?redirect_url=…`.
- `app/login/page.tsx` — forward `redirect_url` through `/post-auth-redirect?next=…` (same-origin guarded).
- `app/post-auth-redirect/page.tsx` — honor the `next` deep link and select the elected-office org for briefings destinations.
- `app/dashboard/shared/serveAccess.ts` — switch to the elected-office org when it exists but isn't selected; otherwise keep the `/dashboard` bounce.

## Flows handled
- Logged out → login → elected-office org selected → `/dashboard/briefings` renders.
- Logged in on the wrong org → org switched → briefings renders.
- No elected office → `/dashboard` (unchanged/expected).

## Test plan
- [x] `tsc --noEmit` clean, prettier clean
- [x] `app/post-auth-redirect/page.test.tsx` — added cases: honors same-origin deep link, selects elected-office org for briefings, blocks protocol-relative open redirects (10/10 pass)
- [x] Manual: logged-out click of `/dashboard/briefings` from email → login → lands on briefings (requires an account with an elected office, e.g. Joe's, or impersonation)
- [x] Manual: logged-in (campaign org active) click → lands on briefings
- [ ] Manual: account without elected office → lands on `/dashboard`

> Note: an account without an elected office will still correctly land on `/dashboard` — validate the success path with an account that has briefings access.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication middleware, login/post-auth redirects, and org cookie selection; mitigated by `isSafeInternalPath` and same-origin URL rebuilding, but redirect logic is still security-sensitive.
> 
> **Overview**
> Fixes **marketing deep links** to elected-official **serve** pages (`/dashboard/briefings`, polls) for logged-out users and for logged-in users on the **wrong org**.
> 
> **Middleware** now sends unauthenticated users to `/login` with `redirect_url` (instead of Clerk `auth.protect()` 404s) and forwards **`x-search`** with **`x-pathname`** so server code can rebuild the full URL.
> 
> **Login** and **`/post-auth-redirect`** honor safe internal `next` / `redirect_url` paths via new **`isSafeInternalPath`**, always routing through post-auth so **`ORG_SLUG_COOKIE`** is set. Post-auth picks the **elected-office org** when the destination is a serve route.
> 
> **`serveAccess`** no longer always bounces to `/dashboard` on failed elected-office lookup: if the user has an elected-office org that isn’t selected, it redirects through **`/post-auth-redirect?next=…`** (preserving path/query from headers) with loop guards; otherwise behavior is unchanged.
> 
> New **`isServeRoutePath`** helper and unit tests cover redirects and serve-route matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6f0c690924859478ad54137abfb8cd8f9dc6c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->