### PR TITLE
fix(ComplianceModal): gate texting-compliance copy on pro-upgrade1 flag

### DIFF
--- a/app/dashboard/shared/ComplianceModal.tsx
+++ b/app/dashboard/shared/ComplianceModal.tsx
@@ -6,6 +6,7 @@ import Body2 from '@shared/typography/Body2'
 import Button from '@shared/buttons/Button'
 import { TCR_COMPLIANCE_STATUS } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
 import type { TcrComplianceStatus } from 'helpers/types'
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 
 interface ComplianceModalProps {
   open: boolean
@@ -18,6 +19,29 @@ export function ComplianceModal({
   tcrComplianceStatus,
   onClose,
 }: ComplianceModalProps): React.JSX.Element {
+  const { ready, enabled } = useProUpgradeFlag()
+  const phase1Enabled = ready && enabled
+
+  const helpTrailer = (
+    <>
+      <br />
+      <br />
+      Have questions? Visit{' '}
+      <a
+        href="https://support.goodparty.org/help-center/getting-text-compliant"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className="underline"
+      >
+        our help center
+      </a>{' '}
+      for more information or send us an email at{' '}
+      <a href="mailto:campaignsuccess@goodparty.org" className="underline">
+        campaignsuccess@goodparty.org
+      </a>
+    </>
+  )
+
   let title: string,
     description: string | React.ReactNode,
     cta: string,
@@ -49,26 +73,10 @@ export function ComplianceModal({
       title = 'Action required: register for texting compliance'
       description = (
         <>
-          Carrier requirements mean you must register before sending your first
-          text. You&apos;ll need your Campaign EIN, your official filing link,
-          and an active website purchased through GoodParty.org. Don&apos;t have
-          a site yet? You can build and launch one right from your dashboard
-          before getting started.
-          <br />
-          <br />
-          Have questions? Visit{' '}
-          <a
-            href="https://support.goodparty.org/help-center/getting-text-compliant"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            className="underline"
-          >
-            our help center
-          </a>{' '}
-          for more information or send us an email at{' '}
-          <a href="mailto:campaignsuccess@goodparty.org" className="underline">
-            campaignsuccess@goodparty.org
-          </a>
+          {phase1Enabled
+            ? "Carrier requirements mean you must register before sending your first text. You'll need your Campaign EIN and your official filing link. Ready? Click Start Your Registration to get started."
+            : "Carrier requirements mean you must register before sending your first text. You'll need your Campaign EIN, your official filing link, and an active website purchased through GoodParty.org. Don't have a site yet? You can build and launch one right from your dashboard before getting started."}
+          {helpTrailer}
         </>
       )
       cta = 'Start Registration'


### PR DESCRIPTION
Update the 10 DLC texting-compliance modal so candidates in the Pro Upgrade1 (Phase 1) experience no longer see 'an active website purchased through GoodParty.org' listed as a requirement, since the website is now created automatically. When the flag is on, the modal asks only for the Campaign EIN and official filing link and directs the candidate to start their registration; when the flag is off or still loading, the existing copy is shown unchanged. Both variants route to the same texting-compliance destination. Also extracts the shared help-center and contact trailer into a single helpTrailer const so the description ternaries only the one sentence that actually differs between the two experiences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and a feature-flag branch in a dashboard modal only; no auth, API, or compliance workflow logic changes.
> 
> **Overview**
> The default **10DLC compliance** modal copy is now **split by the `pro-upgrade1` feature flag**. When Phase 1 is active (`ready && enabled`), users see requirements limited to **Campaign EIN** and **official filing link**, without mentioning a GoodParty-purchased website or dashboard site setup. When the flag is off or still loading, the **previous** messaging (including website requirement) is unchanged.
> 
> Shared **help center** and **campaignsuccess@** contact links are moved into a **`helpTrailer`** fragment so only the requirement sentence varies between variants. **CTA** and **href** to texting compliance are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809b62ec37e93befd6c5bfd8199d8095960d8686. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->