### PR TITLE
Display domain transfer banner on settings page 

### DIFF
--- a/app/dashboard/components/DashboardContent.tsx
+++ b/app/dashboard/components/DashboardContent.tsx
@@ -6,10 +6,8 @@ import DashboardPage from './DashboardPage'
 import type { Task } from './tasks/TaskItem'
 import type { TcrCompliance } from 'helpers/types'
 import CampaignManager from './campaignManager/CampaignManager'
-import {
-  WebsiteSunsetModal,
-  WEBSITE_SUNSET_NOTICE_ENABLED,
-} from '../shared/WebsiteSunsetModal'
+import { WebsiteSunsetModal } from '../shared/WebsiteSunsetModal'
+import { WEBSITE_SUNSET_NOTICE_ENABLED } from '../shared/websiteSunset'
 
 const AI_CAMPAIGN_MANAGER_FLAG_KEY = 'ai-campaign-manager'
 const WEBSITE_SUNSET_MODAL_DISMISSED_KEY = 'websiteSunsetModalDismissed'

--- a/app/dashboard/profile/components/ProfilePage.tsx
+++ b/app/dashboard/profile/components/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { AccountSettingsSection } from 'app/dashboard/profile/components/Account
 import { User, Website, TcrCompliance, Campaign } from 'helpers/types'
 import DashboardLayout from 'app/dashboard/shared/DashboardLayout'
 import TextingComplianceFeatureFlag from 'app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag'
+import { WebsiteSunsetBanner } from 'app/dashboard/shared/WebsiteSunsetBanner'
 
 interface ProfilePageProps {
   user: User
@@ -27,6 +28,7 @@ export default function ProfilePage({
     <DashboardLayout pathname="/dashboard/profile">
       <div className="bg-indigo-100 min-h-[calc(100vh-60px)]">
         <div className="max-w-screen-md mx-auto px-4 py-4 xl:p-0 xl:pt-4">
+          <WebsiteSunsetBanner hasWebsite={!!website} />
           <ContactInfoSection user={user} />
           {!!campaign && <AccountSettingsSection />}
           {!!campaign && isPro && (

--- a/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
+++ b/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { WebsiteSunsetBanner } from './WebsiteSunsetBanner'
+import { HUBSPOT_DOMAIN_TRANSFER_FORM_URL } from './websiteSunset'
+
+describe('WebsiteSunsetBanner', () => {
+  it('shows the discontinuation notice and a Transfer link to the HubSpot form when the candidate has a website', () => {
+    render(<WebsiteSunsetBanner hasWebsite />)
+
+    expect(screen.getByText('Website discontinued')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Please transfer your domain to a provider of your choice.',
+      ),
+    ).toBeInTheDocument()
+
+    const cta = screen.getByRole('link', { name: 'Transfer' })
+    expect(cta).toHaveAttribute('href', HUBSPOT_DOMAIN_TRANSFER_FORM_URL)
+    expect(cta).toHaveAttribute('target', '_blank')
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders nothing when the candidate has no website', () => {
+    const { container } = render(<WebsiteSunsetBanner hasWebsite={false} />)
+
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText('Website discontinued')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/shared/WebsiteSunsetBanner.tsx
+++ b/app/dashboard/shared/WebsiteSunsetBanner.tsx
@@ -1,0 +1,43 @@
+import { buttonVariants } from '@styleguide/components/ui/button'
+import {
+  HUBSPOT_DOMAIN_TRANSFER_FORM_URL,
+  WEBSITE_SUNSET_NOTICE_ENABLED,
+} from './websiteSunset'
+
+interface WebsiteSunsetBannerProps {
+  hasWebsite: boolean
+}
+
+// Persistent (non-dismissible) counterpart to WebsiteSunsetModal. The modal
+// shows once on the dashboard; this banner gives candidates a permanent path
+// back to the domain-transfer form from Settings (ENG-10304). Same eligibility
+// as the modal: a candidate with a website while the notice is enabled.
+export function WebsiteSunsetBanner({
+  hasWebsite,
+}: WebsiteSunsetBannerProps): React.JSX.Element | null {
+  if (!hasWebsite || !WEBSITE_SUNSET_NOTICE_ENABLED) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex items-center gap-3 rounded-lg border border-neutral-400 bg-card px-4 py-3 text-card-foreground"
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold">Website discontinued</p>
+        <p className="text-sm">
+          Please transfer your domain to a provider of your choice.
+        </p>
+      </div>
+      <a
+        href={HUBSPOT_DOMAIN_TRANSFER_FORM_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={buttonVariants({ variant: 'outline', size: 'xSmall' })}
+      >
+        Transfer
+      </a>
+    </div>
+  )
+}

--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -9,17 +9,7 @@ import {
   DialogTitle,
 } from '@styleguide/components/ui/dialog'
 import { Button } from '@styleguide/components/ui/button'
-
-// Set to the real HubSpot domain-transfer form URL once the form is built in
-// HubSpot (ENG-10295). While empty, WEBSITE_SUNSET_NOTICE_ENABLED is false and
-// the notice is never shown (see DashboardContent). This avoids both linking to
-// a non-existent form and opting users out of the notice before the form they
-// need exists. The URL is opened in a new tab from the CTA.
-const HUBSPOT_DOMAIN_TRANSFER_FORM_URL =
-  'https://cuqn1.share.hsforms.com/24lFrnq6gQ6-FWs_7qUr5SQ'
-
-export const WEBSITE_SUNSET_NOTICE_ENABLED =
-  HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0
+import { HUBSPOT_DOMAIN_TRANSFER_FORM_URL } from './websiteSunset'
 
 interface WebsiteSunsetModalProps {
   open: boolean

--- a/app/dashboard/shared/websiteSunset.ts
+++ b/app/dashboard/shared/websiteSunset.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the website-discontinuation (sunset) notice.
+// Both WebsiteSunsetModal (dashboard home) and WebsiteSunsetBanner (Settings)
+// read from here so the HubSpot form URL and the enabled flag live in one place.
+//
+// Set to the real HubSpot domain-transfer form URL once the form is built in
+// HubSpot (ENG-10295). While empty, WEBSITE_SUNSET_NOTICE_ENABLED is false and
+// neither the modal nor the banner is shown. This avoids both linking to a
+// non-existent form and opting users out of the notice before the form they
+// need exists.
+export const HUBSPOT_DOMAIN_TRANSFER_FORM_URL =
+  'https://cuqn1.share.hsforms.com/24lFrnq6gQ6-FWs_7qUr5SQ'
+
+export const WEBSITE_SUNSET_NOTICE_ENABLED =
+  HUBSPOT_DOMAIN_TRANSFER_FORM_URL.length > 0


### PR DESCRIPTION
…egration

- Removed unnecessary imports from DashboardContent and updated the import path for WEBSITE_SUNSET_NOTICE_ENABLED.
- Added WebsiteSunsetBanner to ProfilePage for improved user notification regarding website sunset.
- Refactored WebsiteSunsetModal to import HUBSPOT_DOMAIN_TRANSFER_FORM_URL from a new module, ensuring cleaner code structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only messaging and import refactor; no auth, billing, or data-layer changes.
> 
> **Overview**
> Centralizes website sunset configuration in a new `websiteSunset` module (HubSpot transfer URL and `WEBSITE_SUNSET_NOTICE_ENABLED`), and updates `DashboardContent` and `WebsiteSunsetModal` to import from there instead of defining those values inline.
> 
> Adds a **non-dismissible** `WebsiteSunsetBanner` on the profile/settings page for candidates who still have a website while the notice is enabled—same eligibility as the one-time dashboard modal, but a permanent path back to the domain-transfer form (ENG-10304). Includes unit tests for visible content, CTA link behavior, and hiding when there is no website.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff43f8e448d7a4c5cdf44d783eab013448188e7c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->