### PR TITLE
feat: enhance CandidateProfile component with bio editor and priority…

### DIFF
--- a/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.test.tsx
@@ -32,6 +32,19 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
+describe('WhyRunningSection — bio editor mounts with no website yet (ENG-10284)', () => {
+  it('renders the "Why are you running?" editor when getUserWebsite resolves to null', async () => {
+    // A candidate who has not created a website yet gets `null` from
+    // getUserWebsite (saveAboutFields creates the website on save). The bio
+    // editor must still mount so they can fill it in — otherwise the field is
+    // completely absent and there is no way to edit it from this page.
+    getUserWebsite.mockResolvedValue(null)
+    render(<WhyRunningSection />)
+
+    expect(await screen.findByTestId('rich-editor')).toBeInTheDocument()
+  })
+})
+
 describe('WhyRunningSection — save validation messaging', () => {
   it('keeps the Save button enabled when the bio is incomplete', async () => {
     getUserWebsite.mockResolvedValue(websiteWithBio(''))

--- a/app/dashboard/campaign-details/components/WhyRunningSection.tsx
+++ b/app/dashboard/campaign-details/components/WhyRunningSection.tsx
@@ -33,7 +33,7 @@ const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
 export default function WhyRunningSection(): React.JSX.Element {
   const queryClient = useQueryClient()
   const { errorSnackbar, successSnackbar } = useSnackbar()
-  const { data: website } = useQuery<Website | null>({
+  const { data: website, isSuccess } = useQuery<Website | null>({
     queryKey: USER_WEBSITE_QUERY_KEY,
     queryFn: getUserWebsite,
   })
@@ -55,15 +55,21 @@ export default function WhyRunningSection(): React.JSX.Element {
   const seededRef = useRef(false)
 
   useEffect(() => {
-    if (seededRef.current || !website) return
-    const initial = website.content?.about?.bio ?? ''
+    // Seed once the website query has settled, not only when `website` is
+    // truthy. A candidate who hasn't created a website yet resolves to `null`
+    // here (saveAboutFields creates the site on save), so gating on a truthy
+    // `website` would leave `initialBio` null forever and the bio editor would
+    // never mount — the field would be completely absent. Seed from an empty
+    // bio in that case so the editor renders and they can fill it in.
+    if (seededRef.current || !isSuccess) return
+    const initial = website?.content?.about?.bio ?? ''
     setBio(initial)
     // Seed length up-front so Save isn't falsely disabled before the editor
     // emits its first onTextLengthChange.
     setBioPlainLength(getBioPlainLength(initial))
     setInitialBio(initial)
     seededRef.current = true
-  }, [website])
+  }, [isSuccess, website])
 
   const bioError = getBioError(bioPlainLength)
 

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -109,6 +109,24 @@ describe('CandidateProfile — bio editor mounts with no website yet (ENG-10283)
 
     expect(await screen.findByTestId('rich-editor')).toBeInTheDocument()
   })
+
+  it('seeds issues to [] so submit surfaces the policy-priority error', async () => {
+    // Guards the null-website seeding path: `setIssues(normalizeIssues(undefined))`
+    // must produce an empty array. If it ever seeded a phantom priority, the
+    // user would be silently blocked (no priority to add, yet submit fails), so
+    // assert the priority error fires rather than just that the editor mounts.
+    const user = userEvent.setup()
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+
+    await screen.findByTestId('rich-editor')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+  })
 })
 
 describe('CandidateProfile — deleting a policy priority persists (ENG-10270)', () => {

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -97,3 +97,61 @@ describe('CandidateProfile — submit validation messaging', () => {
     expect(screen.queryByText('Please add your bio')).not.toBeInTheDocument()
   })
 })
+
+describe('CandidateProfile — bio editor mounts with no website yet (ENG-10283)', () => {
+  it('renders the "Why are you running?" editor when getUserWebsite resolves to null', async () => {
+    // A Pro candidate who has not created a website yet gets `null` from
+    // getUserWebsite (saveAboutFields creates the website on submit). The bio
+    // editor must still mount so they can fill it in — otherwise the field is
+    // completely absent and the compliance flow is unfinishable.
+    getUserWebsite.mockResolvedValue(null)
+    render(<CandidateProfile />)
+
+    expect(await screen.findByTestId('rich-editor')).toBeInTheDocument()
+  })
+})
+
+describe('CandidateProfile — deleting a policy priority persists (ENG-10270)', () => {
+  it('submits the reduced issues array after deleting a priority', async () => {
+    const user = userEvent.setup()
+    const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+    // Start with two priorities so the post-delete list still satisfies the
+    // "at least one priority" requirement and Submit isn't blocked.
+    getUserWebsite.mockResolvedValue(websiteWith(validBio, 2))
+    saveAboutFields.mockResolvedValue(true)
+    render(<CandidateProfile />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+
+    // Open the second priority's edit form, click Delete, then confirm in the
+    // alert dialog. The edit modal unmounts on Delete, so by the confirm step
+    // the only remaining "Delete" button is the alert dialog's proceed action.
+    await user.click(
+      await screen.findByRole('button', { name: 'Edit Priority 2' }),
+    )
+    await user.click(await screen.findByRole('button', { name: /^delete$/i }))
+    expect(
+      await screen.findByText(
+        'Are you sure you want to delete this policy priority?',
+      ),
+    ).toBeInTheDocument()
+    await user.click(await screen.findByRole('button', { name: /^delete$/i }))
+
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    // The deletion must persist: the saved array is the exact reduced list —
+    // a single element that is Priority 1 only, with the removed Priority 2
+    // gone. This is the regression guard for the reported "deleted priority
+    // reappears" bug.
+    expect(saveAboutFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bio: validBio,
+        issues: [expect.objectContaining({ title: 'Priority 1' })],
+      }),
+    )
+    await waitFor(() =>
+      expect(router.push).toHaveBeenCalledWith('/dashboard/profile'),
+    )
+  })
+})

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -36,7 +36,7 @@ export default function CandidateProfile(): React.JSX.Element {
   const router = useRouter()
   const queryClient = useQueryClient()
   const { errorSnackbar } = useSnackbar()
-  const { data: website } = useQuery<Website | null>({
+  const { data: website, isSuccess } = useQuery<Website | null>({
     queryKey: USER_WEBSITE_QUERY_KEY,
     queryFn: getUserWebsite,
   })
@@ -59,16 +59,22 @@ export default function CandidateProfile(): React.JSX.Element {
   const seededRef = useRef(false)
 
   useEffect(() => {
-    if (seededRef.current || !website) return
-    const initialBioValue = website.content?.about?.bio ?? ''
+    // Seed once the website query has settled, not only when `website` is
+    // truthy. A candidate who hasn't created a website yet resolves to `null`
+    // here (saveAboutFields creates the site on submit), so gating on a truthy
+    // `website` would leave `initialBio` null forever and the bio editor would
+    // never mount — the field would be completely absent. Seed from an empty
+    // bio in that case so the editor renders and they can fill it in.
+    if (seededRef.current || !isSuccess) return
+    const initialBioValue = website?.content?.about?.bio ?? ''
     setBio(initialBioValue)
     // Seed length up-front so Submit doesn't show a false "add your bio" error
     // before the dynamically-imported editor emits its first onTextLengthChange.
     setBioPlainLength(getBioPlainLength(initialBioValue))
     setInitialBio(initialBioValue)
-    setIssues(normalizeIssues(website.content?.about?.issues))
+    setIssues(normalizeIssues(website?.content?.about?.issues))
     seededRef.current = true
-  }, [website])
+  }, [isSuccess, website])
 
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)


### PR DESCRIPTION
… deletion tests

- Added tests to ensure the bio editor mounts correctly when no website is available, allowing candidates to fill in their bio.
- Implemented tests to verify that deleting a policy priority persists the changes correctly, preventing previously deleted priorities from reappearing.
- Updated CandidateProfile component to handle bio initialization based on the success of the website query, improving user experience during profile editing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to query-success seeding in the compliance profile flow plus tests; no auth or backend changes.
> 
> **Overview**
> Fixes **CandidateProfile** so bio and policy priorities seed when `getUserWebsite` finishes successfully with **`null`** (no website yet), not only when a website object exists. The effect now keys off **`isSuccess`** and optional-chains website fields, so **`initialBio`** is set to an empty string and the **“Why are you running?”** rich editor mounts instead of staying hidden and blocking texting compliance.
> 
> Adds regression tests: one for the null-website editor case (**ENG-10283**), and one that deletes a policy priority and asserts **`saveAboutFields`** receives only the remaining issue (**ENG-10270**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408f8312aff3ad87d03726fa49ee7848f30592d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->