### PR TITLE
Update submodule pointer for ai-rules and change calendar link in Ele…

### DIFF
--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -19,7 +19,7 @@ const ElectionOver = (): React.JSX.Element => {
         Contact us for a debrief about how the election went.
       </Body1>
       <ScheduleModal
-        calendar="https://meetings.hubspot.com/kennedy-mason/candidate-debrief-interviews"
+        calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
         btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
       />
     </section>


### PR DESCRIPTION
…ctionOver component

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single hardcoded calendar URL change with no auth, data, or scheduling logic changes.
> 
> **Overview**
> Updates the **election debrief** scheduling link on the post-race dashboard (`ElectionOver`). The `ScheduleModal` `calendar` prop now points to Good Party’s **campaign-success / election-debrief** meeting page on `join.goodparty.org` instead of the previous HubSpot **candidate-debrief-interviews** URL. Copy and UI are unchanged; only where “Contact us for a debrief” sends users to book time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7247d6b9115d296532aa0fa6697fd3a42987bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->