### PR TITLE
feat(pro-upgrade3): wizard shell, step-derivation router, and flag (ENG-10322)

### DIFF
--- a/app/dashboard/pro-upgrade/candidate-profile/page.tsx
+++ b/app/dashboard/pro-upgrade/candidate-profile/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Your candidate profile"
+      taskNote="Candidate-profile step — ships in task 12"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import { useQuery } from '@tanstack/react-query'
+import ProUpgradeEntry from './ProUpgradeEntry'
+
+// Mock only useQuery so we control pending vs resolved; keep the real
+// QueryClient/QueryClientProvider that the render helper relies on.
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return { ...actual, useQuery: vi.fn() }
+})
+
+const mockUseQuery = vi.mocked(useQuery)
+
+const queryResult = (isPending: boolean): ReturnType<typeof useQuery> =>
+  ({ data: null, isPending } as unknown as ReturnType<typeof useQuery>)
+
+describe('ProUpgradeEntry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a spinner and does not redirect while the queries are pending', () => {
+    mockUseQuery.mockReturnValue(queryResult(true))
+
+    render(<ProUpgradeEntry />)
+
+    // LoadingAnimation renders a "POWERED BY" marker.
+    expect(screen.getByText(/powered by/i)).toBeInTheDocument()
+    expect(router.replace).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing once the queries resolve and schedules the redirect', () => {
+    mockUseQuery.mockReturnValue(queryResult(false))
+
+    const { container } = render(<ProUpgradeEntry />)
+
+    // No canonical state → first incomplete step is the value-prop intro.
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText(/powered by/i)).not.toBeInTheDocument()
+    expect(router.replace).toHaveBeenCalledWith(
+      '/dashboard/pro-upgrade/value-prop',
+    )
+  })
+})

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -22,7 +22,7 @@ const queryResult = (
     isPending: overrides.isPending ?? false,
     isError: overrides.isError ?? false,
     refetch: vi.fn(),
-  } as unknown as ReturnType<typeof useQuery>)
+  }) as unknown as ReturnType<typeof useQuery>
 
 describe('ProUpgradeEntry', () => {
   beforeEach(() => {

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -14,8 +14,15 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 
 const mockUseQuery = vi.mocked(useQuery)
 
-const queryResult = (isPending: boolean): ReturnType<typeof useQuery> =>
-  ({ data: null, isPending } as unknown as ReturnType<typeof useQuery>)
+const queryResult = (
+  overrides: { isPending?: boolean; isError?: boolean } = {},
+): ReturnType<typeof useQuery> =>
+  ({
+    data: null,
+    isPending: overrides.isPending ?? false,
+    isError: overrides.isError ?? false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useQuery>)
 
 describe('ProUpgradeEntry', () => {
   beforeEach(() => {
@@ -23,7 +30,7 @@ describe('ProUpgradeEntry', () => {
   })
 
   it('renders a spinner and does not redirect while the queries are pending', () => {
-    mockUseQuery.mockReturnValue(queryResult(true))
+    mockUseQuery.mockReturnValue(queryResult({ isPending: true }))
 
     render(<ProUpgradeEntry />)
 
@@ -33,7 +40,7 @@ describe('ProUpgradeEntry', () => {
   })
 
   it('renders nothing once the queries resolve and schedules the redirect', () => {
-    mockUseQuery.mockReturnValue(queryResult(false))
+    mockUseQuery.mockReturnValue(queryResult())
 
     const { container } = render(<ProUpgradeEntry />)
 
@@ -43,5 +50,19 @@ describe('ProUpgradeEntry', () => {
     expect(router.replace).toHaveBeenCalledWith(
       '/dashboard/pro-upgrade/value-prop',
     )
+  })
+
+  it('shows a recoverable error and does not redirect when a query fails', () => {
+    // A failed fetch leaves data undefined; redirecting would mis-derive a
+    // returning candidate back to the intro as if they had zero progress.
+    mockUseQuery.mockReturnValue(queryResult({ isError: true }))
+
+    render(<ProUpgradeEntry />)
+
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /try again/i }),
+    ).toBeInTheDocument()
+    expect(router.replace).not.toHaveBeenCalled()
   })
 })

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
@@ -3,6 +3,9 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
+import { Button } from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
 import {
@@ -28,19 +31,33 @@ const ProUpgradeEntry = (): React.JSX.Element | null => {
   const router = useRouter()
   const [campaign] = useCampaign()
 
-  const { data: website, isPending: websitePending } = useQuery({
+  const {
+    data: website,
+    isPending: websitePending,
+    isError: websiteError,
+    refetch: refetchWebsite,
+  } = useQuery({
     queryKey: USER_WEBSITE_QUERY_KEY,
     queryFn: getUserWebsite,
   })
-  const { data: tcrCompliance, isPending: tcrPending } = useQuery({
+  const {
+    data: tcrCompliance,
+    isPending: tcrPending,
+    isError: tcrError,
+    refetch: refetchTcr,
+  } = useQuery({
     queryKey: TCR_COMPLIANCE_QUERY_KEY,
     queryFn: getTcrCompliance,
   })
 
   const ready = !websitePending && !tcrPending
+  const hasError = websiteError || tcrError
 
   useEffect(() => {
-    if (!ready) return
+    // Don't derive a step from partial state: a failed fetch leaves data
+    // undefined, which would mis-derive a returning candidate back to the
+    // value-prop intro as if they had zero progress.
+    if (!ready || hasError) return
 
     const { filingComplete, pinComplete } =
       getTcrComplianceStatusCompletions(tcrCompliance)
@@ -61,13 +78,35 @@ const ProUpgradeEntry = (): React.JSX.Element | null => {
     })
 
     router.replace(proUpgradeStepPath(step))
-  }, [ready, campaign, website, tcrCompliance, router])
+  }, [ready, hasError, campaign, website, tcrCompliance, router])
 
-  // Spinner only while the canonical-state queries are pending. Once ready, the
-  // redirect is already scheduled in the effect above, so return null — a
-  // silently-failed router.replace can't strand the user on a permanent spinner.
+  // Spinner only while the canonical-state queries are pending.
   if (!ready) return <LoadingAnimation />
 
+  // A fetch failed: show a recoverable error instead of mis-routing to the
+  // intro. Refetching clears the error and re-runs the redirect effect.
+  if (hasError) {
+    return (
+      <div className="text-center">
+        <H2 className="mb-2">Something went wrong</H2>
+        <Body2 className="mb-6 text-gray-600">
+          We couldn&apos;t load your upgrade details. Please try again.
+        </Body2>
+        <Button
+          onClick={() => {
+            void refetchWebsite()
+            void refetchTcr()
+          }}
+        >
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  // Ready, no error: the redirect is already scheduled in the effect above, so
+  // return null — a silently-failed router.replace can't strand the user on a
+  // permanent spinner.
   return null
 }
 

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
@@ -24,7 +24,7 @@ import {
 // Wizard index: derives the resume step from canonical state and redirects to
 // it. There is no server-side wizard session (tech doc v2), so every entry
 // re-derives, landing a returning candidate on the first incomplete step.
-const ProUpgradeEntry = (): React.JSX.Element => {
+const ProUpgradeEntry = (): React.JSX.Element | null => {
   const router = useRouter()
   const [campaign] = useCampaign()
 
@@ -63,7 +63,12 @@ const ProUpgradeEntry = (): React.JSX.Element => {
     router.replace(proUpgradeStepPath(step))
   }, [ready, campaign, website, tcrCompliance, router])
 
-  return <LoadingAnimation />
+  // Spinner only while the canonical-state queries are pending. Once ready, the
+  // redirect is already scheduled in the effect above, so return null — a
+  // silently-failed router.replace can't strand the user on a permanent spinner.
+  if (!ready) return <LoadingAnimation />
+
+  return null
 }
 
 export default ProUpgradeEntry

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
+import {
+  USER_WEBSITE_QUERY_KEY,
+  getUserWebsite,
+} from 'app/dashboard/website/util/website.util'
+import {
+  TCR_COMPLIANCE_QUERY_KEY,
+  getTcrCompliance,
+  getTcrComplianceStatusCompletions,
+} from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
+import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+import {
+  deriveProUpgradeStep,
+  proUpgradeStepPath,
+  type FilingStatus,
+} from '../proUpgradeStep'
+
+// Wizard index: derives the resume step from canonical state and redirects to
+// it. There is no server-side wizard session (tech doc v2), so every entry
+// re-derives, landing a returning candidate on the first incomplete step.
+const ProUpgradeEntry = (): React.JSX.Element => {
+  const router = useRouter()
+  const [campaign] = useCampaign()
+
+  const { data: website, isPending: websitePending } = useQuery({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+  const { data: tcrCompliance, isPending: tcrPending } = useQuery({
+    queryKey: TCR_COMPLIANCE_QUERY_KEY,
+    queryFn: getTcrCompliance,
+  })
+
+  const ready = !websitePending && !tcrPending
+
+  useEffect(() => {
+    if (!ready) return
+
+    const { filingComplete, pinComplete } =
+      getTcrComplianceStatusCompletions(tcrCompliance)
+
+    // TODO(task 07): map the candidate's persisted filing-status answer here
+    // once its campaign.details key is decided. Until then it is unanswered,
+    // so a candidate is held at the filing-status step rather than skipped past
+    // it.
+    const filingStatus: FilingStatus = 'unanswered'
+
+    const step = deriveProUpgradeStep({
+      isPro: Boolean(campaign?.isPro),
+      filingStatus,
+      hasEin: Boolean(campaign?.details?.einNumber),
+      filingComplete,
+      profileComplete: isCandidateProfileComplete(website),
+      pinComplete,
+    })
+
+    router.replace(proUpgradeStepPath(step))
+  }, [ready, campaign, website, tcrCompliance, router])
+
+  return <LoadingAnimation />
+}
+
+export default ProUpgradeEntry

--- a/app/dashboard/pro-upgrade/components/ProUpgradeStepPlaceholder.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeStepPlaceholder.tsx
@@ -1,0 +1,23 @@
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+
+interface ProUpgradeStepPlaceholderProps {
+  title: string
+  // Which epic task lands the real screen for this step. Foundation-only
+  // placeholder: tasks 06–15 replace each step page's body.
+  taskNote: string
+}
+
+// Temporary content for a wizard step whose real screen ships in a later task.
+// Lets the route tree, shell, and step-derivation router work end-to-end now.
+const ProUpgradeStepPlaceholder = ({
+  title,
+  taskNote,
+}: ProUpgradeStepPlaceholderProps): React.JSX.Element => (
+  <>
+    <H2 className="mb-2">{title}</H2>
+    <Body2 className="text-gray-600">{taskNote}</Body2>
+  </>
+)
+
+export default ProUpgradeStepPlaceholder

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import ProUpgradeWizard from './ProUpgradeWizard'
+import { useProUpgrade3Flag } from '@shared/experiments/proUpgrade3Flag'
+import { usePathname } from 'next/navigation'
+import { noop } from '@shared/utils/noop'
+
+vi.mock('@shared/experiments/proUpgrade3Flag', () => ({
+  useProUpgrade3Flag: vi.fn(),
+}))
+
+// The global setup mocks next/navigation with useRouter only; this component
+// also needs usePathname, so override the module for this file.
+vi.mock('next/navigation', () => ({
+  useRouter: () => router,
+  usePathname: vi.fn(),
+}))
+
+const mockUseProUpgrade3Flag = vi.mocked(useProUpgrade3Flag)
+const mockUsePathname = vi.mocked(usePathname)
+
+describe('ProUpgradeWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, 'scrollTo').mockImplementation(noop)
+    mockUsePathname.mockReturnValue('/dashboard/pro-upgrade/ein')
+  })
+
+  it('renders a spinner and does not redirect while the flag is not ready', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: false, enabled: false })
+
+    render(
+      <ProUpgradeWizard>
+        <div>step-content</div>
+      </ProUpgradeWizard>,
+    )
+
+    // LoadingAnimation renders a "POWERED BY" marker.
+    expect(screen.getByText(/powered by/i)).toBeInTheDocument()
+    expect(screen.queryByText('step-content')).not.toBeInTheDocument()
+    expect(router.replace).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing (not a permanent spinner) and redirects the off cohort', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: false })
+
+    const { container } = render(
+      <ProUpgradeWizard>
+        <div>step-content</div>
+      </ProUpgradeWizard>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByText(/powered by/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('step-content')).not.toBeInTheDocument()
+    expect(router.replace).toHaveBeenCalledWith('/dashboard/pro-sign-up')
+  })
+
+  it('renders the step children when the flag is ready and enabled', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: true })
+
+    render(
+      <ProUpgradeWizard>
+        <div>step-content</div>
+      </ProUpgradeWizard>,
+    )
+
+    expect(screen.getByText('step-content')).toBeInTheDocument()
+    expect(router.replace).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
@@ -70,4 +70,19 @@ describe('ProUpgradeWizard', () => {
     expect(screen.getByText('step-content')).toBeInTheDocument()
     expect(router.replace).not.toHaveBeenCalled()
   })
+
+  it('does not show a Back control on the post-payment success surface', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: true })
+    mockUsePathname.mockReturnValue('/dashboard/pro-upgrade/success')
+
+    render(
+      <ProUpgradeWizard>
+        <div>step-content</div>
+      </ProUpgradeWizard>,
+    )
+
+    expect(
+      screen.queryByRole('button', { name: /go back/i }),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.test.tsx
@@ -85,4 +85,19 @@ describe('ProUpgradeWizard', () => {
       screen.queryByRole('button', { name: /go back/i }),
     ).not.toBeInTheDocument()
   })
+
+  it('shows a Back control on the filing-instructions dead-end (off-order route)', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: true })
+    mockUsePathname.mockReturnValue(
+      '/dashboard/pro-upgrade/filing-instructions',
+    )
+
+    render(
+      <ProUpgradeWizard>
+        <div>step-content</div>
+      </ProUpgradeWizard>,
+    )
+
+    expect(screen.getByRole('button', { name: /go back/i })).toBeInTheDocument()
+  })
 })

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
@@ -120,11 +120,15 @@ const ProUpgradeWizard = ({
   if (!enabled) return null
 
   const canGoBack = currentStep !== null && orderIndex !== 0
-  // value-prop and the post-payment SUCCESS surface don't show step progress.
+  // value-prop (index 0) and the post-payment SUCCESS surface (last index)
+  // don't show step progress.
   const showProgress =
     orderIndex > 0 && orderIndex < PRO_UPGRADE_STEP_ORDER.length - 1
+  // The bar spans the visible steps only (index 1 .. last-1). Excluding both
+  // value-prop and SUCCESS from the denominator makes the final visible step
+  // (PAYMENT) read 100% instead of capping short.
   const progressValue = showProgress
-    ? (orderIndex / (PRO_UPGRADE_STEP_ORDER.length - 1)) * 100
+    ? (orderIndex / (PRO_UPGRADE_STEP_ORDER.length - 2)) * 100
     : 0
 
   return (

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
@@ -61,7 +61,7 @@ interface ProUpgradeWizardProps {
 
 const ProUpgradeWizard = ({
   children,
-}: ProUpgradeWizardProps): React.JSX.Element => {
+}: ProUpgradeWizardProps): React.JSX.Element | null => {
   const router = useRouter()
   const pathname = usePathname()
   const { ready, enabled } = useProUpgrade3Flag()
@@ -105,15 +105,19 @@ const ProUpgradeWizard = ({
     [currentStep, goToStep, goToNextStep, goToPreviousStep],
   )
 
-  // Hold the experience until the flag resolves so the off cohort never sees a
-  // flash of the wizard before the redirect fires.
-  if (!ready || !enabled) {
+  // Hold the experience with a spinner only while the flag is resolving.
+  if (!ready) {
     return (
       <FocusedExperienceWrapper>
         <LoadingAnimation />
       </FocusedExperienceWrapper>
     )
   }
+
+  // Off cohort: the redirect to pro-sign-up is already scheduled in the effect
+  // above. Render nothing rather than a spinner so a silently-failed
+  // router.replace can't strand the user on a permanent "loading" screen.
+  if (!enabled) return null
 
   const canGoBack = currentStep !== null && orderIndex !== 0
   // value-prop and the post-payment SUCCESS surface don't show step progress.

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
@@ -119,12 +119,15 @@ const ProUpgradeWizard = ({
   // router.replace can't strand the user on a permanent "loading" screen.
   if (!enabled) return null
 
-  // No Back on value-prop (index 0, nothing before it) or the post-payment
-  // SUCCESS surface (last index — must not navigate back to PAYMENT).
+  // Show Back on the middle linear steps and on off-order routes
+  // (filing-instructions dead-end and the guidance interstitial, orderIndex -1,
+  // where goToPreviousStep falls back to router.back()). No Back on value-prop
+  // (index 0, nothing before it) or the post-payment SUCCESS surface (last
+  // index — must not navigate back to PAYMENT).
   const canGoBack =
     currentStep !== null &&
-    orderIndex > 0 &&
-    orderIndex < PRO_UPGRADE_STEP_ORDER.length - 1
+    (orderIndex === -1 ||
+      (orderIndex > 0 && orderIndex < PRO_UPGRADE_STEP_ORDER.length - 1))
   // value-prop (index 0) and the post-payment SUCCESS surface (last index)
   // don't show step progress.
   const showProgress =

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { ArrowLeftIcon } from '@styleguide/components/ui/icons'
+import { Button, Progress } from '@styleguide'
+import { FocusedExperienceWrapper } from 'app/dashboard/shared/FocusedExperienceWrapper'
+import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
+import { noop } from '@shared/utils/noop'
+import { useProUpgrade3Flag } from '@shared/experiments/proUpgrade3Flag'
+import {
+  PRO_UPGRADE_BASE_PATH,
+  PRO_UPGRADE_STEP_ORDER,
+  proUpgradeStepPath,
+  type ProUpgradeStep,
+} from '../proUpgradeStep'
+
+// Where the off cohort is sent. The legacy /dashboard/pro-sign-up flow is the
+// pro-upgrade3 = off fallback and is intentionally left untouched.
+const PRO_SIGN_UP_PATH = '/dashboard/pro-sign-up'
+
+interface ProUpgradeWizardContextValue {
+  // null on the wizard index (before redirect) or on any non-step path.
+  currentStep: ProUpgradeStep | null
+  goToStep: (step: ProUpgradeStep) => void
+  goToNextStep: () => void
+  goToPreviousStep: () => void
+}
+
+const ProUpgradeWizardContext = createContext<ProUpgradeWizardContextValue>({
+  currentStep: null,
+  goToStep: noop,
+  goToNextStep: noop,
+  goToPreviousStep: noop,
+})
+
+// Per-step pages (tasks 06–14) read this to drive their own forward CTAs and
+// to know which step is active.
+export const useProUpgradeWizard = (): ProUpgradeWizardContextValue =>
+  useContext(ProUpgradeWizardContext)
+
+const stepFromPathname = (pathname: string | null): ProUpgradeStep | null => {
+  if (!pathname?.startsWith(PRO_UPGRADE_BASE_PATH)) return null
+  const segment = pathname.slice(PRO_UPGRADE_BASE_PATH.length + 1).split('/')[0]
+  const match = PRO_UPGRADE_STEP_ORDER.find((step) => step === segment)
+  // `filing-instructions` is a valid path but not in the linear order; surface
+  // it as a step so the chrome can render Back without offering linear nav.
+  if (match) return match
+  return segment ? (segment as ProUpgradeStep) : null
+}
+
+interface ProUpgradeWizardProps {
+  children: React.ReactNode
+}
+
+const ProUpgradeWizard = ({
+  children,
+}: ProUpgradeWizardProps): React.JSX.Element => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const { ready, enabled } = useProUpgrade3Flag()
+
+  const currentStep = stepFromPathname(pathname)
+  const orderIndex = currentStep
+    ? PRO_UPGRADE_STEP_ORDER.indexOf(currentStep)
+    : -1
+
+  // Off cohort: send the candidate to the legacy pro-sign-up flow unchanged.
+  useEffect(() => {
+    if (ready && !enabled) router.replace(PRO_SIGN_UP_PATH)
+  }, [ready, enabled, router])
+
+  // Reset scroll to the top whenever the active step changes (dashboard convention).
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [currentStep])
+
+  const goToStep = useCallback(
+    (step: ProUpgradeStep) => router.push(proUpgradeStepPath(step)),
+    [router],
+  )
+
+  const goToNextStep = useCallback(() => {
+    if (orderIndex < 0 || orderIndex >= PRO_UPGRADE_STEP_ORDER.length - 1)
+      return
+    router.push(proUpgradeStepPath(PRO_UPGRADE_STEP_ORDER[orderIndex + 1]!))
+  }, [orderIndex, router])
+
+  const goToPreviousStep = useCallback(() => {
+    if (orderIndex > 0) {
+      router.push(proUpgradeStepPath(PRO_UPGRADE_STEP_ORDER[orderIndex - 1]!))
+    } else {
+      router.back()
+    }
+  }, [orderIndex, router])
+
+  const contextValue = useMemo<ProUpgradeWizardContextValue>(
+    () => ({ currentStep, goToStep, goToNextStep, goToPreviousStep }),
+    [currentStep, goToStep, goToNextStep, goToPreviousStep],
+  )
+
+  // Hold the experience until the flag resolves so the off cohort never sees a
+  // flash of the wizard before the redirect fires.
+  if (!ready || !enabled) {
+    return (
+      <FocusedExperienceWrapper>
+        <LoadingAnimation />
+      </FocusedExperienceWrapper>
+    )
+  }
+
+  const canGoBack = currentStep !== null && orderIndex !== 0
+  // value-prop and the post-payment SUCCESS surface don't show step progress.
+  const showProgress =
+    orderIndex > 0 && orderIndex < PRO_UPGRADE_STEP_ORDER.length - 1
+  const progressValue = showProgress
+    ? (orderIndex / (PRO_UPGRADE_STEP_ORDER.length - 1)) * 100
+    : 0
+
+  return (
+    <ProUpgradeWizardContext.Provider value={contextValue}>
+      <FocusedExperienceWrapper>
+        {(canGoBack || showProgress) && (
+          <div className="mb-6 flex items-center gap-3">
+            {canGoBack && (
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={goToPreviousStep}
+                aria-label="Go back"
+              >
+                <ArrowLeftIcon className="h-5 w-5" />
+              </Button>
+            )}
+            {showProgress && (
+              <Progress value={progressValue} className="flex-1" />
+            )}
+          </div>
+        )}
+        {children}
+      </FocusedExperienceWrapper>
+    </ProUpgradeWizardContext.Provider>
+  )
+}
+
+export default ProUpgradeWizard

--- a/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeWizard.tsx
@@ -119,7 +119,12 @@ const ProUpgradeWizard = ({
   // router.replace can't strand the user on a permanent "loading" screen.
   if (!enabled) return null
 
-  const canGoBack = currentStep !== null && orderIndex !== 0
+  // No Back on value-prop (index 0, nothing before it) or the post-payment
+  // SUCCESS surface (last index — must not navigate back to PAYMENT).
+  const canGoBack =
+    currentStep !== null &&
+    orderIndex > 0 &&
+    orderIndex < PRO_UPGRADE_STEP_ORDER.length - 1
   // value-prop (index 0) and the post-payment SUCCESS surface (last index)
   // don't show step progress.
   const showProgress =

--- a/app/dashboard/pro-upgrade/ein/page.tsx
+++ b/app/dashboard/pro-upgrade/ein/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Your EIN"
+      taskNote="EIN step — ships in task 10"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/filing-details/page.tsx
+++ b/app/dashboard/pro-upgrade/filing-details/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Your filing details"
+      taskNote="Filing-details step — ships in task 11"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/filing-instructions/page.tsx
+++ b/app/dashboard/pro-upgrade/filing-instructions/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="How to file to run for office"
+      taskNote="Filing-instructions screen — ships in task 08"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/guidance/page.tsx
+++ b/app/dashboard/pro-upgrade/guidance/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="What to expect next"
+      taskNote="Guidance interstitial — ships in task 09"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/layout.tsx
+++ b/app/dashboard/pro-upgrade/layout.tsx
@@ -1,0 +1,11 @@
+import ProUpgradeWizard from './components/ProUpgradeWizard'
+
+export const dynamic = 'force-dynamic'
+
+export default function ProUpgradeLayout({
+  children,
+}: {
+  children: React.ReactNode
+}): React.JSX.Element {
+  return <ProUpgradeWizard>{children}</ProUpgradeWizard>
+}

--- a/app/dashboard/pro-upgrade/page.tsx
+++ b/app/dashboard/pro-upgrade/page.tsx
@@ -1,0 +1,15 @@
+import pageMetaData from 'helpers/metadataHelper'
+import ProUpgradeEntry from './components/ProUpgradeEntry'
+
+const meta = pageMetaData({
+  title: 'Upgrade to Pro | GoodParty.org',
+  description: 'Upgrade to GoodParty.org Pro',
+  slug: '/dashboard/pro-upgrade',
+})
+export const metadata = meta
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return <ProUpgradeEntry />
+}

--- a/app/dashboard/pro-upgrade/payment/page.tsx
+++ b/app/dashboard/pro-upgrade/payment/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Complete your upgrade"
+      taskNote="Payment step (embedded) — ships in task 13"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/proUpgradeStep.test.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveProUpgradeStep,
+  PRO_UPGRADE_STEP,
+  type FilingStatus,
+  type ProUpgradeStepInputs,
+} from './proUpgradeStep'
+
+// A candidate who has answered "yes, I've filed" and has every pre-payment
+// prerequisite complete. Individual cases override one field at a time so the
+// assertion isolates the step that field gates.
+const allComplete: ProUpgradeStepInputs = {
+  isPro: false,
+  filingStatus: 'has-filed',
+  hasEin: true,
+  filingComplete: true,
+  profileComplete: true,
+  pinComplete: true,
+}
+
+describe('deriveProUpgradeStep', () => {
+  describe('already Pro', () => {
+    // isPro short-circuits to the post-payment surface regardless of every
+    // pre-payment input, including PIN/filing completeness.
+    const proCases: Array<Partial<ProUpgradeStepInputs>> = [
+      {
+        filingStatus: 'unanswered',
+        hasEin: false,
+        filingComplete: false,
+        profileComplete: false,
+        pinComplete: false,
+      },
+      {
+        filingStatus: 'not-filed',
+        hasEin: false,
+        filingComplete: false,
+        profileComplete: false,
+        pinComplete: false,
+      },
+      {
+        filingStatus: 'has-filed',
+        hasEin: true,
+        filingComplete: true,
+        profileComplete: true,
+        pinComplete: false,
+      },
+      {
+        filingStatus: 'has-filed',
+        hasEin: true,
+        filingComplete: true,
+        profileComplete: true,
+        pinComplete: true,
+      },
+    ]
+
+    it.each(proCases)(
+      'routes an already-Pro candidate to SUCCESS, never payment (%o)',
+      (overrides) => {
+        const step = deriveProUpgradeStep({
+          ...allComplete,
+          isPro: true,
+          ...overrides,
+        })
+        expect(step).toBe(PRO_UPGRADE_STEP.SUCCESS)
+        expect(step).not.toBe(PRO_UPGRADE_STEP.PAYMENT)
+      },
+    )
+  })
+
+  describe('not yet Pro — first incomplete step wins', () => {
+    it('lands a brand-new candidate (no progress) on the value-prop intro', () => {
+      expect(
+        deriveProUpgradeStep({
+          isPro: false,
+          filingStatus: 'unanswered',
+          hasEin: false,
+          filingComplete: false,
+          profileComplete: false,
+          pinComplete: false,
+        }),
+      ).toBe(PRO_UPGRADE_STEP.VALUE_PROP)
+    })
+
+    it('skips the value-prop intro once any progress exists', () => {
+      // Profile started but filing question still unanswered: past the intro,
+      // so the filing-status question is the first incomplete step.
+      expect(
+        deriveProUpgradeStep({
+          isPro: false,
+          filingStatus: 'unanswered',
+          hasEin: false,
+          filingComplete: false,
+          profileComplete: true,
+          pinComplete: false,
+        }),
+      ).toBe(PRO_UPGRADE_STEP.STATUS)
+    })
+
+    it('routes "not filed" to the filing-instructions dead-end', () => {
+      // The dead-end is sticky: even with later prerequisites somehow present,
+      // an un-filed candidate must file before the flow advances.
+      expect(
+        deriveProUpgradeStep({ ...allComplete, filingStatus: 'not-filed' }),
+      ).toBe(PRO_UPGRADE_STEP.FILING_INSTRUCTIONS)
+    })
+
+    // With the filing question answered "has-filed", each remaining
+    // prerequisite gates its step in canonical order.
+    const orderedCases: Array<{
+      name: string
+      overrides: Partial<ProUpgradeStepInputs>
+      expected: string
+    }> = [
+      {
+        name: 'no EIN → EIN step',
+        overrides: { hasEin: false },
+        expected: PRO_UPGRADE_STEP.EIN,
+      },
+      {
+        name: 'EIN present but TCR filing incomplete → filing-details step',
+        overrides: { filingComplete: false },
+        expected: PRO_UPGRADE_STEP.FILING_DETAILS,
+      },
+      {
+        name: 'filing complete but profile incomplete → candidate-profile step',
+        overrides: { profileComplete: false },
+        expected: PRO_UPGRADE_STEP.CANDIDATE_PROFILE,
+      },
+      {
+        name: 'everything collected, not yet Pro → payment step',
+        overrides: {},
+        expected: PRO_UPGRADE_STEP.PAYMENT,
+      },
+    ]
+
+    it.each(orderedCases)('$name', ({ overrides, expected }) => {
+      expect(deriveProUpgradeStep({ ...allComplete, ...overrides })).toBe(
+        expected,
+      )
+    })
+
+    it('returns the earliest incomplete step, not a later one (profile complete, no EIN → EIN)', () => {
+      expect(
+        deriveProUpgradeStep({
+          ...allComplete,
+          hasEin: false,
+          filingComplete: false,
+          profileComplete: true,
+        }),
+      ).toBe(PRO_UPGRADE_STEP.EIN)
+    })
+
+    it('ignores PIN completeness when gating pre-payment steps', () => {
+      // PIN is a post-payment concern; toggling it must not change the
+      // pre-payment landing step.
+      const base: ProUpgradeStepInputs = { ...allComplete, hasEin: false }
+      const withPin = deriveProUpgradeStep({ ...base, pinComplete: true })
+      const withoutPin = deriveProUpgradeStep({ ...base, pinComplete: false })
+      expect(withPin).toBe(PRO_UPGRADE_STEP.EIN)
+      expect(withoutPin).toBe(PRO_UPGRADE_STEP.EIN)
+    })
+  })
+
+  it('covers every filing-status value', () => {
+    const statuses: FilingStatus[] = ['unanswered', 'has-filed', 'not-filed']
+    for (const filingStatus of statuses) {
+      expect(() =>
+        deriveProUpgradeStep({ ...allComplete, filingStatus }),
+      ).not.toThrow()
+    }
+  })
+})

--- a/app/dashboard/pro-upgrade/proUpgradeStep.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.ts
@@ -28,13 +28,18 @@ export const proUpgradeStepPath = (step: ProUpgradeStep): string =>
   `${PRO_UPGRADE_BASE_PATH}/${step}`
 
 // Linear forward-navigation order for the wizard shell's Back/Next controls.
-// `filing-instructions` is intentionally absent: it is a dead-end branch off
-// `status` (the candidate has not yet filed to run), not a resumable step in
-// the linear flow.
+// Every entry is a step `deriveProUpgradeStep` can actually land on, so the
+// progress bar and nav stay in sync with the router.
+//
+// Two steps are intentionally absent:
+// - `filing-instructions`: a dead-end branch off `status` (the candidate has
+//   not yet filed to run), not a resumable step in the linear flow.
+// - `guidance`: an interstitial with no persisted "seen" state, so the router
+//   cannot derive it. TODO(task 09): insert it here once that task defines how
+//   it is reached and advanced past.
 export const PRO_UPGRADE_STEP_ORDER: ProUpgradeStep[] = [
   PRO_UPGRADE_STEP.VALUE_PROP,
   PRO_UPGRADE_STEP.STATUS,
-  PRO_UPGRADE_STEP.GUIDANCE,
   PRO_UPGRADE_STEP.EIN,
   PRO_UPGRADE_STEP.FILING_DETAILS,
   PRO_UPGRADE_STEP.CANDIDATE_PROFILE,

--- a/app/dashboard/pro-upgrade/proUpgradeStep.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.ts
@@ -1,0 +1,102 @@
+// Step-derivation router for the pre-payment Pro upgrade wizard.
+//
+// Per tech doc v2 there is no server-side wizard session: the current step is
+// derived purely from canonical state (campaign.isPro, the candidate's
+// filing-status answer, EIN presence, TCR filing + PIN completeness, and
+// candidate-profile completeness) so a candidate who leaves and returns lands
+// on the correct step. This module must stay pure and side-effect-free — it
+// only reads the inputs it is handed.
+
+export const PRO_UPGRADE_STEP = {
+  VALUE_PROP: 'value-prop',
+  STATUS: 'status',
+  FILING_INSTRUCTIONS: 'filing-instructions',
+  GUIDANCE: 'guidance',
+  EIN: 'ein',
+  FILING_DETAILS: 'filing-details',
+  CANDIDATE_PROFILE: 'candidate-profile',
+  PAYMENT: 'payment',
+  SUCCESS: 'success',
+} as const
+
+export type ProUpgradeStep =
+  (typeof PRO_UPGRADE_STEP)[keyof typeof PRO_UPGRADE_STEP]
+
+export const PRO_UPGRADE_BASE_PATH = '/dashboard/pro-upgrade'
+
+export const proUpgradeStepPath = (step: ProUpgradeStep): string =>
+  `${PRO_UPGRADE_BASE_PATH}/${step}`
+
+// Linear forward-navigation order for the wizard shell's Back/Next controls.
+// `filing-instructions` is intentionally absent: it is a dead-end branch off
+// `status` (the candidate has not yet filed to run), not a resumable step in
+// the linear flow.
+export const PRO_UPGRADE_STEP_ORDER: ProUpgradeStep[] = [
+  PRO_UPGRADE_STEP.VALUE_PROP,
+  PRO_UPGRADE_STEP.STATUS,
+  PRO_UPGRADE_STEP.GUIDANCE,
+  PRO_UPGRADE_STEP.EIN,
+  PRO_UPGRADE_STEP.FILING_DETAILS,
+  PRO_UPGRADE_STEP.CANDIDATE_PROFILE,
+  PRO_UPGRADE_STEP.PAYMENT,
+  PRO_UPGRADE_STEP.SUCCESS,
+]
+
+// The candidate's answer to "have you already filed to run for this office?".
+// Task 07 owns where/how this is persisted (a campaign.details key decided
+// there); the router only needs the normalized tri-state, so its caller maps
+// the stored value into this. `unanswered` means the question has not been
+// answered yet.
+export type FilingStatus = 'unanswered' | 'has-filed' | 'not-filed'
+
+export interface ProUpgradeStepInputs {
+  isPro: boolean
+  filingStatus: FilingStatus
+  hasEin: boolean
+  filingComplete: boolean
+  profileComplete: boolean
+  // Whether TCR PIN verification has happened. Not used to gate any
+  // pre-payment step (PIN entry is a post-payment concern); carried here so
+  // the post-payment status states (task 15) can refine the SUCCESS surface
+  // without changing this contract.
+  pinComplete: boolean
+}
+
+/**
+ * Returns the step the candidate should land on, derived from canonical state.
+ *
+ * Already-Pro candidates are routed to the post-payment SUCCESS surface and
+ * never back to a pre-payment step. Otherwise the first incomplete step in
+ * canonical order wins, so completed prerequisites are skipped on return (e.g.
+ * a candidate with a complete profile but no EIN lands on the EIN step).
+ */
+export const deriveProUpgradeStep = (
+  inputs: ProUpgradeStepInputs,
+): ProUpgradeStep => {
+  const { isPro, filingStatus, hasEin, filingComplete, profileComplete } =
+    inputs
+
+  // Payment already happened — route to the post-payment surface, never back
+  // to a pre-payment step. (Post-payment sub-states are refined in task 15.)
+  if (isPro) return PRO_UPGRADE_STEP.SUCCESS
+
+  // Brand-new candidate with nothing collected yet lands on the value-prop
+  // intro. Any persisted progress means they are past the intro.
+  const hasProgress =
+    filingStatus !== 'unanswered' || hasEin || filingComplete || profileComplete
+  if (!hasProgress) return PRO_UPGRADE_STEP.VALUE_PROP
+
+  // Filing-status gate (task 07). Unanswered → ask. "Not filed" → the
+  // filing-instructions dead-end (task 08); the candidate must file with their
+  // election authority before the flow can advance, so we do not skip ahead.
+  if (filingStatus === 'unanswered') return PRO_UPGRADE_STEP.STATUS
+  if (filingStatus === 'not-filed') return PRO_UPGRADE_STEP.FILING_INSTRUCTIONS
+
+  // Remaining pre-payment data steps, in canonical order; first incomplete wins.
+  if (!hasEin) return PRO_UPGRADE_STEP.EIN
+  if (!filingComplete) return PRO_UPGRADE_STEP.FILING_DETAILS
+  if (!profileComplete) return PRO_UPGRADE_STEP.CANDIDATE_PROFILE
+
+  // Everything collected, not yet Pro → payment.
+  return PRO_UPGRADE_STEP.PAYMENT
+}

--- a/app/dashboard/pro-upgrade/status/page.tsx
+++ b/app/dashboard/pro-upgrade/status/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Your texting compliance status"
+      taskNote="Filing-status branch — ships in task 07"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/success/page.tsx
+++ b/app/dashboard/pro-upgrade/success/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="You're all set"
+      taskNote="Success / post-payment states — ship in tasks 14–15"
+    />
+  )
+}

--- a/app/dashboard/pro-upgrade/value-prop/page.tsx
+++ b/app/dashboard/pro-upgrade/value-prop/page.tsx
@@ -1,0 +1,12 @@
+import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page(): React.JSX.Element {
+  return (
+    <ProUpgradeStepPlaceholder
+      title="Upgrade to GoodParty.org Pro"
+      taskNote="Value-prop / paywall — ships in task 06"
+    />
+  )
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Card } from '@styleguide'
+
+// Placeholder for the pro-upgrade3 post-payment compliance surface. The
+// precedence wiring in TextingComplianceFeatureFlag routes the pro-upgrade3
+// cohort here now; task 15 replaces this body with the real status states.
+export default function ProUpgrade3Compliance(): React.JSX.Element {
+  return (
+    <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+      <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+      <p className="text-sm text-secondary">
+        Your Pro upgrade status will appear here.
+      </p>
+    </Card>
+  )
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.test.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.test.tsx
@@ -65,4 +65,17 @@ describe('TextingComplianceFeatureFlag', () => {
     expect(screen.queryByText('pro-upgrade3-surface')).not.toBeInTheDocument()
     expect(screen.queryByText('agentic-surface')).not.toBeInTheDocument()
   })
+
+  it('shows the legacy surface until the flags resolve, even with a cached "on" variant', () => {
+    // useFlagOn returns `on` independently of `ready`, so a cached/early
+    // variant must not flash a flagged surface before Amplitude resolves.
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: false, enabled: true })
+    mockUseProUpgradeFlag.mockReturnValue({ ready: false, enabled: true })
+
+    render(<TextingComplianceFeatureFlag />)
+
+    expect(screen.getByText('legacy-surface')).toBeInTheDocument()
+    expect(screen.queryByText('pro-upgrade3-surface')).not.toBeInTheDocument()
+    expect(screen.queryByText('agentic-surface')).not.toBeInTheDocument()
+  })
 })

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.test.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import TextingComplianceFeatureFlag from './TextingComplianceFeatureFlag'
+import { useProUpgrade3Flag } from '@shared/experiments/proUpgrade3Flag'
+import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
+
+vi.mock('@shared/experiments/proUpgrade3Flag', () => ({
+  useProUpgrade3Flag: vi.fn(),
+}))
+vi.mock('@shared/experiments/proUpgradeFlag', () => ({
+  useProUpgradeFlag: vi.fn(),
+}))
+
+// Stub the three surfaces with identifiable markers so the assertions verify
+// which surface the precedence logic selects, not each surface's internals.
+vi.mock('./ProUpgrade3Compliance', () => ({
+  default: () => <div>pro-upgrade3-surface</div>,
+}))
+vi.mock('./TextingComplianceAgentic', () => ({
+  default: () => <div>agentic-surface</div>,
+}))
+vi.mock(
+  'app/dashboard/profile/texting-compliance/components/TextingCompliance',
+  () => ({ default: () => <div>legacy-surface</div> }),
+)
+
+const mockUseProUpgrade3Flag = vi.mocked(useProUpgrade3Flag)
+const mockUseProUpgradeFlag = vi.mocked(useProUpgradeFlag)
+
+describe('TextingComplianceFeatureFlag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the pro-upgrade3 surface when pro-upgrade3 is on (even if pro-upgrade1 is also on)', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: true })
+    mockUseProUpgradeFlag.mockReturnValue({ ready: true, enabled: true })
+
+    render(<TextingComplianceFeatureFlag />)
+
+    expect(screen.getByText('pro-upgrade3-surface')).toBeInTheDocument()
+    expect(screen.queryByText('agentic-surface')).not.toBeInTheDocument()
+    expect(screen.queryByText('legacy-surface')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the agentic surface when only pro-upgrade1 is on', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: false })
+    mockUseProUpgradeFlag.mockReturnValue({ ready: true, enabled: true })
+
+    render(<TextingComplianceFeatureFlag />)
+
+    expect(screen.getByText('agentic-surface')).toBeInTheDocument()
+    expect(screen.queryByText('pro-upgrade3-surface')).not.toBeInTheDocument()
+    expect(screen.queryByText('legacy-surface')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the legacy surface when neither flag is on', () => {
+    mockUseProUpgrade3Flag.mockReturnValue({ ready: true, enabled: false })
+    mockUseProUpgradeFlag.mockReturnValue({ ready: true, enabled: false })
+
+    render(<TextingComplianceFeatureFlag />)
+
+    expect(screen.getByText('legacy-surface')).toBeInTheDocument()
+    expect(screen.queryByText('pro-upgrade3-surface')).not.toBeInTheDocument()
+    expect(screen.queryByText('agentic-surface')).not.toBeInTheDocument()
+  })
+})

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
@@ -11,12 +11,18 @@ import ProUpgrade3Compliance from './ProUpgrade3Compliance'
 export default function TextingComplianceFeatureFlag(
   props: TextingComplianceProps,
 ): React.JSX.Element {
-  const { enabled: proUpgrade3Enabled } = useProUpgrade3Flag()
+  const { ready, enabled: proUpgrade3Enabled } = useProUpgrade3Flag()
   const { enabled: proUpgrade1Enabled } = useProUpgradeFlag()
 
-  // Precedence: pro-upgrade3 > pro-upgrade1 > legacy. Both variants default to
-  // "off" until the Amplitude client resolves, so the legacy surface shows
-  // during load and the flagged surfaces appear only once a variant is known.
+  // Precedence: pro-upgrade3 > pro-upgrade1 > legacy. Gate on `ready` first:
+  // `useFlagOn` does not tie `on` to `ready`, so a cached/early variant could
+  // otherwise flash a flagged surface before Amplitude resolves. Both flags
+  // come from the same client, so one `ready` covers both; until it resolves
+  // (and for the off cohort) the legacy surface renders.
+  if (!ready) {
+    return <TextingCompliance {...props} />
+  }
+
   if (proUpgrade3Enabled) {
     return <ProUpgrade3Compliance />
   }

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceFeatureFlag.tsx
@@ -1,19 +1,29 @@
 'use client'
 
+import { useProUpgrade3Flag } from '@shared/experiments/proUpgrade3Flag'
 import { useProUpgradeFlag } from '@shared/experiments/proUpgradeFlag'
 import TextingCompliance, {
   TextingComplianceProps,
 } from 'app/dashboard/profile/texting-compliance/components/TextingCompliance'
 import TextingComplianceAgentic from './TextingComplianceAgentic'
+import ProUpgrade3Compliance from './ProUpgrade3Compliance'
 
 export default function TextingComplianceFeatureFlag(
   props: TextingComplianceProps,
 ): React.JSX.Element {
-  const { ready, enabled } = useProUpgradeFlag()
+  const { enabled: proUpgrade3Enabled } = useProUpgrade3Flag()
+  const { enabled: proUpgrade1Enabled } = useProUpgradeFlag()
 
-  if (!ready || !enabled) {
-    return <TextingCompliance {...props} />
+  // Precedence: pro-upgrade3 > pro-upgrade1 > legacy. Both variants default to
+  // "off" until the Amplitude client resolves, so the legacy surface shows
+  // during load and the flagged surfaces appear only once a variant is known.
+  if (proUpgrade3Enabled) {
+    return <ProUpgrade3Compliance />
   }
 
-  return <TextingComplianceAgentic />
+  if (proUpgrade1Enabled) {
+    return <TextingComplianceAgentic />
+  }
+
+  return <TextingCompliance {...props} />
 }

--- a/app/shared/experiments/proUpgrade3Flag.ts
+++ b/app/shared/experiments/proUpgrade3Flag.ts
@@ -1,0 +1,13 @@
+import { useFlagOn } from './FeatureFlagsProvider'
+
+export const PRO_UPGRADE3_FLAG_KEY = 'pro-upgrade3'
+
+interface UseProUpgrade3FlagResult {
+  ready: boolean
+  enabled: boolean
+}
+
+export const useProUpgrade3Flag = (): UseProUpgrade3FlagResult => {
+  const { ready, on } = useFlagOn(PRO_UPGRADE3_FLAG_KEY)
+  return { ready, enabled: on }
+}


### PR DESCRIPTION
## What

Foundation for the Phase 3 pre-payment Pro upgrade wizard (ENG-10322) — the new `pro-upgrade3` flag, the multi-step wizard shell, and the step-derivation router that every other Phase 3 UI ticket (06–16) plugs into. Per tech doc v2 there is **no server-side wizard session**: the shell derives the current step from canonical state so a candidate who leaves and returns lands on the right step.

ClickUp: https://app.clickup.com/t/86ahxptfc

## Changes

- **`proUpgrade3Flag.ts`** — `useProUpgrade3Flag()` / `PRO_UPGRADE3_FLAG_KEY`, mirrors the existing `pro-upgrade1` flag hook.
- **`proUpgradeStep.ts`** — pure, side-effect-free `deriveProUpgradeStep(...)`. Returns the first incomplete step from canonical state (`isPro`, filing-status answer, EIN presence, TCR filing/PIN completeness, profile completeness). `isPro` short-circuits to the post-payment SUCCESS surface, never back to payment.
- **`ProUpgradeWizard.tsx`** — `FocusedExperienceWrapper` shell: flag gate (off cohort redirects to the untouched `/dashboard/pro-sign-up`), progress indicator, Back control, scroll reset, and a `useProUpgradeWizard` nav context for the step tasks. New route tree under `app/dashboard/pro-upgrade/` with per-step placeholder pages (tasks 06–15 replace each body).
- **`TextingComplianceFeatureFlag.tsx`** — precedence `pro-upgrade3 > pro-upgrade1 > legacy`, with a `ProUpgrade3Compliance` placeholder for the task-15 post-payment surface.

## Foundation seams (filled by dependent tickets)

1. **Filing-status answer** is a normalized `FilingStatus` tri-state into the pure derivation; `ProUpgradeEntry` maps it to `'unanswered'` with a `TODO(task 07)` until task 07 decides its `campaign.details` key.
2. **`pinComplete`** is in the input contract but doesn't gate a pre-payment step — reserved for task 15's post-payment states.

## ⚠️ Before enabling

The **`pro-upgrade3` Amplitude flag (variant `on`) must be created in the Amplitude console** before this works end-to-end — coordinate with the `pro-upgrade1` flag owner. With the flag off (current state), the wizard route redirects to the existing `/dashboard/pro-sign-up` flow, so no behavior change ships for any cohort yet.

## Testing

- `proUpgradeStep.test.ts` — 14 table-driven derivation cases over `(isPro, profileComplete, filingComplete, hasEin, pinComplete, filingStatus)`.
- `TextingComplianceFeatureFlag.test.tsx` — precedence: pro-upgrade3 surface when on, agentic when only pro-upgrade1 on, legacy when neither.
- `npx tsc`, `eslint`, and `prettier` all clean. No regressions in the affected dirs (33 tests pass).
- Manual Amplitude toggle is **not** verifiable until the flag exists in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches upgrade and texting-compliance entry points behind a new flag; behavior is unchanged until `pro-upgrade3` is enabled in Amplitude, but enabling it will route users through a new payment/compliance path.
> 
> **Overview**
> Adds the **Phase 3 Pro upgrade wizard foundation** under `/dashboard/pro-upgrade`: a `pro-upgrade3` Amplitude hook, a pure **`deriveProUpgradeStep`** router (no server session—resume from campaign/TCR/website state), and a **`ProUpgradeWizard`** shell (flag gate, back/progress, nav context) with placeholder step routes for later tasks.
> 
> The wizard **index** (`ProUpgradeEntry`) loads website + TCR data and **`router.replace`s** to the first incomplete step; filing status is stubbed as `'unanswered'` until task 07. When **`pro-upgrade3` is off**, the shell redirects to the existing **`/dashboard/pro-sign-up`** flow after the flag resolves.
> 
> **Texting compliance** routing now prefers **`pro-upgrade3` > `pro-upgrade1` > legacy**, with a **`ProUpgrade3Compliance`** placeholder for the post-payment surface. Unit tests cover step derivation and flag precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3872e2a9668468d1e6f71e15043549cff2086620. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->