### PR TITLE
Update sections to reflect new opposition response.

### DIFF
--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -336,36 +336,6 @@ const OppositionResearch = ({
               <li>Party: {opp.partyAffiliation}</li>
             ) : null}
             {opp.incumbent === true ? <li>Incumbent</li> : null}
-            {opp.politicalSummary ? <li>{opp.politicalSummary}</li> : null}
-            {opp.keyFacts.length > 0 ? (
-              <li>
-                Key facts:
-                <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
-                  {opp.keyFacts.map((fact) => (
-                    <li key={fact}>{fact}</li>
-                  ))}
-                </ul>
-              </li>
-            ) : null}
-            {opp.websites.length > 0 ? (
-              <li>
-                Websites:
-                <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
-                  {opp.websites.map((w) => (
-                    <li key={w}>
-                      <a
-                        href={w}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-components-input-active hover:underline"
-                      >
-                        {w}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            ) : null}
           </ul>
         </li>
       ))}

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -196,17 +196,13 @@ export interface GlossaryRow {
   definition: string
 }
 
-// Mirrors `StrategicLandscapeOpponent` from gp-api. Some pre-strategy
-// fallbacks (hubspotIncumbent, runningAgainst) still produce records with
-// `politicalSummary === ''` and `keyFacts === []` when no rich data is
-// available — the renderer hides empty fields.
+// Mirrors `StrategicLandscapeOpponent` from gp-api. Who is running: name,
+// party, incumbency. Narrative profiling (summary, key facts, websites) isn't
+// part of this section.
 export interface Opponent {
   fullName: string
   partyAffiliation: string
   incumbent: boolean | null
-  politicalSummary: string
-  keyFacts: string[]
-  websites: string[]
 }
 
 export interface VoterInsightIssue {
@@ -820,11 +816,9 @@ const buildOpponents = (
   hubspotIncumbentName: string | null,
 ): Opponent[] => {
   // Source priority:
-  //   1. strategicLandscape — full shape (politicalSummary, keyFacts,
-  //      websites). The LLM endpoint is the richest source.
+  //   1. strategicLandscape — the CAP endpoint's opponent roster.
   //   2. raceCandidates — BR/election-api filings via raceTargetMetrics.
-  //      Authoritative for who's on the ballot + incumbent flag, but no
-  //      narrative fields.
+  //      Authoritative for who's on the ballot + incumbent flag.
   //   3. runningAgainst — user-entered onboarding answers.
   //   4. hubspotIncumbent — last-ditch incumbent name from HubSpot.
   if (strategicLandscape?.opponents.length) {
@@ -832,9 +826,6 @@ const buildOpponents = (
       fullName: o.fullName,
       partyAffiliation: o.partyAffiliation,
       incumbent: o.incumbent,
-      politicalSummary: o.politicalSummary,
-      keyFacts: o.keyFacts,
-      websites: o.websites,
     }))
   }
   const fromRaceCandidates: Opponent[] = raceCandidates
@@ -843,9 +834,6 @@ const buildOpponents = (
       fullName: c.fullName.trim(),
       partyAffiliation: c.party?.trim() ?? '',
       incumbent: c.isIncumbent,
-      politicalSummary: '',
-      keyFacts: [],
-      websites: c.websiteUrl ? [c.websiteUrl] : [],
     }))
   if (fromRaceCandidates.length > 0) return fromRaceCandidates
   const fromRunningAgainst: Opponent[] = runningAgainst
@@ -854,9 +842,6 @@ const buildOpponents = (
       fullName: o.name?.trim() ?? '',
       partyAffiliation: o.party?.trim() ?? '',
       incumbent: false,
-      politicalSummary: o.description?.trim() ?? '',
-      keyFacts: [],
-      websites: [],
     }))
   if (fromRunningAgainst.length > 0) return fromRunningAgainst
   if (hubspotIncumbentName && hubspotIncumbentName.trim() !== '') {
@@ -865,9 +850,6 @@ const buildOpponents = (
         fullName: hubspotIncumbentName.trim(),
         partyAffiliation: '',
         incumbent: true,
-        politicalSummary: '',
-        keyFacts: [],
-        websites: [],
       },
     ]
   }

--- a/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
+++ b/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
@@ -789,9 +789,6 @@ export const CampaignPlanPdfDocument = ({
                     ? [`Party: ${opp.partyAffiliation}`]
                     : []),
                   ...(opp.incumbent === true ? ['Incumbent'] : []),
-                  ...(opp.politicalSummary ? [opp.politicalSummary] : []),
-                  ...opp.keyFacts,
-                  ...opp.websites,
                 ]}
               />
             </View>

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -55,15 +55,12 @@ export interface MeetingBriefingAwaitingDto {
 }
 
 // Mirrors `OpponentSchema` in gp-api
-// (`src/campaignStrategy/schemas/strategicLandscape.schema.ts`). `incumbent`
-// is nullable because the LLM may legitimately not know.
+// (`src/campaignStrategy/schemas/strategicLandscape.schema.ts`). Who is
+// running: name, party, incumbency. No narrative profiling.
 export interface StrategicLandscapeOpponent {
   fullName: string
   partyAffiliation: string
   incumbent: boolean | null
-  politicalSummary: string
-  keyFacts: string[]
-  websites: string[]
 }
 
 export interface StrategicLandscapeData {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation and client type alignment only; no auth or persistence changes, and removed fields are unused elsewhere in the repo.
> 
> **Overview**
> Opposition research in the onboarding **campaign plan** (web, PDF, and plan data layer) now lists opponents as **name, party, and incumbency only**, matching a slimmer strategic-landscape / CAP opponent shape.
> 
> **`Opponent`** and **`StrategicLandscapeOpponent`** drop `politicalSummary`, `keyFacts`, and `websites`. **`buildOpponents`** no longer maps narrative fields from the API or fills empty summaries / website lists from race filings, onboarding answers, or HubSpot. **Opposition Research** UI and PDF bullets stop rendering summaries, key facts, and website links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bba97e1ebbb4d72e0c178c8f1128c8b826f3771. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->