### PR TITLE
fix(analytics): update event names for candidate profile and DLC comp…

### DIFF
--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -464,7 +464,7 @@ export const EVENTS = {
     },
     CandidateProfile: {
       ClickSubmit: 'Profile - Candidate Profile: Click Submit',
-      SubmitSuccess: 'Profile - Candidate Profile: Submit Success',
+      SubmitSuccess: 'Pro Upgrade - Candidate Profile Submitted',
       SubmitError: 'Profile - Candidate Profile: Submit Error',
     },
   },
@@ -497,7 +497,7 @@ export const EVENTS = {
       ComplianceStarted: 'Voter Outreach - 10DLC Compliance Started',
     },
     DlcCompliance: {
-      RegistrationSubmitted: '10 DLC Compliance - Registration Submitted',
+      RegistrationSubmitted: 'Pro Upgrade - Filing Details Submitted',
       PinVerificationCompleted:
         '10 DLC Compliance - PIN Verification Completed',
     },


### PR DESCRIPTION
…liance submissions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production analytics event names for widely reused submit signals, which can break existing Segment reports until queries are updated; no application logic changes.
> 
> **Overview**
> Renames two **Segment event display strings** in `EVENTS` so submit milestones read as **Pro Upgrade** funnel steps instead of generic profile / 10DLC labels.
> 
> `Profile.CandidateProfile.SubmitSuccess` becomes **`Pro Upgrade - Candidate Profile Submitted`** (was `Profile - Candidate Profile: Submit Success`). `Outreach.DlcCompliance.RegistrationSubmitted` becomes **`Pro Upgrade - Filing Details Submitted`** (was `10 DLC Compliance - Registration Submitted`). Keys and `trackEvent` call sites are unchanged—only the names sent to analytics change, including flows that already fire these constants (agentic compliance and legacy register).
> 
> **Impact:** Dashboards or funnels keyed on the old event names will need to follow the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f1aa6de393d34e80f864521631970c39451374. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->