### PR TITLE
fix: post-migration visual regressions (modal sizing, TextField className, chat-history color)

### DIFF
--- a/app/dashboard/campaign-assistant/components/ChatHistory.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatHistory.tsx
@@ -75,7 +75,7 @@ const ChatHistory = (): React.JSX.Element => {
         onOpenChange={(next) => !next && closeDrawer()}
         direction="right"
       >
-        <DrawerContent className="bg-primary-dark min-w-[300px] h-full text-white">
+        <DrawerContent className="bg-gray-900 min-w-[300px] h-full text-white">
           <DrawerHeader className="border-b border-slate-50">
             <DrawerTitle asChild>
               <H2>History</H2>

--- a/app/dashboard/campaign-assistant/components/ChatHistoryThread.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatHistoryThread.tsx
@@ -23,7 +23,7 @@ const ChatHistoryThread = ({
   }
   return (
     <div
-      className="py-2 flex justify-between px-3 pb-3 hover:bg-primary-main rounded-md transition-colors cursor-pointer max-w-xs"
+      className="py-2 flex justify-between px-3 pb-3 hover:bg-white/10 rounded-md transition-colors cursor-pointer max-w-xs"
       onClick={handleClick}
     >
       <div className="flex">

--- a/app/dashboard/campaign-assistant/components/DeleteThread.tsx
+++ b/app/dashboard/campaign-assistant/components/DeleteThread.tsx
@@ -44,7 +44,7 @@ const DeleteThread = ({ chat }: DeleteThreadProps): React.JSX.Element => {
             className="fixed h-screen w-screen top-14 left-0"
             onClick={toggleShow}
           />
-          <div className="absolute bg-primary-main p-2 rounded-xl shadow-lg z-10 right-2 top-2 min-w-[240px]">
+          <div className="absolute bg-gray-800 p-2 rounded-xl shadow-lg z-10 right-2 top-2 min-w-[240px]">
             <div
               className="p-2 hover:bg-white hover:bg-opacity-10 hover:rounded transition-colors"
               onClick={showDelete}

--- a/app/shared/inputs/TextField.tsx
+++ b/app/shared/inputs/TextField.tsx
@@ -160,7 +160,6 @@ const TextField = ({
         error && 'border-destructive',
         startAdornment ? 'pl-9' : null,
         endAdornment ? 'pr-9' : null,
-        className,
       )}
       {...inputProps}
     />
@@ -173,7 +172,6 @@ const TextField = ({
         error && 'border-destructive',
         startAdornment ? 'pl-9' : null,
         endAdornment ? 'pr-9' : null,
-        className,
       )}
       {...inputProps}
     />
@@ -199,7 +197,7 @@ const TextField = ({
     )
 
   return (
-    <div className="flex w-full flex-col gap-1.5">
+    <div className={cn('flex w-full flex-col gap-1.5', className)}>
       {label ? (
         <Label
           htmlFor={inputId}

--- a/app/shared/utils/Modal.tsx
+++ b/app/shared/utils/Modal.tsx
@@ -44,7 +44,7 @@ const Modal = ({
     ) : null}
     <DialogContent
       className={cn(
-        '!min-w-[calc(100%-theme(space.4))] sm:!min-w-[500px] sm:!p-4 md:!p-8 max-h-[90vh] overflow-y-auto',
+        'w-auto !min-w-[calc(100%-theme(space.4))] sm:!min-w-[500px] sm:!max-w-[calc(100vw-2rem)] sm:!p-4 md:!p-8 max-h-[90vh] overflow-y-auto',
         hideClose && '[&>button:last-child]:hidden',
         boxClassName,
       )}


### PR DESCRIPTION
## Why

Post-migration QA on dev surfaced four visual regressions from the MUI → shadcn work. This fixes three of them (the fourth, off-color buttons, is being handled by the separate button-consolidation effort since it's a systemic PrimaryButton issue).

- **Modals squashed to a narrow fixed width** — the shared `Modal` was capped at the styleguide Dialog's `sm:max-w-lg`, so wide-content modals (outreach target-audience selector, content "finish onboarding") wrapped to one character/word per line or clipped. The old MUI Modal grew to its content. Restored that: the Dialog now sizes to content (`w-auto`) up to the viewport instead of the 512px cap.
- **committee-check upload squashed** — the migrated shared `TextField` was applying the consumer's `className` to the inner `<input>` instead of the root wrapper. In `CommitteeSupportingFilesUpload` that grid cell's `col-span-7` landed on the wrong element, so the field collapsed to ~1 of 10 columns. MUI applied `className` to the root; restored that (functional classes like error/adornment padding stay on the input).
- **AI Assistant chat-history panel rendered blue** — migrating the panel into the styleguide `DrawerContent` (which carries `data-slot`) pulled the whole subtree under the styleguide color scope, flipping its webapp-navy `primary-*` tokens to the styleguide blue. Switched the panel background, item hover, and delete popover to stable dark tokens that don't get re-scoped.

## Audit

Manual dev QA: confirm the outreach + content modals size to their content; the committee-check upload row lays out normally; and the AI Assistant history drawer is dark (not blue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small styling and className-placement fixes in shared UI and campaign-assistant components; no auth, data, or API changes.
> 
> **Overview**
> Fixes three post-migration visual regressions without changing behavior.
> 
> **Shared `Modal`** — `DialogContent` now uses `w-auto` and `sm:!max-w-[calc(100vw-2rem)]` so wide modals grow with content instead of staying capped at the styleguide’s narrow `max-w-lg`.
> 
> **Shared `TextField`** — Consumer `className` is applied to the outer wrapper again (not the inner `Input`/`Textarea`), so layout classes like grid `col-span-*` affect the field container as before MUI.
> 
> **Campaign Assistant chat history** — Drawer and thread UI drop `primary-*` tokens (re-scoped to styleguide blue inside `DrawerContent`) in favor of `bg-gray-900`, `hover:bg-white/10`, and `bg-gray-800` on the delete menu so the panel stays dark navy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5444b20a55d2a75242c048fa5ef03fcbed20e388. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->