### PR TITLE
dev -> qa

### DIFF
--- a/app/dashboard/components/ElectionOver.test.tsx
+++ b/app/dashboard/components/ElectionOver.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import ElectionOver from './ElectionOver'
+
+const mockUseCampaign = vi.fn()
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => mockUseCampaign(),
+}))
+
+const DEBRIEF_COPY = 'Contact us for a debrief about how the election went.'
+const CONSOLATION_COPY =
+  "You ran a great race, sorry you didn't come out on top"
+const DEBRIEF_BUTTON = 'Contact us for a debrief'
+
+describe('ElectionOver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the consolation copy and hides the debrief button for non-pro campaigns', () => {
+    mockUseCampaign.mockReturnValue([{ id: 'campaign-1', isPro: false }])
+
+    render(<ElectionOver />)
+
+    expect(screen.getByText(CONSOLATION_COPY)).toBeInTheDocument()
+    expect(screen.queryByText(DEBRIEF_COPY)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: DEBRIEF_BUTTON }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the debrief copy and button for pro campaigns', () => {
+    mockUseCampaign.mockReturnValue([{ id: 'campaign-1', isPro: true }])
+
+    render(<ElectionOver />)
+
+    expect(screen.getByText(DEBRIEF_COPY)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: DEBRIEF_BUTTON }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(CONSOLATION_COPY)).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -20,16 +20,16 @@ const ElectionOver = (): React.JSX.Element => {
         height={172}
         alt="election over"
       />
+      <Body1 className="my-5">
+        {isPro
+          ? 'Contact us for a debrief about how the election went.'
+          : "You ran a great race, sorry you didn't come out on top"}
+      </Body1>
       {isPro && (
-        <>
-          <Body1 className="my-5">
-            Contact us for a debrief about how the election went.
-          </Body1>
-          <ScheduleModal
-            calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
-            btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
-          />
-        </>
+        <ScheduleModal
+          calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
+          btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
+        />
       )}
     </section>
   )

--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -1,11 +1,16 @@
+'use client'
 import PrimaryButton from '@shared/buttons/PrimaryButton'
 import Body1 from '@shared/typography/Body1'
 import H1 from '@shared/typography/H1'
 import ScheduleModal from 'app/onboarding/shared/ScheduleModal'
+import { useCampaign } from '@shared/hooks/useCampaign'
 
 import Image from 'next/image'
 
 const ElectionOver = (): React.JSX.Element => {
+  const [campaign] = useCampaign()
+  const isPro = campaign?.isPro || false
+
   return (
     <section className="py-10 flex items-center flex-col">
       <H1 className="mb-4">This race has concluded!</H1>
@@ -15,13 +20,17 @@ const ElectionOver = (): React.JSX.Element => {
         height={172}
         alt="election over"
       />
-      <Body1 className="my-5">
-        Contact us for a debrief about how the election went.
-      </Body1>
-      <ScheduleModal
-        calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
-        btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
-      />
+      {isPro && (
+        <>
+          <Body1 className="my-5">
+            Contact us for a debrief about how the election went.
+          </Body1>
+          <ScheduleModal
+            calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
+            btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
+          />
+        </>
+      )}
     </section>
   )
 }

--- a/app/dashboard/components/ElectionOver.tsx
+++ b/app/dashboard/components/ElectionOver.tsx
@@ -19,7 +19,7 @@ const ElectionOver = (): React.JSX.Element => {
         Contact us for a debrief about how the election went.
       </Body1>
       <ScheduleModal
-        calendar="https://meetings.hubspot.com/kennedy-mason/candidate-debrief-interviews"
+        calendar="https://join.goodparty.org/meetings/campaign-success/election-debrief"
         btn={<PrimaryButton>Contact us for a debrief</PrimaryButton>}
       />
     </section>

--- a/app/onboarding/success/components/PlanSectionNav.tsx
+++ b/app/onboarding/success/components/PlanSectionNav.tsx
@@ -47,6 +47,22 @@ const PlanSectionNav = ({
     onStuckChange?.(isStuck)
   }, [isStuck, onStuckChange])
 
+  // When sections changes (e.g. Section 2 drops out after strategy
+  // resolves ready-but-empty), the previously-tracked activeId may no
+  // longer be in the list. The controlled <Select value={activeId}>
+  // would then have no matching <SelectItem> — Radix renders an empty
+  // trigger with no label until the user clicks. Snap activeId back to
+  // the first available section whenever the list shrinks past it.
+  useEffect(() => {
+    if (sections.length === 0) return
+    if (!sections.some((s) => s.id === activeId)) {
+      setActiveId(sections[0]?.id ?? '')
+    }
+    // Intentionally omit activeId from deps — we only want to re-check
+    // when sections changes, not every time we update activeId here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sections])
+
   useEffect(() => {
     if (sections.length === 0) return
 

--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -462,9 +462,19 @@ const PlanSections = ({
   const isEventsError = eventsState?.isError ?? false
   const isPressOutletsGenerating = pressOutletsState?.isGenerating ?? false
   const isPressOutletsError = pressOutletsState?.isError ?? false
-  // Hide section 2 entirely on error (per product decision); keep it in
-  // the nav only when we're either showing the skeleton or have data.
-  const showSection2 = !isStrategyError
+  // Hide section 2 entirely on error (per product decision), and also
+  // hide it when the strategy resolved ready-but-empty. Ready-empty
+  // happens when gp-api short-circuits an election-api 404 with
+  // `{ status: 'ready', data: <empty> }` to break the polling loop —
+  // there's nothing useful to show, and rendering three empty
+  // subsections under the intro paragraph would look broken. We still
+  // show the section while generating so the skeleton has a place.
+  const hasStrategyContent =
+    plan.opportunities.length > 0 ||
+    plan.challenges.length > 0 ||
+    plan.opponents.length > 0
+  const showSection2 =
+    !isStrategyError && (isStrategyGenerating || hasStrategyContent)
   const navSections = showSection2
     ? PLAN_SECTIONS
     : PLAN_SECTIONS.filter((s) => s.id !== 'plan-section-2')

--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -469,10 +469,14 @@ const PlanSections = ({
   // there's nothing useful to show, and rendering three empty
   // subsections under the intro paragraph would look broken. We still
   // show the section while generating so the skeleton has a place.
+  //
+  // Guard only on opportunities/challenges, NOT opponents:
+  // `buildOpponents` falls back to `raceCandidates` (and other
+  // pre-strategy fallbacks) when the LLM strategy is empty, so
+  // `plan.opponents` is often populated even in the ready-empty case.
+  // Including it here would defeat the guard.
   const hasStrategyContent =
-    plan.opportunities.length > 0 ||
-    plan.challenges.length > 0 ||
-    plan.opponents.length > 0
+    plan.opportunities.length > 0 || plan.challenges.length > 0
   const showSection2 =
     !isStrategyError && (isStrategyGenerating || hasStrategyContent)
   const navSections = showSection2

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -126,31 +126,38 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   )?.onboarding?.structuredOffice
   const ballotReadyPositionId = onboardingStructuredOffice?.positionId
 
-  // Section 7 press outlets — reuse the onboarding local-news endpoint
-  // that was already populated during the LocalNewsSourcesSection step.
-  // Cache key MUST match what onboarding sent for both halves of the
-  // hit to land:
-  //   - React Query cache (in the browser): same keyArgs → no refetch
-  //   - gp-api persisted cache (campaign.data.onboarding.localMediaOutlets):
-  //     same (office, city, state) → no re-generation
-  // Onboarding uses `answers.structuredOffice.{positionName, city, state}`
-  // verbatim. The success page's polished `race` (election-api's
-  // officialOfficeName, e.g. "Anytown Council") differs from BR's
-  // positionName ("City Council Member"), so reading from race here would
-  // miss both caches and trigger a fresh Gemini run.
+  // Cache-key alignment with onboarding: any query that was warmed by
+  // onboarding must use the SAME (office, city, state) tuple onboarding
+  // sent, otherwise React Query cold-misses and gp-api re-runs the
+  // upstream call. Two consumers below depend on this:
   //
-  // The endpoint's Zod schema rejects empty-string city/office/state
-  // (min 1 char). Pass `undefined` for empty values so the request shape
-  // omits the field — onboarding-only-typed `city` is optional, but
-  // serializing `city: ''` hits the validator and 400s.
-  const localNewsOffice = onboardingStructuredOffice?.positionName || race
-  const localNewsCity = onboardingStructuredOffice?.city || city
-  const localNewsState = onboardingStructuredOffice?.state || stateValue
+  //   1. local-news query (Section 7 press outlets) — onboarding's
+  //      `LocalNewsSourcesSection` populated both React Query and
+  //      `campaign.data.onboarding.localMediaOutlets` using
+  //      `answers.structuredOffice.{positionName, city, state}`.
+  //   2. voter-issues query + `voterInsightsContext` (Section 3 + 4) —
+  //      onboarding's `TopVoterIssuesSection` populated React Query
+  //      with the same triple.
+  //
+  // The success page's polished `race` is election-api's
+  // `officialOfficeName` (e.g. "Anytown Council"), which differs from
+  // BR's `positionName` ("City Council Member") that onboarding used.
+  // Reading from `race` here would miss both warm caches. Pull from
+  // `onboardingStructuredOffice` first, fall back to the existing
+  // chain for manual-office-entry candidates who never populated it.
+  //
+  // The endpoints' Zod schemas reject empty-string fields (min 1
+  // char). Pass `undefined` for empty values so the request shape
+  // omits the field — serializing `city: ''` would hit the validator
+  // and 400.
+  const onboardingOffice = onboardingStructuredOffice?.positionName || race
+  const onboardingCity = onboardingStructuredOffice?.city || city
+  const onboardingState = onboardingStructuredOffice?.state || stateValue
   const localNewsQuery = useQuery(
     localNewsQueryOptions({
-      city: localNewsCity || undefined,
-      state: localNewsState || undefined,
-      office: localNewsOffice || undefined,
+      city: onboardingCity || undefined,
+      state: onboardingState || undefined,
+      office: onboardingOffice || undefined,
     }),
   )
   const pressOutletsFromApi: ApiPressOutlet[] | undefined =
@@ -165,13 +172,15 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
     localNewsQuery.isPending || localNewsQuery.data?.status === 'pending'
 
   // Same cache key as TopVoterIssuesSection in onboarding — keeps the PDF's
-  // Section 3 in sync with what the user already saw on screen.
+  // Section 3 in sync with what the user already saw on screen. See the
+  // onboardingOffice/City/State derivation above for why we don't use
+  // `race`/`city`/`stateValue` directly.
   const voterIssuesQuery = useQuery(
     voterIssuesQueryOptions({
       ballotReadyPositionId,
-      city,
-      state: stateValue,
-      office: race,
+      city: onboardingCity,
+      state: onboardingState,
+      office: onboardingOffice,
     }),
   )
   const voterIssuesFromApi = voterIssuesQuery.data?.issues
@@ -287,9 +296,9 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
             }}
             voterInsightsContext={{
               ballotReadyPositionId,
-              city,
-              state: stateValue,
-              office: race,
+              city: onboardingCity,
+              state: onboardingState,
+              office: onboardingOffice,
             }}
           />
         </div>

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -97,20 +97,60 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   // fires after office submit in onboarding, so the cache is usually warm
   // by the time the user lands here.
   const events = useCommunityEvents()
+  // The BR position ID is in-memory on `answers.structuredOffice.positionId`
+  // during onboarding. After pledge submit, `OnboardingFlow` persists the
+  // whole `answers` object under `campaign.data.onboarding`, so it survives
+  // the navigation to /onboarding/success.
+  //
+  // gp-api separately resolves the BR ID to an internal Position UUID and
+  // stores that on `organization.positionId` — which is NOT what the
+  // /onboarding/contacts/stats endpoint expects, so we read directly from
+  // the persisted onboarding answers instead.
+  //
+  // We also pull positionName / city / state from the same source for the
+  // local-news query below so the cache key matches what
+  // LocalNewsSourcesSection used during onboarding — see comment there.
+  const onboardingStructuredOffice = (
+    campaign?.data as
+      | {
+          onboarding?: {
+            structuredOffice?: {
+              positionId?: string
+              positionName?: string
+              city?: string
+              state?: string
+            }
+          }
+        }
+      | undefined
+  )?.onboarding?.structuredOffice
+  const ballotReadyPositionId = onboardingStructuredOffice?.positionId
+
   // Section 7 press outlets — reuse the onboarding local-news endpoint
   // that was already populated during the LocalNewsSourcesSection step.
-  // Cache key matches (city, state, office) so we hit the same persisted
-  // row from `campaign.data.onboarding.localMediaOutlets`.
+  // Cache key MUST match what onboarding sent for both halves of the
+  // hit to land:
+  //   - React Query cache (in the browser): same keyArgs → no refetch
+  //   - gp-api persisted cache (campaign.data.onboarding.localMediaOutlets):
+  //     same (office, city, state) → no re-generation
+  // Onboarding uses `answers.structuredOffice.{positionName, city, state}`
+  // verbatim. The success page's polished `race` (election-api's
+  // officialOfficeName, e.g. "Anytown Council") differs from BR's
+  // positionName ("City Council Member"), so reading from race here would
+  // miss both caches and trigger a fresh Gemini run.
   //
   // The endpoint's Zod schema rejects empty-string city/office/state
   // (min 1 char). Pass `undefined` for empty values so the request shape
   // omits the field — onboarding-only-typed `city` is optional, but
   // serializing `city: ''` hits the validator and 400s.
+  const localNewsOffice = onboardingStructuredOffice?.positionName || race
+  const localNewsCity = onboardingStructuredOffice?.city || city
+  const localNewsState = onboardingStructuredOffice?.state || stateValue
   const localNewsQuery = useQuery(
     localNewsQueryOptions({
-      city: city || undefined,
-      state: stateValue || undefined,
-      office: race || undefined,
+      city: localNewsCity || undefined,
+      state: localNewsState || undefined,
+      office: localNewsOffice || undefined,
     }),
   )
   const pressOutletsFromApi: ApiPressOutlet[] | undefined =
@@ -123,27 +163,6 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   // table or stale templated rows.
   const isLocalNewsGenerating =
     localNewsQuery.isPending || localNewsQuery.data?.status === 'pending'
-  // Section 3 voter insights — share the cache key with the on-screen
-  // TopVoterIssuesSection from the earlier onboarding step, so this is
-  // almost always a synchronous cache hit. When the cache misses (direct
-  // nav to /success), buildVoterInsights falls through to candidate
-  // customIssues/stances and finally the stub copy.
-  // The BR position ID is in-memory on `answers.structuredOffice.positionId`
-  // during onboarding. After pledge submit, `OnboardingFlow` persists the
-  // whole `answers` object under `campaign.data.onboarding`, so it survives
-  // the navigation to /onboarding/success.
-  //
-  // gp-api separately resolves the BR ID to an internal Position UUID and
-  // stores that on `organization.positionId` — which is NOT what the
-  // /onboarding/contacts/stats endpoint expects, so we read directly from
-  // the persisted onboarding answers instead.
-  const onboardingAnswers = (
-    campaign?.data as
-      | { onboarding?: { structuredOffice?: { positionId?: string } } }
-      | undefined
-  )?.onboarding
-  const ballotReadyPositionId =
-    onboardingAnswers?.structuredOffice?.positionId ?? undefined
 
   // Same cache key as TopVoterIssuesSection in onboarding — keeps the PDF's
   // Section 3 in sync with what the user already saw on screen.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI and query-key alignment changes with tests on ElectionOver; no auth or payment logic touched.
> 
> **Overview**
> **Post-election dashboard** now branches on `campaign.isPro`: Pro users see debrief copy and a **ScheduleModal** (new Good Party calendar URL); non-Pro users see consolation messaging with no debrief CTA. Vitest coverage was added for both paths.
> 
> **Onboarding success plan** fixes cache alignment and empty UI states: `SuccessPage` drives local-news, voter-issues, and voter-insights queries from persisted `campaign.data.onboarding.structuredOffice` (`positionName`, city, state) so React Query keys match onboarding warm caches instead of election-api’s `race` label. **Strategic Landscape** (section 2) is hidden when strategy is ready-but-empty (only opportunities/challenges count—opponents can still exist from fallbacks), while still showing during generation. **PlanSectionNav** resets `activeId` when the section list shrinks so the jump-to select doesn’t render blank.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf25ca68ae43f0e5491a8c9ae9fcfe77d1da3a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->