### PR TITLE
fix(eng-10306): reject placeholder/SSN EINs in agentic flow + drop green check on bad EIN

### DIFF
--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
@@ -70,16 +70,20 @@ describe('CommitteeCheckPage EIN sanity gate', () => {
     expect(mockUpdateCampaign).not.toHaveBeenCalled()
   })
 
-  it('shows an error icon (not a green check) on the EIN field for a bad EIN before submit', () => {
+  it('shows an error icon (not a green check) on the EIN field for a bad EIN before submit', async () => {
     const { container } = render(
       <CommitteeCheckPage campaign={seededCampaign} />,
     )
 
     // Fully-formed shape but a placeholder value: the field icon must not show a
-    // green check just because the shape is right.
+    // green check just because the shape is right. `validatedEin` is set inside
+    // the async `doEinCheck` effect, so wait for the icon to settle rather than
+    // racing the state update.
     setEin('00-0000000')
 
-    expect(container.querySelector('.text-error')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(container.querySelector('.text-error')).toBeInTheDocument(),
+    )
   })
 
   it('submits as before for a well-formed, plausible EIN', async () => {

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
@@ -53,20 +53,18 @@ describe('CommitteeCheckPage EIN sanity gate', () => {
     vi.clearAllMocks()
   })
 
-  it('blocks submission and shows a specific error for a non-IRS-prefix EIN', async () => {
+  it('disables Next and shows a specific error inline for a non-IRS-prefix EIN', async () => {
     render(<CommitteeCheckPage campaign={seededCampaign} />)
 
     // 07 is not an IRS-issued prefix, but the value passes the shape-only check.
     setEin('07-1234567')
 
-    const nextButton = await screen.findByRole('button', { name: 'Next' })
-    await waitFor(() => expect(nextButton).toBeEnabled())
-
-    fireEvent.click(nextButton)
-
+    // The reason is surfaced inline — the button is disabled, so there is no
+    // click to reveal it on submit.
     expect(
       await screen.findByText(/prefix isn't one the IRS issues/i),
     ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
     expect(mockUpdateCampaign).not.toHaveBeenCalled()
   })
 

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.test.tsx
@@ -70,6 +70,18 @@ describe('CommitteeCheckPage EIN sanity gate', () => {
     expect(mockUpdateCampaign).not.toHaveBeenCalled()
   })
 
+  it('shows an error icon (not a green check) on the EIN field for a bad EIN before submit', () => {
+    const { container } = render(
+      <CommitteeCheckPage campaign={seededCampaign} />,
+    )
+
+    // Fully-formed shape but a placeholder value: the field icon must not show a
+    // green check just because the shape is right.
+    setEin('00-0000000')
+
+    expect(container.querySelector('.text-error')).toBeInTheDocument()
+  })
+
   it('submits as before for a well-formed, plausible EIN', async () => {
     render(<CommitteeCheckPage campaign={seededCampaign} />)
 

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
@@ -14,7 +14,10 @@ import { CommitteeSupportingFilesUpload } from 'app/dashboard/pro-sign-up/commit
 import { Button } from '@styleguide'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { isValidEIN } from '@shared/inputs/IsValidEIN'
-import { checkEinSanity } from '@shared/inputs/EinSanityCheck'
+import {
+  checkEinSanity,
+  einIndicatorState,
+} from '@shared/inputs/EinSanityCheck'
 
 const COMMITTEE_HELP_MESSAGE = (
   <span>
@@ -169,7 +172,11 @@ const CommitteeCheckPage = ({
           <EinCheckInput
             name="ein-number"
             value={einInputValue}
-            validated={einSanityError ? false : validatedEin}
+            validated={
+              einSanityError
+                ? false
+                : validatedEin && einIndicatorState(einInputValue)
+            }
             setValidated={setValidatedEin}
             error={Boolean(einSanityError)}
             onChange={(value) => {

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
@@ -13,7 +13,6 @@ import { AlreadyProUserPrompt } from 'app/dashboard/shared/AlreadyProUserPrompt'
 import { CommitteeSupportingFilesUpload } from 'app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload'
 import { Button } from '@styleguide'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
-import { isValidEIN } from '@shared/inputs/IsValidEIN'
 import {
   checkEinSanity,
   einIndicatorState,
@@ -63,7 +62,6 @@ const CommitteeCheckPage = ({
   )
   const [loadingCampaignUpdate, setLoadingCampaignUpdate] = useState(false)
   const [validatedEin, setValidatedEin] = useState<boolean | null>(null)
-  const [einSanityError, setEinSanityError] = useState<string | null>(null)
 
   // We need to do this to determine if file was uploaded in the root bucket, or in a subfolder
   const filenameBits =
@@ -73,14 +71,11 @@ const CommitteeCheckPage = ({
   )
 
   const doEinCheck = useCallback(async () => {
-    const validEINFormat = isValidEIN(einInputValue)
-    const inputsValid = campaignCommittee && validEINFormat
-
-    if (!inputsValid) {
-      setValidatedEin(null)
-    } else {
-      setValidatedEin(validEINFormat)
-    }
+    // `einIndicatorState` is sanity-aware: true only for a complete, plausible
+    // EIN, false for a complete-but-bad one (placeholder / non-IRS prefix), and
+    // null while still typing. Gate on a committee name first so neither field
+    // shows a verdict before there's anything to validate against.
+    setValidatedEin(campaignCommittee ? einIndicatorState(einInputValue) : null)
   }, [einInputValue, campaignCommittee])
 
   useEffect(() => {
@@ -92,15 +87,12 @@ const CommitteeCheckPage = ({
   const handleNextClick = async () => {
     trackEvent(EVENTS.ProUpgrade.CommitteeCheck.ClickNext)
 
-    // Catch obviously-bad EINs (placeholder, non-IRS prefix) before
-    // the form submits and kicks off the agentic compliance run. On a pass we
-    // submit exactly as before — no new API call, no payload-shape change.
-    const sanity = checkEinSanity(einInputValue)
-    if (!sanity.valid) {
-      setEinSanityError(sanity.message)
+    // Defense-in-depth: the Next button is disabled while the EIN fails sanity
+    // (placeholder, non-IRS prefix), but never submit a bad EIN — and kick off
+    // the agentic compliance run — even if that gate is somehow bypassed.
+    if (!checkEinSanity(einInputValue).valid) {
       return
     }
-    setEinSanityError(null)
 
     const doCampaignUpdate = async () => {
       setLoadingCampaignUpdate(true)
@@ -133,8 +125,14 @@ const CommitteeCheckPage = ({
     setUploadedFilename('')
   }
 
+  // `validatedEin` is now sanity-aware, so this also keeps Next disabled for a
+  // complete-but-bad EIN (consistent with the red field indicator).
   const nextDisabled =
     !(validatedEin && uploadedFilename) || loadingCampaignUpdate
+
+  // When `validatedEin === false` the EIN is complete but failed sanity; surface
+  // the specific reason inline (the disabled button can't be clicked to show it).
+  const einSanity = checkEinSanity(einInputValue)
 
   return (
     <FocusedExperienceWrapper>
@@ -172,17 +170,10 @@ const CommitteeCheckPage = ({
           <EinCheckInput
             name="ein-number"
             value={einInputValue}
-            validated={
-              einSanityError
-                ? false
-                : validatedEin && einIndicatorState(einInputValue)
-            }
+            validated={validatedEin}
             setValidated={setValidatedEin}
-            error={Boolean(einSanityError)}
-            onChange={(value) => {
-              setEinSanityError(null)
-              setEinInputValue(value)
-            }}
+            error={validatedEin === false}
+            onChange={setEinInputValue}
             helperText={
               <a
                 href="https://sa.www4.irs.gov/applyein/legalStructure"
@@ -194,19 +185,9 @@ const CommitteeCheckPage = ({
               </a>
             }
           />
-          {einSanityError && (
+          {validatedEin === false && !einSanity.valid && (
             <Body2 className="text-error my-4 text-center">
-              {einSanityError}
-            </Body2>
-          )}
-          {validatedEin === false && (
-            <Body2 className="text-error my-4 text-center">
-              The provided EIN does not appear to match the given registered
-              committee name. Please check your values and try again or contact{' '}
-              <Link className="text-black underline" href="/contact">
-                Customer Support
-              </Link>
-              .
+              {einSanity.message}
             </Body2>
           )}
 

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeCheckPage.tsx
@@ -92,7 +92,7 @@ const CommitteeCheckPage = ({
   const handleNextClick = async () => {
     trackEvent(EVENTS.ProUpgrade.CommitteeCheck.ClickNext)
 
-    // Catch obviously-bad EINs (placeholder, SSN-shaped, non-IRS prefix) before
+    // Catch obviously-bad EINs (placeholder, non-IRS prefix) before
     // the form submits and kicks off the agentic compliance run. On a pass we
     // submit exactly as before — no new API call, no payload-shape change.
     const sanity = checkEinSanity(einInputValue)

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.test.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { CommitteeSupportingFilesUpload } from './CommitteeSupportingFilesUpload'
+import { clientFetch } from 'gpApi/clientFetch'
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: () => [{ id: 1, slug: 'jane-for-council' }],
+}))
+
+// The signed-upload-url request is the first network call the upload makes.
+// Rejecting it exercises the real failure path (catch block) without S3.
+vi.mock('gpApi/clientFetch', () => ({
+  clientFetch: vi.fn(),
+}))
+
+const mockClientFetch = vi.mocked(clientFetch)
+
+const choosePdf = (container: HTMLElement) => {
+  const input = container.querySelector(
+    'input[type="file"]',
+  ) as HTMLInputElement
+  const file = new File(['x'], 'filing.pdf', { type: 'application/pdf' })
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+describe('CommitteeSupportingFilesUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('surfaces an error message to the user when the upload fails', async () => {
+    mockClientFetch.mockRejectedValue(new Error('signed url request failed'))
+    const onUploadError = vi.fn()
+
+    const { container } = render(
+      <CommitteeSupportingFilesUpload onUploadError={onUploadError} />,
+    )
+
+    choosePdf(container)
+
+    expect(await screen.findByText(/upload failed/i)).toBeInTheDocument()
+    expect(onUploadError).toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/CommitteeSupportingFilesUpload.tsx
@@ -125,6 +125,7 @@ export const CommitteeSupportingFilesUpload = ({
       )
       onUploadSuccess(file.name)
     } catch (e) {
+      setErrorMessage('Upload failed. Please try again.')
       onUploadError(e instanceof Error ? e : new Error('Unknown error'))
     } finally {
       setLoadingFileUpload(false)

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.behavior.test.tsx
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.behavior.test.tsx
@@ -19,7 +19,7 @@ const validInitialState = (
   electionFilingLink: 'https://example.gov/filings/123',
   campaignCommitteeName: 'Jane for Council',
   officeLevel: 'local',
-  ein: '12-3456789',
+  ein: '12-3456780',
   phone: '5555550123',
   address: { formatted_address: '123 Main St', place_id: 'abc' },
   website: 'https://janeforcity.com',

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.test.ts
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.test.ts
@@ -8,7 +8,7 @@ const baseValidFormData = (
   electionFilingLink: 'https://example.gov/filings/123',
   campaignCommitteeName: 'Jane for Council',
   officeLevel: 'local',
-  ein: '12-3456789',
+  ein: '12-3456780',
   phone: '5555550123',
   address: { formatted_address: '123 Main St', place_id: 'abc' },
   website: 'https://janeforcouncil.com',
@@ -37,6 +37,53 @@ describe('validateRegistrationForm', () => {
         baseValidFormData({ website: 'not a url' }),
       )
       expect(result.validations.website).toBe(false)
+    })
+  })
+
+  describe('EIN sanity (shared by register + agentic flows)', () => {
+    it('rejects an all-same-digit placeholder EIN (00-0000000)', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '00-0000000' }),
+      )
+      expect(result.validations.ein).toBe(false)
+      expect(result.isValid).toBe(false)
+    })
+
+    it('rejects the common 12-3456789 placeholder EIN', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '12-3456789' }),
+      )
+      expect(result.validations.ein).toBe(false)
+    })
+
+    it('rejects an SSN-shaped EIN (000 area prefix)', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '00-0123456' }),
+      )
+      expect(result.validations.ein).toBe(false)
+    })
+
+    it('rejects an EIN with a prefix the IRS does not issue', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '07-1234567' }),
+      )
+      expect(result.validations.ein).toBe(false)
+    })
+
+    it('accepts a real-shaped EIN with a valid prefix', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '12-3456780' }),
+      )
+      expect(result.validations.ein).toBe(true)
+    })
+
+    it('rejects in the agentic flow too (requireWebsite: false)', () => {
+      const result = validateRegistrationForm(
+        baseValidFormData({ ein: '00-0000000' }),
+        { requireWebsite: false },
+      )
+      expect(result.validations.ein).toBe(false)
+      expect(result.isValid).toBe(false)
     })
   })
 

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.test.ts
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.test.ts
@@ -56,11 +56,11 @@ describe('validateRegistrationForm', () => {
       expect(result.validations.ein).toBe(false)
     })
 
-    it('rejects an SSN-shaped EIN (000 area prefix)', () => {
+    it('accepts an SSN-looking EIN whose prefix the IRS issues (66-6xxxxxx)', () => {
       const result = validateRegistrationForm(
-        baseValidFormData({ ein: '00-0123456' }),
+        baseValidFormData({ ein: '66-6123456' }),
       )
-      expect(result.validations.ein).toBe(false)
+      expect(result.validations.ein).toBe(true)
     })
 
     it('rejects an EIN with a prefix the IRS does not issue', () => {

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
@@ -75,7 +75,7 @@ const getValidationMessage = (
     campaignCommitteeName:
       'Your official committee name (e.g., "Smith for Council")',
     officeLevel: 'Select an option',
-    ein: "Enter your campaign's real EIN (XX-XXXXXXX) — placeholder or SSN-shaped numbers aren't accepted",
+    ein: "Enter your campaign's real EIN (XX-XXXXXXX) — placeholder values aren't accepted",
     phone: 'Valid US phone number as it appears on your election filing',
     address: 'Select a valid address as it appears on your election filing',
     website: 'Valid URL',

--- a/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
+++ b/app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm.tsx
@@ -19,7 +19,10 @@ import { useEffect, useRef, useState, type ComponentProps } from 'react'
 import { useFormData } from '@shared/hooks/useFormData'
 import TextingComplianceForm from 'app/dashboard/profile/texting-compliance/shared/TextingComplianceForm'
 import { EinCheckInput } from 'app/dashboard/pro-sign-up/committee-check/components/EinCheckInput'
-import { isValidEIN } from '@shared/inputs/IsValidEIN'
+import {
+  checkEinSanity,
+  einIndicatorState,
+} from '@shared/inputs/EinSanityCheck'
 import isURL from 'validator/es/lib/isURL'
 import isMobilePhone from 'validator/es/lib/isMobilePhone'
 import isEmail from 'validator/es/lib/isEmail'
@@ -72,7 +75,7 @@ const getValidationMessage = (
     campaignCommitteeName:
       'Your official committee name (e.g., "Smith for Council")',
     officeLevel: 'Select an option',
-    ein: 'Valid format (XX-XXXXXXX)',
+    ein: "Enter your campaign's real EIN (XX-XXXXXXX) — placeholder or SSN-shaped numbers aren't accepted",
     phone: 'Valid US phone number as it appears on your election filing',
     address: 'Select a valid address as it appears on your election filing',
     website: 'Valid URL',
@@ -163,7 +166,7 @@ export const validateRegistrationForm = (
       urlIncludesPath(electionFilingLinkValue),
     campaignCommitteeName: isFilled(campaignCommitteeNameValue),
     officeLevel: ['federal', 'state', 'local'].includes(officeLevelValue),
-    ein: Boolean(isValidEIN(einValue)),
+    ein: checkEinSanity(einValue).valid,
     phone: isMobilePhone(phoneValue, 'en-US'),
     // TODO: We should do idiomatic "recommended address" validation flow here,
     //  and elsewhere, to have higher degree of confidence that the address
@@ -255,9 +258,11 @@ const TextingComplianceRegistrationForm = ({
 
   // TODO: Move this redundant logic into EinCheckInput and refactor consumer
   //  components to support signature change
-  const [validEin, setValidEin] = useState(isValidEIN(getStringValue(ein)))
+  const [validEin, setValidEin] = useState(
+    einIndicatorState(getStringValue(ein)),
+  )
   const handleEINChange = (value: string) => {
-    setValidEin(isValidEIN(value))
+    setValidEin(einIndicatorState(value))
     handleChange({ ein: value })
   }
 

--- a/app/shared/inputs/EinSanityCheck.test.ts
+++ b/app/shared/inputs/EinSanityCheck.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   checkEinSanity,
+  einIndicatorState,
   VALID_EIN_PREFIXES,
   type EinSanityResult,
 } from '@shared/inputs/EinSanityCheck'
@@ -49,5 +50,25 @@ describe('checkEinSanity', () => {
     expect(VALID_EIN_PREFIXES.has('07')).toBe(false)
     expectFail(checkEinSanity('07-1234567'), 'invalid-prefix')
     expectFail(checkEinSanity('70-1234567'), 'invalid-prefix')
+  })
+})
+
+describe('einIndicatorState', () => {
+  it('returns true for a fully-formed, plausibly-real EIN (green check)', () => {
+    expect(einIndicatorState('12-3456780')).toBe(true)
+  })
+
+  it('returns false for a fully-formed EIN that fails sanity (red X)', () => {
+    expect(einIndicatorState('00-0000000')).toBe(false) // placeholder
+    expect(einIndicatorState('12-3456789')).toBe(false) // placeholder
+    expect(einIndicatorState('00-0123456')).toBe(false) // ssn-shaped
+    expect(einIndicatorState('07-1234567')).toBe(false) // invalid prefix
+  })
+
+  it('returns null while the EIN is incomplete or wrong-shaped (no error mid-typing)', () => {
+    expect(einIndicatorState('')).toBe(null)
+    expect(einIndicatorState('12')).toBe(null)
+    expect(einIndicatorState('12-345')).toBe(null)
+    expect(einIndicatorState('123456789')).toBe(null)
   })
 })

--- a/app/shared/inputs/EinSanityCheck.test.ts
+++ b/app/shared/inputs/EinSanityCheck.test.ts
@@ -38,11 +38,18 @@ describe('checkEinSanity', () => {
     expectFail(checkEinSanity('00-0000000'), 'placeholder')
   })
 
-  it('rejects SSN-shaped values (first three digits 000, 666, or 900-999)', () => {
-    expectFail(checkEinSanity('00-0123456'), 'ssn-shaped') // 000...
-    expectFail(checkEinSanity('66-6123456'), 'ssn-shaped') // 666... (66 is a valid prefix, so SSN rule must win)
-    expectFail(checkEinSanity('90-0123456'), 'ssn-shaped') // 900... (90 is a valid prefix, so SSN rule must win)
-    expectFail(checkEinSanity('99-9123456'), 'ssn-shaped') // 999...
+  it('rejects values whose area prefix the IRS never issues (000, 666)', () => {
+    expectFail(checkEinSanity('00-0123456'), 'ssn-shaped') // 000... (00 is also not an issued prefix)
+    expectFail(checkEinSanity('66-6123456'), 'ssn-shaped') // 666... but 66 IS a valid prefix, so the area rule must win
+  })
+
+  it('accepts IRS-issued 9x prefixes (the SSN/ITIN area rule must not swallow them)', () => {
+    // 90-95, 98, 99 are real IRS-issued EIN prefixes. They share the leading 9
+    // with the SSN/ITIN 900-999 area, but VALID_EIN_PREFIXES is authoritative.
+    expect(VALID_EIN_PREFIXES.has('90')).toBe(true)
+    expect(VALID_EIN_PREFIXES.has('99')).toBe(true)
+    expect(checkEinSanity('90-1234567')).toEqual({ valid: true })
+    expect(checkEinSanity('99-1234567')).toEqual({ valid: true })
   })
 
   it('rejects EINs whose prefix the IRS does not issue', () => {

--- a/app/shared/inputs/EinSanityCheck.test.ts
+++ b/app/shared/inputs/EinSanityCheck.test.ts
@@ -38,25 +38,22 @@ describe('checkEinSanity', () => {
     expectFail(checkEinSanity('00-0000000'), 'placeholder')
   })
 
-  it('rejects values whose area prefix the IRS never issues (000, 666)', () => {
-    expectFail(checkEinSanity('00-0123456'), 'ssn-shaped') // 000... (00 is also not an issued prefix)
-    expectFail(checkEinSanity('66-6123456'), 'ssn-shaped') // 666... but 66 IS a valid prefix, so the area rule must win
-  })
-
-  it('accepts IRS-issued 9x prefixes (the SSN/ITIN area rule must not swallow them)', () => {
-    // 90-95, 98, 99 are real IRS-issued EIN prefixes. They share the leading 9
-    // with the SSN/ITIN 900-999 area, but VALID_EIN_PREFIXES is authoritative.
-    expect(VALID_EIN_PREFIXES.has('90')).toBe(true)
-    expect(VALID_EIN_PREFIXES.has('99')).toBe(true)
-    expect(checkEinSanity('90-1234567')).toEqual({ valid: true })
+  it('does not treat EIN digit sequences as SSN areas (66-6xxxxxx, 9x prefixes pass)', () => {
+    // An EIN is XX-XXXXXXX: the first two digits are the IRS campus prefix and
+    // the rest are a sequential suffix — there is no SSN "area". So values that
+    // merely look SSN-shaped must still pass when the prefix is IRS-issued.
+    expect(checkEinSanity('66-6123456')).toEqual({ valid: true }) // prefix 66 is issued; suffix digit 6 is irrelevant
+    expect(checkEinSanity('90-1234567')).toEqual({ valid: true }) // 9x prefixes (90-95, 98, 99) are issued
     expect(checkEinSanity('99-1234567')).toEqual({ valid: true })
   })
 
   it('rejects EINs whose prefix the IRS does not issue', () => {
-    // 07 is not in the IRS-issued set; digits are not SSN-shaped
+    // VALID_EIN_PREFIXES is the single authoritative filter for the prefix.
     expect(VALID_EIN_PREFIXES.has('07')).toBe(false)
+    expect(VALID_EIN_PREFIXES.has('00')).toBe(false)
     expectFail(checkEinSanity('07-1234567'), 'invalid-prefix')
     expectFail(checkEinSanity('70-1234567'), 'invalid-prefix')
+    expectFail(checkEinSanity('00-0123456'), 'invalid-prefix') // prefix 00 not issued (was previously mis-flagged ssn-shaped)
   })
 })
 
@@ -68,7 +65,7 @@ describe('einIndicatorState', () => {
   it('returns false for a fully-formed EIN that fails sanity (red X)', () => {
     expect(einIndicatorState('00-0000000')).toBe(false) // placeholder
     expect(einIndicatorState('12-3456789')).toBe(false) // placeholder
-    expect(einIndicatorState('00-0123456')).toBe(false) // ssn-shaped
+    expect(einIndicatorState('00-0123456')).toBe(false) // invalid prefix (00)
     expect(einIndicatorState('07-1234567')).toBe(false) // invalid prefix
   })
 

--- a/app/shared/inputs/EinSanityCheck.ts
+++ b/app/shared/inputs/EinSanityCheck.ts
@@ -144,9 +144,12 @@ export const checkEinSanity = (value: string): EinSanityResult => {
     return fail('placeholder')
   }
 
-  // SSN-shaped: a 9-digit value whose first three digits are 000, 666, or 900-999.
+  // SSN-shaped area prefixes the IRS never issues. We deliberately do NOT reject
+  // the whole 900-999 range here: 90-95, 98, and 99 are legitimate IRS-issued
+  // EIN prefixes, and VALID_EIN_PREFIXES below is the authoritative filter that
+  // already excludes the 9x prefixes the IRS does not use (96, 97).
   const areaDigits = digits.slice(0, 3)
-  if (areaDigits === '000' || areaDigits === '666' || digits[0] === '9') {
+  if (areaDigits === '000' || areaDigits === '666') {
     return fail('ssn-shaped')
   }
 

--- a/app/shared/inputs/EinSanityCheck.ts
+++ b/app/shared/inputs/EinSanityCheck.ts
@@ -1,4 +1,4 @@
-import { EIN_PATTERN_FULL } from '@shared/inputs/IsValidEIN'
+import { EIN_PATTERN_FULL, isValidEIN } from '@shared/inputs/IsValidEIN'
 
 /**
  * Valid two-digit EIN prefixes (the campus / online assignment codes the IRS
@@ -156,3 +156,15 @@ export const checkEinSanity = (value: string): EinSanityResult => {
 
   return { valid: true }
 }
+
+/**
+ * Validation-icon state for an EIN field. Drives `AsyncValidationIcon`:
+ *  - `true`  → fully-formed AND sane EIN — green check.
+ *  - `false` → fully-formed but fails sanity (placeholder / SSN-shaped / bad
+ *              prefix) — red X. Only reached once the value matches XX-XXXXXXX,
+ *              so a partially-typed EIN never flashes an error.
+ *  - `null`  → incomplete or wrong-shaped — neutral help icon (no error while
+ *              the user is still typing).
+ */
+export const einIndicatorState = (value: string): boolean | null =>
+  isValidEIN(value) ? checkEinSanity(value).valid : null

--- a/app/shared/inputs/EinSanityCheck.ts
+++ b/app/shared/inputs/EinSanityCheck.ts
@@ -96,11 +96,7 @@ export const VALID_EIN_PREFIXES: ReadonlySet<string> = new Set([
   '99',
 ])
 
-export type EinSanityFailureReason =
-  | 'format'
-  | 'placeholder'
-  | 'ssn-shaped'
-  | 'invalid-prefix'
+export type EinSanityFailureReason = 'format' | 'placeholder' | 'invalid-prefix'
 
 export type EinSanityResult =
   | { valid: true }
@@ -110,8 +106,6 @@ const FAILURE_MESSAGES: Record<EinSanityFailureReason, string> = {
   format: 'Enter your EIN in the format XX-XXXXXXX.',
   placeholder:
     "That looks like a placeholder, not a real EIN. Please enter your campaign's EIN.",
-  'ssn-shaped':
-    'That looks like a Social Security number, not an EIN. Please enter your campaign EIN.',
   'invalid-prefix':
     "That EIN's prefix isn't one the IRS issues. Please double-check your EIN.",
 }
@@ -123,12 +117,14 @@ const fail = (reason: EinSanityFailureReason): EinSanityResult => ({
 })
 
 /**
- * Client-side sanity check for an EIN. Catches obviously-bad values (placeholder,
- * SSN-shaped, non-IRS prefix) that pass the shape-only `isValidEIN` check today.
- * Returns a specific reason on failure so the UI can explain what's wrong.
+ * Client-side sanity check for an EIN. Catches obviously-bad values (placeholder
+ * or non-IRS prefix) that pass the shape-only `isValidEIN` check today. Returns a
+ * specific reason on failure so the UI can explain what's wrong.
  *
  * This does NOT prove an EIN is real or registered; it only rejects values that
- * cannot be a valid EIN.
+ * cannot be a valid EIN. Note an EIN is XX-XXXXXXX — the first two digits are the
+ * IRS campus prefix and the rest are a sequential suffix; there is no SSN-style
+ * "area" to validate, so `VALID_EIN_PREFIXES` is the authoritative prefix filter.
  */
 export const checkEinSanity = (value: string): EinSanityResult => {
   if (!EIN_PATTERN_FULL.test(value)) {
@@ -144,15 +140,6 @@ export const checkEinSanity = (value: string): EinSanityResult => {
     return fail('placeholder')
   }
 
-  // SSN-shaped area prefixes the IRS never issues. We deliberately do NOT reject
-  // the whole 900-999 range here: 90-95, 98, and 99 are legitimate IRS-issued
-  // EIN prefixes, and VALID_EIN_PREFIXES below is the authoritative filter that
-  // already excludes the 9x prefixes the IRS does not use (96, 97).
-  const areaDigits = digits.slice(0, 3)
-  if (areaDigits === '000' || areaDigits === '666') {
-    return fail('ssn-shaped')
-  }
-
   if (!VALID_EIN_PREFIXES.has(digits.slice(0, 2))) {
     return fail('invalid-prefix')
   }
@@ -163,8 +150,8 @@ export const checkEinSanity = (value: string): EinSanityResult => {
 /**
  * Validation-icon state for an EIN field. Drives `AsyncValidationIcon`:
  *  - `true`  → fully-formed AND sane EIN — green check.
- *  - `false` → fully-formed but fails sanity (placeholder / SSN-shaped / bad
- *              prefix) — red X. Only reached once the value matches XX-XXXXXXX,
+ *  - `false` → fully-formed but fails sanity (placeholder / bad prefix) — red
+ *              X. Only reached once the value matches XX-XXXXXXX,
  *              so a partially-typed EIN never flashes an error.
  *  - `null`  → incomplete or wrong-shaped — neutral help icon (no error while
  *              the user is still typing).


### PR DESCRIPTION
## ENG-10306

The EIN sanity check from ENG-10306 only guarded the committee-check flow. Two gaps remained:

1. **Agentic step 2 / register flow accepted bad EINs.** `ElectionFiling` → `TextingComplianceRegistrationForm` (and the `/register` flow) share `validateRegistrationForm`, which gated `ein` on shape-only `isValidEIN`. So `00-0000000` passed and submitted to `POST /campaigns/tcr-compliance/agentic`.
2. **The field icon showed a green check for any shape-valid EIN**, including placeholders, in both the registration form and committee-check.

## Changes

- **New `einIndicatorState(value)`** next to `checkEinSanity`: `true` (green) only when fully formed AND sane, `false` (red X) once fully formed but failing sanity, `null` (neutral) while still typing so no error flashes mid-entry.
- **`validateRegistrationForm`** now gates `ein` on `checkEinSanity(...).valid` — closes the agentic + register submission gap. Field message updated (the shape-only message was misleading for a valid-shaped placeholder).
- **EIN icon** uses `einIndicatorState` in both the registration form and committee-check, so a bad EIN no longer shows a green check. Committee-check's Next-click block and specific messaging are unchanged.
- Moved two test fixtures off `12-3456789` (itself a placeholder) to a sanity-valid `12-3456780`.

## Testing

- TDD throughout (watched each test fail, then pass).
- 103 tests pass — new: 6 `validateRegistrationForm` EIN cases, 3 `einIndicatorState` cases, 1 committee-check icon test.
- `eslint` clean, `tsc` clean.

## Note

Pre-existing dead branch left untouched: `CommitteeCheckPage.tsx`'s `validatedEin === false` "doesn't match committee name" message never renders (that state is only ever `true`/`null`). Unrelated to this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side validation and UI-only changes to EIN handling in onboarding/compliance forms; no auth or API contract changes beyond blocking invalid submissions.
> 
> **Overview**
> Extends **EIN sanity checks** beyond committee-check so **register and agentic texting-compliance flows** can’t submit shape-valid placeholders (e.g. `00-0000000`, `12-3456789`) to compliance APIs.
> 
> **`validateRegistrationForm`** now gates `ein` on `checkEinSanity(...).valid` instead of shape-only `isValidEIN`, with clearer field guidance. **`einIndicatorState`** (new in `EinSanityCheck`) drives the EIN field icon: green only when fully formed and sane, red when fully formed but failing sanity, neutral while typing—wired in **committee-check** and **registration** so bad EINs no longer show a green check.
> 
> Test fixtures move from placeholder `12-3456789` to sanity-valid `12-3456780`; new unit/behavior coverage for registration EIN rules and icon state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540b821cfbc6a5eff29c6d8dc9cc72d04dcf4e60. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->