### PR TITLE
feat: implement funnel view events for compliance flow

### DIFF
--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -4,8 +4,20 @@ import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import type { Website } from 'helpers/types'
+import { EVENTS } from 'helpers/analyticsHelper'
 import { MIN_BIO_LENGTH } from '../candidateProfile.utils'
 import CandidateProfile from './CandidateProfile'
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
 
 vi.mock('app/shared/utils/RichEditor', async () => ({
   default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
@@ -171,5 +183,17 @@ describe('CandidateProfile — deleting a policy priority persists (ENG-10270)',
     await waitFor(() =>
       expect(router.push).toHaveBeenCalledWith('/dashboard/profile'),
     )
+  })
+})
+
+describe('CandidateProfile — funnel view event (ENG-10294)', () => {
+  it('fires Candidate Profile Viewed when the step renders', async () => {
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
+    render(<CandidateProfile />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.CandidateProfileViewed,
+      )
+    })
   })
 })

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -76,6 +76,12 @@ export default function CandidateProfile(): React.JSX.Element {
     seededRef.current = true
   }, [isSuccess, website])
 
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
+  // matching "submitted" signal is the existing SubmitSuccess event below.
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.CandidateProfileViewed)
+  }, [])
+
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)
 

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -15,12 +15,20 @@ vi.mock('helpers/analyticsHelper', async (importOriginal) => {
   }
 })
 
+// [user, setUser, userLoading] — default to a loaded user so `ready` is true.
+type UseUserReturn = [
+  { email: string; phone: string } | null,
+  () => void,
+  boolean,
+]
+const readyUser: UseUserReturn = [
+  { email: 'jane@example.com', phone: '5551234567' },
+  vi.fn(),
+  false,
+]
+const mockUseUser = vi.fn<() => UseUserReturn>(() => readyUser)
 vi.mock('@shared/hooks/useUser', () => ({
-  useUser: () => [
-    { email: 'jane@example.com', phone: '5551234567' },
-    vi.fn(),
-    false,
-  ],
+  useUser: () => mockUseUser(),
 }))
 
 vi.mock('@shared/hooks/useCampaign', () => ({
@@ -45,15 +53,30 @@ vi.mock(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockUseUser.mockReturnValue(readyUser)
 })
 
 describe('ElectionFiling — funnel view event (ENG-10294)', () => {
-  it('fires Filing Details Viewed when the step renders', async () => {
+  it('fires Filing Details Viewed when the form is shown (ready)', async () => {
     render(<ElectionFiling />)
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
       )
     })
+  })
+
+  it('does not fire while only the loading state is shown (not ready)', async () => {
+    // userLoading=true → `ready` is false → the form is hidden behind the
+    // Loading… spinner, so the view event must not fire (matches EnterPin's
+    // gated behavior — no over-counting users who never see the form).
+    mockUseUser.mockReturnValue([null, vi.fn(), true])
+    render(<ElectionFiling />)
+    await waitFor(() => {
+      expect(mockUseUser).toHaveBeenCalled()
+    })
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+    )
   })
 })

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { EVENTS } from 'helpers/analyticsHelper'
+import ElectionFiling from './ElectionFiling'
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
+
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: () => [
+    { email: 'jane@example.com', phone: '5551234567' },
+    vi.fn(),
+    false,
+  ],
+}))
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => [{ details: {} }],
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+// Stub the heavy registration form — this test only verifies the funnel view
+// event fires when the step renders, not the form's behavior. Both the default
+// export and the named `validateRegistrationForm` (used at module load) must be
+// provided or the import of ElectionFiling throws.
+vi.mock(
+  'app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm',
+  () => ({
+    default: () => <div data-testid="registration-form" />,
+    validateRegistrationForm: () => ({}),
+  }),
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ElectionFiling — funnel view event (ENG-10294)', () => {
+  it('fires Filing Details Viewed when the step renders', async () => {
+    render(<ElectionFiling />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+      )
+    })
+  })
+})

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -2,7 +2,7 @@
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { FormDataProvider, FormDataState } from '@shared/hooks/useFormData'
 import { useUser } from '@shared/hooks/useUser'
@@ -35,11 +35,17 @@ export default function ElectionFiling(): React.JSX.Element {
 
   const ready = !userLoading && Boolean(user) && Boolean(campaign)
 
-  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
-  // matching "submitted" signal is the existing RegistrationSubmitted event.
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). Fire
+  // only once the form is actually shown — the form is gated behind `ready`, so
+  // a bare mount event would count users who only see the Loading… spinner. The
+  // matching "submitted" signal is the existing RegistrationSubmitted event in
+  // handleFormSubmit.
+  const filingViewTrackedRef = useRef(false)
   useEffect(() => {
+    if (!ready || filingViewTrackedRef.current) return
+    filingViewTrackedRef.current = true
     trackEvent(EVENTS.ProUpgrade.Compliance.FilingDetailsViewed)
-  }, [])
+  }, [ready])
 
   const handleFormSubmit = async (formData: FormDataState) => {
     setLoading(true)

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -2,7 +2,7 @@
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { FormDataProvider, FormDataState } from '@shared/hooks/useFormData'
 import { useUser } from '@shared/hooks/useUser'
@@ -34,6 +34,12 @@ export default function ElectionFiling(): React.JSX.Element {
   const [hasSubmissionError, setHasSubmissionError] = useState(false)
 
   const ready = !userLoading && Boolean(user) && Boolean(campaign)
+
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
+  // matching "submitted" signal is the existing RegistrationSubmitted event.
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingDetailsViewed)
+  }, [])
 
   const handleFormSubmit = async (formData: FormDataState) => {
     setLoading(true)

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { api } from 'helpers/test-utils/api-mocking'
 import type { TcrCompliance, TcrComplianceStatus } from 'helpers/types'
+import { EVENTS } from 'helpers/analyticsHelper'
 import EnterPin from './EnterPin'
 
 const mockGetTcrCompliance = vi.fn<() => Promise<TcrCompliance | null>>()
@@ -139,6 +140,33 @@ describe('EnterPin — gating', () => {
   })
 })
 
+describe('EnterPin — funnel view event (ENG-10294)', () => {
+  it('fires PIN Entry Viewed once the PIN form is shown (status submitted)', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+    render(<EnterPin />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.PinEntryViewed,
+      )
+    })
+  })
+
+  it.each<[TcrComplianceStatus | null]>([['pending'], ['approved'], [null]])(
+    'does not fire PIN Entry Viewed when the form is never shown (status %s)',
+    async (status) => {
+      mockGetTcrCompliance.mockResolvedValue(tcrWith(status))
+      render(<EnterPin />)
+      // Let the gating/redirect effects settle before asserting non-emission.
+      await waitFor(() => {
+        expect(mockGetTcrCompliance).toHaveBeenCalled()
+      })
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.PinEntryViewed,
+      )
+    },
+  )
+})
+
 describe('EnterPin — submit flow', () => {
   it('happy path: submits PIN, fires analytics, invalidates cache, redirects', async () => {
     const user = userEvent.setup()
@@ -165,7 +193,13 @@ describe('EnterPin — submit flow', () => {
     })
 
     expect(receivedBody).toEqual({ pin: '123456' })
-    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+    // Submit fires the PIN-verification event. (The mount-time PinEntryViewed
+    // funnel event also fires for `submitted` status — assert the specific
+    // submit event rather than a raw call count.)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      EVENTS.Outreach.DlcCompliance.PinVerificationCompleted,
+      expect.objectContaining({ dlcComplianceStatus: 'Yes' }),
+    )
     expect(mockSuccessSnackbar).toHaveBeenCalledWith(
       expect.stringMatching(/PIN submitted/i),
     )

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -53,6 +53,18 @@ export default function EnterPin(): React.JSX.Element {
       router.push(PROFILE_ROUTE)
     }
   }, [shouldRedirect, router])
+
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). Fire
+  // only once the PIN entry UI is actually shown — this page redirects away for
+  // PENDING/APPROVED, so a bare mount event would count users who never see it.
+  // The matching "submitted" signal is the existing PinVerificationCompleted
+  // event in handleSubmit below.
+  const pinViewTrackedRef = useRef(false)
+  useEffect(() => {
+    if (isPending || !isAwaitingPin || pinViewTrackedRef.current) return
+    pinViewTrackedRef.current = true
+    trackEvent(EVENTS.ProUpgrade.Compliance.PinEntryViewed)
+  }, [isPending, isAwaitingPin])
 
   const handleSubmit = async (pin: string): Promise<void> => {
     if (!tcrCompliance) return

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -328,6 +328,17 @@ export const EVENTS = {
       ClickFinish: 'Pro Upgrade - Service Agreement Page: Click finish',
     },
     ClickGoToStripe: 'Pro Upgrade: Click Go to Stripe',
+    // Agentic Pro Upgrade → 10DLC compliance funnel (ENG-10294). Kept separate
+    // from the legacy Modal / SplashPage / CommitteeCheck events above, which
+    // belong to the older upgrade UX. The funnel's submit/checkout-start signals
+    // already exist and are reused (Profile.CandidateProfile.SubmitSuccess,
+    // Outreach.DlcCompliance.RegistrationSubmitted / PinVerificationCompleted,
+    // ProUpgrade.ClickGoToStripe); the "viewed" steps below were the gap.
+    Compliance: {
+      CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
+      FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
+      PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',
+    },
   },
   Contacts: {
     Download: 'Contacts - Download',


### PR DESCRIPTION
Added tracking for "Candidate Profile Viewed", "Filing Details Viewed", and "PIN Entry Viewed" events to enhance analytics for the agentic compliance flow. This includes updates to the CandidateProfile and EnterPin components to ensure events are fired appropriately when the respective views are rendered. The analytics helper was also updated to include these new event types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation and tests; no auth, API, or business-logic changes beyond firing Segment events on page views.
> 
> **Overview**
> Adds **Pro Upgrade compliance funnel “viewed”** analytics (ENG-10294) so each agentic 10DLC step can be measured alongside existing submit events.
> 
> New `EVENTS.ProUpgrade.Compliance` entries cover **Candidate Profile**, **Filing Details**, and **PIN Entry** viewed. `CandidateProfile` and `ElectionFiling` fire their events on mount. `EnterPin` fires **PIN Entry Viewed** only when the PIN form is shown (`submitted` status), not on redirect or out-of-state paths. Tests mock `trackEvent` and assert the new events (and tighten the PIN submit test to assert `PinVerificationCompleted` specifically).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620a7a8574564b6ab15e8da305b746520b2f6eb7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->