### PR TITLE
Release: qa → master (2026-06-04)

### DIFF
--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
 import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
@@ -9,6 +9,7 @@ import CampaignManager from './campaignManager/CampaignManager'
 import { WebsiteSunsetModal } from '../shared/WebsiteSunsetModal'
 
 const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
+const WEBSITE_SUNSET_MODAL_DISMISSED_KEY = 'websiteSunsetModalDismissed'
 
 interface DashboardContentProps {
   pathname: string
@@ -26,14 +27,30 @@ export default function DashboardContent({
   const { ready, on: aiCampaignManagerEnabled } = useFlagOn(
     AI_CAMPAIGN_MANAGER_FLAG_KEY,
   )
-  const [sunsetModalOpen, setSunsetModalOpen] = useState(true)
+  const [sunsetModalOpen, setSunsetModalOpen] = useState(false)
+
+  useEffect(() => {
+    if (
+      hasWebsite &&
+      localStorage.getItem(WEBSITE_SUNSET_MODAL_DISMISSED_KEY) !== '1'
+    ) {
+      setSunsetModalOpen(true)
+    }
+  }, [hasWebsite])
+
+  const handleSunsetModalOpenChange = (open: boolean): void => {
+    if (!open) {
+      localStorage.setItem(WEBSITE_SUNSET_MODAL_DISMISSED_KEY, '1')
+    }
+    setSunsetModalOpen(open)
+  }
 
   return (
     <>
       {hasWebsite && (
         <WebsiteSunsetModal
           open={sunsetModalOpen}
-          onOpenChange={setSunsetModalOpen}
+          onOpenChange={handleSunsetModalOpenChange}
         />
       )}
       {ready && aiCampaignManagerEnabled ? (

--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -6,7 +6,10 @@ import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
 import type { TcrCompliance } from 'helpers/types'
 import CampaignManager from './campaignManager/CampaignManager'
-import { WebsiteSunsetModal } from '../shared/WebsiteSunsetModal'
+import {
+  WebsiteSunsetModal,
+  WEBSITE_SUNSET_NOTICE_ENABLED,
+} from '../shared/WebsiteSunsetModal'
 
 const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
 const WEBSITE_SUNSET_MODAL_DISMISSED_KEY = 'websiteSunsetModalDismissed'
@@ -32,6 +35,7 @@ export default function DashboardContent({
   useEffect(() => {
     if (
       hasWebsite &&
+      WEBSITE_SUNSET_NOTICE_ENABLED &&
       localStorage.getItem(WEBSITE_SUNSET_MODAL_DISMISSED_KEY) !== '1'
     ) {
       setSunsetModalOpen(true)

--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import { useState } from 'react'
 import { useFlagOn } from '@shared/experiments/FeatureFlagsProvider'
 import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
 import type { TcrCompliance } from 'helpers/types'
 import CampaignManager from './campaignManager/CampaignManager'
+import { WebsiteSunsetModal } from '../shared/WebsiteSunsetModal'
 
 const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
 
@@ -12,26 +14,37 @@ interface DashboardContentProps {
   pathname: string
   tasks: Task[]
   tcrCompliance: TcrCompliance | null
+  hasWebsite: boolean
 }
 
 export default function DashboardContent({
   pathname,
   tasks,
   tcrCompliance,
+  hasWebsite,
 }: DashboardContentProps): React.JSX.Element {
   const { ready, on: aiCampaignManagerEnabled } = useFlagOn(
     AI_CAMPAIGN_MANAGER_FLAG_KEY,
   )
-
-  if (ready && aiCampaignManagerEnabled) {
-    return <CampaignManager pathname={pathname} tcrCompliance={tcrCompliance} />
-  }
+  const [sunsetModalOpen, setSunsetModalOpen] = useState(true)
 
   return (
-    <DashboardPage
-      pathname={pathname}
-      tasks={tasks}
-      tcrCompliance={tcrCompliance}
-    />
+    <>
+      {hasWebsite && (
+        <WebsiteSunsetModal
+          open={sunsetModalOpen}
+          onOpenChange={setSunsetModalOpen}
+        />
+      )}
+      {ready && aiCampaignManagerEnabled ? (
+        <CampaignManager pathname={pathname} tcrCompliance={tcrCompliance} />
+      ) : (
+        <DashboardPage
+          pathname={pathname}
+          tasks={tasks}
+          tcrCompliance={tcrCompliance}
+        />
+      )}
+    </>
   )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import DashboardContent from './components/DashboardContent'
 import candidateAccess from './shared/candidateAccess'
 import { apiRoutes } from 'gpApi/routes'
 import { serverFetch } from 'gpApi/serverFetch'
+import { fetchUserWebsite } from 'helpers/fetchUserWebsite'
 import HubSpotChatWidgetScript from '@shared/scripts/HubSpotChatWidgetScript'
 import { redirect } from 'next/navigation'
 import type { Task } from './components/tasks/TaskItem'
@@ -40,9 +41,10 @@ export default async function Page(): Promise<React.JSX.Element> {
     return redirect('/dashboard/briefings')
   }
 
-  const [tasks, tcrComplianceResponse] = await Promise.all([
+  const [tasks, tcrComplianceResponse, website] = await Promise.all([
     fetchTasks(),
     serverFetch<TcrCompliance>(apiRoutes.campaign.tcrCompliance.fetch),
+    fetchUserWebsite(),
   ])
 
   const tcrCompliance = tcrComplianceResponse.ok
@@ -56,6 +58,7 @@ export default async function Page(): Promise<React.JSX.Element> {
         pathname="/dashboard"
         tasks={tasks}
         tcrCompliance={tcrCompliance}
+        hasWebsite={!!website}
       />
     </>
   )

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -4,8 +4,20 @@ import userEvent from '@testing-library/user-event'
 import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import type { Website } from 'helpers/types'
+import { EVENTS } from 'helpers/analyticsHelper'
 import { MIN_BIO_LENGTH } from '../candidateProfile.utils'
 import CandidateProfile from './CandidateProfile'
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
 
 vi.mock('app/shared/utils/RichEditor', async () => ({
   default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
@@ -171,5 +183,17 @@ describe('CandidateProfile — deleting a policy priority persists (ENG-10270)',
     await waitFor(() =>
       expect(router.push).toHaveBeenCalledWith('/dashboard/profile'),
     )
+  })
+})
+
+describe('CandidateProfile — funnel view event (ENG-10294)', () => {
+  it('fires Candidate Profile Viewed when the step renders', async () => {
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
+    render(<CandidateProfile />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.CandidateProfileViewed,
+      )
+    })
   })
 })

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -76,6 +76,12 @@ export default function CandidateProfile(): React.JSX.Element {
     seededRef.current = true
   }, [isSuccess, website])
 
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
+  // matching "submitted" signal is the existing SubmitSuccess event below.
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.CandidateProfileViewed)
+  }, [])
+
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)
 

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { waitFor } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
 import { EVENTS } from 'helpers/analyticsHelper'
-import ElectionFiling from './ElectionFiling'
+import ElectionFiling, { getInitialFormState } from './ElectionFiling'
+
+type Campaign = Parameters<typeof getInitialFormState>[0]
 
 const mockTrackEvent = vi.fn()
 vi.mock('helpers/analyticsHelper', async (importOriginal) => {
@@ -78,5 +80,31 @@ describe('ElectionFiling — funnel view event (ENG-10294)', () => {
     expect(mockTrackEvent).not.toHaveBeenCalledWith(
       EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
     )
+  })
+})
+
+describe('getInitialFormState — filing contact info not auto-filled (ENG-10290)', () => {
+  const campaign = {
+    details: { einNumber: '12-3456789', campaignCommittee: 'Friends of Jane' },
+  } as Campaign
+
+  it('leaves email and phone blank so the candidate must enter filing values', () => {
+    const state = getInitialFormState(campaign)
+    expect(state.email).toBe('')
+    expect(state.phone).toBe('')
+  })
+
+  it('still pre-fills EIN and committee from the campaign filing details', () => {
+    const state = getInitialFormState(campaign)
+    expect(state.ein).toBe('12-3456789')
+    expect(state.campaignCommitteeName).toBe('Friends of Jane')
+  })
+
+  it('defaults committee and EIN to empty when campaign details are missing', () => {
+    const state = getInitialFormState({} as Campaign)
+    expect(state.ein).toBe('')
+    expect(state.campaignCommitteeName).toBe('')
+    expect(state.email).toBe('')
+    expect(state.phone).toBe('')
   })
 })

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -15,12 +15,20 @@ vi.mock('helpers/analyticsHelper', async (importOriginal) => {
   }
 })
 
+// [user, setUser, userLoading] — default to a loaded user so `ready` is true.
+type UseUserReturn = [
+  { email: string; phone: string } | null,
+  () => void,
+  boolean,
+]
+const readyUser: UseUserReturn = [
+  { email: 'jane@example.com', phone: '5551234567' },
+  vi.fn(),
+  false,
+]
+const mockUseUser = vi.fn<() => UseUserReturn>(() => readyUser)
 vi.mock('@shared/hooks/useUser', () => ({
-  useUser: () => [
-    { email: 'jane@example.com', phone: '5551234567' },
-    vi.fn(),
-    false,
-  ],
+  useUser: () => mockUseUser(),
 }))
 
 vi.mock('@shared/hooks/useCampaign', () => ({
@@ -45,15 +53,30 @@ vi.mock(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockUseUser.mockReturnValue(readyUser)
 })
 
 describe('ElectionFiling — funnel view event (ENG-10294)', () => {
-  it('fires Filing Details Viewed when the step renders', async () => {
+  it('fires Filing Details Viewed when the form is shown (ready)', async () => {
     render(<ElectionFiling />)
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalledWith(
         EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
       )
     })
+  })
+
+  it('does not fire while only the loading state is shown (not ready)', async () => {
+    // userLoading=true → `ready` is false → the form is hidden behind the
+    // Loading… spinner, so the view event must not fire (matches EnterPin's
+    // gated behavior — no over-counting users who never see the form).
+    mockUseUser.mockReturnValue([null, vi.fn(), true])
+    render(<ElectionFiling />)
+    await waitFor(() => {
+      expect(mockUseUser).toHaveBeenCalled()
+    })
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+    )
   })
 })

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { EVENTS } from 'helpers/analyticsHelper'
+import ElectionFiling from './ElectionFiling'
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
+
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: () => [
+    { email: 'jane@example.com', phone: '5551234567' },
+    vi.fn(),
+    false,
+  ],
+}))
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => [{ details: {} }],
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: vi.fn(), successSnackbar: vi.fn() }),
+}))
+
+// Stub the heavy registration form — this test only verifies the funnel view
+// event fires when the step renders, not the form's behavior. Both the default
+// export and the named `validateRegistrationForm` (used at module load) must be
+// provided or the import of ElectionFiling throws.
+vi.mock(
+  'app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm',
+  () => ({
+    default: () => <div data-testid="registration-form" />,
+    validateRegistrationForm: () => ({}),
+  }),
+)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ElectionFiling — funnel view event (ENG-10294)', () => {
+  it('fires Filing Details Viewed when the step renders', async () => {
+    render(<ElectionFiling />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+      )
+    })
+  })
+})

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -2,7 +2,7 @@
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { FormDataProvider, FormDataState } from '@shared/hooks/useFormData'
 import { useUser } from '@shared/hooks/useUser'
@@ -35,11 +35,17 @@ export default function ElectionFiling(): React.JSX.Element {
 
   const ready = !userLoading && Boolean(user) && Boolean(campaign)
 
-  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
-  // matching "submitted" signal is the existing RegistrationSubmitted event.
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). Fire
+  // only once the form is actually shown — the form is gated behind `ready`, so
+  // a bare mount event would count users who only see the Loading… spinner. The
+  // matching "submitted" signal is the existing RegistrationSubmitted event in
+  // handleFormSubmit.
+  const filingViewTrackedRef = useRef(false)
   useEffect(() => {
+    if (!ready || filingViewTrackedRef.current) return
+    filingViewTrackedRef.current = true
     trackEvent(EVENTS.ProUpgrade.Compliance.FilingDetailsViewed)
-  }, [])
+  }, [ready])
 
   const handleFormSubmit = async (formData: FormDataState) => {
     setLoading(true)

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -88,7 +88,7 @@ export default function ElectionFiling(): React.JSX.Element {
         <div className="mt-10">
           {ready ? (
             <FormDataProvider
-              initialState={getInitialFormState(user, campaign)}
+              initialState={getInitialFormState(campaign)}
               validator={validateAgenticForm}
             >
               <TextingComplianceRegistrationForm
@@ -107,8 +107,14 @@ export default function ElectionFiling(): React.JSX.Element {
   )
 }
 
-const getInitialFormState = (
-  user: ReturnType<typeof useUser>[0],
+// Email and phone are intentionally left blank rather than seeded from the
+// candidate's GoodParty account (ENG-10290). Account contact info frequently
+// does not match what is on the official campaign filing; pre-filling it led
+// candidates to submit a mismatch without noticing, causing compliance
+// failures. They must enter the email/phone exactly as filed. EIN and
+// committee come from campaign.details, which reflect the filing, so those
+// stay pre-filled.
+export const getInitialFormState = (
   campaign: ReturnType<typeof useCampaign>[0],
 ): FormDataState => {
   const details = (campaign?.details ?? {}) as {
@@ -120,9 +126,9 @@ const getInitialFormState = (
     campaignCommitteeName: details.campaignCommittee || '',
     officeLevel: '',
     ein: details.einNumber || '',
-    phone: user?.phone || '',
+    phone: '',
     address: { formatted_address: '', place_id: '' },
     website: '',
-    email: user?.email || '',
+    email: '',
   }
 }

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -2,7 +2,7 @@
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { FormDataProvider, FormDataState } from '@shared/hooks/useFormData'
 import { useUser } from '@shared/hooks/useUser'
@@ -34,6 +34,12 @@ export default function ElectionFiling(): React.JSX.Element {
   const [hasSubmissionError, setHasSubmissionError] = useState(false)
 
   const ready = !userLoading && Boolean(user) && Boolean(campaign)
+
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
+  // matching "submitted" signal is the existing RegistrationSubmitted event.
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingDetailsViewed)
+  }, [])
 
   const handleFormSubmit = async (formData: FormDataState) => {
     setLoading(true)

--- a/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
+++ b/app/dashboard/profile/texting-compliance/election-filing/components/ElectionFiling.tsx
@@ -57,7 +57,13 @@ export default function ElectionFiling(): React.JSX.Element {
         'Failed to submit election filing',
       )
       trackEvent(EVENTS.Outreach.DlcCompliance.RegistrationSubmitted, {
-        email: user?.email,
+        // The filing email the candidate just submitted, not their account
+        // email (user?.email). The two deliberately differ here (see
+        // getInitialFormState), and trackEvent already attaches the account
+        // email to every event by default — so this override is only useful if
+        // it records the filing value. isValid gates submit on isEmail, so this
+        // is always a valid non-empty string.
+        email: formData.email,
         dlcComplianceStatus: 'Pending',
       })
       successSnackbar('Election filing submitted')

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.test.tsx
@@ -5,6 +5,7 @@ import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { api } from 'helpers/test-utils/api-mocking'
 import type { TcrCompliance, TcrComplianceStatus } from 'helpers/types'
+import { EVENTS } from 'helpers/analyticsHelper'
 import EnterPin from './EnterPin'
 
 const mockGetTcrCompliance = vi.fn<() => Promise<TcrCompliance | null>>()
@@ -139,6 +140,33 @@ describe('EnterPin — gating', () => {
   })
 })
 
+describe('EnterPin — funnel view event (ENG-10294)', () => {
+  it('fires PIN Entry Viewed once the PIN form is shown (status submitted)', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+    render(<EnterPin />)
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.PinEntryViewed,
+      )
+    })
+  })
+
+  it.each<[TcrComplianceStatus | null]>([['pending'], ['approved'], [null]])(
+    'does not fire PIN Entry Viewed when the form is never shown (status %s)',
+    async (status) => {
+      mockGetTcrCompliance.mockResolvedValue(tcrWith(status))
+      render(<EnterPin />)
+      // Let the gating/redirect effects settle before asserting non-emission.
+      await waitFor(() => {
+        expect(mockGetTcrCompliance).toHaveBeenCalled()
+      })
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.PinEntryViewed,
+      )
+    },
+  )
+})
+
 describe('EnterPin — submit flow', () => {
   it('happy path: submits PIN, fires analytics, invalidates cache, redirects', async () => {
     const user = userEvent.setup()
@@ -165,7 +193,13 @@ describe('EnterPin — submit flow', () => {
     })
 
     expect(receivedBody).toEqual({ pin: '123456' })
-    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+    // Submit fires the PIN-verification event. (The mount-time PinEntryViewed
+    // funnel event also fires for `submitted` status — assert the specific
+    // submit event rather than a raw call count.)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      EVENTS.Outreach.DlcCompliance.PinVerificationCompleted,
+      expect.objectContaining({ dlcComplianceStatus: 'Yes' }),
+    )
     expect(mockSuccessSnackbar).toHaveBeenCalledWith(
       expect.stringMatching(/PIN submitted/i),
     )

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -53,6 +53,18 @@ export default function EnterPin(): React.JSX.Element {
       router.push(PROFILE_ROUTE)
     }
   }, [shouldRedirect, router])
+
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). Fire
+  // only once the PIN entry UI is actually shown — this page redirects away for
+  // PENDING/APPROVED, so a bare mount event would count users who never see it.
+  // The matching "submitted" signal is the existing PinVerificationCompleted
+  // event in handleSubmit below.
+  const pinViewTrackedRef = useRef(false)
+  useEffect(() => {
+    if (isPending || !isAwaitingPin || pinViewTrackedRef.current) return
+    pinViewTrackedRef.current = true
+    trackEvent(EVENTS.ProUpgrade.Compliance.PinEntryViewed)
+  }, [isPending, isAwaitingPin])
 
   const handleSubmit = async (pin: string): Promise<void> => {
     if (!tcrCompliance) return

--- a/app/dashboard/shared/ComplianceModal.tsx
+++ b/app/dashboard/shared/ComplianceModal.tsx
@@ -6,6 +6,7 @@ import Body2 from '@shared/typography/Body2'
 import Button from '@shared/buttons/Button'
 import { TCR_COMPLIANCE_STATUS } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
 import type { TcrComplianceStatus } from 'helpers/types'
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 
 interface ComplianceModalProps {
   open: boolean
@@ -18,6 +19,29 @@ export function ComplianceModal({
   tcrComplianceStatus,
   onClose,
 }: ComplianceModalProps): React.JSX.Element {
+  const { ready, enabled } = useProUpgradeFlag()
+  const phase1Enabled = ready && enabled
+
+  const helpTrailer = (
+    <>
+      <br />
+      <br />
+      Have questions? Visit{' '}
+      <a
+        href="https://support.goodparty.org/help-center/getting-text-compliant"
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className="underline"
+      >
+        our help center
+      </a>{' '}
+      for more information or send us an email at{' '}
+      <a href="mailto:campaignsuccess@goodparty.org" className="underline">
+        campaignsuccess@goodparty.org
+      </a>
+    </>
+  )
+
   let title: string,
     description: string | React.ReactNode,
     cta: string,
@@ -49,26 +73,10 @@ export function ComplianceModal({
       title = 'Action required: register for texting compliance'
       description = (
         <>
-          Carrier requirements mean you must register before sending your first
-          text. You&apos;ll need your Campaign EIN, your official filing link,
-          and an active website purchased through GoodParty.org. Don&apos;t have
-          a site yet? You can build and launch one right from your dashboard
-          before getting started.
-          <br />
-          <br />
-          Have questions? Visit{' '}
-          <a
-            href="https://support.goodparty.org/help-center/getting-text-compliant"
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            className="underline"
-          >
-            our help center
-          </a>{' '}
-          for more information or send us an email at{' '}
-          <a href="mailto:campaignsuccess@goodparty.org" className="underline">
-            campaignsuccess@goodparty.org
-          </a>
+          {phase1Enabled
+            ? "Carrier requirements mean you must register before sending your first text. You'll need your Campaign EIN and your official filing link. Ready? Click Start Your Registration to get started."
+            : "Carrier requirements mean you must register before sending your first text. You'll need your Campaign EIN, your official filing link, and an active website purchased through GoodParty.org. Don't have a site yet? You can build and launch one right from your dashboard before getting started."}
+          {helpTrailer}
         </>
       )
       cta = 'Start Registration'

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@styleguide/components/ui/dialog'
+import { Button } from '@styleguide/components/ui/button'
+
+// TODO(ENG-10295): replace with the real HubSpot domain-transfer form URL once
+// the form is built in HubSpot. Opened in a new tab from the CTA below.
+const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = 'https://share.hsforms.com/REPLACE_ME'
+
+interface WebsiteSunsetModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function WebsiteSunsetModal({
+  open,
+  onOpenChange,
+}: WebsiteSunsetModalProps): React.JSX.Element {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="gap-1.5">
+          <DialogTitle>Website is being discontinued</DialogTitle>
+          <DialogDescription>
+            Your site will remain live for one year from your original purchase
+            date, and you can still update your website content anytime under My
+            Profile. To fully own and manage your domain, click Transfer
+            Website.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            onClick={() =>
+              window.open(
+                HUBSPOT_DOMAIN_TRANSFER_FORM_URL,
+                '_blank',
+                'noopener,noreferrer',
+              )
+            }
+          >
+            Transfer website
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -15,7 +15,8 @@ import { Button } from '@styleguide/components/ui/button'
 // the notice is never shown (see DashboardContent). This avoids both linking to
 // a non-existent form and opting users out of the notice before the form they
 // need exists. The URL is opened in a new tab from the CTA.
-const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = ''
+const HUBSPOT_DOMAIN_TRANSFER_FORM_URL =
+  'https://cuqn1.share.hsforms.com/24lFrnq6gQ6-FWs_7qUr5SQ'
 
 export const WEBSITE_SUNSET_NOTICE_ENABLED =
   HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -31,7 +31,11 @@ export function WebsiteSunsetModal({
 }: WebsiteSunsetModalProps): React.JSX.Element {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader className="gap-1.5">
           <DialogTitle>Website is being discontinued</DialogTitle>
           <DialogDescription>
@@ -43,13 +47,14 @@ export function WebsiteSunsetModal({
         </DialogHeader>
         <DialogFooter>
           <Button
-            onClick={() =>
+            onClick={() => {
               window.open(
                 HUBSPOT_DOMAIN_TRANSFER_FORM_URL,
                 '_blank',
                 'noopener,noreferrer',
               )
-            }
+              onOpenChange(false)
+            }}
           >
             Transfer website
           </Button>

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -10,9 +10,10 @@ import {
 } from '@styleguide/components/ui/dialog'
 import { Button } from '@styleguide/components/ui/button'
 
-// TODO(ENG-10295): replace with the real HubSpot domain-transfer form URL once
-// the form is built in HubSpot. Opened in a new tab from the CTA below.
-const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = 'https://share.hsforms.com/REPLACE_ME'
+// Set to the real HubSpot domain-transfer form URL once the form is built in
+// HubSpot (ENG-10295). While empty, the "Transfer website" button is disabled
+// so we never ship a link to a non-existent form. Opened in a new tab.
+const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = ''
 
 interface WebsiteSunsetModalProps {
   open: boolean
@@ -23,6 +24,7 @@ export function WebsiteSunsetModal({
   open,
   onOpenChange,
 }: WebsiteSunsetModalProps): React.JSX.Element {
+  const formReady = HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -37,6 +39,7 @@ export function WebsiteSunsetModal({
         </DialogHeader>
         <DialogFooter>
           <Button
+            disabled={!formReady}
             onClick={() =>
               window.open(
                 HUBSPOT_DOMAIN_TRANSFER_FORM_URL,

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -11,9 +11,14 @@ import {
 import { Button } from '@styleguide/components/ui/button'
 
 // Set to the real HubSpot domain-transfer form URL once the form is built in
-// HubSpot (ENG-10295). While empty, the "Transfer website" button is disabled
-// so we never ship a link to a non-existent form. Opened in a new tab.
+// HubSpot (ENG-10295). While empty, WEBSITE_SUNSET_NOTICE_ENABLED is false and
+// the notice is never shown (see DashboardContent). This avoids both linking to
+// a non-existent form and opting users out of the notice before the form they
+// need exists. The URL is opened in a new tab from the CTA.
 const HUBSPOT_DOMAIN_TRANSFER_FORM_URL = ''
+
+export const WEBSITE_SUNSET_NOTICE_ENABLED =
+  HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0
 
 interface WebsiteSunsetModalProps {
   open: boolean
@@ -24,7 +29,6 @@ export function WebsiteSunsetModal({
   open,
   onOpenChange,
 }: WebsiteSunsetModalProps): React.JSX.Element {
-  const formReady = HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -39,7 +43,6 @@ export function WebsiteSunsetModal({
         </DialogHeader>
         <DialogFooter>
           <Button
-            disabled={!formReady}
             onClick={() =>
               window.open(
                 HUBSPOT_DOMAIN_TRANSFER_FORM_URL,

--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -336,36 +336,6 @@ const OppositionResearch = ({
               <li>Party: {opp.partyAffiliation}</li>
             ) : null}
             {opp.incumbent === true ? <li>Incumbent</li> : null}
-            {opp.politicalSummary ? <li>{opp.politicalSummary}</li> : null}
-            {opp.keyFacts.length > 0 ? (
-              <li>
-                Key facts:
-                <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
-                  {opp.keyFacts.map((fact) => (
-                    <li key={fact}>{fact}</li>
-                  ))}
-                </ul>
-              </li>
-            ) : null}
-            {opp.websites.length > 0 ? (
-              <li>
-                Websites:
-                <ul className="mt-1 space-y-1 pl-5 [list-style:circle]">
-                  {opp.websites.map((w) => (
-                    <li key={w}>
-                      <a
-                        href={w}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-components-input-active hover:underline"
-                      >
-                        {w}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </li>
-            ) : null}
           </ul>
         </li>
       ))}

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -196,17 +196,13 @@ export interface GlossaryRow {
   definition: string
 }
 
-// Mirrors `StrategicLandscapeOpponent` from gp-api. Some pre-strategy
-// fallbacks (hubspotIncumbent, runningAgainst) still produce records with
-// `politicalSummary === ''` and `keyFacts === []` when no rich data is
-// available — the renderer hides empty fields.
+// Mirrors `StrategicLandscapeOpponent` from gp-api. Who is running: name,
+// party, incumbency. Narrative profiling (summary, key facts, websites) isn't
+// part of this section.
 export interface Opponent {
   fullName: string
   partyAffiliation: string
   incumbent: boolean | null
-  politicalSummary: string
-  keyFacts: string[]
-  websites: string[]
 }
 
 export interface VoterInsightIssue {
@@ -820,11 +816,9 @@ const buildOpponents = (
   hubspotIncumbentName: string | null,
 ): Opponent[] => {
   // Source priority:
-  //   1. strategicLandscape — full shape (politicalSummary, keyFacts,
-  //      websites). The LLM endpoint is the richest source.
+  //   1. strategicLandscape — the CAP endpoint's opponent roster.
   //   2. raceCandidates — BR/election-api filings via raceTargetMetrics.
-  //      Authoritative for who's on the ballot + incumbent flag, but no
-  //      narrative fields.
+  //      Authoritative for who's on the ballot + incumbent flag.
   //   3. runningAgainst — user-entered onboarding answers.
   //   4. hubspotIncumbent — last-ditch incumbent name from HubSpot.
   if (strategicLandscape?.opponents.length) {
@@ -832,9 +826,6 @@ const buildOpponents = (
       fullName: o.fullName,
       partyAffiliation: o.partyAffiliation,
       incumbent: o.incumbent,
-      politicalSummary: o.politicalSummary,
-      keyFacts: o.keyFacts,
-      websites: o.websites,
     }))
   }
   const fromRaceCandidates: Opponent[] = raceCandidates
@@ -843,9 +834,6 @@ const buildOpponents = (
       fullName: c.fullName.trim(),
       partyAffiliation: c.party?.trim() ?? '',
       incumbent: c.isIncumbent,
-      politicalSummary: '',
-      keyFacts: [],
-      websites: c.websiteUrl ? [c.websiteUrl] : [],
     }))
   if (fromRaceCandidates.length > 0) return fromRaceCandidates
   const fromRunningAgainst: Opponent[] = runningAgainst
@@ -854,9 +842,6 @@ const buildOpponents = (
       fullName: o.name?.trim() ?? '',
       partyAffiliation: o.party?.trim() ?? '',
       incumbent: false,
-      politicalSummary: o.description?.trim() ?? '',
-      keyFacts: [],
-      websites: [],
     }))
   if (fromRunningAgainst.length > 0) return fromRunningAgainst
   if (hubspotIncumbentName && hubspotIncumbentName.trim() !== '') {
@@ -865,9 +850,6 @@ const buildOpponents = (
         fullName: hubspotIncumbentName.trim(),
         partyAffiliation: '',
         incumbent: true,
-        politicalSummary: '',
-        keyFacts: [],
-        websites: [],
       },
     ]
   }

--- a/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
+++ b/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
@@ -789,9 +789,6 @@ export const CampaignPlanPdfDocument = ({
                     ? [`Party: ${opp.partyAffiliation}`]
                     : []),
                   ...(opp.incumbent === true ? ['Incumbent'] : []),
-                  ...(opp.politicalSummary ? [opp.politicalSummary] : []),
-                  ...opp.keyFacts,
-                  ...opp.websites,
                 ]}
               />
             </View>

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -55,15 +55,12 @@ export interface MeetingBriefingAwaitingDto {
 }
 
 // Mirrors `OpponentSchema` in gp-api
-// (`src/campaignStrategy/schemas/strategicLandscape.schema.ts`). `incumbent`
-// is nullable because the LLM may legitimately not know.
+// (`src/campaignStrategy/schemas/strategicLandscape.schema.ts`). Who is
+// running: name, party, incumbency. No narrative profiling.
 export interface StrategicLandscapeOpponent {
   fullName: string
   partyAffiliation: string
   incumbent: boolean | null
-  politicalSummary: string
-  keyFacts: string[]
-  websites: string[]
 }
 
 export interface StrategicLandscapeData {

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -328,6 +328,17 @@ export const EVENTS = {
       ClickFinish: 'Pro Upgrade - Service Agreement Page: Click finish',
     },
     ClickGoToStripe: 'Pro Upgrade: Click Go to Stripe',
+    // Agentic Pro Upgrade → 10DLC compliance funnel (ENG-10294). Kept separate
+    // from the legacy Modal / SplashPage / CommitteeCheck events above, which
+    // belong to the older upgrade UX. The funnel's submit/checkout-start signals
+    // already exist and are reused (Profile.CandidateProfile.SubmitSuccess,
+    // Outreach.DlcCompliance.RegistrationSubmitted / PinVerificationCompleted,
+    // ProUpgrade.ClickGoToStripe); the "viewed" steps below were the gap.
+    Compliance: {
+      CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
+      FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
+      PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',
+    },
   },
   Contacts: {
     Download: 'Contacts - Download',


### PR DESCRIPTION
## Included PRs (qa → master)

- 12739360f feat(Dashboard): update HubSpot domain transfer form URL in WebsiteSunsetModal
- 6f6e8ca74 fix(ElectionFiling): correct email tracking for election filing submissions
- 456853ca7 feat(ElectionFiling): update initial form state handling for campaign filings
- 5b574ab6a feat(Dashboard): improve WebsiteSunsetModal interaction handling
- 750dfc41f feat(Dashboard): enable conditional display of sunset notice based on HubSpot URL
- e0aa45c61 feat(Dashboard): enhance sunset modal functionality and update HubSpot URL handling
- 4f668a594 feat(Dashboard): integrate website fetching and sunset modal display
- aa4a6610a fix(ComplianceModal): gate texting-compliance copy on pro-upgrade1 flag (#1941)
- 1a8989906 Update sections to reflect new opposition response. (#1940)
- 18e2db3da refactor(ElectionFiling): enhance event tracking for compliance flow
- 620a7a857 feat: implement funnel view events for compliance flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect 10DLC registration UX and analytics (blank contact fields and event payloads) plus a blocking modal for website customers; incorrect gating or copy could confuse compliance submissions or support load.
> 
> **Overview**
> **Dashboard website sunset:** The dashboard server-load now fetches whether the user has a website and passes `hasWebsite` into `DashboardContent`, which can show a **website discontinuation** dialog (HubSpot domain-transfer CTA, dismiss stored in `localStorage`) when a HubSpot form URL is configured and the notice flag is on.
> 
> **10DLC / Pro compliance flow:** New **funnel “viewed”** analytics fire only when each step’s UI is actually visible (candidate profile on mount; election filing and PIN entry gated behind `ready` / `submitted` status). **Election filing** no longer pre-fills **email or phone** from the GoodParty account—only EIN and committee from campaign details—and **registration submitted** events record the **filing email** from the form. **`ComplianceModal`** default copy is split by the **pro-upgrade flag**: Phase 1 drops the GoodParty-website requirement; legacy copy still mentions it.
> 
> **Campaign plan opposition section:** Opponent data and rendering (web plan + PDF + API types) are narrowed to **name, party, and incumbency**—narrative fields (summary, key facts, websites) are removed from the model and UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3133c090b6a9c76d49d23d1cb46a2b4fa2e03d72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->