### PR TITLE
Admin briefing review mode (impersonation-gated)

### DIFF
--- a/app/dashboard/admin-review/briefings/[slug]/[itemId]/page.tsx
+++ b/app/dashboard/admin-review/briefings/[slug]/[itemId]/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation'
+import { briefingItemDomId } from '@shared/briefings/routes'
+
+type PageProps = {
+  params: Promise<{ slug: string; itemId: string }>
+}
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Legacy per-item route for the admin-review tree. All agenda items render
+ * inline on the review overview page; this redirects deep links to the
+ * matching hash anchor on that page.
+ */
+export default async function Page({ params }: PageProps): Promise<never> {
+  const { slug, itemId } = await params
+  redirect(
+    `/dashboard/admin-review/briefings/${slug}#${briefingItemDomId(itemId)}`,
+  )
+}

--- a/app/dashboard/admin-review/briefings/[slug]/layout.tsx
+++ b/app/dashboard/admin-review/briefings/[slug]/layout.tsx
@@ -1,0 +1,102 @@
+import { notFound } from 'next/navigation'
+import { getBriefingBySlug } from '@shared/briefings/server'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
+} from '@shared/briefings/routes'
+import ReviewAnnotationsScope from '@shared/annotations/review/ReviewAnnotationsScope'
+import serveAccess from '../../../shared/serveAccess'
+import DashboardLayout from '../../../shared/DashboardLayout'
+import ActiveCardScrollSpy from '../../../briefings/components/detail/ActiveCardScrollSpy'
+import DetailToc from '../../../briefings/components/detail/DetailToc'
+import ShareScope from '../../../briefings/components/detail/ShareScope'
+import BriefingAwaitingPage from '../../../briefings/components/BriefingAwaitingPage'
+import ReviewDetailHeader from '../components/ReviewDetailHeader'
+import ReviewBottomBars from '../components/ReviewBottomBars'
+import AdminReviewGate from '../components/AdminReviewGate'
+
+type Props = {
+  params: Promise<{ slug: string }>
+  children: React.ReactNode
+}
+
+/**
+ * Admin-review chrome — a parallel of the candidate-facing briefing layout.
+ * Structurally identical (sticky header, sidebar TOC, scroll-spy, responsive
+ * containers, ShareScope) but mounts ReviewAnnotationsScope instead of
+ * AnnotationsScope and uses review-only header / bottom-bar variants. The
+ * whole subtree is gated to impersonating staff via AdminReviewGate.
+ */
+export default async function AdminReviewBriefingChromeLayout({
+  params,
+  children,
+}: Props): Promise<React.JSX.Element> {
+  await serveAccess()
+  const { slug } = await params
+  const briefing = await getBriefingBySlug(slug)
+  if (!briefing) notFound()
+
+  if ('status' in briefing) {
+    return (
+      <DashboardLayout
+        pathname="/dashboard/briefings"
+        showAlert={false}
+        wrapperClassName="!p-0"
+      >
+        <AdminReviewGate slug={slug}>
+          <BriefingAwaitingPage briefing={briefing} />
+        </AdminReviewGate>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout
+      pathname="/dashboard/briefings"
+      showAlert={false}
+      wrapperClassName="!p-0"
+    >
+      <AdminReviewGate slug={slug}>
+        <ReviewAnnotationsScope
+          meetingDate={slug}
+          items={briefing.items}
+          initialActiveCard={{
+            key: BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+            jsonPath: BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH,
+            titleJsonPath: BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH,
+            title: 'Executive Summary',
+          }}
+        >
+          <ActiveCardScrollSpy items={briefing.items} />
+          <ShareScope briefing={briefing}>
+            <div className="relative">
+              <div className="flex min-h-full flex-col bg-muted pb-20 lg:h-svh lg:min-h-0 lg:overflow-hidden lg:pb-20">
+                <ReviewDetailHeader briefing={briefing} />
+
+                <div className="mx-auto w-full max-w-[1120px] px-4 py-6 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col lg:overflow-hidden lg:px-8">
+                  <div className="lg:flex lg:min-h-0 lg:flex-1 lg:items-stretch lg:gap-8 lg:overflow-hidden">
+                    <aside className="hidden rounded-2xl border border-border bg-card p-3 lg:block lg:w-[260px] lg:shrink-0 lg:overflow-y-auto">
+                      <DetailToc briefingSlug={slug} items={briefing.items} />
+                    </aside>
+
+                    <div
+                      id="briefing-detail-pane"
+                      data-briefing-scroll-container
+                      style={{ WebkitTouchCallout: 'none' }}
+                      className="flex flex-col gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:p-0.5"
+                    >
+                      {children}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <ReviewBottomBars />
+            </div>
+          </ShareScope>
+        </ReviewAnnotationsScope>
+      </AdminReviewGate>
+    </DashboardLayout>
+  )
+}

--- a/app/dashboard/admin-review/briefings/[slug]/page.tsx
+++ b/app/dashboard/admin-review/briefings/[slug]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound } from 'next/navigation'
+import pageMetaData from 'helpers/metadataHelper'
+import { getBriefingBySlug, isFullBriefing } from '@shared/briefings/server'
+import {
+  BRIEFING_EXECUTIVE_SUMMARY_DOM_ID,
+  briefingItemDomId,
+} from '@shared/briefings/routes'
+import ExecutiveSummaryCard from '../../../briefings/components/detail/ExecutiveSummaryCard'
+import AgendaItemCard from '../../../briefings/components/detail/AgendaItemCard'
+import TrackBriefingViewed from '../../../briefings/components/TrackBriefingViewed'
+
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params
+  const result = await getBriefingBySlug(slug)
+  const briefing = result && isFullBriefing(result) ? result : null
+  return pageMetaData({
+    title: briefing
+      ? `${briefing.title} (review) | GoodParty.org`
+      : 'Briefing review | GoodParty.org',
+    description: briefing?.executive_summary.lead_in ?? 'Meeting briefing',
+    slug: `/dashboard/admin-review/briefings/${slug}`,
+  })
+}
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Admin-review briefing detail page. Reuses the candidate-facing page body
+ * verbatim — the cards are mode-agnostic and read whatever AnnotationsCtx
+ * the layout provides (ReviewAnnotationsScope in this tree).
+ */
+export default async function Page({
+  params,
+}: PageProps): Promise<React.JSX.Element> {
+  const { slug } = await params
+  const result = await getBriefingBySlug(slug)
+  if (!result || !isFullBriefing(result)) notFound()
+  const briefing = result
+
+  return (
+    <>
+      <TrackBriefingViewed briefingId={slug} />
+      <ExecutiveSummaryCard
+        summary={briefing.executive_summary}
+        agendaItemIds={briefing.items.map((item) => item.id)}
+        domId={BRIEFING_EXECUTIVE_SUMMARY_DOM_ID}
+      />
+
+      {briefing.items.map((item, index) => {
+        const isFeatured = item.tier === 'featured'
+        return (
+          <AgendaItemCard
+            key={item.id}
+            item={item}
+            itemIndex={index}
+            sources={briefing.sources}
+            domId={briefingItemDomId(item.id)}
+            meetingDate={slug}
+            showFeedback={isFeatured}
+            variant={isFeatured ? 'full' : 'whatToExpectOnly'}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/app/dashboard/admin-review/briefings/components/AdminReviewGate.tsx
+++ b/app/dashboard/admin-review/briefings/components/AdminReviewGate.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
+import { useAuth } from '@clerk/nextjs'
 import { briefingOverviewHref } from '@shared/briefings/routes'
 
 type Props = {
@@ -20,16 +20,20 @@ export default function AdminReviewGate({
   slug,
   children,
 }: Props): React.JSX.Element | null {
-  const isImpersonating = useIsImpersonating()
+  const { actor, isLoaded } = useAuth()
   const router = useRouter()
+  const isImpersonating = !!actor
 
   useEffect(() => {
-    if (!isImpersonating) {
+    // Wait for Clerk to finish loading before deciding — `actor` is undefined
+    // until then, so redirecting eagerly would bounce a legitimate
+    // impersonation session off the page on first paint.
+    if (isLoaded && !isImpersonating) {
       router.replace(briefingOverviewHref(slug))
     }
-  }, [isImpersonating, router, slug])
+  }, [isLoaded, isImpersonating, router, slug])
 
-  if (!isImpersonating) return null
+  if (!isLoaded || !isImpersonating) return null
 
   return <>{children}</>
 }

--- a/app/dashboard/admin-review/briefings/components/AdminReviewGate.tsx
+++ b/app/dashboard/admin-review/briefings/components/AdminReviewGate.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
+import { briefingOverviewHref } from '@shared/briefings/routes'
+
+type Props = {
+  slug: string
+  children: React.ReactNode
+}
+
+/**
+ * Client gate for the admin-review route tree. Review mode only makes sense
+ * while a staff member is impersonating a candidate (the reviewer is acting
+ * inside the candidate's session). If not impersonating, bounce to the
+ * normal candidate-facing briefing and render nothing.
+ */
+export default function AdminReviewGate({
+  slug,
+  children,
+}: Props): React.JSX.Element | null {
+  const isImpersonating = useIsImpersonating()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isImpersonating) {
+      router.replace(briefingOverviewHref(slug))
+    }
+  }, [isImpersonating, router, slug])
+
+  if (!isImpersonating) return null
+
+  return <>{children}</>
+}

--- a/app/dashboard/admin-review/briefings/components/ReviewBottomBars.tsx
+++ b/app/dashboard/admin-review/briefings/components/ReviewBottomBars.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { Button, IconButton, MessageSquareIcon } from '@styleguide'
+import { useReviewAnnotationsCtx } from '@shared/annotations/review/ReviewAnnotationsScope'
+
+/**
+ * Review-mode bottom bars. A single action — open the review-comments
+ * cycler — at both breakpoints, replacing the candidate-facing
+ * Notes / Assistant bars. Highlighting briefing text and using the
+ * floating toolbar remains the primary way to add a comment; this bar is
+ * the always-available way to browse existing comments.
+ */
+export default function ReviewBottomBars(): React.JSX.Element {
+  const { openReviewsSurface, reviewsCount } = useReviewAnnotationsCtx()
+  const label =
+    reviewsCount > 0 ? `Review comments (${reviewsCount})` : 'Review comments'
+
+  return (
+    <>
+      <div className="fixed bottom-0 right-0 left-0 z-[5] hidden border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 lg:left-[var(--sidebar-width,16rem)] lg:block">
+        <div className="mx-auto flex w-full max-w-[1120px] items-center justify-end gap-2 px-8 py-3">
+          <Button
+            variant="outline"
+            onClick={() => openReviewsSurface()}
+            className="text-sm!"
+          >
+            <MessageSquareIcon className="size-4" aria-hidden />
+            {label}
+          </Button>
+        </div>
+      </div>
+
+      <div className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-sidebar/95 backdrop-blur supports-[backdrop-filter]:bg-sidebar/80 lg:hidden">
+        <div className="mx-auto flex w-full max-w-[800px] items-center justify-end gap-2 px-4 py-3">
+          <IconButton
+            type="button"
+            size="medium"
+            variant="outline"
+            aria-label={label}
+            onClick={() => openReviewsSurface()}
+          >
+            <MessageSquareIcon className="size-5" aria-hidden />
+          </IconButton>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/dashboard/admin-review/briefings/components/ReviewDetailHeader.tsx
+++ b/app/dashboard/admin-review/briefings/components/ReviewDetailHeader.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeftIcon, Button, MessageSquareIcon } from '@styleguide'
+import { briefingsLandingHref } from '@shared/briefings/routes'
+import { formatBriefingMeetingDate } from '@shared/briefings/dateHelpers'
+import type { Briefing } from '@shared/briefings/types'
+import { useReviewAnnotationsCtx } from '@shared/annotations/review/ReviewAnnotationsScope'
+
+type Props = {
+  briefing: Briefing
+}
+
+/**
+ * Review-mode sticky header. Mirrors DetailHeader's layout (back arrow +
+ * three-line title block) but swaps the candidate-facing Share / Read aloud
+ * actions for a single "Add review comment" affordance. Built as a separate
+ * variant rather than threading a mode flag through DetailHeader.
+ */
+export default function ReviewDetailHeader({
+  briefing,
+}: Props): React.JSX.Element {
+  const formattedDate = formatBriefingMeetingDate(briefing.meeting_date)
+  const { openReviewsSurface, reviewsCount } = useReviewAnnotationsCtx()
+  return (
+    <div className="sticky top-0 z-20 border-b border-border bg-sidebar">
+      <div className="mx-auto flex w-full max-w-[1120px] items-start gap-3 px-4 py-4 lg:px-8">
+        <Link
+          href={briefingsLandingHref()}
+          aria-label="Back to meetings"
+          className="mt-1 inline-flex size-8 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ArrowLeftIcon className="size-5" aria-hidden />
+        </Link>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <h1 className="text-lg font-semibold leading-tight text-foreground lg:text-xl">
+            {briefing.meeting_name}
+          </h1>
+          <p className="text-sm text-muted-foreground">{formattedDate}</p>
+          {briefing.location ? (
+            <p className="text-sm text-muted-foreground">{briefing.location}</p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2 self-center">
+          <Button
+            variant="outline"
+            onClick={() => openReviewsSurface()}
+            className="hidden text-sm! lg:inline-flex"
+          >
+            <MessageSquareIcon className="size-4" aria-hidden />
+            Review comments
+            {reviewsCount > 0 ? ` (${reviewsCount})` : ''}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsHighlightLayer.tsx
@@ -7,7 +7,7 @@ import {
   findAnchorEl,
   pointToOffset,
 } from '@shared/briefings/anchorResolver'
-import type { Annotation, AnnotationKind } from '@shared/briefings/types'
+import type { Annotation } from '@shared/briefings/types'
 
 type Props = {
   annotations: Annotation[]
@@ -18,7 +18,7 @@ type ResolvedRange = {
   range: Range
 }
 
-const HIGHLIGHT_NAMES: Record<AnnotationKind, string> = {
+const HIGHLIGHT_NAMES: Record<MarkerKind, string> = {
   note: 'briefing-annotation-note',
   chat: 'briefing-annotation-chat',
   bug_report: 'briefing-annotation-bug',
@@ -50,7 +50,7 @@ const STYLE_RULES = `
    selection. We still allow selection itself — the toolbar reads the
    live selection — and the callout suppression is iOS-specific, which
    is where the conflict is most visible. */
-[data-briefing-json-path] {
+[data-anchor-json-path] {
   -webkit-touch-callout: none;
 }
 ::highlight(${HIGHLIGHT_NAMES.note}) {
@@ -221,7 +221,7 @@ export default function AnnotationsHighlightLayer({
 
     removeAllMarkers()
 
-    const rangesByKind: Record<AnnotationKind, Range[]> = {
+    const rangesByKind: Record<MarkerKind, Range[]> = {
       note: [],
       chat: [],
       bug_report: [],
@@ -229,6 +229,9 @@ export default function AnnotationsHighlightLayer({
     const resolved: ResolvedRange[] = []
 
     for (const a of annotations) {
+      // Review annotations are painted by the admin-review layer, not this
+      // candidate-facing one — skip them here.
+      if (a.kind === 'review') continue
       if (!a.jsonPath || a.start === null || a.end === null) continue
       const el = findAnchorEl(a.jsonPath)
       if (!el) continue
@@ -246,7 +249,7 @@ export default function AnnotationsHighlightLayer({
 
     resolvedRef.current = resolved
 
-    const kinds: AnnotationKind[] = ['note', 'chat', 'bug_report']
+    const kinds: MarkerKind[] = ['note', 'chat', 'bug_report']
     for (const k of kinds) {
       const ranges = rangesByKind[k]
       const name = HIGHLIGHT_NAMES[k]

--- a/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
+++ b/app/dashboard/briefings/components/annotations/AnnotationsScope.tsx
@@ -101,7 +101,7 @@ export type ActiveCard = {
    * card-level chat from the header — the new chat is anchored to the
    * title (jsonPath + start=0 + end=title.length) just as if the user
    * had highlighted the title themselves. There must be a DOM element
-   * carrying this path under `data-briefing-json-path` so the anchor
+   * carrying this path under `data-anchor-json-path` so the anchor
    * resolves back to a quote.
    */
   titleJsonPath: string
@@ -109,7 +109,7 @@ export type ActiveCard = {
   title: string
 }
 
-type Ctx = {
+export type Ctx = {
   meetingDate: string
   /**
    * Id of the user's existing top-level chat annotation on this briefing,
@@ -161,7 +161,7 @@ type Ctx = {
   }) => void
 }
 
-const AnnotationsCtx = createContext<Ctx | null>(null)
+export const AnnotationsCtx = createContext<Ctx | null>(null)
 
 export function useAnnotationsCtx(): Ctx {
   const ctx = useContext(AnnotationsCtx)
@@ -218,8 +218,10 @@ export default function AnnotationsScope({
 }: Props): React.JSX.Element {
   const liveAnchor = useSelection()
   const queryClient = useQueryClient()
-  const { annotations, create, updateNote, remove } =
-    useAnnotations(meetingDate)
+  const { annotations, create, updateNote, remove } = useAnnotations({
+    resourceType: 'briefing',
+    resourceId: meetingDate,
+  })
   const [overlay, setOverlay] = useState<OverlayState>({ kind: 'closed' })
   const [activeCard, setActiveCard] = useState<ActiveCard | null>(
     initialActiveCard ?? null,
@@ -484,7 +486,7 @@ export default function AnnotationsScope({
     if (typeof window === 'undefined') return
     function onContextMenu(e: MouseEvent) {
       if (!(e.target instanceof HTMLElement)) return
-      if (e.target.closest('[data-briefing-json-path]')) {
+      if (e.target.closest('[data-anchor-json-path]')) {
         e.preventDefault()
       }
     }

--- a/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.pendingAnchor.test.tsx
+++ b/app/dashboard/briefings/components/annotations/BriefingAssistantSurface.pendingAnchor.test.tsx
@@ -50,7 +50,7 @@ describe('<BriefingAssistantSurface> — pendingAnchor takes precedence', () => 
 
   afterEach(() => {
     document
-      .querySelectorAll('[data-briefing-json-path]')
+      .querySelectorAll('[data-anchor-json-path]')
       .forEach((el) => el.remove())
   })
 
@@ -104,7 +104,7 @@ describe('<BriefingAssistantSurface> — pendingAnchor takes precedence', () => 
     // resolveQuoteFromAnchor rebuilds the quote from the live DOM, so the
     // anchored passage must exist in the document for the quote to resolve.
     const passage = document.createElement('p')
-    passage.setAttribute('data-briefing-json-path', '/items/0/display/summary')
+    passage.setAttribute('data-anchor-json-path', '/items/0/display/summary')
     passage.textContent = 'The council will vote on the budget.'
     document.body.appendChild(passage)
 

--- a/app/dashboard/briefings/components/annotations/enrichForCycler.test.ts
+++ b/app/dashboard/briefings/components/annotations/enrichForCycler.test.ts
@@ -97,8 +97,8 @@ describe('enrichForCycler', () => {
   describe('DOM resolution', () => {
     beforeEach(() => {
       document.body.innerHTML =
-        '<span data-briefing-json-path="/a">Hello world</span>' +
-        '<span data-briefing-json-path="/b">Bye</span>'
+        '<span data-anchor-json-path="/a">Hello world</span>' +
+        '<span data-anchor-json-path="/b">Bye</span>'
     })
 
     it('resolves docOrderIndex and highlightedText for an anchored annotation', () => {
@@ -160,9 +160,9 @@ describe('enrichForCycler', () => {
   describe('duplicate jsonPath dedupe', () => {
     beforeEach(() => {
       document.body.innerHTML =
-        '<span data-briefing-json-path="/dup">First</span>' +
-        '<span data-briefing-json-path="/dup">Second</span>' +
-        '<span data-briefing-json-path="/c">Third element</span>'
+        '<span data-anchor-json-path="/dup">First</span>' +
+        '<span data-anchor-json-path="/dup">Second</span>' +
+        '<span data-anchor-json-path="/c">Third element</span>'
     })
 
     it('uses the first occurrence to resolve docOrderIndex on duplicate jsonPath', () => {
@@ -192,8 +192,8 @@ describe('enrichForCycler', () => {
   describe('sort integration', () => {
     beforeEach(() => {
       document.body.innerHTML =
-        '<span data-briefing-json-path="/first">AAAA</span>' +
-        '<span data-briefing-json-path="/second">BBBB</span>'
+        '<span data-anchor-json-path="/first">AAAA</span>' +
+        '<span data-anchor-json-path="/second">BBBB</span>'
     })
 
     it('orders unanchored first, then resolved by docOrderIndex asc, then unresolved by createdAt asc', () => {
@@ -276,9 +276,9 @@ describe('predictNewAnnotationPosition', () => {
 
   it('predicts the new anchored note slots between earlier and later anchored notes by docOrderIndex', () => {
     document.body.innerHTML = `
-      <div data-briefing-json-path="a">A</div>
-      <div data-briefing-json-path="b">B</div>
-      <div data-briefing-json-path="c">C</div>
+      <div data-anchor-json-path="a">A</div>
+      <div data-anchor-json-path="b">B</div>
+      <div data-anchor-json-path="c">C</div>
     `
     const existing = [
       makeAnnotation({ id: 'na', kind: 'note', jsonPath: 'a', start: 0 }),

--- a/app/dashboard/briefings/components/annotations/enrichForCycler.ts
+++ b/app/dashboard/briefings/components/annotations/enrichForCycler.ts
@@ -2,7 +2,7 @@ import type { Annotation } from '@shared/briefings/types'
 import { resolveAnnotationHighlight } from '@shared/briefings/anchorResolver'
 import { compareForCycler } from './annotationSort'
 
-const ANCHOR_ATTR = 'data-briefing-json-path'
+const ANCHOR_ATTR = 'data-anchor-json-path'
 
 export interface EnrichedAnnotation extends Annotation {
   docOrderIndex: number | null

--- a/app/dashboard/briefings/components/annotations/useEnrichedAnnotations.ts
+++ b/app/dashboard/briefings/components/annotations/useEnrichedAnnotations.ts
@@ -25,6 +25,12 @@ function signatureOf(
     if (a.note) {
       s += `;n=${a.note.updatedAt}`
     }
+    // Review body edits bump AnnotationReview.updatedAt but not the parent
+    // Annotation.updatedAt — the same nested-payload pitfall as notes above,
+    // so the cycler would otherwise keep showing the pre-edit review body.
+    if (a.review) {
+      s += `;r=${a.review.updated_at}`
+    }
     // Attachments mutate independently of `updatedAt` on the parent
     // annotation (presign/complete + delete don't bump it before the
     // 5s OCR poll lands), so include their ids in the signature.

--- a/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
+++ b/app/dashboard/briefings/components/detail/AgendaItemCard.tsx
@@ -168,7 +168,7 @@ const formatSentimentLine = (meanScore: number): string => {
  * Summary, Budget Impact, Constituent Sentiment, Recent News, Talking Points,
  * Sources collapsible, feedback row.
  *
- * Every string rendered as body text carries a `data-briefing-json-path`
+ * Every string rendered as body text carries a `data-anchor-json-path`
  * attribute so phase 4's selection toolbar can build an anchor that maps to
  * the v2 artifact shape.
  */
@@ -226,7 +226,7 @@ const AgendaItemCard = ({
       // Card-level notes use this exact path as their jsonPath; without
       // an element carrying it, `enrichForCycler` couldn't place them in
       // document order and dropped them to the end of the list.
-      data-briefing-json-path={base}
+      data-anchor-json-path={base}
       aria-current={isActive ? 'true' : undefined}
       className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-4 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
         isActive
@@ -243,7 +243,7 @@ const AgendaItemCard = ({
               opens that thread directly. */}
           <h3
             className="w-fit cursor-pointer text-lg font-semibold text-foreground"
-            data-briefing-json-path={titlePath}
+            data-anchor-json-path={titlePath}
             onClick={(e) => {
               if (titleChat) {
                 e.stopPropagation()
@@ -262,7 +262,7 @@ const AgendaItemCard = ({
         <SectionLabel>What to expect</SectionLabel>
         <p
           className="text-sm leading-6 text-foreground"
-          data-briefing-json-path={`${base}/display/summary`}
+          data-anchor-json-path={`${base}/display/summary`}
         >
           {display.summary}
         </p>
@@ -275,7 +275,7 @@ const AgendaItemCard = ({
               <SectionLabel>Budget impact</SectionLabel>
               <p
                 className="text-sm leading-6 text-foreground"
-                data-briefing-json-path={`${base}/display/budget_impact/summary`}
+                data-anchor-json-path={`${base}/display/budget_impact/summary`}
               >
                 {budget.summary}
               </p>
@@ -303,14 +303,14 @@ const AgendaItemCard = ({
               )}
               <p
                 className="text-sm leading-6 text-foreground"
-                data-briefing-json-path={`${base}/display/constituent_sentiment/summary`}
+                data-anchor-json-path={`${base}/display/constituent_sentiment/summary`}
               >
                 {sentiment.summary}
               </p>
               {sentiment.detail ? (
                 <p
                   className="text-sm leading-6 text-foreground"
-                  data-briefing-json-path={`${base}/display/constituent_sentiment/detail`}
+                  data-anchor-json-path={`${base}/display/constituent_sentiment/detail`}
                 >
                   {sentiment.detail}
                 </p>

--- a/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
+++ b/app/dashboard/briefings/components/detail/ExecutiveSummaryCard.tsx
@@ -79,7 +79,7 @@ export default function ExecutiveSummaryCard({
       // Make the card root addressable in the cycler's DOM-order index.
       // Card-level notes carry this path; without it, the enricher
       // couldn't slot them into document order.
-      data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH}
+      data-anchor-json-path={BRIEFING_EXECUTIVE_SUMMARY_CARD_PATH}
       aria-current={isActive ? 'true' : undefined}
       className={`flex scroll-mt-[104px] cursor-pointer flex-col gap-3 rounded-2xl border bg-card p-6 transition-colors lg:scroll-mt-3 ${
         isActive
@@ -87,13 +87,13 @@ export default function ExecutiveSummaryCard({
           : 'border-border hover:border-foreground/20'
       }`}
     >
-      {/* `data-briefing-json-path` makes the title resolvable as an anchor
+      {/* `data-anchor-json-path` makes the title resolvable as an anchor
           target — card-level chats hang off this element. With no chat yet,
           clicking selects its full text so the HighlightToolbar surfaces
           anchored to the title; with a chat, it opens that thread. */}
       <h2
         className="min-w-0 cursor-pointer text-2xl font-semibold text-foreground"
-        data-briefing-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
+        data-anchor-json-path={BRIEFING_EXECUTIVE_SUMMARY_TITLE_PATH}
         onClick={(e) => {
           if (titleChat) {
             e.stopPropagation()
@@ -107,7 +107,7 @@ export default function ExecutiveSummaryCard({
       </h2>
       <p
         className="text-sm text-muted-foreground"
-        data-briefing-json-path="/executive_summary/lead_in"
+        data-anchor-json-path="/executive_summary/lead_in"
       >
         {summary.lead_in}
       </p>
@@ -119,7 +119,7 @@ export default function ExecutiveSummaryCard({
               <li
                 key={item.item_id}
                 className="list-item!"
-                data-briefing-json-path={`/executive_summary/items/${originalIndex}`}
+                data-anchor-json-path={`/executive_summary/items/${originalIndex}`}
               >
                 <a
                   href={`#${itemDomId}`}

--- a/app/dashboard/briefings/components/detail/RecentNewsList.tsx
+++ b/app/dashboard/briefings/components/detail/RecentNewsList.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 /**
  * Bulleted list of recent news links. Each headline is anchored for highlighting
- * via `data-briefing-json-path` so phase 4's selection toolbar can resolve it.
+ * via `data-anchor-json-path` so phase 4's selection toolbar can resolve it.
  */
 export default function RecentNewsList({
   items,
@@ -24,7 +24,7 @@ export default function RecentNewsList({
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-start gap-1 font-medium text-info hover:underline"
-            data-briefing-json-path={`${pathPrefix}/${i}/headline`}
+            data-anchor-json-path={`${pathPrefix}/${i}/headline`}
           >
             <span>{n.headline}</span>
             <ExternalLink aria-hidden className="mt-1 size-3 shrink-0" />

--- a/app/dashboard/briefings/components/detail/TalkingPointsList.tsx
+++ b/app/dashboard/briefings/components/detail/TalkingPointsList.tsx
@@ -18,7 +18,7 @@ export default function TalkingPointsList({
         <li
           key={`${pathPrefix}/${i}`}
           className="list-item!"
-          data-briefing-json-path={`${pathPrefix}/${i}`}
+          data-anchor-json-path={`${pathPrefix}/${i}`}
         >
           {p}
         </li>

--- a/app/impersonate/ImpersonatePageContent.tsx
+++ b/app/impersonate/ImpersonatePageContent.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from 'react'
 import { useClerk } from '@clerk/nextjs'
 import { useSearchParams } from 'next/navigation'
 
-const isSafeReturnTo = (s: string | null): boolean => {
+const isSafeRelativePath = (s: string | null): s is string => {
   if (typeof s !== 'string') return false
   if (!s.startsWith('/')) return false
-  if (s.startsWith('//') || s.startsWith('/\\')) return false
-  return s.startsWith('/dashboard/')
+  // Block protocol-relative ("//host") and backslash ("/\host") open redirects.
+  return !(s.startsWith('//') || s.startsWith('/\\'))
 }
+
+// returnTo is a gp-webapp path, so restrict it to the dashboard.
+const isSafeReturnTo = (s: string | null): s is string =>
+  isSafeRelativePath(s) && s.startsWith('/dashboard/')
+
+// adminReturnTo is a gp-admin portal path (handed to GP_ADMIN_URL on stop), so
+// it must NOT be held to gp-webapp's /dashboard/ allowlist — any safe relative
+// path is valid there.
+const isSafeAdminReturnTo = (s: string | null): s is string =>
+  isSafeRelativePath(s)
 
 export default function ImpersonatePageContent() {
   const { client, setActive, signOut, loaded } = useClerk()
@@ -50,11 +60,11 @@ export default function ImpersonatePageContent() {
         }
 
         await setActive({ session: result.createdSessionId })
-        if (isSafeReturnTo(adminReturnTo)) {
-          sessionStorage.setItem('gp_admin_return_to', adminReturnTo!)
+        if (isSafeAdminReturnTo(adminReturnTo)) {
+          sessionStorage.setItem('gp_admin_return_to', adminReturnTo)
         }
         window.location.href = isSafeReturnTo(returnTo)
-          ? returnTo!
+          ? returnTo
           : '/dashboard'
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)

--- a/app/impersonate/ImpersonatePageContent.tsx
+++ b/app/impersonate/ImpersonatePageContent.tsx
@@ -4,12 +4,21 @@ import { useEffect, useState } from 'react'
 import { useClerk } from '@clerk/nextjs'
 import { useSearchParams } from 'next/navigation'
 
+const isSafeReturnTo = (s: string | null): boolean => {
+  if (typeof s !== 'string') return false
+  if (!s.startsWith('/')) return false
+  if (s.startsWith('//') || s.startsWith('/\\')) return false
+  return s.startsWith('/dashboard/')
+}
+
 export default function ImpersonatePageContent() {
   const { client, setActive, signOut, loaded } = useClerk()
   const searchParams = useSearchParams()
   const [error, setError] = useState<string | null>(null)
 
   const ticket = searchParams?.get('__clerk_ticket') ?? null
+  const returnTo = searchParams?.get('returnTo') ?? null
+  const adminReturnTo = searchParams?.get('adminReturnTo') ?? null
 
   useEffect(() => {
     if (!loaded) return
@@ -41,7 +50,12 @@ export default function ImpersonatePageContent() {
         }
 
         await setActive({ session: result.createdSessionId })
-        window.location.href = '/dashboard'
+        if (isSafeReturnTo(adminReturnTo)) {
+          sessionStorage.setItem('gp_admin_return_to', adminReturnTo!)
+        }
+        window.location.href = isSafeReturnTo(returnTo)
+          ? returnTo!
+          : '/dashboard'
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         console.error('[impersonate] Failed:', err)
@@ -50,7 +64,7 @@ export default function ImpersonatePageContent() {
     }
 
     run()
-  }, [loaded, ticket])
+  }, [loaded, ticket, returnTo, adminReturnTo])
 
   if (error) {
     return (

--- a/app/shared/annotations/review/ReviewAnnotationsScope.tsx
+++ b/app/shared/annotations/review/ReviewAnnotationsScope.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import {
+  EMPTY_ANCHOR,
+  pointToOffset,
+  type ResolvedAnchor,
+} from '@shared/briefings/anchorResolver'
+import { useAnnotations } from '@shared/briefings/use-annotations'
+import { useSelection } from '@shared/briefings/use-selection'
+import type {
+  Annotation,
+  AnnotationAnchor,
+  Item,
+} from '@shared/briefings/types'
+import {
+  AnnotationsCtx,
+  type ActiveCard,
+  type Ctx as AnnotationsCtxValue,
+} from '../../../dashboard/briefings/components/annotations/AnnotationsScope'
+import ReviewHighlightLayer from './ReviewHighlightLayer'
+import ReviewHighlightToolbar from './ReviewHighlightToolbar'
+import { ReviewSurface } from './ReviewSurface'
+
+type OverlayState =
+  | { kind: 'closed' }
+  | { kind: 'surface_reviews'; initialAnnotationId?: string }
+  | { kind: 'compose_review'; anchor: AnnotationAnchor }
+
+type ReviewCtx = {
+  reviewsCount: number
+  addReview: (anchor: AnnotationAnchor, body: string) => Promise<Annotation>
+  editReview: (id: string, body: string) => Promise<void>
+  deleteReview: (id: string) => Promise<void>
+  openReviewsSurface: (initialAnnotationId?: string) => void
+}
+
+const ReviewAnnotationsCtx = createContext<ReviewCtx | null>(null)
+
+export function useReviewAnnotationsCtx(): ReviewCtx {
+  const ctx = useContext(ReviewAnnotationsCtx)
+  if (!ctx) {
+    throw new Error('useReviewAnnotationsCtx outside <ReviewAnnotationsScope>')
+  }
+  return ctx
+}
+
+type Props = {
+  /** The briefing's meeting date (YYYY-MM-DD). */
+  meetingDate: string
+  initialActiveCard?: ActiveCard
+  items?: readonly Item[]
+  children: React.ReactNode
+}
+
+function anchorPayload(anchor: ResolvedAnchor | null): AnnotationAnchor {
+  if (!anchor) return EMPTY_ANCHOR
+  return { jsonPath: anchor.jsonPath, start: anchor.start, end: anchor.end }
+}
+
+const NOOP = () => undefined
+
+/**
+ * Review-mode peer of AnnotationsScope. Built purpose-small: it loads ONLY
+ * review-kind annotations, renders a single-action toolbar + the review
+ * cycler drawer + a teal highlight layer, and exposes review mutations for
+ * the admin-review chrome to read.
+ *
+ * It still provides the candidate-facing AnnotationsCtx so the shared
+ * briefing detail cards (which call `useAnnotationsCtx`) render unchanged —
+ * but every note/chat/bug entry point on that context is a no-op here, and
+ * `annotations` only ever carries reviews.
+ */
+export default function ReviewAnnotationsScope({
+  meetingDate,
+  initialActiveCard,
+  items: briefingItems,
+  children,
+}: Props): React.JSX.Element {
+  const liveAnchor = useSelection()
+  const { annotations, create, updateReview, remove } = useAnnotations(
+    { resourceType: 'briefing', resourceId: meetingDate },
+    { kinds: ['review'] },
+  )
+  const [overlay, setOverlay] = useState<OverlayState>({ kind: 'closed' })
+  const [activeCard, setActiveCard] = useState<ActiveCard | null>(
+    initialActiveCard ?? null,
+  )
+
+  const openReviewsSurface = useCallback((initialAnnotationId?: string) => {
+    setOverlay({ kind: 'surface_reviews', initialAnnotationId })
+  }, [])
+
+  const closeSheet = useCallback(() => {
+    setOverlay({ kind: 'closed' })
+  }, [])
+
+  // Compose-then-save: open the surface in compose mode holding a
+  // client-only anchor. Nothing is POSTed yet — the gp-api review create
+  // rejects empty bodies, so the row is only persisted once the reviewer
+  // types something and hits Save (handled by `addReview` below).
+  const openAddReviewFromSelection = useCallback(() => {
+    if (!liveAnchor) return
+    const anchor = anchorPayload(liveAnchor)
+    window.getSelection()?.removeAllRanges()
+    setOverlay({ kind: 'compose_review', anchor })
+  }, [liveAnchor])
+
+  const addReview = useCallback(
+    (anchor: AnnotationAnchor, body: string) =>
+      create.mutateAsync({ kind: 'review', anchor, payload: { body } }),
+    [create],
+  )
+
+  const editReview = useCallback(
+    async (id: string, body: string) => {
+      await updateReview.mutateAsync({ id, body })
+    },
+    [updateReview],
+  )
+
+  const deleteReview = useCallback(
+    async (id: string) => {
+      await remove.mutateAsync(id)
+    },
+    [remove],
+  )
+
+  // Click-to-open: clicking inside a review highlight (or its marker) opens
+  // that review in the cycler. Only review-kind annotations are handled.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    function onClick(e: MouseEvent) {
+      const sel = window.getSelection()
+      if (sel && !sel.isCollapsed && sel.toString().length > 0) return
+      if (!(e.target instanceof HTMLElement)) return
+      const target = e.target
+
+      const marker = target.closest(
+        '.briefing-review-marker[data-annotation-id]',
+      )
+      if (marker instanceof HTMLElement) {
+        const id = marker.dataset.annotationId
+        const ann = id ? annotations.find((a) => a.id === id) : null
+        if (ann && ann.kind === 'review') {
+          openReviewsSurface(ann.id)
+          e.preventDefault()
+        }
+        return
+      }
+
+      if (target.closest('a, button, [role=button], input, textarea, select')) {
+        return
+      }
+
+      const hit = pointToOffset(e.clientX, e.clientY)
+      if (!hit) return
+      for (const ann of annotations) {
+        if (ann.kind !== 'review') continue
+        if (ann.jsonPath !== hit.jsonPath) continue
+        if (ann.start === null || ann.end === null) continue
+        if (hit.offset < ann.start || hit.offset >= ann.end) continue
+        openReviewsSurface(ann.id)
+        e.preventDefault()
+        return
+      }
+    }
+
+    document.addEventListener('click', onClick)
+    return () => document.removeEventListener('click', onClick)
+  }, [annotations, openReviewsSurface])
+
+  const reviewsCount = useMemo(
+    () => annotations.filter((a) => a.kind === 'review').length,
+    [annotations],
+  )
+
+  const reviewCtxValue: ReviewCtx = useMemo(
+    () => ({
+      reviewsCount,
+      addReview,
+      editReview,
+      deleteReview,
+      openReviewsSurface,
+    }),
+    [reviewsCount, addReview, editReview, deleteReview, openReviewsSurface],
+  )
+
+  // Candidate-facing context, satisfied with review-mode behavior so the
+  // shared detail cards render. Note/chat/bug entry points are no-ops.
+  const annotationsCtxValue: AnnotationsCtxValue = useMemo(
+    () => ({
+      meetingDate,
+      topLevelChatAnnotationId: undefined,
+      annotations,
+      activeCard,
+      setActiveCard,
+      openAddNoteFromSelection: NOOP,
+      openAddNoteTopLevel: NOOP,
+      openReportErrorFromSelection: NOOP,
+      openEditNote: NOOP,
+      openViewReport: NOOP,
+      openNotesSurface: NOOP,
+      openChatsSurface: NOOP,
+      openCardLevelChat: NOOP,
+      openBugReportsSurface: NOOP,
+      notesCount: 0,
+      chatsCount: 0,
+      bugReportsCount: 0,
+      closeSheet,
+      onChatCreated: NOOP,
+    }),
+    [meetingDate, annotations, activeCard, closeSheet],
+  )
+
+  return (
+    <ReviewAnnotationsCtx.Provider value={reviewCtxValue}>
+      <AnnotationsCtx.Provider value={annotationsCtxValue}>
+        {children}
+        <ReviewHighlightLayer annotations={annotations} />
+        <ReviewHighlightToolbar
+          anchor={liveAnchor}
+          onAddReview={openAddReviewFromSelection}
+        />
+        <ReviewSurface
+          open={
+            overlay.kind === 'surface_reviews' ||
+            overlay.kind === 'compose_review'
+          }
+          onClose={closeSheet}
+          annotations={annotations}
+          briefingItems={briefingItems}
+          onSaveEdit={editReview}
+          onDeleteReview={(ann) => deleteReview(ann.id).then(() => undefined)}
+          initialAnnotationId={
+            overlay.kind === 'surface_reviews'
+              ? overlay.initialAnnotationId
+              : undefined
+          }
+          pendingAnchor={
+            overlay.kind === 'compose_review' ? overlay.anchor : null
+          }
+          onCreate={async (anchor, body) => {
+            const created = await addReview(anchor, body)
+            // First save persisted the review — swap from compose into the
+            // cycler focused on the new row.
+            setOverlay({
+              kind: 'surface_reviews',
+              initialAnnotationId: created.id,
+            })
+          }}
+        />
+      </AnnotationsCtx.Provider>
+    </ReviewAnnotationsCtx.Provider>
+  )
+}

--- a/app/shared/annotations/review/ReviewHighlightLayer.tsx
+++ b/app/shared/annotations/review/ReviewHighlightLayer.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+import {
+  buildRangeIn,
+  findAnchorEl,
+  pointToOffset,
+} from '@shared/briefings/anchorResolver'
+import type { Annotation } from '@shared/briefings/types'
+
+type Props = {
+  annotations: Annotation[]
+}
+
+type ResolvedRange = {
+  annotation: Annotation
+  range: Range
+}
+
+const HIGHLIGHT_NAME = 'briefing-annotation-review'
+const HOVER_NAME = 'briefing-annotation-review-hover'
+const REVIEW_MARKER_CLASS = 'briefing-review-marker'
+const STYLE_TAG_ID = 'briefing-review-highlight-style'
+
+// Reviews use a teal treatment so they don't clash with the blue note /
+// red bug highlights from the candidate-facing annotation layer.
+const STYLE_RULES = `
+::highlight(${HIGHLIGHT_NAME}) {
+  background-color: color-mix(in srgb, var(--success, #0f9d8a) 24%, transparent);
+  color: inherit;
+}
+::highlight(${HOVER_NAME}) {
+  background-color: color-mix(in srgb, var(--success, #0f9d8a) 38%, transparent);
+}
+.${REVIEW_MARKER_CLASS} {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 1.27em;
+  vertical-align: middle;
+  position: relative;
+  top: -0.13em;
+  margin: 0 4px 0 0;
+  padding: 0 4px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  background-color: color-mix(in srgb, var(--success, #0f9d8a) 24%, transparent);
+  color: var(--success, #0f9d8a);
+}
+.${REVIEW_MARKER_CLASS} svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+.${REVIEW_MARKER_CLASS}[data-hover='true'] {
+  background-color: color-mix(in srgb, var(--success, #0f9d8a) 34%, transparent);
+  color: color-mix(in srgb, var(--success, #0f9d8a) 80%, black);
+}
+`
+
+// Lucide MessageSquareText — distinct review-comment marker.
+const REVIEW_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M13 8H7"/><path d="M17 12H7"/></svg>`
+
+const MARKER_SELECTOR = `.${REVIEW_MARKER_CLASS}[data-annotation-id]`
+
+function removeAllMarkers() {
+  if (typeof document === 'undefined') return
+  const nodes = document.querySelectorAll(`.${REVIEW_MARKER_CLASS}`)
+  for (const n of Array.from(nodes)) n.remove()
+}
+
+function insertMarker(range: Range, annotationId: string) {
+  const span = document.createElement('span')
+  span.className = REVIEW_MARKER_CLASS
+  span.dataset.annotationId = annotationId
+  span.setAttribute('contenteditable', 'false')
+  span.setAttribute('aria-label', 'Open review comment')
+  span.innerHTML = REVIEW_ICON_SVG
+  const at = range.cloneRange()
+  at.collapse(false)
+  at.insertNode(span)
+}
+
+function findMarker(annotationId: string): HTMLElement | null {
+  const escaped = CSS.escape(annotationId)
+  return document.querySelector(
+    `.${REVIEW_MARKER_CLASS}[data-annotation-id="${escaped}"]`,
+  )
+}
+
+/**
+ * Paints review-kind annotations onto the briefing in a teal treatment,
+ * with a trailing marker icon per review and a hover state. Mirrors the
+ * candidate-facing AnnotationsHighlightLayer but is scoped to a single kind
+ * and palette so the two layers can coexist without clashing.
+ */
+export default function ReviewHighlightLayer({ annotations }: Props): null {
+  const pathname = usePathname()
+  const resolvedRef = useRef<ResolvedRange[]>([])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const CSSAny = CSS as unknown as {
+      highlights?: {
+        set(name: string, h: unknown): void
+        delete(name: string): void
+      }
+    }
+    const HighlightCtorMaybe = (
+      window as unknown as {
+        Highlight?: new (...ranges: Range[]) => unknown
+      }
+    ).Highlight
+    if (!CSSAny.highlights || !HighlightCtorMaybe) return
+    const HighlightCtor = HighlightCtorMaybe
+
+    if (!document.getElementById(STYLE_TAG_ID)) {
+      const tag = document.createElement('style')
+      tag.id = STYLE_TAG_ID
+      tag.textContent = STYLE_RULES
+      document.head.appendChild(tag)
+    }
+
+    removeAllMarkers()
+
+    const ranges: Range[] = []
+    const resolved: ResolvedRange[] = []
+    for (const a of annotations) {
+      if (a.kind !== 'review') continue
+      if (!a.jsonPath || a.start === null || a.end === null) continue
+      const el = findAnchorEl(a.jsonPath)
+      if (!el) continue
+      const range = buildRangeIn(el, a.start, a.end)
+      if (!range) continue
+      ranges.push(range)
+      resolved.push({ annotation: a, range })
+      insertMarker(range, a.id)
+    }
+
+    resolvedRef.current = resolved
+
+    if (ranges.length === 0) CSSAny.highlights.delete(HIGHLIGHT_NAME)
+    else CSSAny.highlights.set(HIGHLIGHT_NAME, new HighlightCtor(...ranges))
+
+    let hoveredId: string | null = null
+    let hoveredMarker: HTMLElement | null = null
+    let raf = 0
+    let pendingX = 0
+    let pendingY = 0
+
+    function update() {
+      raf = 0
+      let nextId: string | null = null
+      let nextRange: Range | null = null
+
+      const elAtPoint = document.elementFromPoint(pendingX, pendingY)
+      const markerEl = elAtPoint
+        ? (elAtPoint.closest(MARKER_SELECTOR) as HTMLElement | null)
+        : null
+      if (markerEl?.dataset.annotationId) {
+        const id = markerEl.dataset.annotationId
+        const forIcon = resolvedRef.current.find((r) => r.annotation.id === id)
+        if (forIcon) {
+          nextId = id
+          nextRange = forIcon.range
+        }
+      } else {
+        const hit = pointToOffset(pendingX, pendingY)
+        if (hit) {
+          for (const { annotation, range } of resolvedRef.current) {
+            if (annotation.jsonPath !== hit.jsonPath) continue
+            if (annotation.start === null || annotation.end === null) continue
+            if (hit.offset < annotation.start || hit.offset >= annotation.end)
+              continue
+            nextId = annotation.id
+            nextRange = range
+            break
+          }
+        }
+      }
+
+      if (nextId === hoveredId) return
+      hoveredId = nextId
+
+      if (hoveredMarker) {
+        hoveredMarker.removeAttribute('data-hover')
+        hoveredMarker = null
+      }
+      if (nextId) {
+        const marker = findMarker(nextId)
+        if (marker) {
+          marker.setAttribute('data-hover', 'true')
+          hoveredMarker = marker
+        }
+      }
+
+      if (nextRange) {
+        CSSAny.highlights?.set(HOVER_NAME, new HighlightCtor(nextRange))
+        document.body.style.cursor = 'pointer'
+      } else {
+        CSSAny.highlights?.delete(HOVER_NAME)
+        document.body.style.cursor = ''
+      }
+    }
+
+    function onMove(e: MouseEvent) {
+      pendingX = e.clientX
+      pendingY = e.clientY
+      if (raf === 0) raf = requestAnimationFrame(update)
+    }
+
+    document.addEventListener('mousemove', onMove)
+
+    return () => {
+      document.removeEventListener('mousemove', onMove)
+      if (raf !== 0) cancelAnimationFrame(raf)
+      CSSAny.highlights?.delete(HIGHLIGHT_NAME)
+      CSSAny.highlights?.delete(HOVER_NAME)
+      document.body.style.cursor = ''
+      if (hoveredMarker) hoveredMarker.removeAttribute('data-hover')
+      resolvedRef.current = []
+      removeAllMarkers()
+    }
+  }, [annotations, pathname])
+
+  return null
+}

--- a/app/shared/annotations/review/ReviewHighlightToolbar.tsx
+++ b/app/shared/annotations/review/ReviewHighlightToolbar.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { Button, IconButton, MessageSquareIcon, XMarkIcon } from '@styleguide'
+import type { ResolvedAnchor } from '@shared/briefings/anchorResolver'
+
+type Props = {
+  anchor: ResolvedAnchor | null
+  onAddReview: () => void
+}
+
+/**
+ * Floating pill anchored to the reviewer's text selection. Single action —
+ * "Add review comment" — plus a dismiss button. Mirrors the candidate-facing
+ * HighlightToolbar's positioning math but exposes only the review affordance.
+ */
+export default function ReviewHighlightToolbar({
+  anchor,
+  onAddReview,
+}: Props): React.JSX.Element | null {
+  if (!anchor) return null
+  const rect = anchor.rect
+
+  const toolbarApproxWidth = 220
+  const margin = 8
+  const viewportW = typeof window !== 'undefined' ? window.innerWidth : 1280
+  const rawLeft = rect.left + rect.width / 2 - toolbarApproxWidth / 2
+  const left = Math.max(
+    margin,
+    Math.min(rawLeft, viewportW - toolbarApproxWidth - margin),
+  )
+  const top = Math.max(margin, rect.top - 48)
+
+  function dismiss() {
+    if (typeof window !== 'undefined') {
+      window.getSelection()?.removeAllRanges()
+    }
+  }
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Review actions"
+      className="fixed z-40 flex items-center gap-1 rounded-full border border-border bg-card p-1 shadow-md"
+      style={{ top, left }}
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      <Button type="button" size="small" onClick={onAddReview}>
+        <MessageSquareIcon className="size-3.5" aria-hidden />
+        Add review comment
+      </Button>
+      <IconButton
+        type="button"
+        size="small"
+        variant="ghost"
+        aria-label="Dismiss"
+        onClick={dismiss}
+      >
+        <XMarkIcon className="size-4" aria-hidden />
+      </IconButton>
+    </div>
+  )
+}

--- a/app/shared/annotations/review/ReviewSurface.tsx
+++ b/app/shared/annotations/review/ReviewSurface.tsx
@@ -1,0 +1,455 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  Button,
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+  PencilIcon,
+  Textarea,
+} from '@styleguide'
+import { useIsMobile } from '@styleguide/hooks/use-mobile'
+import type {
+  Annotation,
+  AnnotationAnchor,
+  Item,
+} from '@shared/briefings/types'
+import { resolveQuoteFromAnchor } from '@shared/briefings/anchorResolver'
+import { reportErrorToSentry } from '@shared/sentry'
+import { AnnotationSurfaceSheet } from '../../../dashboard/briefings/components/annotations/AnnotationSurfaceSheet'
+import type { EnrichedAnnotation } from '../../../dashboard/briefings/components/annotations/enrichForCycler'
+import { AnchoredQuote } from '../../../dashboard/briefings/components/annotations/AnchoredQuote'
+import { DeleteAnnotationButton } from '../../../dashboard/briefings/components/annotations/DeleteAnnotationButton'
+import { SurfaceEmptyState } from '../../../dashboard/briefings/components/annotations/SurfaceEmptyState'
+import { useEnrichedAnnotations } from '../../../dashboard/briefings/components/annotations/useEnrichedAnnotations'
+import { sectionLabelFromPath } from '../../../dashboard/briefings/components/annotations/sectionLabel'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  annotations: Annotation[]
+  /**
+   * Persist an in-place body edit. ReviewSurface keeps draft state local
+   * and only calls this once the reviewer clicks Save.
+   */
+  onSaveEdit: (annotationId: string, body: string) => Promise<void>
+  onDeleteReview: (annotation: Annotation) => Promise<void>
+  initialAnnotationId?: string
+  briefingItems?: readonly Item[]
+  /**
+   * When set, the surface opens in compose mode against a client-only
+   * anchor — no review row exists yet. The first Save POSTs via `onCreate`
+   * (the gp-api review create requires a non-empty body, so Save stays
+   * disabled until the reviewer types something). Closing with an empty
+   * body discards the anchor without persisting anything.
+   */
+  pendingAnchor?: AnnotationAnchor | null
+  onCreate?: (anchor: AnnotationAnchor, body: string) => Promise<void>
+}
+
+function relativeTime(iso: string): string {
+  try {
+    const date = new Date(iso)
+    if (Number.isNaN(date.getTime())) return ''
+    return formatDistanceToNow(date, { addSuffix: true })
+  } catch {
+    return ''
+  }
+}
+
+function ReviewBody({
+  item,
+  briefingItems,
+  editing,
+  draftBody,
+  onDraftChange,
+  onCancelEdit,
+  onCommitEdit,
+  saving,
+  saveError,
+}: {
+  item: EnrichedAnnotation
+  briefingItems?: readonly Item[]
+  editing: boolean
+  draftBody: string
+  onDraftChange: (next: string) => void
+  onCancelEdit: () => void
+  onCommitEdit: () => void
+  saving: boolean
+  saveError: string | null
+}) {
+  const sectionLabel = sectionLabelFromPath(item.jsonPath, briefingItems)
+  const canSave = draftBody.trim().length > 0 && !saving
+  const reviewerEmail = item.review?.reviewer_email ?? null
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+      {item.highlightedText ? (
+        <AnchoredQuote
+          text={item.highlightedText}
+          showLabel={sectionLabel !== null}
+          label={sectionLabel ?? undefined}
+          filled
+        />
+      ) : sectionLabel ? (
+        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {sectionLabel}
+        </span>
+      ) : null}
+      <div className="flex flex-col gap-2 rounded-md border border-border bg-card p-4 text-card-foreground">
+        <div className="flex items-baseline gap-2 text-sm">
+          <span className="font-semibold text-foreground">
+            {reviewerEmail ?? 'Reviewer'}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {relativeTime(item.updatedAt)}
+          </span>
+        </div>
+        {editing ? (
+          <>
+            <Textarea
+              value={draftBody}
+              onChange={(e) => onDraftChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (
+                  e.key !== 'Enter' ||
+                  e.shiftKey ||
+                  e.nativeEvent.isComposing
+                ) {
+                  return
+                }
+                e.preventDefault()
+                if (canSave) onCommitEdit()
+              }}
+              placeholder="Write a review comment, then tap Save..."
+              rows={3}
+              disabled={saving}
+              className="max-h-[180px] min-h-[96px] w-full resize-none rounded-2xl"
+            />
+            {saveError ? (
+              <p role="alert" className="text-sm text-destructive">
+                {saveError}
+              </p>
+            ) : null}
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="link"
+                size="small"
+                onClick={onCancelEdit}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={onCommitEdit}
+                disabled={!canSave}
+                loading={saving}
+              >
+                Save
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className="whitespace-pre-wrap text-base">
+            {item.review?.body ?? ''}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Compose drawer for a not-yet-persisted review. Mirrors the cycler sheet's
+ * Drawer chrome but holds a client-only anchor and an empty draft. Save is
+ * blocked until the body is non-empty (the gp-api create rejects empty
+ * bodies); closing discards the draft without persisting.
+ */
+function ReviewComposeSheet({
+  open,
+  onClose,
+  anchor,
+  briefingItems,
+  onCreate,
+}: {
+  open: boolean
+  onClose: () => void
+  anchor: AnnotationAnchor
+  briefingItems?: readonly Item[]
+  onCreate: (anchor: AnnotationAnchor, body: string) => Promise<void>
+}) {
+  const isDesktop = !useIsMobile()
+  const direction = isDesktop ? 'right' : 'bottom'
+  const [draftBody, setDraftBody] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // Reset the draft each time the compose sheet opens against a new anchor.
+  useEffect(() => {
+    if (open) {
+      setDraftBody('')
+      setSaveError(null)
+    }
+  }, [open, anchor])
+
+  const sectionLabel = sectionLabelFromPath(anchor.jsonPath, briefingItems)
+  const quote = resolveQuoteFromAnchor(anchor)
+  const canSave = draftBody.trim().length > 0 && !saving
+
+  async function handleSave() {
+    if (!canSave) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await onCreate(anchor, draftBody.trim())
+    } catch (err) {
+      reportErrorToSentry(err, {
+        surface: 'briefing-review',
+        op: 'createReview',
+      })
+      const msg = err instanceof Error ? err.message : String(err)
+      setSaveError(`Couldn't save your review comment: ${msg}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Drawer
+      open={open}
+      onOpenChange={(v) => (v ? null : onClose())}
+      direction={direction}
+    >
+      <DrawerContent className="flex flex-col gap-0 p-0 data-[vaul-drawer-direction=bottom]:max-h-[85vh] data-[vaul-drawer-direction=right]:sm:max-w-[480px]">
+        <DrawerTitle className="sr-only">Add review comment</DrawerTitle>
+        <DrawerDescription className="sr-only">
+          Write a review comment for the anchored passage.
+        </DrawerDescription>
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+          {quote ? (
+            <AnchoredQuote
+              text={quote}
+              showLabel={sectionLabel !== null}
+              label={sectionLabel ?? undefined}
+              filled
+            />
+          ) : sectionLabel ? (
+            <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {sectionLabel}
+            </span>
+          ) : null}
+          <Textarea
+            autoFocus
+            value={draftBody}
+            onChange={(e) => setDraftBody(e.target.value)}
+            onKeyDown={(e) => {
+              if (
+                e.key !== 'Enter' ||
+                e.shiftKey ||
+                e.nativeEvent.isComposing
+              ) {
+                return
+              }
+              e.preventDefault()
+              if (canSave) void handleSave()
+            }}
+            placeholder="Write a review comment, then tap Save..."
+            rows={3}
+            disabled={saving}
+            className="max-h-[180px] min-h-[96px] w-full resize-none rounded-2xl"
+          />
+          {saveError ? (
+            <p role="alert" className="text-sm text-destructive">
+              {saveError}
+            </p>
+          ) : null}
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="link"
+              size="small"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canSave}
+              loading={saving}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+/**
+ * Cycler drawer over persisted reviews. Modeled on NotesSurface but pared
+ * down: a single body textarea per review, Save + Delete, no attachments
+ * and no dictation.
+ */
+function ReviewCyclerSheet({
+  open,
+  onClose,
+  annotations,
+  onSaveEdit,
+  onDeleteReview,
+  initialAnnotationId,
+  briefingItems,
+}: Omit<Props, 'pendingAnchor' | 'onCreate'>) {
+  const items = useEnrichedAnnotations(open, annotations, 'review')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftBody, setDraftBody] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  function startEdit(item: EnrichedAnnotation) {
+    setEditingId(item.id)
+    setDraftBody(item.review?.body ?? '')
+    setSaveError(null)
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+    setDraftBody('')
+    setSaveError(null)
+  }
+
+  async function commitEdit(item: EnrichedAnnotation) {
+    if (saving) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      await onSaveEdit(item.id, draftBody)
+      setEditingId(null)
+      setDraftBody('')
+    } catch (err) {
+      reportErrorToSentry(err, {
+        surface: 'briefing-review',
+        op: 'updateReview',
+        annotationId: item.id,
+      })
+      const msg = err instanceof Error ? err.message : String(err)
+      setSaveError(`Couldn't save your review comment: ${msg}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <AnnotationSurfaceSheet
+      open={open}
+      onClose={onClose}
+      title={null}
+      accessibleTitle="Review comments"
+      subtitle="Highlight any text in the briefing to leave a review comment for the team."
+      positionLabel="Comment"
+      items={items}
+      onActiveAnnotationChange={(nextId) => {
+        setSaveError(null)
+        if (editingId && nextId !== editingId && !saving) {
+          setEditingId(null)
+          setDraftBody('')
+        }
+      }}
+      renderItem={(item) => (
+        <ReviewBody
+          item={item}
+          briefingItems={briefingItems}
+          editing={editingId === item.id}
+          draftBody={draftBody}
+          onDraftChange={setDraftBody}
+          onCancelEdit={cancelEdit}
+          onCommitEdit={() => void commitEdit(item)}
+          saving={saving}
+          saveError={editingId === item.id ? saveError : null}
+        />
+      )}
+      footer={(current) => {
+        if (!current) return null
+        const isEditingCurrent = editingId === current.id
+        return (
+          <div className="flex flex-col gap-2">
+            {isEditingCurrent ? null : (
+              <Button
+                onClick={() => startEdit(current)}
+                className="w-full gap-2 text-sm!"
+              >
+                <PencilIcon className="size-4" aria-hidden="true" />
+                Edit comment
+              </Button>
+            )}
+            <DeleteAnnotationButton
+              current={current}
+              label="Delete comment"
+              title="Delete this review comment?"
+              description="This review comment will be permanently removed. You can't undo this."
+              onDelete={onDeleteReview}
+            />
+          </div>
+        )
+      }}
+      emptyState={
+        <SurfaceEmptyState
+          label="No review comments yet"
+          message="Highlight a passage in the briefing to add one."
+        />
+      }
+      initialAnnotationId={initialAnnotationId}
+    />
+  )
+}
+
+/**
+ * Review-comment surface. Thin dispatcher with no hooks of its own so it
+ * can switch between two children whose hook usage differs: a compose sheet
+ * for a not-yet-persisted anchor, and the cycler over persisted reviews.
+ * Compose mode takes precedence so the empty-body create path never POSTs.
+ * Lives in the shared review/ folder so the admin-review route tree and any
+ * future host can mount it without reaching into the candidate-facing
+ * briefings dir.
+ */
+export function ReviewSurface({
+  open,
+  onClose,
+  annotations,
+  onSaveEdit,
+  onDeleteReview,
+  initialAnnotationId,
+  briefingItems,
+  pendingAnchor,
+  onCreate,
+}: Props) {
+  if (pendingAnchor && onCreate) {
+    return (
+      <ReviewComposeSheet
+        open={open}
+        onClose={onClose}
+        anchor={pendingAnchor}
+        briefingItems={briefingItems}
+        onCreate={onCreate}
+      />
+    )
+  }
+  return (
+    <ReviewCyclerSheet
+      open={open}
+      onClose={onClose}
+      annotations={annotations}
+      onSaveEdit={onSaveEdit}
+      onDeleteReview={onDeleteReview}
+      initialAnnotationId={initialAnnotationId}
+      briefingItems={briefingItems}
+    />
+  )
+}

--- a/app/shared/briefings/anchorResolver.test.ts
+++ b/app/shared/briefings/anchorResolver.test.ts
@@ -9,7 +9,7 @@ import {
 describe('selectElementContents', () => {
   it('makes the element’s full text the document selection', () => {
     document.body.innerHTML =
-      '<h3 data-briefing-json-path="/items/0/title">My Title</h3>'
+      '<h3 data-anchor-json-path="/items/0/title">My Title</h3>'
     const h3 = document.querySelector('h3') as HTMLElement
     const removeAllRanges = vi.fn()
     const addRange = vi.fn()
@@ -64,7 +64,7 @@ describe('resolveSelection', () => {
 
   it('resolves a text-node selection (drag / double-click word)', () => {
     document.body.innerHTML =
-      '<ul><li data-briefing-json-path="/items/0/talking_points/0">hello world</li></ul>'
+      '<ul><li data-anchor-json-path="/items/0/talking_points/0">hello world</li></ul>'
     const text = document.querySelector('li')?.firstChild as Node
     const anchor = resolveSelection(
       asSelection(rangeBetween([text, 0], [text, 11])),
@@ -79,7 +79,7 @@ describe('resolveSelection', () => {
 
   it('resolves a block selection whose boundary is the element node (triple-click / full-highlight)', () => {
     document.body.innerHTML =
-      '<ul><li data-briefing-json-path="/items/0/talking_points/0">hello world</li></ul>'
+      '<ul><li data-anchor-json-path="/items/0/talking_points/0">hello world</li></ul>'
     const li = document.querySelector('li') as HTMLElement
     // Block selections set the boundary on the element itself (child index),
     // not a text node: start before child 0, end after child 0.
@@ -97,8 +97,8 @@ describe('resolveSelection', () => {
     // boundary on that sibling, whose nearest anchor is the card — not the
     // passage. We must still resolve against the passage.
     document.body.innerHTML =
-      '<article data-briefing-json-path="/items/1">' +
-      '<p data-briefing-json-path="/items/1/display/summary">hello world</p>' +
+      '<article data-anchor-json-path="/items/1">' +
+      '<p data-anchor-json-path="/items/1/display/summary">hello world</p>' +
       '<span>source</span>' +
       '</article>'
     const summaryText = document.querySelector('p')?.firstChild as Node
@@ -121,7 +121,7 @@ describe('resolveSelection', () => {
     document.body.innerHTML =
       '<div>' +
       '<span>preamble </span>' +
-      '<p data-briefing-json-path="/items/2/body">hello world</p>' +
+      '<p data-anchor-json-path="/items/2/body">hello world</p>' +
       '</div>'
     const preamble = document.querySelector('span')?.firstChild as Node
     const bodyText = document.querySelector('p')?.firstChild as Node
@@ -145,7 +145,7 @@ describe('resolveSelection', () => {
   })
 
   it('returns null for a collapsed selection', () => {
-    document.body.innerHTML = '<li data-briefing-json-path="/x">hello</li>'
+    document.body.innerHTML = '<li data-anchor-json-path="/x">hello</li>'
     const text = document.querySelector('li')?.firstChild as Node
     expect(
       resolveSelection(asSelection(rangeBetween([text, 2], [text, 2]))),
@@ -179,7 +179,7 @@ describe('scrollAnchorIntoView', () => {
 
   function makeAnchorEl(jsonPath: string, rect: Partial<DOMRect>): HTMLElement {
     const el = document.createElement('div')
-    el.setAttribute('data-briefing-json-path', jsonPath)
+    el.setAttribute('data-anchor-json-path', jsonPath)
     document.body.appendChild(el)
     el.getBoundingClientRect = () =>
       ({

--- a/app/shared/briefings/anchorResolver.ts
+++ b/app/shared/briefings/anchorResolver.ts
@@ -3,7 +3,7 @@
  *
  * Converts a browser `Selection` (or a `Range`) into an
  * `{ jsonPath, start, end, quote }` anchor by walking up to the nearest
- * element carrying a `data-briefing-json-path` attribute and computing
+ * element carrying a `data-anchor-json-path` attribute and computing
  * character offsets within that element's plain text.
  *
  * Conversely, builds a DOM `Range` inside a target element from
@@ -13,8 +13,8 @@
 
 import type { AnnotationAnchor } from './types'
 
-const ANCHOR_ATTR = 'data-briefing-json-path'
-const ANCHOR_SELECTOR = '[data-briefing-json-path]'
+const ANCHOR_ATTR = 'data-anchor-json-path'
+const ANCHOR_SELECTOR = '[data-anchor-json-path]'
 
 export interface ResolvedAnchor {
   jsonPath: string

--- a/app/shared/briefings/annotations-api.ts
+++ b/app/shared/briefings/annotations-api.ts
@@ -44,6 +44,13 @@ function apiInput(input: CreateAnnotationInput): ApiCreateAnnotationInput {
       payload: { description: input.payload.description },
     }
   }
+  if (input.kind === 'review') {
+    return {
+      kind: 'review',
+      anchor: apiAnchor(input.anchor),
+      payload: { body: input.payload.body },
+    }
+  }
   // Chat kind is rejected by the API; surface a clear error instead of
   // sending a request the server will refuse.
   throw new Error('chat_annotations_not_supported_yet')
@@ -94,14 +101,26 @@ function fromApi(row: ApiAnnotation): Annotation {
       createdAt: row.chat.created_at,
     }
   }
+  if (row.review) {
+    result.review = {
+      id: row.review.id,
+      body: row.review.body,
+      reviewer_email: row.review.reviewer_email,
+      created_at: row.review.created_at,
+      updated_at: row.review.updated_at,
+    }
+  }
   return result
 }
 
 export const annotationsApi: AnnotationsClient = {
-  async list(meetingDate) {
+  async list(meetingDate, kinds) {
     const res = await clientRequest(
       'GET /v1/meetings/:date/briefing/annotations',
-      { date: meetingDate },
+      {
+        date: meetingDate,
+        ...(kinds && kinds.length > 0 ? { kinds: kinds.join(',') } : {}),
+      },
     )
     return res.data.annotations.map(fromApi)
   },
@@ -119,6 +138,14 @@ export const annotationsApi: AnnotationsClient = {
       annotationId,
       body,
     })
+    return fromApi(res.data)
+  },
+
+  async updateReview(annotationId, body) {
+    const res = await clientRequest(
+      'PUT /v1/annotations/:annotationId/review',
+      { annotationId, body },
+    )
     return fromApi(res.data)
   },
 

--- a/app/shared/briefings/annotations-client.ts
+++ b/app/shared/briefings/annotations-client.ts
@@ -10,11 +10,12 @@
  * interface so components do not need to change when toggling.
  */
 
-import type { Annotation, CreateAnnotationInput } from './types'
+import type { Annotation, AnnotationKind, CreateAnnotationInput } from './types'
 
 export interface AnnotationsClient {
-  list(meetingDate: string): Promise<Annotation[]>
+  list(meetingDate: string, kinds?: AnnotationKind[]): Promise<Annotation[]>
   create(meetingDate: string, input: CreateAnnotationInput): Promise<Annotation>
   updateNote(annotationId: string, body: string): Promise<Annotation>
+  updateReview(annotationId: string, body: string): Promise<Annotation>
   delete(annotationId: string): Promise<void>
 }

--- a/app/shared/briefings/annotations-stub.ts
+++ b/app/shared/briefings/annotations-stub.ts
@@ -17,6 +17,7 @@ import type {
   AnnotationNoteData,
   AnnotationBugReportData,
   AnnotationChatData,
+  AnnotationReviewData,
   CreateAnnotationInput,
 } from './types'
 import type { AnnotationsClient } from './annotations-client'
@@ -98,6 +99,20 @@ async function createBugReport(
   return finalize(briefingId, 'bug_report', input, { bugReport })
 }
 
+async function createReview(
+  briefingId: string,
+  input: Extract<CreateAnnotationInput, { kind: 'review' }>,
+): Promise<Annotation> {
+  const review: AnnotationReviewData = {
+    id: newId('review'),
+    body: input.payload.body,
+    reviewer_email: null,
+    created_at: nowIso(),
+    updated_at: nowIso(),
+  }
+  return finalize(briefingId, 'review', input, { review })
+}
+
 async function createChat(
   briefingId: string,
   input: Extract<CreateAnnotationInput, { kind: 'chat' }>,
@@ -120,7 +135,7 @@ function finalize(
   briefingId: string,
   kind: AnnotationKind,
   input: CreateAnnotationInput,
-  extras: Partial<Pick<Annotation, 'note' | 'bugReport' | 'chat'>>,
+  extras: Partial<Pick<Annotation, 'note' | 'bugReport' | 'chat' | 'review'>>,
 ): Annotation {
   const annotation: Annotation = {
     id: newId('ann'),
@@ -142,13 +157,16 @@ function finalize(
 }
 
 export const annotationsStub: AnnotationsClient = {
-  async list(briefingId) {
-    return readAll(briefingId)
+  async list(briefingId, kinds) {
+    const all = readAll(briefingId)
+    if (!kinds || kinds.length === 0) return all
+    return all.filter((a) => kinds.includes(a.kind))
   },
 
   async create(briefingId, input) {
     if (input.kind === 'note') return createNote(briefingId, input)
     if (input.kind === 'bug_report') return createBugReport(briefingId, input)
+    if (input.kind === 'review') return createReview(briefingId, input)
     return createChat(briefingId, input)
   },
 
@@ -168,6 +186,26 @@ export const annotationsStub: AnnotationsClient = {
       ...annotation,
       updatedAt: nowIso(),
       note: { ...annotation.note, body, updatedAt: nowIso() },
+    }
+    items[idx] = updated
+    writeAll(briefingId, items)
+    return updated
+  },
+
+  async updateReview(annotationId, body) {
+    const briefingId = findOwningBriefingId(annotationId)
+    if (!briefingId) throw new Error('annotation_not_found')
+    const items = readAll(briefingId)
+    const idx = items.findIndex((a) => a.id === annotationId)
+    if (idx < 0) throw new Error('annotation_not_found')
+    const annotation = items[idx]
+    if (!annotation || annotation.kind !== 'review' || !annotation.review) {
+      throw new Error('annotation_not_a_review')
+    }
+    const updated: Annotation = {
+      ...annotation,
+      updatedAt: nowIso(),
+      review: { ...annotation.review, body, updated_at: nowIso() },
     }
     items[idx] = updated
     writeAll(briefingId, items)

--- a/app/shared/briefings/types.ts
+++ b/app/shared/briefings/types.ts
@@ -95,7 +95,7 @@ export interface BriefingSummary {
 // Annotations (my system) — unchanged
 // ---------------------------------------------------------------------------
 
-export type AnnotationKind = 'note' | 'chat' | 'bug_report'
+export type AnnotationKind = 'note' | 'chat' | 'bug_report' | 'review'
 export type AnnotationResourceType = 'briefing'
 
 export interface AnnotationAnchor {
@@ -143,6 +143,14 @@ export interface AnnotationBugReportData {
   submittedAt: string
 }
 
+export interface AnnotationReviewData {
+  id: string
+  body: string
+  reviewer_email: string | null
+  created_at: string
+  updated_at: string
+}
+
 export interface Annotation {
   id: string
   kind: AnnotationKind
@@ -157,6 +165,7 @@ export interface Annotation {
   note?: AnnotationNoteData
   chat?: AnnotationChatData
   bugReport?: AnnotationBugReportData
+  review?: AnnotationReviewData
 }
 
 export type CreateAnnotationInput =
@@ -175,6 +184,11 @@ export type CreateAnnotationInput =
       kind: 'chat'
       anchor: AnnotationAnchor
       payload: { firstMessage: string | null }
+    }
+  | {
+      kind: 'review'
+      anchor: AnnotationAnchor
+      payload: { body: string }
     }
 
 // ---------------------------------------------------------------------------

--- a/app/shared/briefings/use-annotations.test.ts
+++ b/app/shared/briefings/use-annotations.test.ts
@@ -8,6 +8,7 @@ import type { Annotation } from './types'
 const listMock = vi.fn()
 const createMock = vi.fn()
 const updateNoteMock = vi.fn()
+const updateReviewMock = vi.fn()
 const deleteMock = vi.fn()
 
 vi.mock('./annotations-api', () => ({
@@ -15,6 +16,7 @@ vi.mock('./annotations-api', () => ({
     list: (...args: unknown[]) => listMock(...args),
     create: (...args: unknown[]) => createMock(...args),
     updateNote: (...args: unknown[]) => updateNoteMock(...args),
+    updateReview: (...args: unknown[]) => updateReviewMock(...args),
     delete: (...args: unknown[]) => deleteMock(...args),
   },
 }))
@@ -27,6 +29,7 @@ vi.mock('@shared/sentry', () => ({
 import { useAnnotations, annotationsQueryKey } from './use-annotations'
 
 const MEETING_DATE = '2026-06-08'
+const TARGET = { resourceType: 'briefing', resourceId: MEETING_DATE } as const
 
 const wrapper = (qc: QueryClient) =>
   function Wrapper({ children }: { children: ReactNode }) {
@@ -66,6 +69,7 @@ beforeEach(() => {
   listMock.mockReset()
   createMock.mockReset()
   updateNoteMock.mockReset()
+  updateReviewMock.mockReset()
   deleteMock.mockReset()
   reportErrorToSentryMock.mockReset()
   listMock.mockResolvedValue([])
@@ -76,7 +80,7 @@ describe('useAnnotations — error reporting', () => {
     const err = new Error('create boom')
     createMock.mockRejectedValue(err)
     const qc = newClient()
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -102,7 +106,7 @@ describe('useAnnotations — error reporting', () => {
     const err = new Error('update boom')
     updateNoteMock.mockRejectedValue(err)
     const qc = newClient()
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -124,7 +128,7 @@ describe('useAnnotations — error reporting', () => {
     const err = new Error('remove boom')
     deleteMock.mockRejectedValue(err)
     const qc = newClient()
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -149,7 +153,7 @@ describe('useAnnotations — cache writes without invalidate', () => {
     createMock.mockResolvedValue(created)
     const qc = newClient()
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -164,9 +168,7 @@ describe('useAnnotations — cache writes without invalidate', () => {
 
     await waitFor(() => expect(createMock).toHaveBeenCalled())
     await waitFor(() => {
-      const cache = qc.getQueryData<Annotation[]>(
-        annotationsQueryKey(MEETING_DATE),
-      )
+      const cache = qc.getQueryData<Annotation[]>(annotationsQueryKey(TARGET))
       expect(cache?.some((a) => a.id === 'ann_created')).toBe(true)
     })
 
@@ -200,7 +202,7 @@ describe('useAnnotations — cache writes without invalidate', () => {
 
     const qc = newClient()
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.annotations).toHaveLength(2))
@@ -210,16 +212,12 @@ describe('useAnnotations — cache writes without invalidate', () => {
     })
 
     await waitFor(() => {
-      const cache = qc.getQueryData<Annotation[]>(
-        annotationsQueryKey(MEETING_DATE),
-      )
+      const cache = qc.getQueryData<Annotation[]>(annotationsQueryKey(TARGET))
       const row = cache?.find((a) => a.id === 'ann_1')
       expect(row?.note?.body).toBe('new')
     })
 
-    const cache = qc.getQueryData<Annotation[]>(
-      annotationsQueryKey(MEETING_DATE),
-    )
+    const cache = qc.getQueryData<Annotation[]>(annotationsQueryKey(TARGET))
     expect(cache?.map((a) => a.id)).toEqual(['ann_1', 'ann_2'])
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
@@ -232,7 +230,7 @@ describe('useAnnotations — cache writes without invalidate', () => {
 
     const qc = newClient()
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries')
-    const { result } = renderHook(() => useAnnotations(MEETING_DATE), {
+    const { result } = renderHook(() => useAnnotations(TARGET), {
       wrapper: wrapper(qc),
     })
     await waitFor(() => expect(result.current.annotations).toHaveLength(2))
@@ -242,9 +240,7 @@ describe('useAnnotations — cache writes without invalidate', () => {
     })
 
     await waitFor(() => {
-      const cache = qc.getQueryData<Annotation[]>(
-        annotationsQueryKey(MEETING_DATE),
-      )
+      const cache = qc.getQueryData<Annotation[]>(annotationsQueryKey(TARGET))
       expect(cache?.map((a) => a.id)).toEqual(['ann_2'])
     })
 

--- a/app/shared/briefings/use-annotations.ts
+++ b/app/shared/briefings/use-annotations.ts
@@ -4,10 +4,40 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { reportErrorToSentry } from '@shared/sentry'
 import { annotationsApi } from './annotations-api'
 import type { AnnotationsClient } from './annotations-client'
-import type { Annotation, CreateAnnotationInput } from './types'
+import type {
+  Annotation,
+  AnnotationKind,
+  AnnotationResourceType,
+  CreateAnnotationInput,
+} from './types'
 
-export const annotationsQueryKey = (meetingDate: string) =>
-  ['briefings', meetingDate, 'annotations'] as const
+export interface AnnotationsTarget {
+  resourceType: AnnotationResourceType
+  resourceId: string
+}
+
+export interface UseAnnotationsOptions {
+  kinds?: AnnotationKind[]
+}
+
+export const annotationsQueryKey = (
+  target: AnnotationsTarget | string,
+  kinds?: AnnotationKind[],
+) => {
+  // Tolerate the legacy `(meetingDate)` call shape: a bare string is the
+  // briefing's meeting date, addressing the same resource the object form
+  // describes with resourceType 'briefing'.
+  const resourceType =
+    typeof target === 'string' ? 'briefing' : target.resourceType
+  const resourceId = typeof target === 'string' ? target : target.resourceId
+  return [
+    'briefings',
+    resourceType,
+    resourceId,
+    'annotations',
+    kinds && kinds.length > 0 ? [...kinds].sort().join(',') : 'all',
+  ] as const
+}
 
 const QK = annotationsQueryKey
 
@@ -18,9 +48,9 @@ const QK = annotationsQueryKey
  * (`annotations-stub.ts`) is still available for development against
  * fixtures by swapping the import below.
  *
- * `meetingDate` is the YYYY-MM-DD slug that addresses the briefing in
- * `GET /v1/meetings/:date/briefing`; annotations endpoints nest under the
- * same shape.
+ * For resourceType 'briefing', `resourceId` is the YYYY-MM-DD slug that
+ * addresses the briefing in `GET /v1/meetings/:date/briefing`; annotations
+ * endpoints nest under the same shape.
  */
 const client: AnnotationsClient = annotationsApi
 
@@ -43,19 +73,25 @@ const hasPendingOcr = (annotations: Annotation[] | undefined): boolean => {
   return false
 }
 
-export function useAnnotations(meetingDate: string) {
+export function useAnnotations(
+  target: AnnotationsTarget,
+  options?: UseAnnotationsOptions,
+) {
   const qc = useQueryClient()
+  const { resourceId } = target
+  const kinds = options?.kinds
+  const key = QK(target, kinds)
 
   const list = useQuery<Annotation[]>({
-    queryKey: QK(meetingDate),
-    queryFn: () => client.list(meetingDate),
+    queryKey: key,
+    queryFn: () => client.list(resourceId, kinds),
     refetchInterval: (query) =>
       hasPendingOcr(query.state.data) ? OCR_POLL_INTERVAL_MS : false,
   })
 
   const create = useMutation({
     mutationFn: (input: CreateAnnotationInput) =>
-      client.create(meetingDate, input),
+      client.create(resourceId, input),
     onSuccess: (created) => {
       // Write the new annotation into the cache synchronously so consumers
       // that immediately open a surface focused on `created.id` (e.g.
@@ -63,7 +99,7 @@ export function useAnnotations(meetingDate: string) {
       // present before any refetch settles. Without this, there's a brief
       // window where the new id isn't in `annotations[]`, which used to trip
       // the dangling-reference guard and close the surface mid-mount.
-      qc.setQueryData<Annotation[]>(QK(meetingDate), (prev) => {
+      qc.setQueryData<Annotation[]>(key, (prev) => {
         const list = prev ?? []
         if (list.some((a) => a.id === created.id)) return list
         return [...list, created]
@@ -73,7 +109,7 @@ export function useAnnotations(meetingDate: string) {
       reportErrorToSentry(err, {
         surface: 'briefing-annotations',
         op: 'create',
-        meetingDate,
+        meetingDate: resourceId,
       }),
   })
 
@@ -81,7 +117,7 @@ export function useAnnotations(meetingDate: string) {
     mutationFn: ({ id, body }: { id: string; body: string }) =>
       client.updateNote(id, body),
     onSuccess: (updated) => {
-      qc.setQueryData<Annotation[]>(QK(meetingDate), (prev) =>
+      qc.setQueryData<Annotation[]>(key, (prev) =>
         prev?.map((a) => (a.id === updated.id ? updated : a)),
       )
     },
@@ -89,14 +125,30 @@ export function useAnnotations(meetingDate: string) {
       reportErrorToSentry(err, {
         surface: 'briefing-annotations',
         op: 'updateNote',
-        meetingDate,
+        meetingDate: resourceId,
+      }),
+  })
+
+  const updateReview = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: string }) =>
+      client.updateReview(id, body),
+    onSuccess: (updated) => {
+      qc.setQueryData<Annotation[]>(key, (prev) =>
+        prev?.map((a) => (a.id === updated.id ? updated : a)),
+      )
+    },
+    onError: (err) =>
+      reportErrorToSentry(err, {
+        surface: 'briefing-annotations',
+        op: 'updateReview',
+        meetingDate: resourceId,
       }),
   })
 
   const remove = useMutation({
     mutationFn: (id: string) => client.delete(id),
     onSuccess: (_, removedId) => {
-      qc.setQueryData<Annotation[]>(QK(meetingDate), (prev) =>
+      qc.setQueryData<Annotation[]>(key, (prev) =>
         prev?.filter((a) => a.id !== removedId),
       )
     },
@@ -104,7 +156,7 @@ export function useAnnotations(meetingDate: string) {
       reportErrorToSentry(err, {
         surface: 'briefing-annotations',
         op: 'remove',
-        meetingDate,
+        meetingDate: resourceId,
       }),
   })
 
@@ -113,6 +165,7 @@ export function useAnnotations(meetingDate: string) {
     isLoading: list.isLoading,
     create,
     updateNote,
+    updateReview,
     remove,
   }
 }

--- a/app/shared/briefings/use-selection.ts
+++ b/app/shared/briefings/use-selection.ts
@@ -6,7 +6,7 @@ import { resolveSelection, type ResolvedAnchor } from './anchorResolver'
 /**
  * Hook that watches the document selection and resolves it into a briefing
  * anchor when the user highlights text inside an element carrying
- * `data-briefing-json-path`.
+ * `data-anchor-json-path`.
  *
  * Returns the resolved anchor, or null if there is no valid selection.
  *

--- a/app/shared/user/ImpersonationBanner.tsx
+++ b/app/shared/user/ImpersonationBanner.tsx
@@ -5,6 +5,7 @@ import { useIsImpersonating } from '@shared/hooks/useIsImpersonating'
 import { useUser } from '@shared/hooks/useUser'
 import { useSnackbar } from 'helpers/useSnackbar'
 import { clientRequest } from 'gpApi/typed-request'
+import { usePathname } from 'next/navigation'
 import { useState, useRef, useCallback } from 'react'
 import { ArrowLeftRight, Ban } from 'lucide-react'
 import {
@@ -25,6 +26,8 @@ type SearchResult = { id: number; email: string; name: string | null }
 
 export default function ImpersonationBanner() {
   const isImpersonating = useIsImpersonating()
+  const pathname = usePathname()
+  const isReviewMode = !!pathname?.startsWith('/dashboard/admin-review/')
   const { signOut, client, setActive } = useClerk()
   const [user] = useUser()
   const { errorSnackbar } = useSnackbar()
@@ -92,7 +95,14 @@ export default function ImpersonationBanner() {
 
   async function handleStopImpersonating() {
     await signOut()
-    window.location.href = GP_ADMIN_URL
+    let returnPath = '/'
+    try {
+      returnPath = sessionStorage.getItem('gp_admin_return_to') ?? '/'
+      sessionStorage.removeItem('gp_admin_return_to')
+    } catch {
+      returnPath = '/'
+    }
+    window.location.href = GP_ADMIN_URL + returnPath
   }
 
   function handleOpenChange(next: boolean) {
@@ -113,15 +123,17 @@ export default function ImpersonationBanner() {
           You are impersonating <strong>{user?.email ?? 'this user'}</strong>
         </span>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="xSmall"
-            onClick={() => setOpen(true)}
-            className="bg-green-600 text-white border-green-600 hover:bg-green-700 hover:border-green-700"
-          >
-            <ArrowLeftRight />
-            Switch User
-          </Button>
+          {!isReviewMode && (
+            <Button
+              variant="outline"
+              size="xSmall"
+              onClick={() => setOpen(true)}
+              className="bg-green-600 text-white border-green-600 hover:bg-green-700 hover:border-green-700"
+            >
+              <ArrowLeftRight />
+              Switch User
+            </Button>
+          )}
           <Button
             variant="destructive"
             size="xSmall"

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -340,7 +340,7 @@ export type APIEndpoints = {
   // Annotation shape consumed by components. Briefings are addressed
   // by meeting date (YYYY-MM-DD), matching `GET /v1/meetings/:date/briefing`.
   'GET /v1/meetings/:date/briefing/annotations': {
-    Request: { date: string }
+    Request: { date: string; kinds?: string }
     Response: { annotations: ApiAnnotation[] }
   }
   'POST /v1/meetings/:date/briefing/annotations': {
@@ -348,6 +348,10 @@ export type APIEndpoints = {
     Response: ApiAnnotation
   }
   'PUT /v1/annotations/:annotationId/note': {
+    Request: { body: string }
+    Response: ApiAnnotation
+  }
+  'PUT /v1/annotations/:annotationId/review': {
     Request: { body: string }
     Response: ApiAnnotation
   }
@@ -433,7 +437,7 @@ export type APIEndpoints = {
 // Backend (snake_case) annotation types. Mirrors @goodparty_org/contracts
 // in gp-api. The AnnotationsApi client maps to/from the camelCase shape
 // the rest of the frontend uses.
-export type ApiAnnotationKind = 'note' | 'chat' | 'bug_report'
+export type ApiAnnotationKind = 'note' | 'chat' | 'bug_report' | 'review'
 export type ApiAnnotationResourceType = 'briefing'
 
 export interface ApiAnnotationAnchorInput {
@@ -498,6 +502,14 @@ export interface ApiAnnotationChat {
   created_at: string
 }
 
+export interface ApiAnnotationReview {
+  id: string
+  body: string
+  reviewer_email: string | null
+  created_at: string
+  updated_at: string
+}
+
 export interface ApiAnnotation {
   id: string
   kind: ApiAnnotationKind
@@ -512,6 +524,7 @@ export interface ApiAnnotation {
   note?: ApiAnnotationNote
   bug_report?: ApiAnnotationBugReport
   chat?: ApiAnnotationChat
+  review?: ApiAnnotationReview
 }
 
 export type ApiCreateAnnotationInput =
@@ -525,6 +538,11 @@ export type ApiCreateAnnotationInput =
       kind: 'bug_report'
       anchor: ApiAnnotationAnchorInput
       payload: { description: string }
+    }
+  | {
+      kind: 'review'
+      anchor: ApiAnnotationAnchorInput
+      payload: { body: string }
     }
 
 export type ApiArtifactResourceType = 'agenda_item'

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -49,4 +49,5 @@ beforeEach(() => {
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => router),
+  usePathname: vi.fn(() => '/'),
 }))


### PR DESCRIPTION
## Why

The frontend half of the admin briefing-review feature (companion to gp-api #1760). Admins QA the AI-generated meeting briefings by viewing them as the user via impersonation and leaving structured "review" comments — a concept kept entirely separate from the user's own notes/chat/bug annotations, and never rendered to the user.

## Why a parallel route tree and a parallel scope (not a `mode` prop)

The briefing chrome — header, TOC, bottom bars, share scope, and the ~900-line `AnnotationsScope` — all live in the `[slug]/layout.tsx`. Threading a `mode` flag through all of that risks regressing the live user experience. Instead this adds a parallel `/dashboard/admin-review/briefings/[slug]` tree and a purpose-built `ReviewAnnotationsScope` (a small peer of `AnnotationsScope`, not a fork) that only knows about the `review` kind. The normal briefing experience is untouched.

## Notes for reviewers

- Every `admin-review` route is gated on an active impersonation session and redirects to the normal briefing route otherwise.
- `useAnnotations` is generalized to `({resourceType, resourceId}, {kinds})`. Normal mode omits `kinds`, so the client never even requests reviews — this complements the server-side default-deny in gp-api, it does not replace it.
- Review creation is **compose-then-save**: nothing is POSTed until a non-empty body is entered (the server rejects empty review bodies).
- `data-briefing-json-path` → `data-anchor-json-path`: the anchor attribute is generic by function; this rename is the only change that touches live briefing rendering, and it is a pure find/replace with test coverage.
- **`gpApi/api-endpoints.ts` is the cross-repo contract** flagged in CLAUDE.md. The edits here are additive only (the `review` kind, a `kinds` query param, the `PUT /v1/annotations/:id/review` route) and mirror gp-api #1760 exactly.
- No frontend test exists yet for the review compose/cycle flow — worth adding as a follow-up since it's now the load-bearing path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live briefing anchor attributes and shared annotations/impersonation plumbing, though review UI is isolated in a parallel route and candidate flows largely omit review kinds.
> 
> **Overview**
> Adds an **impersonation-gated** `/dashboard/admin-review/briefings/[slug]` experience so staff can QA briefings in the candidate’s session and leave **review** comments that stay separate from user notes, chat, and bug reports.
> 
> The route mirrors the normal briefing chrome (layout, TOC, scroll-spy) but swaps in `ReviewAnnotationsScope`, review-only header/bottom bars, teal highlights, a selection toolbar, and a compose-then-save review drawer/cycler. Legacy per-item URLs redirect to hash anchors on the single overview page. `AdminReviewGate` redirects non-impersonators to the standard briefing.
> 
> **Annotations stack:** new `review` kind end-to-end (types, API/stub, `updateReview`, optional `kinds` on list). `useAnnotations` now takes `{ resourceType, resourceId }` and optional `kinds`; review mode loads only reviews. Candidate `AnnotationsHighlightLayer` skips `review` rows. Anchor DOM attribute renamed **`data-briefing-json-path` → `data-anchor-json-path`** everywhere (including tests).
> 
> **Impersonation:** safe `returnTo` / `adminReturnTo` on the impersonate page; banner restores admin URL from `sessionStorage` and hides “Switch User” on admin-review paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b224bc15d26478c5786d0c7d29645d408332b440. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->