### PR TITLE
feat(Dashboard): update HubSpot domain transfer form URL in WebsiteSu…

### DIFF
--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -15,7 +15,8 @@ import { Button } from '@styleguide/components/ui/button'
 // the notice is never shown (see DashboardContent). This avoids both linking to
 // a non-existent form and opting users out of the notice before the form they
 // need exists. The URL is opened in a new tab from the CTA.
-const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = ''
+const HUBSPOT_DOMAIN_TRANSFER_FORM_URL =
+  'https://cuqn1.share.hsforms.com/24lFrnq6gQ6-FWs_7qUr5SQ'
 
 export const WEBSITE_SUNSET_NOTICE_ENABLED =
   HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0


### PR DESCRIPTION
…nsetModal

Set the HUBSPOT_DOMAIN_TRANSFER_FORM_URL to the correct link, enabling the display of the sunset notice when appropriate. This change ensures users have access to the necessary form for domain transfer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant URL update that gates existing UI; no auth, data, or payment logic changes.
> 
> **Overview**
> Sets **`HUBSPOT_DOMAIN_TRANSFER_FORM_URL`** in `WebsiteSunsetModal` from empty to the live HubSpot domain-transfer form, which turns on **`WEBSITE_SUNSET_NOTICE_ENABLED`** and allows the dashboard website-sunset modal (and its **Transfer website** CTA) to appear for eligible users instead of staying disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12739360fa89b9eae2183330630daee4813c851e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->