### PR TITLE
fix(ElectionResultPage): handle updateCampaign failure by throwing an…

### DIFF
--- a/app/dashboard/election-result/components/ElectionResultPage.test.tsx
+++ b/app/dashboard/election-result/components/ElectionResultPage.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import ElectionResultPage from './ElectionResultPage'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+
+const { mockErrorSnackbar } = vi.hoisted(() => ({
+  mockErrorSnackbar: vi.fn(),
+}))
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn(),
+}))
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => [{ id: 1, details: { electionDate: '2025-05-20' } }],
+}))
+
+vi.mock('@shared/hooks/usePositionName', () => ({
+  usePositionName: () => 'Mayor',
+}))
+
+vi.mock('@shared/hooks/CampaignProvider', () => ({
+  CAMPAIGN_QUERY_KEY: ['campaign'],
+}))
+
+vi.mock('@shared/organization-picker', () => ({
+  ORGANIZATIONS_QUERY_KEY: ['organizations'],
+  useSetOrganizationSlug: () => vi.fn(),
+}))
+
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar: mockErrorSnackbar }),
+}))
+
+vi.mock('helpers/analyticsHelper', () => ({
+  EVENTS: {
+    Candidacy: {
+      DidYouWinModalCompleted: 'did_you_win_completed',
+      DidYouWinModalViewed: 'did_you_win_viewed',
+    },
+  },
+  trackEvent: vi.fn(),
+}))
+
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+
+const electedOfficeOrg = {
+  slug: 'eo-1',
+  name: null,
+  positionName: null,
+  position: null,
+  district: null,
+  electedOfficeId: 'eo-1',
+  campaignId: null,
+}
+
+describe('ElectionResultPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not create an elected office when saving the result fails', async () => {
+    mockUpdateCampaign.mockResolvedValue(false)
+
+    let electedOfficeCreated = false
+    api.mock('POST /v1/elected-office', () => {
+      electedOfficeCreated = true
+      return { status: 200, data: { id: 'eo-1', swornInDate: null } }
+    })
+
+    render(<ElectionResultPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'I won my race' }))
+
+    await waitFor(() => {
+      expect(mockErrorSnackbar).toHaveBeenCalled()
+    })
+    expect(electedOfficeCreated).toBe(false)
+  })
+
+  it('creates an elected office when the result is saved', async () => {
+    mockUpdateCampaign.mockResolvedValue({ id: 1 } as never)
+
+    let electedOfficeCreated = false
+    api.mock('POST /v1/elected-office', () => {
+      electedOfficeCreated = true
+      return { status: 200, data: { id: 'eo-1', swornInDate: null } }
+    })
+    api.mock('GET /v1/organizations', {
+      status: 200,
+      data: { organizations: [electedOfficeOrg] },
+    })
+
+    render(<ElectionResultPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'I won my race' }))
+
+    await waitFor(() => {
+      expect(electedOfficeCreated).toBe(true)
+    })
+  })
+})

--- a/app/dashboard/election-result/components/ElectionResultPage.tsx
+++ b/app/dashboard/election-result/components/ElectionResultPage.tsx
@@ -101,7 +101,12 @@ export default function ElectionResultPage(): React.JSX.Element {
     try {
       const wonGeneral = selection === RESULT_WON
 
-      await updateCampaign([{ key: 'details.wonGeneral', value: wonGeneral }])
+      const updated = await updateCampaign([
+        { key: 'details.wonGeneral', value: wonGeneral },
+      ])
+      if (!updated) {
+        throw new Error('Failed to save election result')
+      }
 
       if (campaign) {
         queryClient.setQueryData(CAMPAIGN_QUERY_KEY, {


### PR DESCRIPTION
… error if the election result cannot be saved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in election-result UX with regression tests; no auth or broad API changes.
> 
> **Overview**
> **Election result save** now treats a failed `updateCampaign` (it returns `false`) as a hard error instead of continuing, so a lost save no longer updates local campaign cache or triggers the elected-office flow.
> 
> New **component tests** cover both paths: when save fails, the user sees an error snackbar and `POST /v1/elected-office` is not called; when save succeeds and the user won, elected office creation runs as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e37e019d6214e1f292e9dd23a95ebc2de428c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->