### PR TITLE
feat(committee-check): add EIN sanity check before form submission

### DIFF
--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import CommitteeCheckPage from './CommitteeCheckPage'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn(),
+}))
+
+// The real upload component reaches for useCampaign + clientFetch; the page seeds
+// the uploaded filename from campaign.details.einSupportingDocument, so a stub is
+// enough to satisfy the "file uploaded" precondition for enabling Next.
+vi.mock(
+  'app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload',
+  () => ({
+    CommitteeSupportingFilesUpload: () => null,
+  }),
+)
+
+vi.mock('helpers/analyticsHelper', () => ({
+  EVENTS: {
+    ProUpgrade: {
+      CommitteeCheck: {
+        ClickNext: 'click_next',
+        ClickBack: 'click_back',
+        HoverNameHelp: 'hover_name_help',
+        HoverEinHelp: 'hover_ein_help',
+      },
+    },
+  },
+  trackEvent: vi.fn(),
+}))
+
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+
+// Committee name + a previously-uploaded doc are pre-seeded so the only gate the
+// test exercises is the EIN sanity check.
+const seededCampaign = {
+  details: {
+    campaignCommittee: 'Smith for Council',
+    einSupportingDocument: 'doc.pdf',
+  },
+}
+
+const setEin = (value: string) => {
+  const einInput = screen.getByLabelText('Campaign EIN')
+  fireEvent.change(einInput, { target: { value } })
+}
+
+describe('CommitteeCheckPage EIN sanity gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('blocks submission and shows a specific error for a non-IRS-prefix EIN', async () => {
+    render(<CommitteeCheckPage campaign={seededCampaign} />)
+
+    // 07 is not an IRS-issued prefix, but the value passes the shape-only check.
+    setEin('07-1234567')
+
+    const nextButton = await screen.findByRole('button', { name: 'Next' })
+    await waitFor(() => expect(nextButton).toBeEnabled())
+
+    fireEvent.click(nextButton)
+
+    expect(
+      await screen.findByText(/prefix isn't one the IRS issues/i),
+    ).toBeInTheDocument()
+    expect(mockUpdateCampaign).not.toHaveBeenCalled()
+  })
+
+  it('submits as before for a well-formed, plausible EIN', async () => {
+    render(<CommitteeCheckPage campaign={seededCampaign} />)
+
+    setEin('12-3456780')
+
+    const nextButton = await screen.findByRole('button', { name: 'Next' })
+    await waitFor(() => expect(nextButton).toBeEnabled())
+
+    fireEvent.click(nextButton)
+
+    await waitFor(() => expect(mockUpdateCampaign).toHaveBeenCalledTimes(1))
+    expect(
+      screen.queryByText(/prefix isn't one the IRS issues/i),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
@@ -14,6 +14,7 @@ import { CommitteeSupportingFilesUpload } from 'app/dashboard/pro-sign-up/commit
 import { Button } from '@styleguide'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { isValidEIN } from '@shared/inputs/IsValidEIN'
+import { checkEinSanity } from '@shared/inputs/EinSanityCheck'
 
 const COMMITTEE_HELP_MESSAGE = (
   <span>
@@ -59,6 +60,7 @@ const CommitteeCheckPage = ({
   )
   const [loadingCampaignUpdate, setLoadingCampaignUpdate] = useState(false)
   const [validatedEin, setValidatedEin] = useState<boolean | null>(null)
+  const [einSanityError, setEinSanityError] = useState<string | null>(null)
 
   // We need to do this to determine if file was uploaded in the root bucket, or in a subfolder
   const filenameBits =
@@ -86,6 +88,17 @@ const CommitteeCheckPage = ({
 
   const handleNextClick = async () => {
     trackEvent(EVENTS.ProUpgrade.CommitteeCheck.ClickNext)
+
+    // Catch obviously-bad EINs (placeholder, SSN-shaped, non-IRS prefix) before
+    // the form submits and kicks off the agentic compliance run. On a pass we
+    // submit exactly as before — no new API call, no payload-shape change.
+    const sanity = checkEinSanity(einInputValue)
+    if (!sanity.valid) {
+      setEinSanityError(sanity.message)
+      return
+    }
+    setEinSanityError(null)
+
     const doCampaignUpdate = async () => {
       setLoadingCampaignUpdate(true)
       await updateCampaign([
@@ -156,9 +169,13 @@ const CommitteeCheckPage = ({
           <EinCheckInput
             name="ein-number"
             value={einInputValue}
-            validated={validatedEin}
+            validated={einSanityError ? false : validatedEin}
             setValidated={setValidatedEin}
-            onChange={setEinInputValue}
+            error={Boolean(einSanityError)}
+            onChange={(value) => {
+              setEinSanityError(null)
+              setEinInputValue(value)
+            }}
             helperText={
               <a
                 href="https://sa.www4.irs.gov/applyein/legalStructure"
@@ -170,6 +187,11 @@ const CommitteeCheckPage = ({
               </a>
             }
           />
+          {einSanityError && (
+            <Body2 className="text-error my-4 text-center">
+              {einSanityError}
+            </Body2>
+          )}
           {validatedEin === false && (
             <Body2 className="text-error my-4 text-center">
               The provided EIN does not appear to match the given registered

--- a/app/shared/inputs/EinSanityCheck.test.ts
+++ b/app/shared/inputs/EinSanityCheck.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  checkEinSanity,
+  VALID_EIN_PREFIXES,
+  type EinSanityResult,
+} from '@shared/inputs/EinSanityCheck'
+
+const expectFail = (
+  result: EinSanityResult,
+  reason: Exclude<EinSanityResult, { valid: true }>['reason'],
+) => {
+  expect(result.valid).toBe(false)
+  // narrow for the type checker
+  if (result.valid) throw new Error('expected a failure result')
+  expect(result.reason).toBe(reason)
+  expect(result.message.length).toBeGreaterThan(0)
+}
+
+describe('checkEinSanity', () => {
+  it('passes a well-formed, plausibly-real EIN', () => {
+    // prefix 12 is IRS-issued; not a placeholder, all-same, or SSN-shaped value
+    expect(checkEinSanity('12-3456780')).toEqual({ valid: true })
+  })
+
+  it('rejects a value that does not match XX-XXXXXXX shape', () => {
+    expectFail(checkEinSanity('123456789'), 'format')
+    expectFail(checkEinSanity('1-23456789'), 'format')
+    expectFail(checkEinSanity(''), 'format')
+  })
+
+  it('rejects the common 12-3456789 placeholder', () => {
+    expectFail(checkEinSanity('12-3456789'), 'placeholder')
+  })
+
+  it('rejects all-same-digit values', () => {
+    expectFail(checkEinSanity('11-1111111'), 'placeholder')
+    expectFail(checkEinSanity('00-0000000'), 'placeholder')
+  })
+
+  it('rejects SSN-shaped values (first three digits 000, 666, or 900-999)', () => {
+    expectFail(checkEinSanity('00-0123456'), 'ssn-shaped') // 000...
+    expectFail(checkEinSanity('66-6123456'), 'ssn-shaped') // 666... (66 is a valid prefix, so SSN rule must win)
+    expectFail(checkEinSanity('90-0123456'), 'ssn-shaped') // 900... (90 is a valid prefix, so SSN rule must win)
+    expectFail(checkEinSanity('99-9123456'), 'ssn-shaped') // 999...
+  })
+
+  it('rejects EINs whose prefix the IRS does not issue', () => {
+    // 07 is not in the IRS-issued set; digits are not SSN-shaped
+    expect(VALID_EIN_PREFIXES.has('07')).toBe(false)
+    expectFail(checkEinSanity('07-1234567'), 'invalid-prefix')
+    expectFail(checkEinSanity('70-1234567'), 'invalid-prefix')
+  })
+})

--- a/app/shared/inputs/EinSanityCheck.ts
+++ b/app/shared/inputs/EinSanityCheck.ts
@@ -1,0 +1,158 @@
+import { EIN_PATTERN_FULL } from '@shared/inputs/IsValidEIN'
+
+/**
+ * Valid two-digit EIN prefixes (the campus / online assignment codes the IRS
+ * actually issues). Anything outside this set cannot be a real EIN.
+ *
+ * Source: IRS, "How EINs are assigned and valid EIN prefixes"
+ * https://www.irs.gov/businesses/small-businesses-self-employed/how-eins-are-assigned-and-valid-ein-prefixes
+ *
+ * Keep this list identical to any server-side copy (a future gp-api EIN schema)
+ * so the client and server sanity layers agree.
+ */
+export const VALID_EIN_PREFIXES: ReadonlySet<string> = new Set([
+  '01',
+  '02',
+  '03',
+  '04',
+  '05',
+  '06',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '20',
+  '21',
+  '22',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '30',
+  '31',
+  '32',
+  '33',
+  '34',
+  '35',
+  '36',
+  '37',
+  '38',
+  '39',
+  '40',
+  '41',
+  '42',
+  '43',
+  '44',
+  '45',
+  '46',
+  '47',
+  '48',
+  '50',
+  '51',
+  '52',
+  '53',
+  '54',
+  '55',
+  '56',
+  '57',
+  '58',
+  '59',
+  '60',
+  '61',
+  '62',
+  '63',
+  '64',
+  '65',
+  '66',
+  '67',
+  '68',
+  '71',
+  '72',
+  '73',
+  '74',
+  '75',
+  '76',
+  '77',
+  '80',
+  '81',
+  '82',
+  '83',
+  '84',
+  '85',
+  '86',
+  '87',
+  '88',
+  '90',
+  '91',
+  '92',
+  '93',
+  '94',
+  '95',
+  '98',
+  '99',
+])
+
+export type EinSanityFailureReason =
+  | 'format'
+  | 'placeholder'
+  | 'ssn-shaped'
+  | 'invalid-prefix'
+
+export type EinSanityResult =
+  | { valid: true }
+  | { valid: false; reason: EinSanityFailureReason; message: string }
+
+const FAILURE_MESSAGES: Record<EinSanityFailureReason, string> = {
+  format: 'Enter your EIN in the format XX-XXXXXXX.',
+  placeholder:
+    "That looks like a placeholder, not a real EIN. Please enter your campaign's EIN.",
+  'ssn-shaped':
+    'That looks like a Social Security number, not an EIN. Please enter your campaign EIN.',
+  'invalid-prefix':
+    "That EIN's prefix isn't one the IRS issues. Please double-check your EIN.",
+}
+
+const fail = (reason: EinSanityFailureReason): EinSanityResult => ({
+  valid: false,
+  reason,
+  message: FAILURE_MESSAGES[reason],
+})
+
+/**
+ * Client-side sanity check for an EIN. Catches obviously-bad values (placeholder,
+ * SSN-shaped, non-IRS prefix) that pass the shape-only `isValidEIN` check today.
+ * Returns a specific reason on failure so the UI can explain what's wrong.
+ *
+ * This does NOT prove an EIN is real or registered; it only rejects values that
+ * cannot be a valid EIN.
+ */
+export const checkEinSanity = (value: string): EinSanityResult => {
+  if (!EIN_PATTERN_FULL.test(value)) {
+    return fail('format')
+  }
+
+  // EIN_PATTERN_FULL guarantees `XX-XXXXXXX`, so digits is exactly 9 chars.
+  const digits = value.replace('-', '')
+
+  // All-same-digit (e.g. 11-1111111) and the common placeholder 12-3456789.
+  const allSameDigit = digits.split('').every((d) => d === digits[0])
+  if (allSameDigit || value === '12-3456789') {
+    return fail('placeholder')
+  }
+
+  // SSN-shaped: a 9-digit value whose first three digits are 000, 666, or 900-999.
+  const areaDigits = digits.slice(0, 3)
+  if (areaDigits === '000' || areaDigits === '666' || digits[0] === '9') {
+    return fail('ssn-shaped')
+  }
+
+  if (!VALID_EIN_PREFIXES.has(digits.slice(0, 2))) {
+    return fail('invalid-prefix')
+  }
+
+  return { valid: true }
+}


### PR DESCRIPTION
- Introduced a new sanity check for EIN input to catch invalid formats before submission.
- Updated state management to handle EIN sanity errors and display appropriate messages to users.
- Adjusted the validation logic for EIN input to incorporate sanity check results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only validation on an onboarding step; successful submit behavior and API payloads are unchanged, with solid test coverage.
> 
> **Overview**
> Adds a **client-side EIN sanity gate** on the pro sign-up committee check step so obviously invalid values are blocked **before** `updateCampaign` and downstream compliance work.
> 
> New shared helper `checkEinSanity` rejects bad **format**, common **placeholders** (e.g. `12-3456789`, all-same digits), **SSN-shaped** nine-digit patterns, and two-digit prefixes **outside the IRS-issued set**. Failures return user-facing messages keyed by reason.
> 
> **CommitteeCheckPage** runs this check in `handleNextClick` on **Next** only; successful paths are unchanged (same payload, no extra API). The page tracks `einSanityError`, surfaces it under the EIN field, marks the input in error, and clears the message when the user edits the EIN.
> 
> Unit tests cover `checkEinSanity`; integration tests assert non-IRS-prefix EINs block submit and plausible EINs still call `updateCampaign`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfec2c28e9c24ea12200b811ee0c1612f5de0418. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->