### PR TITLE
fix(buttons): follow-up — vestigial FooterButtonLink prop + acknowledged-button success color

### DIFF
--- a/app/shared/acknowledgements/AcknowledgementQuestion.tsx
+++ b/app/shared/acknowledgements/AcknowledgementQuestion.tsx
@@ -50,7 +50,7 @@ export const AcknowledgementQuestion = ({
               onClick={() => {
                 onAcknowledge(false)
               }}
-              className="flex items-center"
+              className="flex items-center !bg-success-main !text-success-contrast hover:!bg-success-dark"
               size="large"
             >
               <FaCheck />

--- a/app/shared/layouts/footer/Footer.tsx
+++ b/app/shared/layouts/footer/Footer.tsx
@@ -50,10 +50,7 @@ export const Footer = ({
               {column.links.map((link, linkKey) => (
                 <FooterLinkWrapper key={linkKey}>
                   {link.buttonStyle ? (
-                    <FooterButtonLink
-                      {...link}
-                      buttonStyle={link.buttonStyle as 'tertiary' | 'secondary'}
-                    />
+                    <FooterButtonLink {...link} />
                   ) : link.isExternal ? (
                     <FooterExternalLink {...link} />
                   ) : link.useNativeLink ? (

--- a/app/shared/layouts/footer/components/FooterButtonLink.tsx
+++ b/app/shared/layouts/footer/components/FooterButtonLink.tsx
@@ -5,7 +5,6 @@ interface FooterButtonLinkProps {
   link: string
   id: string
   label: string
-  buttonStyle: 'tertiary' | 'secondary'
   isExternal?: boolean
 }
 


### PR DESCRIPTION
Two delegate-review items that landed after #1961 was merged:

- **FooterButtonLink**: the `buttonStyle: 'tertiary' | 'secondary'` prop was advertised but ignored (both collapse to `secondary` under the button-variant remap). Removed it from the component's props; the footer link data keeps its `buttonStyle` flag for the button-vs-plain-link gating.
- **AcknowledgementQuestion**: the migration dropped `color="success"`, so the *acknowledged* state rendered as default blue — visually identical to unacknowledged. Restored the green affordance via success design-token classes.

Small follow-up to the button consolidation (#1961).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational and prop-cleanup changes in footer and acknowledgement UI with no auth, data, or API impact.
> 
> **Overview**
> Follow-up to button consolidation (#1961): fixes **acknowledged** acknowledgement UI and cleans up a dead footer prop.
> 
> **AcknowledgementQuestion** restores a distinct green “agreed” state on the acknowledged button using success design-token classes (`!bg-success-main`, etc.), so it no longer looks like the default unacknowledged blue after `color="success"` was dropped in the migration.
> 
> **FooterButtonLink** drops the unused `buttonStyle` prop (it was never applied—footer buttons always render as `secondary`). Footer link data still uses `buttonStyle` only to choose button vs plain link in `Footer.tsx`; the cast and explicit pass-through are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9672a43a68c4a383690ef5cbbb084138d077d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->