### PR TITLE
ENG-10313: Remove conflict around voter contact goals, texting, and robocalls.

### DIFF
--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -620,13 +620,15 @@ const buildBudgetBreakdown = (
   filingFee: number | null,
 ): BudgetBreakdown => {
   const filing = filingFee ?? DEFAULT_FILING_FEE
-  // Spread the voter contact goal evenly across every text and robocall
-  // campaign, then price each channel at its per-contact rate.
-  const contactsPerCampaign = Math.ceil(
-    voterContactGoal / (TEXT_CAMPAIGN_COUNT + ROBOCALL_CAMPAIGN_COUNT),
+  // Split the voter contact goal across text and robocall campaigns in
+  // proportion to their campaign counts, deriving robocalls as the
+  // remainder so the two channel totals always sum back to the goal
+  // exactly. Then price each channel at its per-contact rate.
+  const totalCampaigns = TEXT_CAMPAIGN_COUNT + ROBOCALL_CAMPAIGN_COUNT
+  const textContacts = Math.round(
+    (voterContactGoal * TEXT_CAMPAIGN_COUNT) / totalCampaigns,
   )
-  const textContacts = TEXT_CAMPAIGN_COUNT * contactsPerCampaign
-  const robocallContacts = ROBOCALL_CAMPAIGN_COUNT * contactsPerCampaign
+  const robocallContacts = voterContactGoal - textContacts
   const textCampaignsCost = textContacts * TEXT_COST
   const robocallCampaignsCost = robocallContacts * ROBOCALL_COST
   const subtotal =

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -622,7 +622,7 @@ const buildBudgetBreakdown = (
   const filing = filingFee ?? DEFAULT_FILING_FEE
   // Spread the voter contact goal evenly across every text and robocall
   // campaign, then price each channel at its per-contact rate.
-  const contactsPerCampaign = Math.floor(
+  const contactsPerCampaign = Math.ceil(
     voterContactGoal / (TEXT_CAMPAIGN_COUNT + ROBOCALL_CAMPAIGN_COUNT),
   )
   const textContacts = TEXT_CAMPAIGN_COUNT * contactsPerCampaign

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -662,20 +662,20 @@ const buildBudgetBreakdown = (
     {
       category: 'Text campaigns',
       amount: formatDollars(textCampaignsCost),
-      rationale: `${TEXT_CAMPAIGN_COUNT} text campaigns, ${contactsPerCampaign.toLocaleString(
+      rationale: `${TEXT_CAMPAIGN_COUNT} text campaigns covering ${textContacts.toLocaleString(
         'en-US',
-      )} contacts each (${textContacts.toLocaleString(
+      )} of your ${voterContactGoal.toLocaleString(
         'en-US',
-      )} texts) at $${TEXT_COST.toFixed(3)} per text.`,
+      )} voter contacts at $${TEXT_COST.toFixed(3)} per text.`,
     },
     {
       category: 'Robocall campaigns',
       amount: formatDollars(robocallCampaignsCost),
-      rationale: `${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns, ${contactsPerCampaign.toLocaleString(
+      rationale: `${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns covering ${robocallContacts.toLocaleString(
         'en-US',
-      )} contacts each (${robocallContacts.toLocaleString(
+      )} of your ${voterContactGoal.toLocaleString(
         'en-US',
-      )} calls) at $${ROBOCALL_COST.toFixed(3)} per call.`,
+      )} voter contacts at $${ROBOCALL_COST.toFixed(3)} per call.`,
     },
     {
       category: 'Contingency (5%)',

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -286,7 +286,6 @@ export interface PlanData {
   filingRequirementsText: string | null
 }
 
-
 const placeholderCity = (city: string): string => city || 'your district'
 
 const buildTimeline = (

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -236,8 +236,6 @@ export interface PlanData {
   voterContactGoal: number
 
   opponentCount: number
-  matchedCellRecords: number
-  matchedLandlineRecords: number
   volunteerHourTarget: number
   totalBudget: number
   averageTouchesPerVoter: number
@@ -288,8 +286,6 @@ export interface PlanData {
   filingRequirementsText: string | null
 }
 
-const PLACEHOLDER_MATCH_RATE_CELL = 0.65
-const PLACEHOLDER_MATCH_RATE_LANDLINE = 0.35
 
 const placeholderCity = (city: string): string => city || 'your district'
 
@@ -620,14 +616,19 @@ interface BudgetBreakdown {
 }
 
 const buildBudgetBreakdown = (
-  matchedCell: number,
-  matchedLandline: number,
+  voterContactGoal: number,
   filingFee: number | null,
 ): BudgetBreakdown => {
   const filing = filingFee ?? DEFAULT_FILING_FEE
-  const textCampaignsCost = TEXT_CAMPAIGN_COUNT * matchedCell * TEXT_COST
-  const robocallCampaignsCost =
-    ROBOCALL_CAMPAIGN_COUNT * matchedLandline * ROBOCALL_COST
+  // Spread the voter contact goal evenly across every text and robocall
+  // campaign, then price each channel at its per-contact rate.
+  const contactsPerCampaign = Math.floor(
+    voterContactGoal / (TEXT_CAMPAIGN_COUNT + ROBOCALL_CAMPAIGN_COUNT),
+  )
+  const textContacts = TEXT_CAMPAIGN_COUNT * contactsPerCampaign
+  const robocallContacts = ROBOCALL_CAMPAIGN_COUNT * contactsPerCampaign
+  const textCampaignsCost = textContacts * TEXT_COST
+  const robocallCampaignsCost = robocallContacts * ROBOCALL_COST
   const subtotal =
     filing +
     YARD_SIGNS_COST +
@@ -661,16 +662,20 @@ const buildBudgetBreakdown = (
     {
       category: 'Text campaigns',
       amount: formatDollars(textCampaignsCost),
-      rationale: `${TEXT_CAMPAIGN_COUNT} text campaigns to ${matchedCell.toLocaleString(
+      rationale: `${TEXT_CAMPAIGN_COUNT} text campaigns, ${contactsPerCampaign.toLocaleString(
         'en-US',
-      )} at $${TEXT_COST.toFixed(3)} per text.`,
+      )} contacts each (${textContacts.toLocaleString(
+        'en-US',
+      )} texts) at $${TEXT_COST.toFixed(3)} per text.`,
     },
     {
       category: 'Robocall campaigns',
       amount: formatDollars(robocallCampaignsCost),
-      rationale: `${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns to ${matchedLandline.toLocaleString(
+      rationale: `${ROBOCALL_CAMPAIGN_COUNT} robocall campaigns, ${contactsPerCampaign.toLocaleString(
         'en-US',
-      )} at $${ROBOCALL_COST.toFixed(3)} per call.`,
+      )} contacts each (${robocallContacts.toLocaleString(
+        'en-US',
+      )} calls) at $${ROBOCALL_COST.toFixed(3)} per call.`,
     },
     {
       category: 'Contingency (5%)',
@@ -1082,34 +1087,13 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   const registeredVotersLow = Math.max(0, Math.round(registeredVoters * 0.9))
   const registeredVotersHigh = Math.round(registeredVoters * 1.1)
 
-  // Real phone-match counts when available. Each L2 record can carry up to
-  // 4 cell numbers and 2 landlines per household — keep the same multipliers
-  // the placeholder heuristic used so downstream budget math stays
-  // consistent regardless of source.
-  const cellMatchRate =
-    input.uniqueCellphones != null && registeredVoters > 0
-      ? input.uniqueCellphones / registeredVoters
-      : PLACEHOLDER_MATCH_RATE_CELL
-  const landlineMatchRate =
-    input.uniqueLandlines != null && registeredVoters > 0
-      ? input.uniqueLandlines / registeredVoters
-      : PLACEHOLDER_MATCH_RATE_LANDLINE
-  const matchedCellRecords = Math.max(
-    0,
-    Math.round(projectedTurnout * cellMatchRate * 4),
-  )
-  const matchedLandlineRecords = Math.max(
-    0,
-    Math.round(projectedTurnout * landlineMatchRate * 2),
-  )
   const averageTouchesPerVoter =
     projectedTurnout > 0
       ? Number((voterContactGoal / projectedTurnout).toFixed(1))
       : 0
 
   const { totalBudget, lineItems: budgetLineItems } = buildBudgetBreakdown(
-    matchedCellRecords,
-    matchedLandlineRecords,
+    voterContactGoal,
     input.filingFee,
   )
 
@@ -1283,8 +1267,6 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     registeredVotersHigh,
     voterContactGoal,
     opponentCount,
-    matchedCellRecords,
-    matchedLandlineRecords,
     volunteerHourTarget,
     totalBudget,
     averageTouchesPerVoter,


### PR DESCRIPTION
Section 5, has math of “4 text campaigns to {registered_voters_with_cellphone} at $0.035 per text.” - which doesn’t make sense - and violates our outreach math (5 x win_number)


So we are favoring the "5 x win_number". We know there are 7 total outreach recommended (3 robo, 4 text), assuming the same goal across both, we re-construct the outreach.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and budget calculation changes in onboarding plan generation only; no auth, APIs, or persistence changes.
> 
> **Overview**
> **Section 5 budget and outreach copy** no longer derives text/robocall volumes from L2 cellphone/landline match heuristics. **`buildBudgetBreakdown`** now takes **`voterContactGoal`**, splits it evenly across **7** scheduled campaigns (4 text + 3 robocall), and prices each channel from those contact counts. Budget rationales describe **contacts per campaign** instead of matched registered-voter phone totals.
> 
> **`PlanData`** drops **`matchedCellRecords`** and **`matchedLandlineRecords`**, along with placeholder match rates and the turnout × match-rate math that fed them. Outreach dollars and narrative stay aligned with the **5× win number** contact goal used elsewhere in the plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d54b5df8cc6b23077f6b2eed3a57d85bd06a00a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->