### PR TITLE
Fix party-select alignment + light-theme the AI chat history drawer

### DIFF
--- a/app/dashboard/campaign-assistant/components/ChatHistory.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatHistory.tsx
@@ -75,8 +75,8 @@ const ChatHistory = (): React.JSX.Element => {
         onOpenChange={(next) => !next && closeDrawer()}
         direction="right"
       >
-        <DrawerContent className="bg-gray-900 min-w-[300px] h-full text-white">
-          <DrawerHeader className="border-b border-slate-50">
+        <DrawerContent className="min-w-[300px] h-full">
+          <DrawerHeader className="border-b border-border">
             <DrawerTitle asChild>
               <H2>History</H2>
             </DrawerTitle>

--- a/app/dashboard/campaign-assistant/components/ChatHistoryGroup.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatHistoryGroup.tsx
@@ -18,7 +18,7 @@ export const ChatHistoryGroup = ({
     <>
       {chats.length > 0 && (
         <div className="p-6 mt-3">
-          <Overline className="mb-2 text-gray-400">{title}</Overline>
+          <Overline className="mb-2 text-muted-foreground">{title}</Overline>
           <div className="">
             {chats.map((chat) => (
               <ChatHistoryThread

--- a/app/dashboard/campaign-assistant/components/ChatHistoryThread.tsx
+++ b/app/dashboard/campaign-assistant/components/ChatHistoryThread.tsx
@@ -23,14 +23,14 @@ const ChatHistoryThread = ({
   }
   return (
     <div
-      className="py-2 flex justify-between px-3 pb-3 hover:bg-white/10 rounded-md transition-colors cursor-pointer max-w-xs"
+      className="py-2 flex justify-between px-3 pb-3 hover:bg-muted rounded-md transition-colors cursor-pointer max-w-xs"
       onClick={handleClick}
     >
       <div className="flex">
         <MdAutoAwesome className=" opacity-50 mt-1" size={20} />
         <div className="ml-2">
           <Body1 className="line-clamp-1">{chat.name}</Body1>
-          <Body2 className="mt-2 text-gray-300">
+          <Body2 className="mt-2 text-muted-foreground">
             {dateUsHelper(chat.updatedAt)}
           </Body2>
         </div>

--- a/app/dashboard/campaign-assistant/components/DeleteThread.tsx
+++ b/app/dashboard/campaign-assistant/components/DeleteThread.tsx
@@ -44,9 +44,9 @@ const DeleteThread = ({ chat }: DeleteThreadProps): React.JSX.Element => {
             className="fixed h-screen w-screen top-14 left-0"
             onClick={toggleShow}
           />
-          <div className="absolute bg-gray-800 p-2 rounded-xl shadow-lg z-10 right-2 top-2 min-w-[240px]">
+          <div className="absolute bg-popover text-popover-foreground border border-border p-2 rounded-xl shadow-lg z-10 right-2 top-2 min-w-[240px]">
             <div
-              className="p-2 hover:bg-white hover:bg-opacity-10 hover:rounded transition-colors"
+              className="p-2 hover:bg-muted hover:rounded transition-colors"
               onClick={showDelete}
             >
               Delete

--- a/app/dashboard/campaign-details/components/CampaignSection.tsx
+++ b/app/dashboard/campaign-details/components/CampaignSection.tsx
@@ -164,7 +164,7 @@ export default function CampaignSection(
           const value = state[field.key] ?? ''
           return (
             <div key={field.key} className="col-span-12 md:col-span-6">
-              <div className={`${field.type === 'select' ? '' : 'pt-5'}`}>
+              <div className="pt-5">
                 <RenderInputField
                   field={field}
                   value={value}


### PR DESCRIPTION
Two visual regressions surfaced during QA of the shadcn migration.

**Party dropdown misaligned on /dashboard/campaign-details.** The per-field wrapper in `CampaignSection` applied top padding to text inputs but explicitly skipped it for `select` fields. That left the Political Party Affiliation select sitting ~20px above its row-neighbor (Campaign website). Applying the same top spacing to every field lines them up; with the select's taller native label, the trigger now lands on the same baseline as the adjacent input.

**AI Assistant history drawer rendered dark.** The drawer was hard-coded to a dark surface (gray-900 + white text) with inner colors picked for that dark background. `DrawerContent` already defaults to the light `bg-background` surface, so this drops the dark overrides and re-points the inner text, borders, hover states, and the delete popover to the light-theme design tokens (`muted`, `muted-foreground`, `border`, `popover`). The history panel now matches the rest of the assistant UI instead of inverting it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS/class-only changes with no logic, data, or auth impact.
> 
> **Overview**
> Fixes two shadcn-migration visual regressions on campaign details and the AI assistant.
> 
> **Campaign details:** Every field wrapper in `CampaignSection` now uses `pt-5`, removing the exception that skipped top padding for `select` fields. The Political Party Affiliation dropdown aligns with neighboring inputs (e.g. campaign website).
> 
> **AI chat history drawer:** Drops hard-coded dark styling (`bg-gray-900`, white text, gray borders) on the drawer and related UI. Surfaces, borders, muted text, row hovers, and the delete thread popover now use light-theme tokens (`border-border`, `text-muted-foreground`, `hover:bg-muted`, `bg-popover`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a62fc92523711e11bb3cffc43dd2faea2dd847e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->