### PR TITLE
feat(ElectionFiling): update initial form state handling for campaign…

### DIFF
--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
 import { EVENTS } from 'helpers/analyticsHelper'
-import ElectionFiling from './ElectionFiling'
+import ElectionFiling, { getInitialFormState } from './ElectionFiling'
+
+type Campaign = Parameters<typeof getInitialFormState>[0]
 
 const mockTrackEvent = vi.fn()
 vi.mock('helpers/analyticsHelper', async (importOriginal) => {
@@ -78,5 +80,31 @@ describe('ElectionFiling — funnel view event (ENG-10294)', () => {
     expect(mockTrackEvent).not.toHaveBeenCalledWith(
       EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
     )
+  })
+})
+
+describe('getInitialFormState — filing contact info not auto-filled (ENG-10290)', () => {
+  const campaign = {
+    details: { einNumber: '12-3456789', campaignCommittee: 'Friends of Jane' },
+  } as Campaign
+
+  it('leaves email and phone blank so the candidate must enter filing values', () => {
+    const state = getInitialFormState(campaign)
+    expect(state.email).toBe('')
+    expect(state.phone).toBe('')
+  })
+
+  it('still pre-fills EIN and committee from the campaign filing details', () => {
+    const state = getInitialFormState(campaign)
+    expect(state.ein).toBe('12-3456789')
+    expect(state.campaignCommitteeName).toBe('Friends of Jane')
+  })
+
+  it('defaults committee and EIN to empty when campaign details are missing', () => {
+    const state = getInitialFormState({} as Campaign)
+    expect(state.ein).toBe('')
+    expect(state.campaignCommitteeName).toBe('')
+    expect(state.email).toBe('')
+    expect(state.phone).toBe('')
   })
 })

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -88,7 +88,7 @@ export default function ElectionFiling(): React.JSX.Element {
         <div className="mt-10">
           {ready ? (
             <FormDataProvider
-              initialState={getInitialFormState(user, campaign)}
+              initialState={getInitialFormState(campaign)}
               validator={validateAgenticForm}
             >
               <TextingComplianceRegistrationForm
@@ -107,8 +107,14 @@ export default function ElectionFiling(): React.JSX.Element {
   )
 }
 
-const getInitialFormState = (
-  user: ReturnType<typeof useUser>[0],
+// Email and phone are intentionally left blank rather than seeded from the
+// candidate's GoodParty account (ENG-10290). Account contact info frequently
+// does not match what is on the official campaign filing; pre-filling it led
+// candidates to submit a mismatch without noticing, causing compliance
+// failures. They must enter the email/phone exactly as filed. EIN and
+// committee come from campaign.details, which reflect the filing, so those
+// stay pre-filled.
+export const getInitialFormState = (
   campaign: ReturnType<typeof useCampaign>[0],
 ): FormDataState => {
   const details = (campaign?.details ?? {}) as {
@@ -120,9 +126,9 @@ const getInitialFormState = (
     campaignCommitteeName: details.campaignCommittee || '',
     officeLevel: '',
     ein: details.einNumber || '',
-    phone: user?.phone || '',
+    phone: '',
     address: { formatted_address: '', place_id: '' },
     website: '',
-    email: user?.email || '',
+    email: '',
   }
 }

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -57,7 +57,13 @@ export default function ElectionFiling(): React.JSX.Element {
         'Failed to submit election filing',
       )
       trackEvent(EVENTS.Outreach.DlcCompliance.RegistrationSubmitted, {
-        email: user?.email,
+        // The filing email the candidate just submitted, not their account
+        // email (user?.email). The two deliberately differ here (see
+        // getInitialFormState), and trackEvent already attaches the account
+        // email to every event by default — so this override is only useful if
+        // it records the filing value. isValid gates submit on isEmail, so this
+        // is always a valid non-empty string.
+        email: formData.email,
         dlcComplianceStatus: 'Pending',
       })
       successSnackbar('Election filing submitted')


### PR DESCRIPTION
… filings

Refactored the getInitialFormState function to ensure email and phone fields are left blank, requiring candidates to enter their contact information manually. This change addresses compliance issues by preventing mismatches with official campaign filings. Updated tests to verify the new behavior and ensure proper pre-filling of EIN and committee details from campaign data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UX change to form defaults on the election filing step with added unit tests; no auth or API changes.
> 
> **Overview**
> Stops seeding **email** and **phone** on the election filing compliance form from the candidate’s GoodParty account (**ENG-10290**). Those fields now start empty so users must enter contact info that matches the official filing, while **EIN** and **campaign committee** still pre-fill from `campaign.details`.
> 
> `getInitialFormState` now takes only the campaign (not the user), is **exported** for tests, and includes an inline rationale. New unit tests lock in blank contact fields, filing-based pre-fill, and empty defaults when details are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 456853ca761724cb09053f0a00095f6d1a7e7976. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->