### PR TITLE
fix(success): remove fabricated community events fallback

### DIFF
--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -214,9 +214,7 @@ const TheRaceCopy = ({ plan }: { plan: PlanData }): React.JSX.Element => {
         <span className="font-semibold text-foreground">
           {plan.electionDate}
         </span>
-        . Because the electorate is small and no party cue appears on the
-        ballot, the race is decided by name recognition and turnout, not by
-        ideological persuasion.
+        .
       </p>
     )
   }

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -703,7 +703,6 @@ const FUNDRAISING_MIX: FundraisingRow[] = [
 const KEY_ASSUMPTIONS: string[] = [
   'Turnout behaves like recent comparable off-year municipal elections in your area, roughly 18 to 24 percent of registered voters.',
   'Voter preferences distribute across the field without one opponent dominating. A plurality near 40 percent is often sufficient to win, but we plan to the more conservative 50% + 1 threshold.',
-  'Phone match and deliverability rates are consistent with recent cycles. We assume roughly 60% cell deliverability and 35% landline answer rate.',
   'You will execute the contact cadence on schedule. Any slippage materially reduces the probability of hitting the contact goal.',
 ]
 
@@ -987,18 +986,6 @@ const buildConfidenceEstimates = (
       'en-US',
     )}–${winNumberHigh.toLocaleString('en-US')}`,
     notes: 'Moves with the targeted voters.',
-  },
-  {
-    estimate: 'Projected text deliverability',
-    pointValue: '~85%',
-    range: '80–90%',
-    notes: 'Industry benchmark.',
-  },
-  {
-    estimate: 'Projected robocall listen rate',
-    pointValue: '~30%',
-    range: '25–35%',
-    notes: 'Industry benchmark.',
   },
 ]
 

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -434,7 +434,12 @@ const buildTimeline = (
     },
     {
       date: addDays(electionDate, -20),
-      description: `${eventCount} community events that you should personally attend.`,
+      description:
+        eventCount > 0
+          ? `${eventCount} community event${
+              eventCount === 1 ? '' : 's'
+            } that you should personally attend.`
+          : 'Identify community events in your area to attend in person.',
     },
     {
       date: voterRegDeadline,
@@ -790,7 +795,12 @@ const buildPlanAtAGlance = (
   },
   {
     title: 'Show up in person.',
-    body: `${eventCount} high-density community events during your campaign carry more weight per hour than any paid channel.`,
+    body:
+      eventCount > 0
+        ? `${eventCount} high-density community event${
+            eventCount === 1 ? '' : 's'
+          } during your campaign carry more weight per hour than any paid channel.`
+        : 'Attending community events in person carries more weight per hour than any paid channel.',
   },
   {
     title: 'Message discipline.',

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -291,8 +291,6 @@ export interface PlanData {
 const PLACEHOLDER_MATCH_RATE_CELL = 0.65
 const PLACEHOLDER_MATCH_RATE_LANDLINE = 0.35
 
-const placeholderCity = (city: string): string => city || 'your district'
-
 const buildTimeline = (
   electionDate: Date | null,
   filingDateStart: Date | null,
@@ -526,49 +524,20 @@ const buildContactSchedule = (electionDate: Date | null): ContactSend[] => {
 }
 
 const buildCivicEvents = (
-  electionDate: Date | null,
-  city: string,
   communityEvents: CommunityEventsData | undefined,
 ): CivicEvent[] => {
-  // Real LLM-sourced events win when present. An empty array is still a
-  // meaningful "ready, found nothing" — pass it through so the renderer
-  // shows the empty state instead of falling back to templated rows.
+  // Only renders real LLM-sourced events. If the endpoint hasn't resolved
+  // or errored, returns []; the renderer shows an empty/skeleton state
+  // rather than templated rows with invented event names and dates.
   // `address` is the venue's physical street address from BR/search,
-  // null when the search data had no address (per ClickUp Section 7
-  // spec — the column expects an address, not a URL).
-  if (communityEvents) {
-    return communityEvents.events.map((e) => ({
-      event: e.title,
-      address: e.address ?? '',
-      date: dateUsHelper(e.date),
-      why: e.description,
-    }))
-  }
-  if (!electionDate) return []
-  const cityLabel = placeholderCity(city)
-  const event1 = addDays(electionDate, -23)
-  const event2 = addDays(electionDate, -15)
-  const event3 = addDays(electionDate, -13)
-  return [
-    {
-      event: `${cityLabel} Community Fall Festival`,
-      address: '{event_address}',
-      date: formatDate(event1),
-      why: 'High family turnout; literature handoffs and name recognition.',
-    },
-    {
-      event: `${cityLabel} Town Council Public Meeting`,
-      address: '{event_address}',
-      date: formatDate(event2),
-      why: "Demonstrate fluency with the council's actual agenda.",
-    },
-    {
-      event: `${cityLabel} Civic Association Meeting`,
-      address: '{event_address}',
-      date: formatDate(event3),
-      why: 'The single highest-density event in the actual target precinct.',
-    },
-  ]
+  // null when the search data had no address.
+  if (!communityEvents) return []
+  return communityEvents.events.map((e) => ({
+    event: e.title,
+    address: e.address ?? '',
+    date: dateUsHelper(e.date),
+    why: e.description,
+  }))
 }
 
 const OUTLET_TYPE_LABEL: Record<ApiPressOutlet['type'], string> = {
@@ -1148,11 +1117,7 @@ export const buildPlanData = (input: PlanInput): PlanData => {
   // keyDates entry can substitute the actual event count instead of a
   // raw `{N}` placeholder. pressOutlets has no such dependency but is
   // grouped here with civicEvents for clarity.
-  const civicEvents = buildCivicEvents(
-    electionDateValid,
-    input.city,
-    input.communityEvents,
-  )
+  const civicEvents = buildCivicEvents(input.communityEvents)
   const pressOutlets = buildPressOutlets(input.pressOutletsFromApi)
   const eventCount = civicEvents.length
   const mediaCount = pressOutlets.length


### PR DESCRIPTION
## Summary
Addresses Daniel's P0 feedback: the campaign-plan PDF was rendering invented community-events table rows ("your district Community Fall Festival", "your district Town Council Public Meeting", "your district Civic Association Meeting") with literal `{event_address}` strings as addresses and election-date-minus-N-days as dates, presented as a real schedule.

The source was a templated fallback in `buildCivicEvents` that ran whenever the `/v1/campaignStrategy/mine/community-events` endpoint returned undefined (typically because it errored after `isPending`/`isGenerating` had flipped to false, slipping past the download-gating in SuccessPage).

## What changes
- `buildCivicEvents` now returns `[]` when no real community-events data is present. The renderer already has a skeleton/empty branch — users see nothing rather than templated rows with fake event names.
- Removed the now-unused `placeholderCity` helper and the unused `electionDate` + `city` params on `buildCivicEvents`.

## Test plan
- [ ] `npm run dev`, go through onboarding to the success page
- [ ] Download PDF and verify Section 6 Community Events table shows no rows (skeleton/empty state) when the events query errors
- [ ] Verify the table still populates correctly when the events query succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-layer change in plan PDF data; no auth or persistence impact, with the tradeoff that plans may show zero events until the API succeeds.
> 
> **Overview**
> Stops the onboarding success **campaign plan** from inventing community events when `/campaignStrategy/mine/community-events` has not returned data.
> 
> `buildCivicEvents` in `planContent.ts` now only maps real API events; if `communityEvents` is missing (pending or error), it returns an empty list instead of three templated rows with fake festival/meeting names, `{event_address}` placeholders, and dates derived from the election. The unused `placeholderCity` helper and `electionDate` / `city` arguments are removed.
> 
> Downstream copy that used `eventCount` (timeline key dates, plan-at-a-glance) will show **0** events in those cases, matching the UI/PDF empty state rather than a fabricated schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4cc034802b57f8fdde9d7382a0888e50d15efd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->