### PR TITLE
feat(ElectionOver): conditionally render debrief section based on cam…

### DIFF
--- a/app/dashboard/components/ElectionOver.test.tsx
+++ b/app/dashboard/components/ElectionOver.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import ElectionOver from './ElectionOver'
+
+const mockUseCampaign = vi.fn()
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => mockUseCampaign(),
+}))
+
+const DEBRIEF_COPY = 'Contact us for a debrief about how the election went.'
+const CONSOLATION_COPY =
+  "You ran a great race, sorry you didn't come out on top"
+const DEBRIEF_BUTTON = 'Contact us for a debrief'
+
+describe('ElectionOver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the consolation copy and hides the debrief button for non-pro campaigns', () => {
+    mockUseCampaign.mockReturnValue([{ id: 'campaign-1', isPro: false }])
+
+    render(<ElectionOver />)
+
+    expect(screen.getByText(CONSOLATION_COPY)).toBeInTheDocument()
+    expect(screen.queryByText(DEBRIEF_COPY)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: DEBRIEF_BUTTON }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the debrief copy and button for pro campaigns', () => {
+    mockUseCampaign.mockReturnValue([{ id: 'campaign-1', isPro: true }])
+
+    render(<ElectionOver />)
+
+    expect(screen.getByText(DEBRIEF_COPY)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: DEBRIEF_BUTTON }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(CONSOLATION_COPY)).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -20,16 +20,16 @@ const ElectionOver = (): React.JSX.Element => {
         height={172}
         alt="election over"
       />
+      <Body1 className="my-5">
+        {isPro
+          ? 'Contact us for a debrief about how the election went.'
+          : "You ran a great race, sorry you didn't come out on top"}
+      </Body1>
       {isPro && (
-        <>
-          <Body1 className="my-5">
-            Contact us for a debrief about how the election went.
-          </Body1>
-          <ScheduleModal
-            calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
-            btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
-          />
-        </>
+        <ScheduleModal
+          calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
+          btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
+        />
       )}
     </section>
   )

--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -1,11 +1,16 @@
+'use client'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
 import Body1 from '@shared/typography/Body1'
 import H1 from '@shared/typography/H1'
 import ScheduleModal from 'app/onboarding/shared/ScheduleModal'
+import { useCampaign } from '@shared/hooks/useCampaign'
 
 import Image from 'next/image'
 
 const ElectionOver = (): React.JSX.Element => {
+  const [campaign] = useCampaign()
+  const isPro = campaign?.isPro || false
+
   return (
     <section className="py-10 flex items-center flex-col">
       <H1 className="mb-4">This race has concluded!</H1>
@@ -15,13 +20,17 @@ const ElectionOver = (): React.JSX.Element => {
         height={172}
         alt="election over"
       />
-      <Body1 className="my-5">
-        Contact us for a debrief about how the election went.
-      </Body1>
-      <ScheduleModal
-        calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
-        btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
-      />
+      {isPro && (
+        <>
+          <Body1 className="my-5">
+            Contact us for a debrief about how the election went.
+          </Body1>
+          <ScheduleModal
+            calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
+            btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
+          />
+        </>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
…paign type

Added logic to display the debrief contact information and scheduling modal only for pro campaigns. This enhances the user experience by tailoring the content based on the campaign type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI conditional with no auth, billing, or data-path changes beyond existing campaign context.
> 
> **Overview**
> The post-election dashboard screen still shows the concluded message and flag for everyone, but the **debrief** copy and **ScheduleModal** CTA now appear only when the active campaign is **Pro**.
> 
> `ElectionOver` is marked `'use client'` and reads `campaign?.isPro` via `useCampaign` to gate that block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266b17c1e6194a44ba74dfc058c3f39d3a12d06c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->