### PR TITLE
Add agenda upload modal and processing/failed row states

### DIFF
--- a/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
+++ b/app/dashboard/briefings/components/AwaitingAgendaRow.tsx
@@ -1,93 +1,104 @@
 'use client'
 
-import { ChevronRight, MapPin } from 'lucide-react'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@styleguide'
-import {
-  countdownLabel,
-  formatDayTime,
-  formatShortDate,
-} from '@shared/briefings/dateHelpers'
+import { useState } from 'react'
+import { ChevronRight, LoaderCircle } from 'lucide-react'
+import { formatDayTime, formatShortDate } from '@shared/briefings/dateHelpers'
 import type { BriefingSummary } from '@shared/briefings/types'
+import UploadAgendaModal from './UploadAgendaModal'
 
 type Props = {
   summary: BriefingSummary
 }
 
+type PillVariant = {
+  label: string
+  className: string
+  icon?: React.ReactNode
+}
+
+const pillFor = (
+  status: BriefingSummary['userAgendaStatus'],
+): PillVariant => {
+  if (status === 'processing') {
+    return {
+      label: 'Processing your agenda…',
+      className: 'bg-primary/10 text-primary',
+      icon: <LoaderCircle className="size-3 animate-spin" aria-hidden />,
+    }
+  }
+  if (status === 'failed') {
+    return {
+      label: 'Briefing failed',
+      className: 'bg-destructive/10 text-destructive',
+    }
+  }
+  return {
+    label: 'Awaiting agenda',
+    className: 'bg-muted text-muted-foreground',
+  }
+}
+
 export default function AwaitingAgendaRow({
   summary,
 }: Props): React.JSX.Element {
+  const [open, setOpen] = useState(false)
   const shortDate = formatShortDate(summary.scheduledAt)
   const dayTime = formatDayTime(summary.scheduledAt)
-  const countdown = countdownLabel(summary.scheduledAt)
+
+  const status = summary.userAgendaStatus
+  const isProcessing = status === 'processing'
+  const pill = pillFor(status)
+
+  // While the user's agenda is processing, don't let them re-open the
+  // modal — they've already submitted. `failed` and `null`/awaiting both
+  // open the modal (failed allows a retry).
+  const rowDisabled = isProcessing
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <button
-          type="button"
-          className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus:bg-muted/60 focus:outline-none"
-        >
-          <span
-            aria-hidden
-            className="inline-block size-2.5 shrink-0 rounded-full border-2 border-current text-muted-foreground/60"
-          />
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (!rowDisabled) setOpen(true)
+        }}
+        aria-disabled={rowDisabled || undefined}
+        className="group flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/60 focus:bg-muted/60 focus:outline-none aria-disabled:cursor-default aria-disabled:hover:bg-transparent"
+      >
+        <span
+          aria-hidden
+          className="inline-block size-2.5 shrink-0 rounded-full border-2 border-current text-muted-foreground/60"
+        />
 
-          <span className="shrink-0 text-xs font-medium text-muted-foreground">
-            <span className="inline-block w-16 md:hidden">{shortDate}</span>
-            <span className="hidden w-52 md:inline-block">
-              {shortDate} · {dayTime}
-            </span>
-          </span>
-
-          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-            {summary.meetingName}
-          </span>
-
-          <span className="inline-flex items-center whitespace-nowrap rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
-            Awaiting agenda
-          </span>
-
-          <ChevronRight
-            aria-hidden
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-        </button>
-      </DialogTrigger>
-
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <div className="mb-1">
-            <span className="inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Upcoming{countdown ? ` · ${countdown}` : ''}
-            </span>
-          </div>
-          <DialogTitle className="text-xl font-bold leading-7">
-            {summary.meetingName}
-          </DialogTitle>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
-          <p>
+        <span className="shrink-0 text-xs font-medium text-muted-foreground">
+          <span className="inline-block w-16 md:hidden">{shortDate}</span>
+          <span className="hidden w-52 md:inline-block">
             {shortDate} · {dayTime}
-          </p>
-          {summary.location ? (
-            <p className="flex items-center gap-1.5">
-              <MapPin className="size-3.5 shrink-0" aria-hidden />
-              {summary.location}
-            </p>
-          ) : null}
-        </div>
+          </span>
+        </span>
 
-        <p className="text-sm">
-          <span className="font-medium">Status:</span> Agenda not posted yet
-        </p>
-      </DialogContent>
-    </Dialog>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          {summary.meetingName}
+        </span>
+
+        <span
+          className={`inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium ${pill.className}`}
+        >
+          {pill.icon}
+          {pill.label}
+        </span>
+
+        <ChevronRight
+          aria-hidden
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      </button>
+
+      <UploadAgendaModal
+        open={open}
+        onOpenChange={setOpen}
+        meetingDate={summary.slug}
+        meetingName={summary.meetingName}
+      />
+    </>
   )
 }

--- a/app/dashboard/briefings/components/UploadAgendaModal.tsx
+++ b/app/dashboard/briefings/components/UploadAgendaModal.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useMutation } from '@tanstack/react-query'
+import { Link as LinkIcon, Upload } from 'lucide-react'
+import { Button, Dialog, DialogContent, DialogHeader, DialogTitle } from '@styleguide'
+import { HiddenFileUploadInput } from '@shared/inputs/HiddenFileUploadInput'
+import {
+  AgendaFileTooLargeError,
+  AgendaFileWrongTypeError,
+  MAX_AGENDA_BYTES,
+  submitAgendaFile,
+  submitAgendaUrl,
+} from '@shared/briefings/agenda-upload-api'
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  meetingDate: string
+  meetingName: string
+}
+
+const MAX_MB = Math.round(MAX_AGENDA_BYTES / 1024 / 1024)
+
+const isLikelyValidUrl = (value: string): boolean => {
+  try {
+    const u = new URL(value.trim())
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export default function UploadAgendaModal({
+  open,
+  onOpenChange,
+  meetingDate,
+  meetingName,
+}: Props): React.JSX.Element {
+  const router = useRouter()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [url, setUrl] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const reset = () => {
+    setUrl('')
+    setFile(null)
+    setErrorMessage(null)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const handleUrlChange = (next: string) => {
+    setUrl(next)
+    if (next && file) setFile(null)
+    if (errorMessage) setErrorMessage(null)
+  }
+
+  const handleFileSelected = (chosen: File) => {
+    setErrorMessage(null)
+    const sizeMb = chosen.size / 1024 / 1024
+    if (chosen.type && chosen.type !== 'application/pdf') {
+      setErrorMessage('That file isn’t a PDF. Please upload a PDF.')
+      return
+    }
+    if (chosen.size > MAX_AGENDA_BYTES) {
+      setErrorMessage(
+        `That file is ${sizeMb.toFixed(1)} MB. Max size is ${MAX_MB} MB.`,
+      )
+      return
+    }
+    setFile(chosen)
+    if (url) setUrl('')
+  }
+
+  const openFilePicker = () => fileInputRef.current?.click()
+
+  const submitMutation = useMutation({
+    mutationFn: async () => {
+      if (file) return submitAgendaFile(meetingDate, file)
+      if (url) return submitAgendaUrl(meetingDate, url.trim())
+      throw new Error('no_input_provided')
+    },
+    onSuccess: () => {
+      handleOpenChange(false)
+      router.refresh()
+    },
+    onError: (err) => {
+      if (err instanceof AgendaFileTooLargeError) {
+        setErrorMessage(`File is too large. Max size is ${MAX_MB} MB.`)
+        return
+      }
+      if (err instanceof AgendaFileWrongTypeError) {
+        setErrorMessage('Only PDF files are supported.')
+        return
+      }
+      setErrorMessage(
+        'Something went wrong submitting your agenda. Please try again.',
+      )
+    },
+  })
+
+  const urlIsValid = url.trim().length > 0 && isLikelyValidUrl(url)
+  const canSubmit =
+    !submitMutation.isPending && (urlIsValid || file !== null)
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md gap-5 rounded-2xl p-6 sm:p-7">
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle className="text-xl font-bold leading-7">
+            {meetingName}
+          </DialogTitle>
+          <p className="text-sm text-muted-foreground">
+            Drop in a link to the meeting packet, or upload the file. We&apos;ll
+            handle the rest.
+          </p>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <label className="sr-only" htmlFor="agenda-url">
+            Meeting packet URL
+          </label>
+          <div className="relative">
+            <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-muted-foreground">
+              <LinkIcon className="size-4" aria-hidden />
+            </span>
+            <input
+              id="agenda-url"
+              type="url"
+              inputMode="url"
+              autoComplete="off"
+              value={url}
+              onChange={(e) => handleUrlChange(e.target.value)}
+              placeholder="Paste a link to the meeting packet"
+              disabled={submitMutation.isPending}
+              className="h-12 w-full rounded-full border border-base-border bg-transparent pl-10 pr-4 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="h-px flex-1 bg-border" aria-hidden />
+            <span>OR</span>
+            <span className="h-px flex-1 bg-border" aria-hidden />
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={openFilePicker}
+            disabled={submitMutation.isPending}
+            className="h-12 w-full"
+          >
+            <Upload className="size-4 shrink-0" aria-hidden />
+            <span className="truncate">
+              {file ? file.name : 'Upload the meeting packet'}
+            </span>
+          </Button>
+
+          <HiddenFileUploadInput
+            ref={fileInputRef}
+            accept="application/pdf"
+            onChange={handleFileSelected}
+          />
+
+          {errorMessage ? (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="upload-agenda-error"
+            >
+              {errorMessage}
+            </p>
+          ) : null}
+
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!canSubmit}
+            loading={submitMutation.isPending}
+            loadingText="Submitting..."
+            onClick={() => submitMutation.mutate()}
+          >
+            Get your briefing
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/dashboard/polls/components/PollImageUpload.tsx
+++ b/app/dashboard/polls/components/PollImageUpload.tsx
@@ -120,7 +120,7 @@ export const PollImageUpload: React.FC<{
 
       <HiddenFileUploadInput
         ref={fileInputRef}
-        onChange={(_, file) => handleFileChoose(file)}
+        onChange={handleFileChoose}
         accept={ACCEPTED_FORMATS.join(',')}
       />
     </div>

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.tsx
@@ -83,10 +83,7 @@ export const CommitteeSupportingFilesUpload = ({
     fileInputRef.current?.click()
   }
 
-  const handleFileChoose = async (
-    _fileData: string | ArrayBuffer | null,
-    file: File,
-  ) => {
+  const handleFileChoose = async (file: File) => {
     setErrorMessage(``)
     const fileSizeMb = file?.size / 1e6
     if (fileSizeMb > FILE_LIMIT_MB) {

--- a/app/shared/briefings/agenda-upload-api.ts
+++ b/app/shared/briefings/agenda-upload-api.ts
@@ -1,0 +1,99 @@
+/**
+ * User-uploaded agenda client. Two submission paths share the same
+ * `POST /v1/meetings/:date/briefing/agenda` finalize call; the difference
+ * is whether the user gave us a URL or a file.
+ *
+ *   URL path:
+ *     submitAgendaUrl(meetingDate, sourceUrl)
+ *       → POST /agenda { source: 'URL', sourceUrl }
+ *
+ *   Upload path (three-step, mirrors attachments-api):
+ *     submitAgendaFile(meetingDate, file)
+ *       1. POST /agenda/presign  → { uploadId, uploadKey, uploadUrl }
+ *       2. PUT bytes to uploadUrl with Content-Type: application/pdf
+ *       3. POST /agenda { source: 'UPLOAD', uploadId, uploadKey }
+ *
+ * Bytes never pass through gp-api — the presigned URL puts them directly
+ * into S3.
+ */
+
+import { clientRequest } from 'gpApi/typed-request'
+import type { UserAgendaSubmitResponse } from 'gpApi/api-endpoints'
+
+export const MAX_AGENDA_BYTES = 75 * 1024 * 1024
+
+export class AgendaFileTooLargeError extends Error {
+  constructor(public readonly byteSize: number) {
+    super(`agenda_file_too_large:${byteSize}`)
+    this.name = 'AgendaFileTooLargeError'
+  }
+}
+
+export class AgendaFileWrongTypeError extends Error {
+  constructor(public readonly mimeType: string) {
+    super(`agenda_file_wrong_type:${mimeType}`)
+    this.name = 'AgendaFileWrongTypeError'
+  }
+}
+
+const PDF_MIME = 'application/pdf'
+
+const looksLikePdf = (file: File): boolean => {
+  if (file.type === PDF_MIME) return true
+  // Some Android pickers report empty file.type for PDFs — accept by
+  // extension when the MIME is missing.
+  if (file.type === '') return file.name.toLowerCase().endsWith('.pdf')
+  return false
+}
+
+export const submitAgendaUrl = async (
+  meetingDate: string,
+  sourceUrl: string,
+): Promise<UserAgendaSubmitResponse> => {
+  const { data } = await clientRequest(
+    'POST /v1/meetings/:date/briefing/agenda',
+    { date: meetingDate, source: 'URL', sourceUrl },
+  )
+  return data
+}
+
+export const submitAgendaFile = async (
+  meetingDate: string,
+  file: File,
+): Promise<UserAgendaSubmitResponse> => {
+  if (!looksLikePdf(file)) {
+    throw new AgendaFileWrongTypeError(file.type)
+  }
+  if (file.size > MAX_AGENDA_BYTES) {
+    throw new AgendaFileTooLargeError(file.size)
+  }
+
+  const { data: presign } = await clientRequest(
+    'POST /v1/meetings/:date/briefing/agenda/presign',
+    {
+      date: meetingDate,
+      contentType: PDF_MIME,
+      byteSize: file.size,
+    },
+  )
+
+  const putResponse = await fetch(presign.uploadUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': PDF_MIME },
+  })
+  if (!putResponse.ok) {
+    throw new Error(`s3_upload_failed:${putResponse.status}`)
+  }
+
+  const { data } = await clientRequest(
+    'POST /v1/meetings/:date/briefing/agenda',
+    {
+      date: meetingDate,
+      source: 'UPLOAD',
+      uploadId: presign.uploadId,
+      uploadKey: presign.uploadKey,
+    },
+  )
+  return data
+}

--- a/app/shared/briefings/server.ts
+++ b/app/shared/briefings/server.ts
@@ -35,6 +35,7 @@ const toSummary = (item: MeetingsListItemDto): BriefingSummary => ({
   scheduledAt: buildScheduledAt(item),
   location: item.location,
   status: item.hasBriefing ? 'briefing_ready' : 'awaiting_agenda',
+  userAgendaStatus: item.userAgendaStatus ?? null,
 })
 
 export const getBriefingsList = async (): Promise<BriefingSummary[]> => {

--- a/app/shared/briefings/types.ts
+++ b/app/shared/briefings/types.ts
@@ -89,6 +89,17 @@ export interface BriefingSummary {
   scheduledAt: string
   location: string
   status: 'briefing_ready' | 'awaiting_agenda'
+  /**
+   * State of a user-supplied agenda run for this meeting (URL or file
+   * upload). `null` (or absent) means the user has not yet submitted one.
+   *
+   * - `processing` — agenda accepted; briefing job is running
+   * - `failed` — agenda submission or run failed; user can retry
+   * - `completed` — briefing produced (the `status` will usually flip to
+   *   `briefing_ready` in the same payload, but this remains as a hint)
+   * - `unknown` — server doesn't know what state the run is in
+   */
+  userAgendaStatus?: 'processing' | 'failed' | 'completed' | 'unknown' | null
 }
 
 // ---------------------------------------------------------------------------

--- a/app/shared/inputs/HiddenFileUploadInput.tsx
+++ b/app/shared/inputs/HiddenFileUploadInput.tsx
@@ -1,11 +1,21 @@
 'use client'
 import React, { forwardRef } from 'react'
 
-interface HiddenFileUploadInputProps extends Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  'onChange' | 'type'
-> {
-  onChange: (result: string | ArrayBuffer | null, file: File) => void
+/**
+ * Hidden `<input type="file">` triggered by a visible Button via the
+ * forwarded ref. Emits the selected File to `onChange`. Consumers handle
+ * upload / validation / preview themselves with the raw File.
+ *
+ * Previously this also FileReader.readAsText'd the file before invoking
+ * onChange, but every consumer underscore-discarded that argument (and on
+ * binary PDFs the text decode produces garbage). Dropped the read entirely.
+ */
+interface HiddenFileUploadInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'onChange' | 'type'
+  > {
+  onChange: (file: File) => void
 }
 
 const HiddenFileUploadInputRender = (
@@ -16,12 +26,8 @@ const HiddenFileUploadInputRender = (
     e: React.ChangeEvent<HTMLInputElement>,
   ): void => {
     const file = e.target.files?.[0]
-    if (!file) {
-      return
-    }
-    const reader = new FileReader()
-    reader.onloadend = () => onChange(reader.result, file)
-    reader.readAsText(file)
+    if (!file) return
+    onChange(file)
   }
 
   return (

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -32,6 +32,40 @@ export interface MeetingsListItemDto {
   meetingName: string
   location: string
   hasBriefing: boolean
+  /**
+   * Status of an in-progress "user-uploaded agenda" briefing run for this
+   * meeting. `null` when the user has never submitted an agenda. Mirrors
+   * gp-api's MeetingsListItemDto.userAgendaStatus.
+   */
+  userAgendaStatus?: UserAgendaStatus | null
+}
+
+export type UserAgendaStatus =
+  | 'processing'
+  | 'failed'
+  | 'completed'
+  | 'unknown'
+
+/** Request/response shapes for the user-agenda-upload flow. */
+export type UserAgendaSubmitRequest =
+  | { source: 'URL'; sourceUrl: string }
+  | { source: 'UPLOAD'; uploadId: string; uploadKey: string }
+
+export interface UserAgendaSubmitResponse {
+  experimentRunId: string
+  status: 'processing'
+}
+
+export interface UserAgendaPresignRequest {
+  contentType: 'application/pdf'
+  byteSize: number
+}
+
+export interface UserAgendaPresignResponse {
+  uploadId: string
+  uploadKey: string
+  uploadUrl: string
+  expiresAt: string
 }
 
 export interface MeetingsListResponseDto {
@@ -323,6 +357,19 @@ export type APIEndpoints = {
   'GET /v1/meetings/:date/briefing': {
     Request: { date: string }
     Response: MeetingBriefingOutput | MeetingBriefingAwaitingDto
+  }
+
+  // User-uploaded agenda flow. Either submit a URL directly, or first call
+  // `/presign` to get a signed S3 PUT URL, upload bytes, then submit the
+  // returned uploadId/uploadKey. gp-api enqueues an experiment run and
+  // surfaces status via MeetingsListItemDto.userAgendaStatus.
+  'POST /v1/meetings/:date/briefing/agenda/presign': {
+    Request: { date: string } & UserAgendaPresignRequest
+    Response: UserAgendaPresignResponse
+  }
+  'POST /v1/meetings/:date/briefing/agenda': {
+    Request: { date: string } & UserAgendaSubmitRequest
+    Response: UserAgendaSubmitResponse
   }
 
   'POST /v1/speech/synthesize': {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New upload flow accepts user URLs and large PDFs via presigned S3 PUT; behavior depends on gp-api endpoints and shared file-input API change (call sites updated here).
> 
> **Overview**
> Adds a **user-supplied agenda** path on the briefings list: clicking an awaiting row opens **`UploadAgendaModal`** (replacing the old read-only meeting dialog) so users can paste an **http(s) packet URL** or upload a **PDF** (up to 75 MB), with client validation and mutation-driven submit/refresh.
> 
> **`AwaitingAgendaRow`** now reflects **`userAgendaStatus`** from `GET /v1/meetings`: pills for *Awaiting agenda*, *Processing your agenda…* (spinner, row non-clickable), and *Briefing failed* (opens modal for retry). List mapping in **`server.ts`** / **`BriefingSummary`** and **`gpApi/api-endpoints`** wire through **`userAgendaStatus`** and typed **`POST …/briefing/agenda`** (+ **`/presign`**) contracts.
> 
> New **`agenda-upload-api`** implements URL finalize vs presign → S3 PUT → upload finalize. **`HiddenFileUploadInput`** now calls **`onChange(file)`** only (drops `FileReader.readAsText`); poll and committee upload handlers are updated in the same PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e5996c71f49e76067a5aca42866d039972723c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->