### PR TITLE
fix(dashboard): clarify website sunset modal copy

### DIFF
--- a/app/dashboard/shared/WebsiteSunsetModal.tsx
+++ b/app/dashboard/shared/WebsiteSunsetModal.tsx
@@ -28,7 +28,9 @@ export function WebsiteSunsetModal({
         onInteractOutside={(e) => e.preventDefault()}
       >
         <DialogHeader className="gap-1.5">
-          <DialogTitle>Website is being discontinued</DialogTitle>
+          <DialogTitle>
+            Our build your own website feature is being discontinued
+          </DialogTitle>
           <DialogDescription>
             Your site will remain live for one year from your original purchase
             date, and you can still update your website content anytime under My


### PR DESCRIPTION
Update the WebsiteSunsetModal title from 'Website is being discontinued' to 'Our build your own website feature is being discontinued' so candidates understand only the website-builder feature is going away, not their entire site. The previous wording read as if we were taking down the whole site, which was unnecessarily alarming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to a dashboard modal title with no logic or data impact.
> 
> **Overview**
> Updates the **WebsiteSunsetModal** dialog title so it names the **build your own website** feature as what is ending, instead of the vaguer “Website is being discontinued.” Body copy, transfer button, and modal behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f92ac595b80781ad00d7ff852b7c6444cf3868e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->