### PR TITLE
QA <- Dev

### DIFF
--- a/app/dashboard/campaign-details/components/CampaignSection.tsx
+++ b/app/dashboard/campaign-details/components/CampaignSection.tsx
@@ -30,6 +30,9 @@ interface FieldConfig {
 
 interface CampaignSectionProps {
   campaign?: Campaign
+  // When rendered inside a Card (pro path), the card supplies the surrounding
+  // spacing, so the section drops its own bottom margin.
+  carded?: boolean
 }
 
 interface FieldState {
@@ -88,7 +91,7 @@ export default function CampaignSection(
   }
   const [state, setState] = useState<FieldState>(initialState)
   const [saving, setSaving] = useState(false)
-  const { campaign } = props
+  const { campaign, carded = false } = props
 
   useEffect(() => {
     if (campaign?.details) {
@@ -178,7 +181,7 @@ export default function CampaignSection(
           )
         })}
       </div>
-      <div className="flex justify-end mb-6">
+      <div className={`flex justify-end ${carded ? '' : 'mb-6'}`}>
         {saving ? (
           <PrimaryButton disabled>
             <div className="px-3">

--- a/app/dashboard/campaign-details/components/DetailsPage.tsx
+++ b/app/dashboard/campaign-details/components/DetailsPage.tsx
@@ -13,6 +13,7 @@ import PolicyPrioritiesSection from './PolicyPrioritiesSection'
 import { CandidatePositionsProvider } from 'app/dashboard/campaign-details/components/issues/CandidatePositionsProvider'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { Campaign, User, CandidatePosition } from 'helpers/types'
+import { Card } from '@styleguide'
 
 interface TopIssue {
   id: number
@@ -39,23 +40,33 @@ export default function DetailsPage(
   return (
     <DashboardLayout {...props}>
       <CandidatePositionsProvider candidatePositions={props.candidatePositions}>
-        <div className="max-w-[940px] mx-auto bg-gray-50 rounded-xl px-6 py-5">
-          {campaign && <CampaignSection {...campaignProps} />}
-          <OfficeSection campaign={campaign ?? undefined} />
-          {useNewSections ? (
-            <>
+        {useNewSections ? (
+          <div className="max-w-[940px] mx-auto flex flex-col gap-4 py-5">
+            {campaign && (
+              <Card className="p-6">
+                <CampaignSection {...campaignProps} carded />
+              </Card>
+            )}
+            <Card className="p-6">
+              <OfficeSection campaign={campaign ?? undefined} carded />
+            </Card>
+            <Card className="p-6">
               <WhyRunningSection />
+            </Card>
+            <Card className="p-6">
               <PolicyPrioritiesSection />
-            </>
-          ) : (
-            <>
-              {campaign && <RunningAgainstSection {...campaignProps} />}
-              {campaign && <WhySection {...campaignProps} />}
-              {campaign && <FunFactSection {...campaignProps} />}
-              {campaign && <IssuesSection {...campaignProps} />}
-            </>
-          )}
-        </div>
+            </Card>
+          </div>
+        ) : (
+          <div className="max-w-[940px] mx-auto bg-gray-50 rounded-xl px-6 py-5">
+            {campaign && <CampaignSection {...campaignProps} />}
+            <OfficeSection campaign={campaign ?? undefined} />
+            {campaign && <RunningAgainstSection {...campaignProps} />}
+            {campaign && <WhySection {...campaignProps} />}
+            {campaign && <FunFactSection {...campaignProps} />}
+            {campaign && <IssuesSection {...campaignProps} />}
+          </div>
+        )}
       </CandidatePositionsProvider>
     </DashboardLayout>
   )

--- a/app/dashboard/campaign-details/components/OfficeSection.tsx
+++ b/app/dashboard/campaign-details/components/OfficeSection.tsx
@@ -18,9 +18,13 @@ import { useQueryClient } from '@tanstack/react-query'
 
 interface OfficeSectionProps {
   campaign?: Campaign
+  // When rendered inside a Card (pro path), the card supplies the section
+  // separation, so the top divider and bottom margin are dropped.
+  carded?: boolean
 }
 
 const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
+  const { carded = false } = props
   const organization = useOrganization()
   const positionName = usePositionName()
   const queryClient = useQueryClient()
@@ -81,7 +85,11 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
   return (
     <section
       className={
-        organization?.electedOfficeId ? 'pt-6' : 'border-t pt-6 border-gray-600'
+        carded
+          ? ''
+          : organization?.electedOfficeId
+          ? 'pt-6'
+          : 'border-t pt-6 border-gray-600'
       }
     >
       <H3 className="pb-6">Office Details</H3>
@@ -96,7 +104,7 @@ const OfficeSection = (props: OfficeSectionProps): React.JSX.Element => {
           }
         />
       </div>
-      <div className="flex justify-end mb-6 mt-2">
+      <div className={`flex justify-end mt-2 ${carded ? '' : 'mb-6'}`}>
         <PrimaryButton onClick={handleEdit}>Edit Office Details</PrimaryButton>
       </div>
       <CampaignOfficeSelectionModal

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type { Website } from 'helpers/types'
+import PolicyPrioritiesSection from './PolicyPrioritiesSection'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWithIssues = (count: number): Website =>
+  ({
+    content: {
+      about: {
+        bio: '',
+        issues: Array.from({ length: count }, (_, i) => ({
+          title: `Priority ${i + 1}`,
+          description: `Description ${i + 1}`,
+        })),
+      },
+    },
+  } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('PolicyPrioritiesSection — save validation messaging', () => {
+  it('keeps the Save button enabled when there are no priorities', async () => {
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    render(<PolicyPrioritiesSection />)
+    expect(await screen.findByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('surfaces the missing-priority error and does not save when there are none', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    render(<PolicyPrioritiesSection />)
+
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+  })
+
+  it('saves when at least one policy priority exists', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(1))
+    saveAboutFields.mockResolvedValue(true)
+    render(<PolicyPrioritiesSection />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith({
+      issues: [{ title: 'Priority 1', description: 'Description 1' }],
+    })
+    expect(
+      screen.queryByText('Please add at least one policy priority'),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import type { Website } from 'helpers/types'
+import { MIN_POLICY_FOCUS_LENGTH } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import PolicyPrioritiesSection from './PolicyPrioritiesSection'
 
 vi.mock('app/shared/utils/RichEditor', async () => ({
@@ -74,6 +75,60 @@ describe('PolicyPrioritiesSection — save validation messaging', () => {
     expect(saveAboutFields).toHaveBeenCalledWith({
       issues: [{ title: 'Priority 1', description: 'Description 1' }],
     })
+    expect(
+      screen.queryByText('Please add at least one policy priority'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not re-show the error on a later invalid edit after a successful save', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithIssues(0))
+    saveAboutFields.mockResolvedValue(true)
+    render(<PolicyPrioritiesSection />)
+
+    await screen.findByRole('button', { name: 'Add a policy priority' })
+
+    // Trigger the error state.
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+
+    // Add a valid priority through the modal.
+    await user.click(
+      screen.getByRole('button', { name: 'Add a policy priority' }),
+    )
+    const addDialog = await screen.findByRole('dialog')
+    await user.type(
+      within(addDialog).getByLabelText('Policy title'),
+      'Education',
+    )
+    fireEvent.change(within(addDialog).getByTestId('rich-editor'), {
+      target: { value: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH) },
+    })
+    await user.click(within(addDialog).getByRole('button', { name: 'Save' }))
+
+    // Save the section successfully (resets the attempted-save flag).
+    await screen.findByRole('button', { name: 'Edit Education' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled(),
+    )
+
+    // Remove the only priority to return to an invalid state.
+    await user.click(screen.getByRole('button', { name: 'Edit Education' }))
+    const editDialog = await screen.findByRole('dialog')
+    await user.click(within(editDialog).getByRole('button', { name: 'Delete' }))
+    await screen.findByText('Delete policy priority')
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    // The error must NOT reappear until the user attempts to save again.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Edit Education' }),
+      ).toBeNull(),
+    )
     expect(
       screen.queryByText('Please add at least one policy priority'),
     ).not.toBeInTheDocument()

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -61,6 +61,9 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
     }
     await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
     successSnackbar('Policy priorities saved')
+    // Clear the attempted-save flag so a later edit back to an invalid state
+    // doesn't re-show the error before the user tries to save again.
+    setAttemptedSave(false)
     setSaving(false)
   }
 

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -3,6 +3,7 @@
 import H3 from '@shared/typography/H3'
 import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
+import { Alert, AlertDescription, CircleAlertIcon } from '@styleguide'
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -14,7 +15,7 @@ import { useSnackbar } from 'helpers/useSnackbar'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { Website, WebsiteIssue } from 'helpers/types'
 import {
-  MIN_POLICY_PRIORITIES,
+  getPolicyPrioritiesError,
   normalizeIssues,
 } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import PolicyPriorities from 'app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyPriorities'
@@ -29,6 +30,10 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
 
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [saving, setSaving] = useState(false)
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error rather than a silently-disabled button. The error only
+  // surfaces once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
   const seededRef = useRef(false)
 
   const websiteIssues = website?.content?.about?.issues
@@ -38,10 +43,14 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
     seededRef.current = true
   }, [website, websiteIssues])
 
-  const canSave = issues.length >= MIN_POLICY_PRIORITIES && !saving
+  const prioritiesError = getPolicyPrioritiesError(issues.length)
 
   const handleSave = async () => {
-    if (!canSave) return
+    if (saving) return
+    if (prioritiesError) {
+      setAttemptedSave(true)
+      return
+    }
     trackEvent(EVENTS.Profile.PolicyPriorities.ClickSave)
     setSaving(true)
     const ok = await saveAboutFields({ issues })
@@ -61,17 +70,22 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters about the policy priorities you&apos;ll focus on.
       </Body1>
+      {attemptedSave && prioritiesError && (
+        <Alert
+          variant="destructive"
+          icon={<CircleAlertIcon />}
+          className="mb-4"
+        >
+          <AlertDescription>{prioritiesError}</AlertDescription>
+        </Alert>
+      )}
       <PolicyPriorities
         issues={issues}
         onChange={setIssues}
         disabled={saving}
       />
       <div className="flex justify-end mt-6">
-        <PrimaryButton
-          loading={saving}
-          disabled={!canSave}
-          onClick={handleSave}
-        >
+        <PrimaryButton loading={saving} disabled={saving} onClick={handleSave}>
           {saving ? 'Saving...' : 'Save'}
         </PrimaryButton>
       </div>

--- a/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
+++ b/app/dashboard/campaign-details/components/PolicyPrioritiesSection.tsx
@@ -56,7 +56,7 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
   }
 
   return (
-    <section className="border-t pt-6 border-gray-600">
+    <section>
       <H3>Your policy priorities</H3>
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters about the policy priorities you&apos;ll focus on.
@@ -66,7 +66,7 @@ export default function PolicyPrioritiesSection(): React.JSX.Element {
         onChange={setIssues}
         disabled={saving}
       />
-      <div className="flex justify-end mt-6 mb-6">
+      <div className="flex justify-end mt-6">
         <PrimaryButton
           loading={saving}
           disabled={!canSave}

--- a/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import type { Website } from 'helpers/types'
@@ -66,6 +66,33 @@ describe('WhyRunningSection — save validation messaging', () => {
 
     await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
     expect(saveAboutFields).toHaveBeenCalledWith({ bio: validBio })
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+
+  it('does not re-show the error on a later invalid edit after a successful save', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    saveAboutFields.mockResolvedValue(true)
+    render(<WhyRunningSection />)
+
+    const editor = await screen.findByTestId('rich-editor')
+
+    // Trigger the error state.
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+
+    // Fix the content and save successfully.
+    fireEvent.change(editor, { target: { value: 'a'.repeat(MIN_BIO_LENGTH) } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    // Save settled (button re-enabled), so attemptedSave has been reset.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled(),
+    )
+
+    // Editing back to an invalid state must NOT re-show the error until the
+    // user attempts to save again.
+    fireEvent.change(editor, { target: { value: '' } })
     expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
   })
 })

--- a/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type { Website } from 'helpers/types'
+import { MIN_BIO_LENGTH } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+import WhyRunningSection from './WhyRunningSection'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWithBio = (bio: string): Website =>
+  ({ content: { about: { bio, issues: [] } } } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('WhyRunningSection — save validation messaging', () => {
+  it('keeps the Save button enabled when the bio is incomplete', async () => {
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    render(<WhyRunningSection />)
+    expect(await screen.findByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('surfaces the bio error and does not save when the bio is empty', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(websiteWithBio(''))
+    render(<WhyRunningSection />)
+
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves the bio when it meets the minimum length', async () => {
+    const user = userEvent.setup()
+    const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+    getUserWebsite.mockResolvedValue(websiteWithBio(validBio))
+    saveAboutFields.mockResolvedValue(true)
+    render(<WhyRunningSection />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await user.click(await screen.findByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith({ bio: validBio })
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -83,6 +83,9 @@ export default function WhyRunningSection(): React.JSX.Element {
     }
     await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
     successSnackbar('Bio saved')
+    // Clear the attempted-save flag so a later edit back to an invalid state
+    // doesn't re-show the error before the user tries to save again.
+    setAttemptedSave(false)
     setSaving(false)
   }
 

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -3,6 +3,7 @@
 import H3 from '@shared/typography/H3'
 import Body1 from '@shared/typography/Body1'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
+import { Alert, AlertDescription, CircleAlertIcon } from '@styleguide'
 import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -16,6 +17,7 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { Website } from 'helpers/types'
 import {
   MIN_BIO_LENGTH,
+  getBioError,
   getBioPlainLength,
 } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 
@@ -46,6 +48,10 @@ export default function WhyRunningSection(): React.JSX.Element {
   // refetch. `null` means "not seeded yet" so we can defer mounting the
   // editor until we have the real value.
   const [initialBio, setInitialBio] = useState<string | null>(null)
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error rather than a silently-disabled button. The error (alert +
+  // red bio border) only surfaces once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -59,10 +65,14 @@ export default function WhyRunningSection(): React.JSX.Element {
     seededRef.current = true
   }, [website])
 
-  const canSave = bioPlainLength >= MIN_BIO_LENGTH && !saving
+  const bioError = getBioError(bioPlainLength)
 
   const handleSave = async () => {
-    if (!canSave) return
+    if (saving) return
+    if (bioError) {
+      setAttemptedSave(true)
+      return
+    }
     trackEvent(EVENTS.Profile.WhyRunning.ClickSave)
     setSaving(true)
     const ok = await saveAboutFields({ bio })
@@ -82,11 +92,21 @@ export default function WhyRunningSection(): React.JSX.Element {
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters why you&apos;re running for office.
       </Body1>
+      {attemptedSave && bioError && (
+        <Alert
+          variant="destructive"
+          icon={<CircleAlertIcon />}
+          className="mb-4"
+        >
+          <AlertDescription>{bioError}</AlertDescription>
+        </Alert>
+      )}
       {initialBio !== null && (
         <RichEditor
           initialText={initialBio}
           onChangeCallback={setBio}
           onTextLengthChange={setBioPlainLength}
+          error={attemptedSave && !!bioError}
         />
       )}
       <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
@@ -94,11 +114,7 @@ export default function WhyRunningSection(): React.JSX.Element {
         <span>{bioPlainLength}</span>
       </div>
       <div className="flex justify-end mt-6">
-        <PrimaryButton
-          loading={saving}
-          disabled={!canSave}
-          onClick={handleSave}
-        >
+        <PrimaryButton loading={saving} disabled={saving} onClick={handleSave}>
           {saving ? 'Saving...' : 'Save'}
         </PrimaryButton>
       </div>

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -77,7 +77,7 @@ export default function WhyRunningSection(): React.JSX.Element {
   }
 
   return (
-    <section className="border-t pt-6 border-gray-600">
+    <section>
       <H3>Why are you running?</H3>
       <Body1 className="text-gray-600 mt-2 pb-6 mb-6">
         Tell potential voters why you&apos;re running for office.
@@ -93,7 +93,7 @@ export default function WhyRunningSection(): React.JSX.Element {
         <span>{MIN_BIO_LENGTH} character minimum</span>
         <span>{bioPlainLength}</span>
       </div>
-      <div className="flex justify-end mt-6 mb-6">
+      <div className="flex justify-end mt-6">
         <PrimaryButton
           loading={saving}
           disabled={!canSave}

--- a/app/dashboard/components/PrimaryResultModal.test.tsx
+++ b/app/dashboard/components/PrimaryResultModal.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import PrimaryResultModal from './PrimaryResultModal'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn().mockResolvedValue({ id: 1 }),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  EVENTS: { Candidacy: { CampaignCompleted: 'campaign_completed' } },
+  trackEvent: vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn() }),
+}))
+
+vi.mock('@shared/animations/PartyAnimation', () => ({
+  default: () => null,
+}))
+
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+
+const optionLabel = { won: 'I won my race', lost: 'I did not win my race' }
+
+describe('PrimaryResultModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(['won', 'lost'] as const)(
+    'submits the selection with the top-level primaryResult key (%s)',
+    async (result) => {
+      render(
+        <PrimaryResultModal
+          open
+          officeName="Mayor"
+          electionDate="2026-11-03"
+          onClose={vi.fn()}
+        />,
+      )
+
+      fireEvent.click(screen.getByText(optionLabel[result]))
+      fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateCampaign).toHaveBeenCalledWith([
+          { key: 'primaryResult', value: result },
+        ])
+      })
+    },
+  )
+})

--- a/app/dashboard/components/PrimaryResultModal.tsx
+++ b/app/dashboard/components/PrimaryResultModal.tsx
@@ -91,7 +91,7 @@ export default function PrimaryResultModal({
 
     try {
       const updatedCampaign = await updateCampaign([
-        { key: 'details.primaryResult', value: primaryResult },
+        { key: 'primaryResult', value: primaryResult },
       ])
       if (updatedCampaign) {
         queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updatedCampaign)

--- a/app/dashboard/components/usePostElectionState.test.ts
+++ b/app/dashboard/components/usePostElectionState.test.ts
@@ -26,10 +26,10 @@ const setCampaign = (overrides: {
   mockUseCampaign.mockReturnValue([
     {
       id: 'campaign-1',
+      primaryResult: overrides.primaryResult ?? null,
       details: {
         electionDate: overrides.electionDate,
         primaryElectionDate: overrides.primaryElectionDate,
-        primaryResult: overrides.primaryResult ?? null,
       },
       goals: overrides.goalsElectionDate
         ? { electionDate: overrides.goalsElectionDate }

--- a/app/dashboard/components/usePostElectionState.ts
+++ b/app/dashboard/components/usePostElectionState.ts
@@ -40,9 +40,7 @@ export function usePostElectionState(): PostElectionState {
   // are always respected after they load — local state only tracks the
   // current session's modal interaction.
   const primaryResult =
-    primaryResultState.overrideResult ??
-    campaign?.details?.primaryResult ??
-    null
+    primaryResultState.overrideResult ?? campaign?.primaryResult ?? null
   const { modalDismissed } = primaryResultState
 
   const weeksUntil = weeksTill(resolvedDate)

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
@@ -69,6 +69,15 @@ describe('getPolicyFormValidation', () => {
     expect(result.focusInvalid).toBe(true)
   })
 
+  it('surfaces both problems when the title is missing and the focus is present but too short', () => {
+    const result = getPolicyFormValidation(0, MIN_POLICY_FOCUS_LENGTH - 1)
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(true)
+    // Both fields render red, so the message must explain both.
+    expect(result.message).toContain('Policy title')
+    expect(result.message).toContain('Policy focus')
+  })
+
   it('returns no message when both fields satisfy their requirements', () => {
     const result = getPolicyFormValidation(5, MIN_POLICY_FOCUS_LENGTH)
     expect(result.message).toBeNull()

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MIN_BIO_LENGTH,
+  MIN_POLICY_FOCUS_LENGTH,
+  getBioError,
+  getPolicyPrioritiesError,
+  getPolicyFormValidation,
+} from './candidateProfile.utils'
+
+describe('getBioError', () => {
+  it('asks the user to add a bio when it is empty', () => {
+    expect(getBioError(0)).toBe('Please add your bio')
+  })
+
+  it('reports the character requirement when the bio is too short', () => {
+    expect(getBioError(MIN_BIO_LENGTH - 1)).toBe(
+      `Your bio requires ${MIN_BIO_LENGTH} characters`,
+    )
+  })
+
+  it('returns null once the bio meets the minimum length', () => {
+    expect(getBioError(MIN_BIO_LENGTH)).toBeNull()
+  })
+})
+
+describe('getPolicyPrioritiesError', () => {
+  it('asks for at least one priority when there are none', () => {
+    expect(getPolicyPrioritiesError(0)).toBe(
+      'Please add at least one policy priority',
+    )
+  })
+
+  it('returns null once at least one priority exists', () => {
+    expect(getPolicyPrioritiesError(1)).toBeNull()
+  })
+})
+
+describe('getPolicyFormValidation', () => {
+  it('asks to add both fields when both are empty (matches Figma)', () => {
+    const result = getPolicyFormValidation(0, 0)
+    expect(result.message).toBe('Please add a Policy title and Policy focus')
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('reports the focus length requirement when the title is set but focus is too short (matches Figma)', () => {
+    const result = getPolicyFormValidation(
+      'Education'.length,
+      MIN_POLICY_FOCUS_LENGTH - 1,
+    )
+    expect(result.message).toBe(
+      `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`,
+    )
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('asks to add the title alone when only the title is missing', () => {
+    const result = getPolicyFormValidation(0, MIN_POLICY_FOCUS_LENGTH)
+    expect(result.message).toBe('Please add a Policy title')
+    expect(result.titleInvalid).toBe(true)
+    expect(result.focusInvalid).toBe(false)
+  })
+
+  it('asks to add the focus alone when only the focus is empty', () => {
+    const result = getPolicyFormValidation(5, 0)
+    expect(result.message).toBe('Please add a Policy focus')
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(true)
+  })
+
+  it('returns no message when both fields satisfy their requirements', () => {
+    const result = getPolicyFormValidation(5, MIN_POLICY_FOCUS_LENGTH)
+    expect(result.message).toBeNull()
+    expect(result.titleInvalid).toBe(false)
+    expect(result.focusInvalid).toBe(false)
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -56,6 +56,10 @@ export const getPolicyFormValidation = (
   let message: string | null = null
   if (missing.length === 2) {
     message = 'Please add a Policy title and Policy focus'
+  } else if (titleInvalid && focusInvalid && focusPlainLength > 0) {
+    // Title is empty AND the focus has content but is too short: both fields
+    // render red, so the message must explain both, not just the empty title.
+    message = `Please add a Policy title. Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`
   } else if (missing.length === 1) {
     message = `Please add a ${missing[0]}`
   } else if (focusInvalid) {

--- a/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils.ts
@@ -8,6 +8,63 @@ export const MIN_POLICY_PRIORITIES = 1
 export const getBioPlainLength = (rawBio: string | undefined | null): number =>
   rawBio ? stripHtml(rawBio).result.trim().length : 0
 
+/**
+ * Error message for the bio ("Why are you running?") field, or null when the
+ * bio meets the minimum length. Consumed by every surface that gates a
+ * Submit/Save on the bio so the copy stays consistent.
+ */
+export const getBioError = (bioPlainLength: number): string | null => {
+  if (bioPlainLength === 0) return 'Please add your bio'
+  if (bioPlainLength < MIN_BIO_LENGTH) {
+    return `Your bio requires ${MIN_BIO_LENGTH} characters`
+  }
+  return null
+}
+
+/**
+ * Error message for the policy-priorities requirement, or null when at least
+ * the minimum number of priorities exist.
+ */
+export const getPolicyPrioritiesError = (count: number): string | null =>
+  count < MIN_POLICY_PRIORITIES
+    ? 'Please add at least one policy priority'
+    : null
+
+export interface PolicyFormValidation {
+  titleInvalid: boolean
+  focusInvalid: boolean
+  message: string | null
+}
+
+/**
+ * Validation state for the policy-priority form (title + focus). `message`
+ * mirrors the Figma error states: missing fields are surfaced as "Please add
+ * a ..." and a present-but-too-short focus as "Policy focus requires N
+ * characters". `titleInvalid` / `focusInvalid` drive the red field borders.
+ */
+export const getPolicyFormValidation = (
+  trimmedTitleLength: number,
+  focusPlainLength: number,
+): PolicyFormValidation => {
+  const titleInvalid = trimmedTitleLength === 0
+  const focusInvalid = focusPlainLength < MIN_POLICY_FOCUS_LENGTH
+
+  const missing: string[] = []
+  if (titleInvalid) missing.push('Policy title')
+  if (focusPlainLength === 0) missing.push('Policy focus')
+
+  let message: string | null = null
+  if (missing.length === 2) {
+    message = 'Please add a Policy title and Policy focus'
+  } else if (missing.length === 1) {
+    message = `Please add a ${missing[0]}`
+  } else if (focusInvalid) {
+    message = `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`
+  }
+
+  return { titleInvalid, focusInvalid, message }
+}
+
 export const normalizeIssues = (
   raw: { title?: string; description?: string }[] | undefined,
 ): WebsiteIssue[] =>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import type { Website } from 'helpers/types'
+import { MIN_BIO_LENGTH } from '../candidateProfile.utils'
+import CandidateProfile from './CandidateProfile'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+const websiteWith = (bio: string, issueCount: number): Website =>
+  ({
+    content: {
+      about: {
+        bio,
+        issues: Array.from({ length: issueCount }, (_, i) => ({
+          title: `Priority ${i + 1}`,
+          description: 'y'.repeat(MIN_BIO_LENGTH),
+        })),
+      },
+    },
+  } as unknown as Website)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CandidateProfile — submit validation messaging', () => {
+  it('keeps the Submit button enabled when the profile is incomplete', async () => {
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+    expect(await screen.findByRole('button', { name: /submit/i })).toBeEnabled()
+  })
+
+  it('surfaces bio and policy-priority errors and does not save an incomplete profile', async () => {
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+
+    await user.click(await screen.findByRole('button', { name: /submit/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves and navigates when the bio and a policy priority are present', async () => {
+    const user = userEvent.setup()
+    const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+    getUserWebsite.mockResolvedValue(websiteWith(validBio, 1))
+    saveAboutFields.mockResolvedValue(true)
+    render(<CandidateProfile />)
+
+    // Wait for the seeded bio to reach the minimum length (editor mounted).
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+
+    await user.click(await screen.findByRole('button', { name: /submit/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bio: validBio,
+        issues: expect.arrayContaining([
+          expect.objectContaining({ title: 'Priority 1' }),
+        ]),
+      }),
+    )
+    await waitFor(() =>
+      expect(router.push).toHaveBeenCalledWith('/dashboard/profile'),
+    )
+    expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -45,17 +45,19 @@ beforeEach(() => {
 
 describe('CandidateProfile — submit validation messaging', () => {
   it('keeps the Submit button enabled when the profile is incomplete', async () => {
-    getUserWebsite.mockResolvedValue(null)
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
     render(<CandidateProfile />)
     expect(await screen.findByRole('button', { name: /submit/i })).toBeEnabled()
   })
 
   it('surfaces bio and policy-priority errors and does not save an incomplete profile', async () => {
     const user = userEvent.setup()
-    getUserWebsite.mockResolvedValue(null)
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
     render(<CandidateProfile />)
 
-    await user.click(await screen.findByRole('button', { name: /submit/i }))
+    // Wait for the editor to mount (profile seeded) before submitting.
+    await screen.findByTestId('rich-editor')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
 
     expect(saveAboutFields).not.toHaveBeenCalled()
     expect(screen.getByText('Please add your bio')).toBeInTheDocument()

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -49,6 +49,13 @@ export default function CandidateProfile(): React.JSX.Element {
   // get a guiding error rather than a silently-disabled button. Errors (alert
   // + red bio border) only surface once they've tried to submit.
   const [attemptedSubmit, setAttemptedSubmit] = useState(false)
+  // `initialBio` must be captured exactly once and never change afterward.
+  // RichEditor re-pastes its content whenever `initialText` changes by value,
+  // so deriving it live from the query would clobber the user's in-progress
+  // edits whenever a refetch lands (e.g. the post-submit `invalidateQueries`
+  // or a window-focus refetch). `null` means "not seeded yet" so we defer
+  // mounting the editor until we have the real value.
+  const [initialBio, setInitialBio] = useState<string | null>(null)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -58,11 +65,10 @@ export default function CandidateProfile(): React.JSX.Element {
     // Seed length up-front so Submit doesn't show a false "add your bio" error
     // before the dynamically-imported editor emits its first onTextLengthChange.
     setBioPlainLength(getBioPlainLength(initialBioValue))
+    setInitialBio(initialBioValue)
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])
-
-  const initialBio = website?.content?.about?.bio ?? ''
 
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)
@@ -115,12 +121,14 @@ export default function CandidateProfile(): React.JSX.Element {
           <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
           </div>
-          <RichEditor
-            initialText={initialBio}
-            onChangeCallback={setBio}
-            onTextLengthChange={setBioPlainLength}
-            error={attemptedSubmit && !!bioError}
-          />
+          {initialBio !== null && (
+            <RichEditor
+              initialText={initialBio}
+              onChangeCallback={setBio}
+              onTextLengthChange={setBioPlainLength}
+              error={attemptedSubmit && !!bioError}
+            />
+          )}
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
             <span>{bioPlainLength}</span>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -17,6 +17,7 @@ import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
   getBioError,
+  getBioPlainLength,
   getPolicyPrioritiesError,
   normalizeIssues,
 } from '../candidateProfile.utils'
@@ -52,7 +53,11 @@ export default function CandidateProfile(): React.JSX.Element {
 
   useEffect(() => {
     if (seededRef.current || !website) return
-    setBio(website.content?.about?.bio ?? '')
+    const initialBioValue = website.content?.about?.bio ?? ''
+    setBio(initialBioValue)
+    // Seed length up-front so Submit doesn't show a false "add your bio" error
+    // before the dynamically-imported editor emits its first onTextLengthChange.
+    setBioPlainLength(getBioPlainLength(initialBioValue))
     setIssues(normalizeIssues(website.content?.about?.issues))
     seededRef.current = true
   }, [website])

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { Button } from '@styleguide'
+import { Alert, AlertDescription, Button, CircleAlertIcon } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import dynamic from 'next/dynamic'
@@ -16,7 +16,8 @@ import { Website, WebsiteIssue } from 'helpers/types'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import {
   MIN_BIO_LENGTH,
-  MIN_POLICY_PRIORITIES,
+  getBioError,
+  getPolicyPrioritiesError,
   normalizeIssues,
 } from '../candidateProfile.utils'
 import PolicyPriorities from './PolicyPriorities'
@@ -43,6 +44,10 @@ export default function CandidateProfile(): React.JSX.Element {
   const [bioPlainLength, setBioPlainLength] = useState(0)
   const [issues, setIssues] = useState<WebsiteIssue[]>([])
   const [submitting, setSubmitting] = useState(false)
+  // The Submit button is always enabled so the user can attempt to submit and
+  // get a guiding error rather than a silently-disabled button. Errors (alert
+  // + red bio border) only surface once they've tried to submit.
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false)
   const seededRef = useRef(false)
 
   useEffect(() => {
@@ -54,13 +59,15 @@ export default function CandidateProfile(): React.JSX.Element {
 
   const initialBio = website?.content?.about?.bio ?? ''
 
-  const canSubmit =
-    bioPlainLength >= MIN_BIO_LENGTH &&
-    issues.length >= MIN_POLICY_PRIORITIES &&
-    !submitting
+  const bioError = getBioError(bioPlainLength)
+  const prioritiesError = getPolicyPrioritiesError(issues.length)
 
   const handleSubmit = async () => {
-    if (!canSubmit) return
+    if (submitting) return
+    if (bioError || prioritiesError) {
+      setAttemptedSubmit(true)
+      return
+    }
     trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
     setSubmitting(true)
     const ok = await saveAboutFields({ bio, issues })
@@ -86,6 +93,19 @@ export default function CandidateProfile(): React.JSX.Element {
           <div>&nbsp;</div>
         </div>
 
+        {attemptedSubmit && (bioError || prioritiesError) && (
+          <Alert
+            variant="destructive"
+            icon={<CircleAlertIcon />}
+            className="mt-6"
+          >
+            <AlertDescription>
+              {bioError && <p>{bioError}</p>}
+              {prioritiesError && <p>{prioritiesError}</p>}
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="mt-10">
           <div className="mb-1.5 block text-sm font-medium">
             Why are you running?
@@ -94,6 +114,7 @@ export default function CandidateProfile(): React.JSX.Element {
             initialText={initialBio}
             onChangeCallback={setBio}
             onTextLengthChange={setBioPlainLength}
+            error={attemptedSubmit && !!bioError}
           />
           <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
             <span>{MIN_BIO_LENGTH} character minimum</span>
@@ -118,7 +139,6 @@ export default function CandidateProfile(): React.JSX.Element {
           variant="secondary"
           type="button"
           onClick={handleSubmit}
-          disabled={!canSubmit}
           loading={submitting}
           loadingText="Submitting"
         >

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
@@ -86,4 +86,30 @@ describe('PolicyForm — validation messaging', () => {
     })
     expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
   })
+
+  it('saves an existing policy without re-typing, before the editor reports a length', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const existing = {
+      title: 'Education',
+      description: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH),
+    }
+    render(
+      <PolicyForm
+        initial={existing}
+        showDelete
+        onSave={onSave}
+        onDelete={vi.fn()}
+      />,
+    )
+
+    // No typing: the description length must be seeded from `initial` so a
+    // valid existing policy isn't falsely blocked before the dynamic editor
+    // fires its first onTextLengthChange.
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith(existing)
+    expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
+  })
 })

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+import PolicyForm from './PolicyForm'
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const typeFocus = (length: number) => {
+  fireEvent.change(screen.getByTestId('rich-editor'), {
+    target: { value: 'x'.repeat(length) },
+  })
+}
+
+describe('PolicyForm — validation messaging', () => {
+  it('keeps the Save button enabled even when the form is empty', () => {
+    render(
+      <PolicyForm showDelete={false} onSave={vi.fn()} onDelete={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+  })
+
+  it('shows the combined add-fields message and flags both fields when empty', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please add a Policy title and Policy focus'),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Policy title')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    )
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('reports the focus length requirement when the title is set but focus is too short', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Policy title'), 'Education')
+    typeFocus(MIN_POLICY_FOCUS_LENGTH - 1)
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        `Policy focus requires ${MIN_POLICY_FOCUS_LENGTH} characters`,
+      ),
+    ).toBeInTheDocument()
+    // Title is valid now, so only the focus field is flagged.
+    expect(screen.getByLabelText('Policy title')).toHaveAttribute(
+      'aria-invalid',
+      'false',
+    )
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('saves the trimmed title and description once the form is valid', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(<PolicyForm showDelete={false} onSave={onSave} onDelete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Policy title'), '  Education  ')
+    typeFocus(MIN_POLICY_FOCUS_LENGTH)
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith({
+      title: 'Education',
+      description: 'x'.repeat(MIN_POLICY_FOCUS_LENGTH),
+    })
+    expect(screen.queryByText(/Please add a Policy/)).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -66,7 +66,7 @@ export default function PolicyForm({
   }
 
   return (
-    <div className="flex flex-col gap-4 p-6">
+    <div className="flex min-w-0 flex-col gap-4 p-6">
       <h2 className="text-lg font-semibold">Policy priority</h2>
 
       {attemptedSave && message && (

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -1,9 +1,18 @@
 'use client'
-import { Button, Input } from '@styleguide'
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  CircleAlertIcon,
+  Input,
+} from '@styleguide'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
-import { MIN_POLICY_FOCUS_LENGTH } from '../candidateProfile.utils'
+import {
+  MIN_POLICY_FOCUS_LENGTH,
+  getPolicyFormValidation,
+} from '../candidateProfile.utils'
 
 const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
   ssr: false,
@@ -31,14 +40,34 @@ export default function PolicyForm({
   const [description, setDescription] = useState(initial?.description ?? '')
   const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
   const [initialDescription] = useState(initial?.description ?? '')
+  // The Save button is always enabled so the user can attempt to save and get
+  // a guiding error instead of a silently-disabled button. Errors (alert +
+  // red field borders) only surface once they've tried to save.
+  const [attemptedSave, setAttemptedSave] = useState(false)
 
   const trimmedTitle = title.trim()
-  const canSave =
-    trimmedTitle.length > 0 && descriptionPlainLength >= MIN_POLICY_FOCUS_LENGTH
+  const { titleInvalid, focusInvalid, message } = getPolicyFormValidation(
+    trimmedTitle.length,
+    descriptionPlainLength,
+  )
+
+  const handleSave = () => {
+    if (message) {
+      setAttemptedSave(true)
+      return
+    }
+    onSave({ title: trimmedTitle, description })
+  }
 
   return (
     <div className="flex flex-col gap-4 p-6">
       <h2 className="text-lg font-semibold">Policy priority</h2>
+
+      {attemptedSave && message && (
+        <Alert variant="destructive" icon={<CircleAlertIcon />}>
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+      )}
 
       <div className="flex flex-col gap-2">
         <label htmlFor="policy-title" className="text-sm font-medium">
@@ -48,6 +77,7 @@ export default function PolicyForm({
           id="policy-title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
+          aria-invalid={attemptedSave && titleInvalid}
           autoFocus
         />
       </div>
@@ -58,6 +88,7 @@ export default function PolicyForm({
           initialText={initialDescription}
           onChangeCallback={setDescription}
           onTextLengthChange={setDescriptionPlainLength}
+          error={attemptedSave && focusInvalid}
         />
         <div className="flex justify-between text-xs text-muted-foreground">
           <span>{MIN_POLICY_FOCUS_LENGTH} character minimum</span>
@@ -78,12 +109,7 @@ export default function PolicyForm({
         ) : (
           <span />
         )}
-        <Button
-          type="button"
-          size="medium"
-          disabled={!canSave}
-          onClick={() => onSave({ title: trimmedTitle, description })}
-        >
+        <Button type="button" size="medium" onClick={handleSave}>
           Save
         </Button>
       </div>

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/PolicyForm.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { WebsiteIssue } from 'helpers/types'
 import {
   MIN_POLICY_FOCUS_LENGTH,
+  getBioPlainLength,
   getPolicyFormValidation,
 } from '../candidateProfile.utils'
 
@@ -38,7 +39,12 @@ export default function PolicyForm({
 }: PolicyFormProps): React.JSX.Element {
   const [title, setTitle] = useState(initial?.title ?? '')
   const [description, setDescription] = useState(initial?.description ?? '')
-  const [descriptionPlainLength, setDescriptionPlainLength] = useState(0)
+  // Seed the length from the existing description so Save isn't falsely
+  // blocked before the dynamically-loaded editor fires its first
+  // onTextLengthChange when editing an existing policy.
+  const [descriptionPlainLength, setDescriptionPlainLength] = useState(() =>
+    getBioPlainLength(initial?.description),
+  )
   const [initialDescription] = useState(initial?.description ?? '')
   // The Save button is always enabled so the user can attempt to save and get
   // a guiding error instead of a silently-disabled button. Errors (alert +

--- a/app/dashboard/shared/serveAccess.test.ts
+++ b/app/dashboard/shared/serveAccess.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Organization } from 'gpApi/api-endpoints'
+import serveAccess from './serveAccess'
+
+const {
+  mockServerFetch,
+  mockGetCurrentUserOrganizations,
+  mockCookiesGet,
+  mockHeadersGet,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockServerFetch: vi.fn(),
+  mockGetCurrentUserOrganizations: vi.fn(),
+  mockCookiesGet: vi.fn(),
+  mockHeadersGet: vi.fn(),
+  mockRedirect: vi.fn(),
+}))
+
+vi.mock('gpApi/serverFetch', () => ({
+  serverFetch: (...args: unknown[]) => mockServerFetch(...args),
+}))
+
+vi.mock('helpers/getCurrentUserOrganizations', () => ({
+  getCurrentUserOrganizations: () => mockGetCurrentUserOrganizations(),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) => mockCookiesGet(name),
+    }),
+  headers: () =>
+    Promise.resolve({
+      get: (name: string) => mockHeadersGet(name),
+    }),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: (url: string) => mockRedirect(url),
+}))
+
+const campaignOrg: Organization = {
+  slug: 'campaign-1',
+  name: '2026 Campaign',
+  positionName: null,
+  position: null,
+  district: null,
+  electedOfficeId: null,
+  campaignId: 1,
+}
+
+const electedOfficeOrg: Organization = {
+  ...campaignOrg,
+  slug: 'serve-org',
+  name: 'Serve Org',
+  electedOfficeId: 'eo-123',
+}
+
+const setCookieSlug = (slug?: string) =>
+  mockCookiesGet.mockImplementation((name: string) =>
+    name === 'organization-slug' && slug ? { value: slug } : undefined,
+  )
+
+const setPathname = (pathname: string, search = '') =>
+  mockHeadersGet.mockImplementation((name: string) => {
+    if (name === 'x-pathname') return pathname
+    if (name === 'x-search') return search
+    return null
+  })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRedirect.mockImplementation(() => undefined as never)
+  mockGetCurrentUserOrganizations.mockResolvedValue([campaignOrg])
+  setCookieSlug(undefined)
+  setPathname('/dashboard/briefings')
+})
+
+describe('serveAccess', () => {
+  it('returns without redirecting when the elected-office lookup succeeds', async () => {
+    mockServerFetch.mockResolvedValue({ ok: true, data: { id: 'eo-123' } })
+
+    await serveAccess()
+
+    expect(mockRedirect).not.toHaveBeenCalled()
+    expect(mockGetCurrentUserOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('switches org via post-auth-redirect when an elected-office org is not selected', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/briefings')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fbriefings',
+    )
+  })
+
+  it('preserves the requested serve path (polls / specific briefing) as next', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/polls/42')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fpolls%2F42',
+    )
+  })
+
+  it('preserves query parameters on serve routes as next', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([
+      campaignOrg,
+      electedOfficeOrg,
+    ])
+    setCookieSlug('campaign-1')
+    setPathname('/dashboard/polls', '?tab=open')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/post-auth-redirect?next=%2Fdashboard%2Fpolls%3Ftab%3Dopen',
+    )
+  })
+
+  it('falls back to /dashboard (no loop) when the elected-office org is already selected', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([electedOfficeOrg])
+    setCookieSlug('serve-org')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('bounces to /dashboard when the user has no elected-office org', async () => {
+    mockServerFetch.mockResolvedValue({ ok: false, data: null })
+    mockGetCurrentUserOrganizations.mockResolvedValue([campaignOrg])
+    setCookieSlug('campaign-1')
+
+    await serveAccess()
+
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard')
+  })
+})

--- a/app/dashboard/shared/serveAccess.ts
+++ b/app/dashboard/shared/serveAccess.ts
@@ -1,10 +1,48 @@
+import { cookies, headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
+import { getCurrentUserOrganizations } from 'helpers/getCurrentUserOrganizations'
+import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
+import { isServeRoutePath } from './serveRoutes'
 
 export default async function serveAccess(): Promise<void> {
   const resp = await serverFetch(apiRoutes.electedOffice.current)
-  if (!resp?.ok || !resp?.data) {
-    return redirect('/dashboard')
+  if (resp?.ok && resp?.data) {
+    return
   }
+
+  // The elected-office (and meetings) endpoints resolve by the selected org's
+  // slug, so the lookup above fails whenever the user lands here with a
+  // different org selected — e.g. a logged-in user opening a /dashboard/briefings
+  // deep link from a marketing email while their campaign org is active. If the
+  // user owns an elected-office org that isn't the one currently selected,
+  // route through /post-auth-redirect to switch the org slug cookie and come
+  // back, rather than incorrectly bouncing them to /dashboard.
+  const [organizations, cookieStore, headerStore] = await Promise.all([
+    getCurrentUserOrganizations(),
+    cookies(),
+    headers(),
+  ])
+  const currentSlug = cookieStore.get(ORG_SLUG_COOKIE)?.value
+  const electedOfficeOrg = organizations.find((org) => org.electedOfficeId)
+
+  // Only redirect when switching to a *different* org could actually help.
+  // If the elected-office org is already selected (or none exists), fall back
+  // to /dashboard so we can't loop back here through post-auth-redirect.
+  if (electedOfficeOrg && electedOfficeOrg.slug !== currentSlug) {
+    // Preserve the page the user actually asked for (set by the middleware on
+    // the `x-pathname` / `x-search` headers) so we return them to e.g. a
+    // specific briefing or a polls route with its query intact — not always the
+    // briefings landing page. Fall back to the briefings landing only when the
+    // pathname is missing or isn't a serve route.
+    const pathname = headerStore.get('x-pathname') ?? ''
+    const search = headerStore.get('x-search') ?? ''
+    const next = isServeRoutePath(pathname)
+      ? `${pathname}${search}`
+      : '/dashboard/briefings'
+    return redirect(`/post-auth-redirect?next=${encodeURIComponent(next)}`)
+  }
+
+  return redirect('/dashboard')
 }

--- a/app/dashboard/shared/serveRoutes.test.ts
+++ b/app/dashboard/shared/serveRoutes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { isServeRoutePath } from './serveRoutes'
+
+describe('isServeRoutePath', () => {
+  it('matches serve route prefixes and their sub-paths', () => {
+    expect(isServeRoutePath('/dashboard/briefings')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings/2026-01-15')).toBe(true)
+    expect(isServeRoutePath('/dashboard/polls')).toBe(true)
+    expect(isServeRoutePath('/dashboard/polls/42/expand')).toBe(true)
+  })
+
+  it('ignores query strings and hashes when matching', () => {
+    expect(isServeRoutePath('/dashboard/polls?tab=open')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings#section')).toBe(true)
+    expect(isServeRoutePath('/dashboard/briefings/2026-01-15?x=1#y')).toBe(true)
+  })
+
+  it('does not match non-serve routes or prefix look-alikes', () => {
+    expect(isServeRoutePath('/dashboard')).toBe(false)
+    expect(isServeRoutePath('/dashboard/profile')).toBe(false)
+    expect(isServeRoutePath('/dashboard/briefings-archive')).toBe(false)
+    expect(isServeRoutePath('/dashboard/pollsters')).toBe(false)
+  })
+})

--- a/app/dashboard/shared/serveRoutes.ts
+++ b/app/dashboard/shared/serveRoutes.ts
@@ -1,0 +1,19 @@
+/**
+ * Route prefixes that make up the elected-official "serve" experience. These
+ * pages are gated by `serveAccess` and are scoped to the org that owns the
+ * user's elected office, so the post-auth flow must select that org (not the
+ * default first org) when landing a user on any of them.
+ */
+export const SERVE_ROUTE_PREFIXES = [
+  '/dashboard/briefings',
+  '/dashboard/polls',
+] as const
+
+export const isServeRoutePath = (path: string): boolean => {
+  // Match on the pathname only — callers may pass a value that still carries a
+  // query string or hash (e.g. `/dashboard/polls?tab=open`).
+  const pathname = path.split(/[?#]/)[0] ?? path
+  return SERVE_ROUTE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  )
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server'
 import { redirect } from 'next/navigation'
 import { SignIn } from '@clerk/nextjs'
 import { getPostAuthRedirectPath } from 'app/dashboard/shared/candidateAccess'
+import { isSafeInternalPath } from 'helpers/isSafeInternalPath'
 import pageMetaData from 'helpers/metadataHelper'
 
 const meta = pageMetaData({
@@ -11,15 +12,56 @@ const meta = pageMetaData({
 })
 export const metadata = meta
 
-export default async function LoginPage() {
-  const { userId } = await auth()
+export default async function LoginPage({
+  searchParams,
+}: PageProps<any>): Promise<React.JSX.Element> {
+  const [{ userId }, { redirect_url: redirectUrlParam }] = await Promise.all([
+    auth(),
+    searchParams,
+  ])
+
+  // When the middleware bounces an unauthenticated deep link (e.g.
+  // /dashboard/briefings from a marketing email) through here, it preserves
+  // the original path in `redirect_url`. Only same-origin relative paths are
+  // honored so the param can't be abused as an open redirect.
+  const redirectUrl = isSafeInternalPath(redirectUrlParam)
+    ? redirectUrlParam
+    : null
+
   if (userId) {
-    redirect(await getPostAuthRedirectPath())
+    // Already signed in: honor an explicit deep link if present, routing it
+    // through /post-auth-redirect (same as the unauthenticated path) so the
+    // org slug cookie is established before landing on org-scoped pages.
+    // Otherwise fall back to the role-aware post-auth resolver.
+    redirect(
+      redirectUrl
+        ? `/post-auth-redirect?next=${encodeURIComponent(redirectUrl)}`
+        : await getPostAuthRedirectPath(),
+    )
   }
+
+  // We can't send the user straight to the deep link after sign-in:
+  // `/post-auth-redirect` is what resolves the user's org and sets the
+  // ORG_SLUG_COOKIE that server requests need, so skipping it leaves pages like
+  // briefings without org context (blank render / server-side bounce to
+  // /dashboard). Route through `/post-auth-redirect` and forward the requested
+  // path as `next` so it can land the user there once setup is done. Set both
+  // sign-in and sign-up redirect props since the embedded "create account" flow
+  // on this page uses the sign-up props; the sign-up variant also carries the
+  // `source=signup` hint so registration tracking still fires.
+  const nextQuery = redirectUrl
+    ? `next=${encodeURIComponent(redirectUrl)}`
+    : null
+  const redirectProps = nextQuery
+    ? {
+        forceRedirectUrl: `/post-auth-redirect?${nextQuery}`,
+        signUpForceRedirectUrl: `/post-auth-redirect?${nextQuery}&source=signup`,
+      }
+    : { fallbackRedirectUrl: '/post-auth-redirect' }
 
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-64px)] py-8">
-      <SignIn fallbackRedirectUrl="/post-auth-redirect" routing="hash" />
+      <SignIn {...redirectProps} routing="hash" />
     </div>
   )
 }

--- a/app/post-auth-redirect/page.test.tsx
+++ b/app/post-auth-redirect/page.test.tsx
@@ -209,6 +209,86 @@ describe('PostAuthRedirectPage', () => {
     expect(mockTrackRegistration).not.toHaveBeenCalled()
   })
 
+  it('next param: honors a same-origin deep link over the resolved path', async () => {
+    setLocation('?next=%2Fdashboard%2Fbriefings')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() =>
+      expect(replaceSpy).toHaveBeenCalledWith('/dashboard/briefings'),
+    )
+    // Org context is still established before navigating to the deep link.
+    expect(mockSetCookie).toHaveBeenCalledWith('organization-slug', 'org-one')
+  })
+
+  it('next param: selects the elected-office org for a briefings deep link', async () => {
+    setLocation('?next=%2Fdashboard%2Fbriefings')
+    const electedOfficeOrg = {
+      ...orgFixture,
+      slug: 'serve-org',
+      name: 'Serve Org',
+      electedOfficeId: 'eo-123',
+    }
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      // Campaign org first (resolveSlug would otherwise pick this one).
+      data: { organizations: [orgFixture, electedOfficeOrg] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 200,
+      data: { id: 'eo-123', swornInDate: '2026-01-01' } as any,
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() =>
+      expect(mockSetCookie).toHaveBeenCalledWith(
+        'organization-slug',
+        'serve-org',
+      ),
+    )
+    expect(replaceSpy).toHaveBeenCalledWith('/dashboard/briefings')
+  })
+
+  it('next param: ignores protocol-relative/open-redirect values', async () => {
+    setLocation('?next=%2F%2Fevil.com')
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [orgFixture] },
+    })
+    api.mock('GET /v1/users/me', { status: 200, data: { roles: [] } as any })
+    api.mock('GET /v1/campaigns/mine/status', {
+      status: 200,
+      data: { status: 'candidate', slug: 'org-one' },
+    })
+    api.mock('GET /v1/elected-office/current', {
+      status: 404,
+      data: { message: 'none' },
+    })
+
+    render(<PostAuthRedirectPage />)
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard'))
+  })
+
   it('login (no source param): does not fire trackRegistrationCompleted', async () => {
     api.mock('GET /v1/organizations', {
       status: 200,

--- a/app/post-auth-redirect/page.tsx
+++ b/app/post-auth-redirect/page.tsx
@@ -13,6 +13,8 @@ import { ORG_SLUG_COOKIE } from '@shared/organizations/constants'
 import { resolveSlug } from '@shared/hooks/useSelectedOrgSlug'
 import { trackRegistrationCompleted } from 'helpers/analyticsHelper'
 import { getReadyAnalytics } from '@shared/utils/analytics'
+import { isSafeInternalPath } from 'helpers/isSafeInternalPath'
+import { isServeRoutePath } from 'app/dashboard/shared/serveRoutes'
 import { LoaderCircle } from 'lucide-react'
 
 const PostAuthRedirectPage = () => {
@@ -30,6 +32,15 @@ const PostAuthRedirectPage = () => {
     ranRef.current = true
     ;(async () => {
       try {
+        // An explicit deep-link destination forwarded by the login flow when
+        // the middleware bounced an unauthenticated deep link (e.g.
+        // /dashboard/briefings from a marketing email). Only same-origin
+        // relative paths are honored so this can't be an open redirect.
+        const nextParam = new URLSearchParams(window.location.search).get(
+          'next',
+        )
+        const safeNext = isSafeInternalPath(nextParam) ? nextParam : null
+
         // First authenticated call after a fresh sign-up may race the gp-api
         // JIT-provisioning of the local user record. Retry once on failure
         // before falling back to an empty list.
@@ -51,7 +62,18 @@ const PostAuthRedirectPage = () => {
           if (retry.ok) organizations = retry.data.organizations
         }
 
-        const slug = resolveSlug(organizations)
+        // The "serve" experience (briefings, polls) is scoped to the org that
+        // owns the user's elected office (the gp-api elected-office + meetings
+        // endpoints resolve by the X-Organization-Slug header). When the deep
+        // link points there, select that org explicitly — otherwise
+        // `resolveSlug` falls back to the first org and those pages can't find
+        // the elected office, bouncing the user to /dashboard.
+        const electedOrg = organizations.find((o) => o.electedOfficeId)
+        const wantsServe = !!safeNext && isServeRoutePath(safeNext)
+        const slug =
+          wantsServe && electedOrg
+            ? electedOrg.slug
+            : resolveSlug(organizations)
         if (slug) {
           setCookie(ORG_SLUG_COOKIE, slug)
         }
@@ -110,14 +132,25 @@ const PostAuthRedirectPage = () => {
           }
         }
 
-        const path = resolvePostAuthRedirectPath(
+        const resolvedPath = resolvePostAuthRedirectPath(
           user,
           campaignStatus,
           hasElectedOffice,
         )
+        // Honor the explicit deep-link destination now that the org slug cookie
+        // is set and the session is established. Re-derive a same-origin
+        // relative path before navigating: `safeNext` is already validated, but
+        // rebuilding from `URL().pathname` strips any host an attacker could
+        // smuggle in, keeping the redirect provably same-origin.
+        const destination = new URL(
+          safeNext ?? resolvedPath,
+          window.location.origin,
+        )
         // Hard nav so the destination renders with fresh auth'd server
         // state (PageWrapper re-runs with isAuthed=true and real orgs).
-        window.location.replace(path)
+        window.location.replace(
+          `${destination.pathname}${destination.search}${destination.hash}`,
+        )
       } catch (e) {
         console.error('post-auth-redirect error', e)
         // Don't strand new users on a blank /dashboard if the resolver

--- a/app/shared/utils/RichEditor.tsx
+++ b/app/shared/utils/RichEditor.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from 'react'
 import { useQuill } from 'react-quilljs'
 import 'quill/dist/quill.bubble.css'
+import { cn } from '@styleguide'
 import { noop } from './noop'
 
 interface RichEditorProps {
@@ -9,12 +10,15 @@ interface RichEditorProps {
   onChangeCallback?: (value: string, flag?: number) => void
   onTextLengthChange?: (length: number) => void
   useOnChange?: boolean
+  // Renders the editor with a destructive border to flag a validation error.
+  error?: boolean
 }
 
 const RichEditor = ({
   initialText = '',
   onChangeCallback = noop,
   onTextLengthChange,
+  error = false,
 }: RichEditorProps): React.JSX.Element => {
   const { quill, quillRef } = useQuill({
     theme: 'bubble',
@@ -57,7 +61,12 @@ const RichEditor = ({
   }, [quill, onChangeCallback, onTextLengthChange])
 
   return (
-    <div className="p-3 border rounded-lg border-gray-200 [&>.quill>.ql-container]:text-base [&_.ql-editor]:wrap-anywhere">
+    <div
+      className={cn(
+        'p-3 border rounded-lg [&>.quill>.ql-container]:text-base [&_.ql-editor]:wrap-anywhere',
+        error ? 'border-destructive' : 'border-gray-200',
+      )}
+    >
       <div ref={quillRef} />
     </div>
   )

--- a/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
+++ b/e2e-tests/tests/app/mobile/mobile-navigation.spec.ts
@@ -72,7 +72,7 @@ test.describe('Mobile Navigation', () => {
     await WaitHelper.waitForPageReady(page)
 
     await NavigationHelper.openMobileMenu(page)
-    await page.locator('#my-content-dashboard').click()
+    await page.getByRole('link', { name: 'Content Builder' }).click()
     // The mobile header renders the page title as a heading in addition to the
     // page's own heading, so scope to the first match to avoid strict mode.
     await expect(

--- a/e2e-tests/tests/app/profile/policy-priority-overflow.spec.ts
+++ b/e2e-tests/tests/app/profile/policy-priority-overflow.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test'
+import { authenticateTestUser } from 'tests/utils/api-registration'
+import { blockSlowScripts } from '../../../src/helpers/navigation.helper'
+
+const LONG_NO_SPACE = 'asdfasdfadsf'.repeat(20)
+
+test.describe('Policy priority overflow (ENG-10268)', () => {
+  test.beforeEach(async ({ page }) => {
+    await blockSlowScripts(page)
+  })
+
+  test('long no-space title does not push the modal off screen', async ({
+    page,
+  }) => {
+    test.setTimeout(120000)
+    await authenticateTestUser(page)
+
+    await page.goto('/dashboard/profile/texting-compliance/candidate-profile')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('button', { name: 'Add a policy priority' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const titleInput = dialog.locator('#policy-title')
+    await titleInput.fill(LONG_NO_SPACE)
+
+    // The rich-text "Policy focus" editor is the field that pushed the modal
+    // wide in the original report; type a long no-space string into it too.
+    const editor = dialog.locator('.ql-editor')
+    await editor.click()
+    await editor.pressSequentially(LONG_NO_SPACE)
+
+    // The reported bug: a long no-space string pushes content off screen,
+    // producing a horizontal scrollbar on the document.
+    const pageOverflowX = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+    )
+    expect(pageOverflowX, 'document should not scroll horizontally').toBe(false)
+
+    // The dialog itself must not be wider than its content box can show.
+    const dialogOverflowX = await dialog.evaluate(
+      (el) => el.scrollWidth > el.clientWidth,
+    )
+    expect(dialogOverflowX, 'dialog should not overflow horizontally').toBe(
+      false,
+    )
+  })
+})

--- a/helpers/isSafeInternalPath.test.ts
+++ b/helpers/isSafeInternalPath.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { isSafeInternalPath } from './isSafeInternalPath'
+
+describe('isSafeInternalPath', () => {
+  it('accepts root-relative paths', () => {
+    expect(isSafeInternalPath('/dashboard/briefings')).toBe(true)
+    expect(isSafeInternalPath('/dashboard/briefings/2026-01-15')).toBe(true)
+    expect(isSafeInternalPath('/dashboard/polls?tab=open')).toBe(true)
+    expect(isSafeInternalPath('/')).toBe(true)
+  })
+
+  it('rejects non-string values', () => {
+    expect(isSafeInternalPath(null)).toBe(false)
+    expect(isSafeInternalPath(undefined)).toBe(false)
+    expect(isSafeInternalPath(42)).toBe(false)
+  })
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(isSafeInternalPath('//evil.com')).toBe(false)
+    expect(isSafeInternalPath('https://evil.com')).toBe(false)
+    expect(isSafeInternalPath('http://evil.com/path')).toBe(false)
+    expect(isSafeInternalPath('evil.com')).toBe(false)
+  })
+
+  it('rejects backslash open-redirect bypasses', () => {
+    expect(isSafeInternalPath('/\\evil.com')).toBe(false)
+    expect(isSafeInternalPath('/\\/evil.com')).toBe(false)
+    expect(isSafeInternalPath('\\\\evil.com')).toBe(false)
+  })
+
+  it('rejects embedded whitespace/control characters', () => {
+    expect(isSafeInternalPath('/\tdashboard')).toBe(false)
+    expect(isSafeInternalPath('/dash board')).toBe(false)
+    expect(isSafeInternalPath('/foo\n//evil.com')).toBe(false)
+  })
+})

--- a/helpers/isSafeInternalPath.ts
+++ b/helpers/isSafeInternalPath.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns true only for a root-relative, same-origin path that is safe to use
+ * as a post-auth redirect target.
+ *
+ * Guards against open-redirect payloads that browsers normalize into an
+ * authority/host: protocol-relative URLs (`//evil.com`), their backslash
+ * variants (`/\evil.com`, which WHATWG/browsers fold into `//evil.com`),
+ * absolute URLs (`https://evil.com`), and any embedded whitespace/control
+ * characters. The `new URL()` origin check is a belt-and-suspenders backstop
+ * in case a novel normalization slips past the explicit string checks.
+ */
+export const isSafeInternalPath = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false
+  if (!value.startsWith('/')) return false
+  if (value.startsWith('//')) return false
+  // Reject backslashes and whitespace anywhere — browsers treat `\` like `/`
+  // and strip tabs/newlines, both of which can smuggle in a host segment.
+  if (/[\\\s]/.test(value)) return false
+  try {
+    const base = 'https://internal.invalid'
+    return new URL(value, base).origin === base
+  } catch {
+    return false
+  }
+}

--- a/helpers/test-utils/RichEditorMock.tsx
+++ b/helpers/test-utils/RichEditorMock.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+
+interface RichEditorMockProps {
+  initialText?: string
+  onChangeCallback?: (value: string, flag?: number) => void
+  onTextLengthChange?: (length: number) => void
+  error?: boolean
+}
+
+/**
+ * Test stand-in for `app/shared/utils/RichEditor`.
+ *
+ * The real editor wraps Quill, which needs browser APIs jsdom does not
+ * implement, so component tests mock it with this controllable textarea.
+ * Typing into it drives the same `onChangeCallback` / `onTextLengthChange`
+ * callbacks the real editor fires (length is the trimmed plain-text length),
+ * letting tests exercise the consumer's validation behavior. The `error` prop
+ * is reflected onto `data-error` so tests can assert the red-border wiring
+ * without rendering real Quill.
+ *
+ * Use via:
+ *   vi.mock('app/shared/utils/RichEditor', async () => ({
+ *     default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+ *   }))
+ */
+export const RichEditorMock = ({
+  initialText = '',
+  onChangeCallback,
+  onTextLengthChange,
+  error = false,
+}: RichEditorMockProps): React.JSX.Element => {
+  useEffect(() => {
+    if (initialText) {
+      onTextLengthChange?.(initialText.trim().length)
+    }
+    // Mirror the real editor, which re-seeds its length whenever `initialText`
+    // changes by value (e.g. after an async data fetch resolves).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialText])
+
+  return (
+    <textarea
+      data-testid="rich-editor"
+      data-error={error}
+      defaultValue={initialText}
+      onChange={(e) => {
+        const value = e.target.value
+        onChangeCallback?.(value)
+        onTextLengthChange?.(value.trim().length)
+      }}
+    />
+  )
+}

--- a/helpers/test-utils/RichEditorMock.tsx
+++ b/helpers/test-utils/RichEditorMock.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 interface RichEditorMockProps {
   initialText?: string
   onChangeCallback?: (value: string, flag?: number) => void
@@ -18,6 +16,13 @@ interface RichEditorMockProps {
  * is reflected onto `data-error` so tests can assert the red-border wiring
  * without rendering real Quill.
  *
+ * It intentionally does NOT report a length on mount from `initialText`. The
+ * real editor is dynamically imported and only emits its first
+ * `onTextLengthChange` once Quill has initialized, so there is a window where
+ * server-provided content exists but no length has been reported. Consumers
+ * that gate a Submit/Save on the length must seed it themselves from the
+ * server value; this mock holds them to that.
+ *
  * Use via:
  *   vi.mock('app/shared/utils/RichEditor', async () => ({
  *     default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
@@ -29,15 +34,6 @@ export const RichEditorMock = ({
   onTextLengthChange,
   error = false,
 }: RichEditorMockProps): React.JSX.Element => {
-  useEffect(() => {
-    if (initialText) {
-      onTextLengthChange?.(initialText.trim().length)
-    }
-    // Mirror the real editor, which re-seeds its length whenever `initialText`
-    // changes by value (e.g. after an async data fetch resolves).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialText])
-
   return (
     <textarea
       data-testid="rich-editor"

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -110,7 +110,6 @@ export interface CampaignDetails {
   ballotLevel?: string
   electionDate?: string
   primaryElectionDate?: string
-  primaryResult?: 'won' | 'lost' | null
   zip?: string
   knowRun?: 'yes' | null
   runForOffice?: 'yes' | 'no' | null
@@ -377,6 +376,7 @@ export interface Campaign {
   isPro?: boolean | null
   isDemo: boolean
   didWin?: boolean | null
+  primaryResult?: 'won' | 'lost' | null
   dateVerified?: Date | string | null
   tier?: CampaignTier | null
   formattedAddress?: string | null

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,10 +12,14 @@ const isPublicRoute = createRouteMatcher([
 ])
 
 export default clerkMiddleware(async (auth, req: NextRequest) => {
-  const { pathname } = req.nextUrl
-  // This is a workaround to pass the pathname to SSR pages
+  const { pathname, search } = req.nextUrl
+  // This is a workaround to pass the pathname to SSR pages. `x-search` carries
+  // the query string separately so server components (e.g. serveAccess) can
+  // reconstruct the full requested URL without changing the `x-pathname`
+  // semantics other consumers rely on.
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set('x-pathname', pathname)
+  requestHeaders.set('x-search', search)
 
   // Handle API request rewrites
   const apiRewriteRequest = pathname.startsWith(`/api${API_VERSION_PREFIX}`)
@@ -31,7 +35,22 @@ export default clerkMiddleware(async (auth, req: NextRequest) => {
   }
 
   if (!isPublicRoute(req)) {
-    await auth.protect()
+    const { userId } = await auth()
+    if (!userId) {
+      // Redirect unauthenticated users to the sign-in page explicitly instead
+      // of relying on `auth.protect()`. When Clerk can't resolve the sign-in
+      // URL on the server it responds with a 404 rather than redirecting (see
+      // clerk/javascript#8302), which breaks deep links like
+      // `/dashboard/briefings` shared in marketing emails. Preserving the
+      // original path in `redirect_url` lets `<SignIn>` route the user back to
+      // the requested page after they log in.
+      const signInUrl = new URL('/login', req.url)
+      signInUrl.searchParams.set(
+        'redirect_url',
+        `${req.nextUrl.pathname}${req.nextUrl.search}`,
+      )
+      return NextResponse.redirect(signInUrl)
+    }
   }
 
   return NextResponse.next({

--- a/styleguide/components/ui/icons.tsx
+++ b/styleguide/components/ui/icons.tsx
@@ -13,6 +13,7 @@ export {
   ChevronLeft as ChevronLeftIcon,
   ChevronRight as ChevronRightIcon,
   ChevronsUpDown as ChevronsUpDownIcon,
+  CircleAlert as CircleAlertIcon,
   CircleUserRound as CircleUserRoundIcon,
   ClipboardList as ClipboardListIcon,
   Copy as CopyIcon,


### PR DESCRIPTION
This PR releases gp-webapp to QA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication redirects and org selection (mitigated by isSafeInternalPath) plus a campaign API shape change for primaryResult; otherwise mostly UI validation and layout.
> 
> **Overview**
> This release improves **campaign profile validation**, **pro campaign-details layout**, **primary-election result persistence**, and **auth/deep-link flows** for elected-official “serve” pages.
> 
> **Campaign details (pro):** When the pro upgrade flag is on, `DetailsPage` lays out campaign, office, why-running, and policy-priority sections in separate `Card`s instead of one gray panel. `CampaignSection` and `OfficeSection` accept a `carded` prop to drop redundant borders/margins inside cards.
> 
> **Validation UX:** Shared helpers (`getBioError`, `getPolicyPrioritiesError`, `getPolicyFormValidation`) drive consistent copy across candidate profile, policy forms, and dashboard sections. Save/Submit stay enabled; destructive alerts and `RichEditor` error borders appear only after an attempted save/submit, and clear again after a successful save so edits back to invalid state don’t nag until the next attempt. Bio/policy editors seed plain-text length from server data and freeze `initialBio` so refetches don’t wipe in-progress edits.
> 
> **Primary result:** `PrimaryResultModal` and post-election state read/write `primaryResult` on the campaign root (not `details.primaryResult`).
> 
> **Auth & serve routes:** Unauthenticated users hit `/login` with `redirect_url` (middleware no longer relies on `auth.protect()` alone). Login and `/post-auth-redirect` honor a validated `next` deep link via `isSafeInternalPath`, set the org cookie, and pick the elected-office org when `next` is a serve path (`/dashboard/briefings`, `/dashboard/polls`). `serveAccess` redirects through post-auth to switch org when the wrong slug is selected, preserving pathname/query via `x-pathname` / `x-search`.
> 
> **Other:** Policy priority modal gets `min-w-0` + e2e guard against horizontal overflow; mobile nav test targets Content Builder by accessible name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e59f61a09dceadad824005b0794df14bd4192d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->