### PR TITLE
feat(pro-upgrade3): value-prop / paywall wizard entry screen (ENG-10326)

### DIFF
--- a/app/dashboard/pro-upgrade/components/ValuePropStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ValuePropStep.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import ValuePropStep from './ValuePropStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const goToNextStep = vi.fn()
+
+describe('ValuePropStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'value-prop',
+      goToStep: vi.fn(),
+      goToNextStep,
+      goToPreviousStep: vi.fn(),
+    })
+  })
+
+  it('renders every comparison row and the Free / Pro column headers', () => {
+    render(<ValuePropStep />)
+
+    for (const label of [
+      'Campaign plan',
+      'Campaign advising',
+      'Voter data & list building',
+      '10DLC compliance',
+      'Texts and robocalls',
+      'Up to 5,000 free texts',
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+
+    expect(screen.getByText('Free')).toBeInTheDocument()
+    expect(screen.getByLabelText('PRO')).toBeInTheDocument()
+  })
+
+  it('maps the Free/Pro check and x marks per the design', () => {
+    const { container } = render(<ValuePropStep />)
+
+    // Pro column: a check on every row (6). Free column: only "Campaign plan"
+    // is included (1). Total checks 7, x marks 5.
+    expect(container.querySelectorAll('svg.lucide-check')).toHaveLength(7)
+    expect(container.querySelectorAll('svg.lucide-x')).toHaveLength(5)
+  })
+
+  it('advances to the next (filing-status) step when "Get Pro" is clicked', () => {
+    render(<ValuePropStep />)
+
+    screen.getByRole('button', { name: /get pro for \$10\/mo/i }).click()
+
+    expect(goToNextStep).toHaveBeenCalledTimes(1)
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
+  it('exits the wizard to the dashboard when "Maybe later" is clicked', () => {
+    render(<ValuePropStep />)
+
+    screen.getByRole('button', { name: /maybe later/i }).click()
+
+    expect(router.push).toHaveBeenCalledWith('/dashboard')
+    expect(goToNextStep).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/ValuePropStep.tsx
+++ b/app/dashboard/pro-upgrade/components/ValuePropStep.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button, ProBadge } from '@styleguide'
+import { CheckIcon, XMarkIcon } from '@styleguide/components/ui/icons'
+import H1 from '@shared/typography/H1'
+import Body2 from '@shared/typography/Body2'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+interface ComparisonRow {
+  label: string
+  free: boolean
+}
+// Free-vs-Pro comparison from the Figma. Every row is included in Pro, so only
+// the Free column varies.
+const COMPARISON_ROWS: ComparisonRow[] = [
+  { label: 'Campaign plan', free: true },
+  { label: 'Campaign advising', free: false },
+  { label: 'Voter data & list building', free: false },
+  { label: '10DLC compliance', free: false },
+  { label: 'Texts and robocalls', free: false },
+  { label: 'Up to 5,000 free texts', free: false },
+]
+
+const ROW_GRID = 'grid grid-cols-[1fr_64px_64px] items-center'
+
+const ValuePropStep = (): React.JSX.Element => {
+  const router = useRouter()
+  const { goToNextStep } = useProUpgradeWizard()
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.ValuePropViewed)
+  }, [])
+
+  const handleGetPro = () => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.ValuePropGetPro)
+    goToNextStep()
+  }
+
+  const handleMaybeLater = () => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.ValuePropMaybeLater)
+    router.push('/dashboard')
+  }
+
+  return (
+    <div>
+      <H1 className="text-center mb-2">76% of candidates who use Pro win</H1>
+      <Body2 className="text-center text-secondary mb-8">
+        Get $300 of value for $10/mo.
+      </Body2>
+
+      <div className="mb-10">
+        <div className={`${ROW_GRID} mb-2`}>
+          <span />
+          <span className="text-center text-secondary">Free</span>
+          <span className="flex justify-center">
+            <ProBadge />
+          </span>
+        </div>
+
+        {COMPARISON_ROWS.map(({ label, free }) => (
+          <div
+            key={label}
+            className={`${ROW_GRID} border-t border-gray-200 py-3`}
+          >
+            <span className="font-medium">{label}</span>
+            <span className="flex justify-center">
+              {free ? (
+                <CheckIcon className="h-5 w-5 text-primary" />
+              ) : (
+                <XMarkIcon className="h-5 w-5 text-destructive" />
+              )}
+            </span>
+            <span className="flex justify-center">
+              <CheckIcon className="h-5 w-5 text-primary" />
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-3">
+        <Button
+          size="large"
+          className="w-full sm:w-auto"
+          onClick={handleGetPro}
+        >
+          Get Pro for $10/mo
+        </Button>
+        <Button variant="ghost" size="large" onClick={handleMaybeLater}>
+          Maybe later
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default ValuePropStep

--- a/app/dashboard/pro-upgrade/value-prop/page.tsx
+++ b/app/dashboard/pro-upgrade/value-prop/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import ValuePropStep from '../components/ValuePropStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Upgrade to GoodParty.org Pro"
-      taskNote="Value-prop / paywall — ships in task 06"
-    />
-  )
+  return <ValuePropStep />
 }

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -335,6 +335,9 @@ export const EVENTS = {
     // Outreach.DlcCompliance.RegistrationSubmitted / PinVerificationCompleted,
     // ProUpgrade.ClickGoToStripe); the "viewed" steps below were the gap.
     Compliance: {
+      ValuePropViewed: 'Pro Upgrade - Value Prop Viewed',
+      ValuePropGetPro: 'Pro Upgrade - Value Prop: Click Get Pro',
+      ValuePropMaybeLater: 'Pro Upgrade - Value Prop: Click Maybe later',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',


### PR DESCRIPTION
## What

First screen of the pro-upgrade3 wizard (ENG-10326): the value-prop / paywall. Sells Pro with the "76% of candidates who use Pro win" headline, the `$10/mo` framing, and the Free-vs-Pro comparison table from the [Figma](https://www.figma.com/design/0RyHuhYvyCOhg0LErhO7tb/Pro-upgrade?node-id=7490-18479). Built on the wizard shell from ENG-10322 (#1982).

ClickUp: https://app.clickup.com/t/86ahxptfp

## Changes

- **`ValuePropStep.tsx`** (new) rendered at the `value-prop` route (replaces the task-01 placeholder). Headline + subtext, the comparison table (`ProBadge` column header, `CheckIcon`/`XMarkIcon` per row), and the two CTAs.
  - **Get Pro for $10/mo** → `useProUpgradeWizard().goToNextStep()` (advances to the filing-status `status` step).
  - **Maybe later** → `router.push('/dashboard')` (exits the wizard).
- Uses the shell's `FocusedExperienceWrapper` as the card; **gating is inherited** from the `pro-upgrade3` route layout (off cohort is redirected to `/dashboard/pro-sign-up` by the shell), so this screen never leaks to the off cohort.
- **Analytics:** added `ValuePropViewed` / `ValuePropGetPro` / `ValuePropMaybeLater` under `EVENTS.ProUpgrade.Compliance` (ENG-10294 naming).
- Responsive: comparison grid + `w-full sm:w-auto` CTA, matching the desktop (1440) and mobile (375) Figma frames.

## Testing

- `ValuePropStep.test.tsx`: renders all six comparison rows + Free/Pro headers; check/x mapping (7 checks, 5 x); Get Pro calls the shell advance; Maybe later pushes `/dashboard`.
- `npx vitest run app/dashboard/pro-upgrade` → 32 pass. `tsc`, `eslint`, prettier 3.8.3 all clean.
- Manual visual pass at both widths is pending (needs the flag on + auth); built to match the Figma screenshots.

## Notes for review

- **Copy variance in the Figma:** the desktop frame says "Campaign plan"; the mobile frame says "Personalized campaign plan". I used "Campaign plan" (desktop + ticket). Designer confirm welcome.
- **Global "← Exit" top-nav:** the Figma shows it on every wizard step, but the ENG-10322 shell doesn't implement it (only a Back button on middle steps). Left out of this screen-scoped PR — recommend a shell follow-up. "Maybe later" covers the exit AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and analytics-only changes on a gated wizard route; no auth, billing, or data-layer changes.
> 
> **Overview**
> Replaces the **value-prop** route placeholder with the first real **pro-upgrade3** wizard screen: headline/subcopy, a **Free vs Pro** comparison grid, and two CTAs wired through the existing wizard shell.
> 
> **Get Pro for $10/mo** calls `goToNextStep()` (next step in the funnel, e.g. filing status). **Maybe later** sends users to `/dashboard`. On mount and on each CTA, the step fires new **`EVENTS.ProUpgrade.Compliance`** analytics (`ValuePropViewed`, `ValuePropGetPro`, `ValuePropMaybeLater`). **`ValuePropStep.test.tsx`** covers copy, check/x icons, and navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcee01a23ccca6019fb6c92c674f8a2ef8f0226a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->