### PR TITLE
fix(campaign-plan): align PDF section order and numbering with on-screen plan

### DIFF
--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -4,6 +4,10 @@ import { Skeleton, SourceCitation } from '@styleguide'
 import { VoterDemographicsStep } from 'app/onboarding/components/VoterDemographicsStep'
 import PlanSectionNav, { type PlanSectionRef } from './PlanSectionNav'
 import type { PlanData } from './planContent'
+import {
+  getNumberedPlanSections,
+  type PlanSectionKey,
+} from '../planSectionManifest'
 
 interface StrategyState {
   isGenerating: boolean
@@ -78,19 +82,22 @@ const Section = ({
   </section>
 )
 
-const PLAN_SECTIONS: PlanSectionRef[] = [
-  { id: 'plan-section-1', label: '1. Executive Summary' },
-  { id: 'plan-section-2', label: '2. Strategic Landscape' },
-  { id: 'plan-section-3', label: '3. Electoral Goals & Key Metrics' },
-  { id: 'plan-section-4', label: '4. Voter Insights For Your District' },
-  { id: 'plan-section-5', label: '5. Projected Minimum Resources Needed' },
-  { id: 'plan-section-6', label: '6. Campaign Timeline' },
-  { id: 'plan-section-7', label: '7. Community Engagement & Earned Media' },
-  { id: 'plan-section-8', label: '8. Voter Contact Plan' },
-  { id: 'plan-section-9', label: '9. Measurement & Accountability' },
-  { id: 'plan-section-10', label: '10. Methodology & Data Sources' },
-  { id: 'plan-section-11', label: '11. Glossary' },
-]
+// Stable DOM anchors for each section, keyed by the shared manifest. These
+// ids never change with display numbering — only the visible "Section N"
+// label and nav number shift when Strategic Landscape drops out.
+const SECTION_DOM_ID: Record<PlanSectionKey, string> = {
+  executiveSummary: 'plan-section-1',
+  strategicLandscape: 'plan-section-2',
+  electoralGoals: 'plan-section-3',
+  voterInsights: 'plan-section-4',
+  resources: 'plan-section-5',
+  timeline: 'plan-section-6',
+  community: 'plan-section-7',
+  voterContact: 'plan-section-8',
+  measurement: 'plan-section-9',
+  methodology: 'plan-section-10',
+  glossary: 'plan-section-11',
+}
 
 interface SubsectionProps {
   title: string
@@ -187,8 +194,8 @@ const TheRaceCopy = ({ plan }: { plan: PlanData }): React.JSX.Element => {
     plan.electionType === 'partisan'
       ? 'partisan'
       : plan.electionType === 'nonpartisan'
-        ? 'nonpartisan'
-        : null
+      ? 'nonpartisan'
+      : null
 
   const electionTypeFragment = electionTypeLabel ? (
     <>
@@ -447,9 +454,16 @@ const PlanSections = ({
     plan.opportunities.length > 0 || plan.challenges.length > 0
   const showSection2 =
     !isStrategyError && (isStrategyGenerating || hasStrategyContent)
-  const navSections = showSection2
-    ? PLAN_SECTIONS
-    : PLAN_SECTIONS.filter((s) => s.id !== 'plan-section-2')
+  // Derive display numbers from the shared manifest so hiding Strategic
+  // Landscape renumbers the rest contiguously (1, 2, 3 … no gap) and stays
+  // in lockstep with the PDF.
+  const numberedSections = getNumberedPlanSections(showSection2)
+  const numberFor = (key: PlanSectionKey): number =>
+    numberedSections.find((s) => s.key === key)?.number ?? 0
+  const navSections: PlanSectionRef[] = numberedSections.map((s) => ({
+    id: SECTION_DOM_ID[s.key],
+    label: `${s.number}. ${s.title}`,
+  }))
 
   return (
     <div className="text-left">
@@ -459,7 +473,7 @@ const PlanSections = ({
         {/* 1. Executive Summary */}
         <Section
           id="plan-section-1"
-          number={1}
+          number={numberFor('executiveSummary')}
           title="Executive Summary"
           transition="The race is mapped by your opponents, your projected votes needed to win, and your timeline. What shapes everything else is you: the issues you're running on, the people and money you can mobilize, and where you are right now in your campaign. Continue to your Campaign Manager and we'll help rebuild this plan around you specifically."
         >
@@ -541,7 +555,7 @@ const PlanSections = ({
         {showSection2 ? (
           <Section
             id="plan-section-2"
-            number={2}
+            number={numberFor('strategicLandscape')}
             title="Strategic Landscape"
             transition="The strategic landscape is drawn from public data and historical election results. What it can't yet account for is the issues you're championing and how you stack up against your opponents. Head to your Campaign Manager to provide us with that information, and we'll reframe the opportunities and challenges around your platform."
           >
@@ -576,7 +590,7 @@ const PlanSections = ({
         {/* 3. Electoral Goals & Key Metrics */}
         <Section
           id="plan-section-3"
-          number={3}
+          number={numberFor('electoralGoals')}
           title="Electoral Goals & Key Metrics"
           transition="These projections come straight from public voter data and proprietary models. Once you confirm your platform issues in Campaign Manager, we can re-forecast against the audience you're actually targeting."
         >
@@ -639,7 +653,7 @@ const PlanSections = ({
         {/* 4. Voter Insights For Your District */}
         <Section
           id="plan-section-4"
-          number={4}
+          number={numberFor('voterInsights')}
           title="Voter Insights For Your District"
           transition="Voter insights sharpen as you fill in your platform and we layer in district-specific survey data. Update your issues in Campaign Manager and this section will re-frame around your priorities."
         >
@@ -656,7 +670,7 @@ const PlanSections = ({
         {/* 5. Projected Minimum Resources Needed */}
         <Section
           id="plan-section-5"
-          number={5}
+          number={numberFor('resources')}
           title="Projected Minimum Resources Needed"
           transition={`The $${plan.totalBudget.toLocaleString(
             'en-US',
@@ -754,7 +768,7 @@ const PlanSections = ({
         {/* 6. Campaign Timeline */}
         <Section
           id="plan-section-6"
-          number={6}
+          number={numberFor('timeline')}
           title="Campaign Timeline"
           transition="The key dates you need to know about your race have been established. What it doesn't yet reflect is your launch event, your fundraising rollout, and the issue moments you want to own. Share those with us on your Campaign Manager and we'll turn this into a working plan."
         >
@@ -782,7 +796,7 @@ const PlanSections = ({
         {/* 7. Community Engagement & Earned Media */}
         <Section
           id="plan-section-7"
-          number={7}
+          number={numberFor('community')}
           title="Community Engagement & Earned Media"
           transition="These are your highest-value rooms and your best media targets. Once you tell us why you're running and what you stand for in Campaign Manager, we can turn this list into ready-to-use talking points for each event and a press pitch you can send this week."
         >
@@ -875,7 +889,7 @@ const PlanSections = ({
         {/* 8. Voter Contact Plan */}
         <Section
           id="plan-section-8"
-          number={8}
+          number={numberFor('voterContact')}
           title="Voter Contact Plan"
           transition="This plan puts you in front of every likely voter at the right moment. But repeated exposure only converts to votes if the message is specific and credible. Once you share your issues and your story in Campaign Manager, we'll help you build the actual message for each campaign so all you need to do is schedule the campaign."
         >
@@ -926,7 +940,7 @@ const PlanSections = ({
         {/* 9. Measurement & Accountability */}
         <Section
           id="plan-section-9"
-          number={9}
+          number={numberFor('measurement')}
           title="Measurement & Accountability"
           transition="The measurement system is live in Campaign Manager. What it's measuring right now is a default campaign. Once you personalize your plan with your goals, your capacity, and your timeline, the dashboard starts tracking the campaign you're actually running, and the gap between where you are and where you need to be becomes a lot easier to read."
         >
@@ -969,7 +983,7 @@ const PlanSections = ({
         {/* 10. Methodology & Data Sources */}
         <Section
           id="plan-section-10"
-          number={10}
+          number={numberFor('methodology')}
           title="Methodology & Data Sources"
           transition="This plan was prepared by GoodParty.org's automated campaign-intelligence system and is intended as a working starting point for the campaign. All estimates should be revisited weekly as new data arrives."
         >
@@ -1051,7 +1065,11 @@ const PlanSections = ({
         </Section>
 
         {/* 11. Glossary */}
-        <Section id="plan-section-11" number={11} title="Glossary">
+        <Section
+          id="plan-section-11"
+          number={numberFor('glossary')}
+          title="Glossary"
+        >
           <PlanTable
             columns={['Term', 'Definition']}
             rows={plan.glossary.map((g) => [

--- a/app/onboarding/success/components/PlanSections.tsx
+++ b/app/onboarding/success/components/PlanSections.tsx
@@ -194,8 +194,8 @@ const TheRaceCopy = ({ plan }: { plan: PlanData }): React.JSX.Element => {
     plan.electionType === 'partisan'
       ? 'partisan'
       : plan.electionType === 'nonpartisan'
-      ? 'nonpartisan'
-      : null
+        ? 'nonpartisan'
+        : null
 
   const electionTypeFragment = electionTypeLabel ? (
     <>

--- a/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
+++ b/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
@@ -13,6 +13,10 @@ import {
   View,
 } from '@react-pdf/renderer'
 import type { PlanData } from '../components/planContent'
+import {
+  getNumberedPlanSections,
+  type PlanSectionKey,
+} from '../planSectionManifest'
 
 const FONT_OPEN_SANS = 'Open Sans'
 
@@ -486,19 +490,24 @@ type DocProps = {
 
 export type TocSection = { id: string; title: string }
 
-export const TOC_SECTIONS: TocSection[] = [
-  { id: 'exec-summary', title: 'Executive Summary' },
-  { id: 'sec-1', title: '1. Strategic Landscape' },
-  { id: 'sec-2', title: '2. Voter Insights For Your District' },
-  { id: 'sec-3', title: '3. Electoral Goals & Key Metrics' },
-  { id: 'sec-4', title: '4. Campaign Timeline' },
-  { id: 'sec-5', title: '5. Projected Minimum Resources Needed' },
-  { id: 'sec-6', title: '6. Community Engagement & Earned Media' },
-  { id: 'sec-7', title: '7. Voter Contact Plan' },
-  { id: 'sec-8', title: '8. Measurement & Accountability' },
-  { id: 'sec-9', title: '9. Methodology & Data Sources' },
-  { id: 'sec-10', title: '10. Glossary' },
-]
+// Stable PDF anchors for each section, keyed by the shared manifest. The
+// table of contents and the section pages are both ordered and numbered
+// from the manifest (see getNumberedPlanSections), so the PDF can't drift
+// from the on-screen plan and renumbers contiguously when Strategic
+// Landscape is hidden.
+const SECTION_ID: Record<PlanSectionKey, string> = {
+  executiveSummary: 'exec-summary',
+  strategicLandscape: 'strategic-landscape',
+  electoralGoals: 'electoral-goals',
+  voterInsights: 'voter-insights',
+  resources: 'resources',
+  timeline: 'timeline',
+  community: 'community',
+  voterContact: 'voter-contact',
+  measurement: 'measurement',
+  methodology: 'methodology',
+  glossary: 'glossary',
+}
 
 // Heart icon only (no wordmark). Used in the running header.
 const HeartIconSvg = ({ height = 18 }: { height?: number }) => (
@@ -774,16 +783,18 @@ const SectionPage = ({
 
 const TableOfContentsPage = ({
   plan,
+  sections,
   tocPageMap,
 }: {
   plan: PlanData
+  sections: TocSection[]
   tocPageMap: SectionPageMap | null | undefined
 }) => (
   <Page size="LETTER" style={styles.page}>
     <RunningHeader plan={plan} />
     <View style={styles.bodyStart}>
       <Text style={styles.tocHeading}>Table of Contents</Text>
-      {TOC_SECTIONS.map((section) => {
+      {sections.map((section) => {
         const pageNumber = tocPageMap?.[section.id]
         return (
           <View key={section.id} style={styles.tocRow}>
@@ -865,8 +876,8 @@ const theRaceCopy = (plan: PlanData): string => {
     plan.electionType === 'partisan'
       ? 'a partisan election'
       : plan.electionType === 'nonpartisan'
-        ? 'a nonpartisan election'
-        : 'a race'
+      ? 'a nonpartisan election'
+      : 'a race'
 
   if (plan.opponentCount === 0) {
     return `You are running for ${plan.race}${district}. As of ${plan.planGenerationDate}, the race is uncontested — we'll update this plan as we become aware of candidates entering the race. Election Day is ${plan.electionDate}. Because the electorate is small and no party cue appears on the ballot, the race is decided by name recognition and turnout, not by ideological persuasion.`
@@ -902,6 +913,20 @@ export const CampaignPlanPdfDocument = ({
 }: DocProps) => {
   const opposition = oppositionCopy(plan)
 
+  // Mirror the on-screen plan: Strategic Landscape is hidden when the
+  // strategy agent failed or returned empty (no opportunities/challenges).
+  // The download is gated until generation settles, so there's no
+  // "generating" state to consider here.
+  const showStrategicLandscape =
+    plan.opportunities.length > 0 || plan.challenges.length > 0
+  const numberedSections = getNumberedPlanSections(showStrategicLandscape)
+  const numberFor = (key: PlanSectionKey): number =>
+    numberedSections.find((s) => s.key === key)?.number ?? 0
+  const tocSections: TocSection[] = numberedSections.map((s) => ({
+    id: SECTION_ID[s.key],
+    title: `${s.number}. ${s.title}`,
+  }))
+
   return (
     <Document
       title={`Campaign plan — ${plan.candidateName || 'Candidate'}`}
@@ -910,11 +935,15 @@ export const CampaignPlanPdfDocument = ({
     >
       <CoverPage plan={plan} liveUrl={liveUrl} liveQrDataUrl={liveQrDataUrl} />
 
-      <TableOfContentsPage plan={plan} tocPageMap={tocPageMap} />
+      <TableOfContentsPage
+        plan={plan}
+        sections={tocSections}
+        tocPageMap={tocPageMap}
+      />
 
       <SectionPage
-        id="exec-summary"
-        title="Executive Summary"
+        id={SECTION_ID.executiveSummary}
+        title={`${numberFor('executiveSummary')}. Executive Summary`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro="This is the whole plan in one view. If you read nothing else, read this."
@@ -965,72 +994,52 @@ export const CampaignPlanPdfDocument = ({
         />
       </SectionPage>
 
-      <SectionPage
-        id="sec-1"
-        title="1. Strategic Landscape"
-        plan={plan}
-        onSectionPage={onSectionPage}
-        intro={`${districtLabel(
-          plan,
-        )} is an electorate where name recognition and turnout (not ideological persuasion) decide most races. The following opportunities and challenges are framed against that reality.`}
-        transition="The strategic landscape is drawn from public data and historical election results. Head to your Campaign Manager to share your platform and your opponents, and we'll reframe these around what you stand for."
-      >
-        <View style={styles.twoColRow}>
-          <View style={styles.twoColCol}>
-            <Text style={styles.h3}>Opportunities</Text>
-            <Bullets items={plan.opportunities} />
-          </View>
-          <View style={styles.twoColCol}>
-            <Text style={styles.h3}>Challenges</Text>
-            <Bullets items={plan.challenges} />
-          </View>
-        </View>
-
-        <Text style={styles.h3}>Opposition Research</Text>
-        {opposition ? (
-          <Text style={styles.para}>{opposition}</Text>
-        ) : (
-          plan.opponents.map((opp) => (
-            <View key={opp.fullName} style={styles.para}>
-              <Text style={styles.paraBold}>{opp.fullName}</Text>
-              <Bullets
-                items={[
-                  ...(opp.partyAffiliation
-                    ? [`Party: ${opp.partyAffiliation}`]
-                    : []),
-                  ...(opp.incumbent === true ? ['Incumbent'] : []),
-                ]}
-              />
+      {showStrategicLandscape ? (
+        <SectionPage
+          id={SECTION_ID.strategicLandscape}
+          title={`${numberFor('strategicLandscape')}. Strategic Landscape`}
+          plan={plan}
+          onSectionPage={onSectionPage}
+          intro={`${districtLabel(
+            plan,
+          )} is an electorate where name recognition and turnout (not ideological persuasion) decide most races. The following opportunities and challenges are framed against that reality.`}
+          transition="The strategic landscape is drawn from public data and historical election results. Head to your Campaign Manager to share your platform and your opponents, and we'll reframe these around what you stand for."
+        >
+          <View style={styles.twoColRow}>
+            <View style={styles.twoColCol}>
+              <Text style={styles.h3}>Opportunities</Text>
+              <Bullets items={plan.opportunities} />
             </View>
-          ))
-        )}
-      </SectionPage>
+            <View style={styles.twoColCol}>
+              <Text style={styles.h3}>Challenges</Text>
+              <Bullets items={plan.challenges} />
+            </View>
+          </View>
+
+          <Text style={styles.h3}>Opposition Research</Text>
+          {opposition ? (
+            <Text style={styles.para}>{opposition}</Text>
+          ) : (
+            plan.opponents.map((opp) => (
+              <View key={opp.fullName} style={styles.para}>
+                <Text style={styles.paraBold}>{opp.fullName}</Text>
+                <Bullets
+                  items={[
+                    ...(opp.partyAffiliation
+                      ? [`Party: ${opp.partyAffiliation}`]
+                      : []),
+                    ...(opp.incumbent === true ? ['Incumbent'] : []),
+                  ]}
+                />
+              </View>
+            ))
+          )}
+        </SectionPage>
+      ) : null}
 
       <SectionPage
-        id="sec-2"
-        title="2. Voter Insights For Your District"
-        plan={plan}
-        onSectionPage={onSectionPage}
-        intro={
-          plan.voterInsightsSource === 'district'
-            ? 'The issues below come from district-level survey data on what voters here care about most right now. Personalize your platform around them in Campaign Manager.'
-            : plan.voterInsightsSource === 'candidate'
-              ? 'The issues below are the ones you flagged during onboarding. Keep them updated in Campaign Manager as your platform evolves.'
-              : 'These are common top issues in races at this level. Personalize them in Campaign Manager to align your plan with the actual race.'
-        }
-        transition="Voter insights sharpen as you fill in your platform and we layer in district-specific survey data. Update your issues in Campaign Manager and this section will re-frame around your priorities."
-      >
-        <DefinitionList
-          items={plan.voterInsightsIssues.map((i) => ({
-            title: i.title,
-            body: i.description,
-          }))}
-        />
-      </SectionPage>
-
-      <SectionPage
-        id="sec-3"
-        title="3. Electoral Goals & Key Metrics"
+        id={SECTION_ID.electoralGoals}
+        title={`${numberFor('electoralGoals')}. Electoral Goals & Key Metrics`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro={`The numbers below are projected from historical voter data and proprietary models for ${districtLabel(
@@ -1053,30 +1062,32 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-4"
-        title="4. Campaign Timeline"
+        id={SECTION_ID.voterInsights}
+        title={`${numberFor(
+          'voterInsights',
+        )}. Voter Insights For Your District`}
         plan={plan}
         onSectionPage={onSectionPage}
-        intro="Dates below are the hard gates the campaign must hit. Each is followed by an internal working deadline (one week earlier wherever possible) to preserve a buffer."
-        transition="The key dates you need to know about your race have been established. Share your launch event, fundraising rollout, and issue moments in Campaign Manager and we'll turn this into a working plan."
+        intro={
+          plan.voterInsightsSource === 'district'
+            ? 'The issues below come from district-level survey data on what voters here care about most right now. Personalize your platform around them in Campaign Manager.'
+            : plan.voterInsightsSource === 'candidate'
+            ? 'The issues below are the ones you flagged during onboarding. Keep them updated in Campaign Manager as your platform evolves.'
+            : 'These are common top issues in races at this level. Personalize them in Campaign Manager to align your plan with the actual race.'
+        }
+        transition="Voter insights sharpen as you fill in your platform and we layer in district-specific survey data. Update your issues in Campaign Manager and this section will re-frame around your priorities."
       >
-        <PlanTable
-          columns={[
-            { key: 'date', header: 'Date', width: 110, bold: true },
-            { key: 'milestone', header: 'Milestone', flex: 1.6 },
-            { key: 'notes', header: 'Notes', flex: 1.4 },
-          ]}
-          rows={plan.timeline.map((t) => ({
-            date: t.date,
-            milestone: t.milestone,
-            notes: t.notes,
+        <DefinitionList
+          items={plan.voterInsightsIssues.map((i) => ({
+            title: i.title,
+            body: i.description,
           }))}
         />
       </SectionPage>
 
       <SectionPage
-        id="sec-5"
-        title="5. Projected Minimum Resources Needed"
+        id={SECTION_ID.resources}
+        title={`${numberFor('resources')}. Projected Minimum Resources Needed`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro={`We project that you need at least ${plan.winNumber.toLocaleString(
@@ -1147,8 +1158,30 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-6"
-        title="6. Community Engagement & Earned Media"
+        id={SECTION_ID.timeline}
+        title={`${numberFor('timeline')}. Campaign Timeline`}
+        plan={plan}
+        onSectionPage={onSectionPage}
+        intro="Dates below are the hard gates the campaign must hit. Each is followed by an internal working deadline (one week earlier wherever possible) to preserve a buffer."
+        transition="The key dates you need to know about your race have been established. Share your launch event, fundraising rollout, and issue moments in Campaign Manager and we'll turn this into a working plan."
+      >
+        <PlanTable
+          columns={[
+            { key: 'date', header: 'Date', width: 110, bold: true },
+            { key: 'milestone', header: 'Milestone', flex: 1.6 },
+            { key: 'notes', header: 'Notes', flex: 1.4 },
+          ]}
+          rows={plan.timeline.map((t) => ({
+            date: t.date,
+            milestone: t.milestone,
+            notes: t.notes,
+          }))}
+        />
+      </SectionPage>
+
+      <SectionPage
+        id={SECTION_ID.community}
+        title={`${numberFor('community')}. Community Engagement & Earned Media`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro="Earned media and in-person visibility are the highest-ROI channels in a race this size. A single mention in a local outlet or a strong showing at a civic association meeting can move more voters than any paid channel at this budget."
@@ -1199,8 +1232,8 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-7"
-        title="7. Voter Contact Plan"
+        id={SECTION_ID.voterContact}
+        title={`${numberFor('voterContact')}. Voter Contact Plan`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro="The contact cadence below is designed so that every likely voter receives at least 1 introductory contact, 1 persuasion contact, 1 early-vote reminder, and 1 Election Day push. Texts are the primary workhorse; robocalls layer on top to catch landline-only voters."
@@ -1239,8 +1272,8 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-8"
-        title="8. Measurement & Accountability"
+        id={SECTION_ID.measurement}
+        title={`${numberFor('measurement')}. Measurement & Accountability`}
         plan={plan}
         onSectionPage={onSectionPage}
         transition="The measurement system is live in Campaign Manager. Once you personalize your plan with your goals, capacity, and timeline, the dashboard starts tracking the campaign you're actually running."
@@ -1271,8 +1304,8 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-9"
-        title="9. Methodology & Data Sources"
+        id={SECTION_ID.methodology}
+        title={`${numberFor('methodology')}. Methodology & Data Sources`}
         plan={plan}
         onSectionPage={onSectionPage}
         intro="This plan was produced by GoodParty.org using public voter data, historical election results, and our proprietary models. Every metric in this document is an estimate derived from the sources below."
@@ -1320,8 +1353,8 @@ export const CampaignPlanPdfDocument = ({
       </SectionPage>
 
       <SectionPage
-        id="sec-10"
-        title="10. Glossary"
+        id={SECTION_ID.glossary}
+        title={`${numberFor('glossary')}. Glossary`}
         plan={plan}
         onSectionPage={onSectionPage}
       >

--- a/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
+++ b/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
@@ -876,8 +876,8 @@ const theRaceCopy = (plan: PlanData): string => {
     plan.electionType === 'partisan'
       ? 'a partisan election'
       : plan.electionType === 'nonpartisan'
-      ? 'a nonpartisan election'
-      : 'a race'
+        ? 'a nonpartisan election'
+        : 'a race'
 
   if (plan.opponentCount === 0) {
     return `You are running for ${plan.race}${district}. As of ${plan.planGenerationDate}, the race is uncontested — we'll update this plan as we become aware of candidates entering the race. Election Day is ${plan.electionDate}. Because the electorate is small and no party cue appears on the ballot, the race is decided by name recognition and turnout, not by ideological persuasion.`
@@ -1072,8 +1072,8 @@ export const CampaignPlanPdfDocument = ({
           plan.voterInsightsSource === 'district'
             ? 'The issues below come from district-level survey data on what voters here care about most right now. Personalize your platform around them in Campaign Manager.'
             : plan.voterInsightsSource === 'candidate'
-            ? 'The issues below are the ones you flagged during onboarding. Keep them updated in Campaign Manager as your platform evolves.'
-            : 'These are common top issues in races at this level. Personalize them in Campaign Manager to align your plan with the actual race.'
+              ? 'The issues below are the ones you flagged during onboarding. Keep them updated in Campaign Manager as your platform evolves.'
+              : 'These are common top issues in races at this level. Personalize them in Campaign Manager to align your plan with the actual race.'
         }
         transition="Voter insights sharpen as you fill in your platform and we layer in district-specific survey data. Update your issues in Campaign Manager and this section will re-frame around your priorities."
       >

--- a/app/onboarding/success/planSectionManifest.test.ts
+++ b/app/onboarding/success/planSectionManifest.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PLAN_SECTION_ORDER,
+  getNumberedPlanSections,
+} from './planSectionManifest'
+
+describe('plan section manifest', () => {
+  it('lists the canonical 11 sections in ClickUp-template order', () => {
+    expect(PLAN_SECTION_ORDER.map((s) => s.key)).toEqual([
+      'executiveSummary',
+      'strategicLandscape',
+      'electoralGoals',
+      'voterInsights',
+      'resources',
+      'timeline',
+      'community',
+      'voterContact',
+      'measurement',
+      'methodology',
+      'glossary',
+    ])
+  })
+
+  it('marks only Strategic Landscape optional', () => {
+    const optional = PLAN_SECTION_ORDER.filter((s) => s.optional).map(
+      (s) => s.key,
+    )
+    expect(optional).toEqual(['strategicLandscape'])
+  })
+
+  describe('getNumberedPlanSections', () => {
+    it('numbers all 11 sections 1..11 when Strategic Landscape is shown', () => {
+      const sections = getNumberedPlanSections(true)
+      expect(sections.map((s) => [s.key, s.number])).toEqual([
+        ['executiveSummary', 1],
+        ['strategicLandscape', 2],
+        ['electoralGoals', 3],
+        ['voterInsights', 4],
+        ['resources', 5],
+        ['timeline', 6],
+        ['community', 7],
+        ['voterContact', 8],
+        ['measurement', 9],
+        ['methodology', 10],
+        ['glossary', 11],
+      ])
+    })
+
+    it('drops Strategic Landscape and renumbers contiguously when hidden', () => {
+      const sections = getNumberedPlanSections(false)
+      // No gap at 2: Electoral Goals shifts up into the vacated slot.
+      expect(sections.map((s) => [s.key, s.number])).toEqual([
+        ['executiveSummary', 1],
+        ['electoralGoals', 2],
+        ['voterInsights', 3],
+        ['resources', 4],
+        ['timeline', 5],
+        ['community', 6],
+        ['voterContact', 7],
+        ['measurement', 8],
+        ['methodology', 9],
+        ['glossary', 10],
+      ])
+      expect(sections.some((s) => s.key === 'strategicLandscape')).toBe(false)
+    })
+  })
+})

--- a/app/onboarding/success/planSectionManifest.ts
+++ b/app/onboarding/success/planSectionManifest.ts
@@ -1,0 +1,56 @@
+// Single source of truth for the campaign-plan section order, titles, and
+// numbering. Both the on-screen plan (`components/PlanSections.tsx`) and the
+// downloadable PDF (`pdf/CampaignPlanPdfDocument.tsx`) derive their ordering,
+// titles, and 1-based numbering from this list so the two views can't drift
+// apart. Order matches the ClickUp campaign-plan template (the product
+// source of truth).
+
+export type PlanSectionKey =
+  | 'executiveSummary'
+  | 'strategicLandscape'
+  | 'electoralGoals'
+  | 'voterInsights'
+  | 'resources'
+  | 'timeline'
+  | 'community'
+  | 'voterContact'
+  | 'measurement'
+  | 'methodology'
+  | 'glossary'
+
+export interface PlanSectionDef {
+  key: PlanSectionKey
+  title: string
+  // Strategic Landscape is the only section that can be hidden — it drops
+  // out when the strategy agent fails or returns empty. Every other section
+  // always renders.
+  optional?: boolean
+}
+
+export const PLAN_SECTION_ORDER: readonly PlanSectionDef[] = [
+  { key: 'executiveSummary', title: 'Executive Summary' },
+  { key: 'strategicLandscape', title: 'Strategic Landscape', optional: true },
+  { key: 'electoralGoals', title: 'Electoral Goals & Key Metrics' },
+  { key: 'voterInsights', title: 'Voter Insights For Your District' },
+  { key: 'resources', title: 'Projected Minimum Resources Needed' },
+  { key: 'timeline', title: 'Campaign Timeline' },
+  { key: 'community', title: 'Community Engagement & Earned Media' },
+  { key: 'voterContact', title: 'Voter Contact Plan' },
+  { key: 'measurement', title: 'Measurement & Accountability' },
+  { key: 'methodology', title: 'Methodology & Data Sources' },
+  { key: 'glossary', title: 'Glossary' },
+]
+
+export interface NumberedPlanSection extends PlanSectionDef {
+  number: number
+}
+
+// Returns the visible sections in order, each carrying its 1-based display
+// number. When Strategic Landscape is hidden, the sections after it shift up
+// so numbering stays contiguous (1, 2, 3 … with no gap).
+export const getNumberedPlanSections = (
+  showStrategicLandscape: boolean,
+): NumberedPlanSection[] =>
+  PLAN_SECTION_ORDER.filter(
+    (section) => showStrategicLandscape || !section.optional,
+  ).map((section, index) => ({ ...section, number: index + 1 }))


### PR DESCRIPTION
## What

Introduces a shared `app/onboarding/success/planSectionManifest.ts` as the single source of truth for campaign-plan section order, titles, and 1-based numbering. Both the on-screen plan (`components/PlanSections.tsx`) and the downloadable PDF (`pdf/CampaignPlanPdfDocument.tsx`) now derive their ordering and numbering from it.

## Why

The PDF and the on-screen plan had drifted apart:

- **Different section order.** The PDF placed Voter Insights before Electoral Goals and Campaign Timeline before Projected Resources — the reverse of the on-screen order.
- **Different numbering.** The PDF started numbering at Strategic Landscape (Executive Summary was unnumbered), so every section number was off by one versus the screen.
- **Strategic Landscape handling.** On screen, Strategic Landscape is hidden when the strategy agent fails or returns empty, and the remaining sections renumber contiguously. The PDF always rendered it.

ENG-10314 asked to align the two. With a shared manifest the views can't drift again.

## Changes

- New `planSectionManifest.ts`: canonical 11-section order matching the ClickUp template, with `getNumberedPlanSections(showStrategicLandscape)` returning visible sections with contiguous 1-based numbers.
- `PlanSections.tsx`: nav + section numbers derived from the manifest; stable DOM ids decoupled from display numbers.
- `CampaignPlanPdfDocument.tsx`: reordered to match the screen, TOC + section titles/numbers derived from the manifest, and Strategic Landscape now hidden (with contiguous renumbering) when there are no opportunities/challenges — mirroring the screen.
- New `planSectionManifest.test.ts`: covers canonical order, the optional-only-Strategic-Landscape rule, and contiguous renumbering when hidden.

## Verification

- `npm run types` clean
- `npx eslint` clean on touched files (one pre-existing `<img>` warning, unrelated)
- `npx prettier --check` clean
- `npx vitest run` manifest test 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible PDF layout, TOC anchor ids, and section numbering; behavior is covered by new manifest tests but PDF two-pass TOC depends on the new ids matching between renders.
> 
> **Overview**
> Adds **`planSectionManifest.ts`** as the shared source for campaign-plan section order, titles, and **contiguous 1-based numbering** (including when **Strategic Landscape** is omitted).
> 
> **On-screen plan** (`PlanSections.tsx`) drops the hard-coded nav list and drives section labels and nav from `getNumberedPlanSections(showSection2)`, while keeping fixed `plan-section-*` DOM ids for anchors.
> 
> **PDF** (`CampaignPlanPdfDocument.tsx`) is reordered to match the screen, builds the TOC from the same manifest, numbers **Executive Summary** like other sections, conditionally omits Strategic Landscape when there are no opportunities/challenges, and uses stable semantic section anchor ids instead of the old `sec-*` / static `TOC_SECTIONS` list.
> 
> **`planSectionManifest.test.ts`** covers canonical order, optional-only Strategic Landscape, and renumbering when hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037a110af3e5b10a3048ee3828e73a29408577d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->