### PR TITLE
ENG-10327: filing-status branch screen (Have you already filed?)

### DIFF
--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
@@ -22,9 +22,8 @@ vi.mock('helpers/useSnackbar', () => ({
 
 // Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
 vi.mock('helpers/analyticsHelper', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('helpers/analyticsHelper')
-  >()
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
   return { ...actual, trackEvent: vi.fn() }
 })
 

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import FilingStatusStep from './FilingStatusStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn(),
+}))
+
+const errorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar }),
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('helpers/analyticsHelper')
+  >()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+const goToStep = vi.fn()
+
+describe('FilingStatusStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'status',
+      goToStep,
+      goToNextStep: vi.fn(),
+      goToPreviousStep: vi.fn(),
+    })
+    // Default: persistence succeeds and returns the updated campaign.
+    mockUpdateCampaign.mockResolvedValue({ id: 1 } as never)
+  })
+
+  it('fires the viewed analytics event on mount', () => {
+    render(<FilingStatusStep />)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingStatusViewed,
+    )
+  })
+
+  it('renders both options with their titles and descriptions', () => {
+    render(<FilingStatusStep />)
+    expect(screen.getByText("Yes, I'm already filed")).toBeInTheDocument()
+    expect(
+      screen.getByText('I have my campaign EIN and filing documents ready'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('No, not yet')).toBeInTheDocument()
+    expect(
+      screen.getByText('I still need to file for this election'),
+    ).toBeInTheDocument()
+  })
+
+  it('persists hasFiledForRace=true and advances to guidance when "Yes" is selected', async () => {
+    render(<FilingStatusStep />)
+
+    fireEvent.click(screen.getByText("Yes, I'm already filed"))
+
+    await waitFor(() => expect(goToStep).toHaveBeenCalledWith('guidance'))
+    expect(mockUpdateCampaign).toHaveBeenCalledWith([
+      { key: 'details.hasFiledForRace', value: true },
+    ])
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingStatusAlreadyFiled,
+    )
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('persists hasFiledForRace=false and routes to filing-instructions when "No" is selected', async () => {
+    render(<FilingStatusStep />)
+
+    fireEvent.click(screen.getByText('No, not yet'))
+
+    await waitFor(() =>
+      expect(goToStep).toHaveBeenCalledWith('filing-instructions'),
+    )
+    expect(mockUpdateCampaign).toHaveBeenCalledWith([
+      { key: 'details.hasFiledForRace', value: false },
+    ])
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingStatusNotFiled,
+    )
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('shows an error and does not navigate when persistence fails', async () => {
+    // updateCampaign swallows API errors and returns false; navigating anyway
+    // would strand an un-persisted answer (re-entry would re-ask the question).
+    mockUpdateCampaign.mockResolvedValue(false)
+
+    render(<FilingStatusStep />)
+
+    fireEvent.click(screen.getByText("Yes, I'm already filed"))
+
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(goToStep).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
@@ -112,5 +112,9 @@ describe('FilingStatusStep', () => {
     await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
     expect(goToStep).not.toHaveBeenCalled()
     expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toBeUndefined()
+    // The selection event must not fire for a write that never committed.
+    expect(trackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingStatusAlreadyFiled,
+    )
   })
 })

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, fireEvent, waitFor } from '@testing-library/react'
-import { render } from 'helpers/test-utils/render'
+import { render, testQueryClient } from 'helpers/test-utils/render'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
 import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import FilingStatusStep from './FilingStatusStep'
@@ -72,6 +73,10 @@ describe('FilingStatusStep', () => {
     expect(mockUpdateCampaign).toHaveBeenCalledWith([
       { key: 'details.hasFiledForRace', value: true },
     ])
+    // The cache write is load-bearing: ProUpgradeEntry derives the resume step
+    // from the campaign in this cache, so without it a returning candidate is
+    // re-asked the question they just answered.
+    expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toEqual({ id: 1 })
     expect(trackEvent).toHaveBeenCalledWith(
       EVENTS.ProUpgrade.Compliance.FilingStatusAlreadyFiled,
     )
@@ -89,6 +94,7 @@ describe('FilingStatusStep', () => {
     expect(mockUpdateCampaign).toHaveBeenCalledWith([
       { key: 'details.hasFiledForRace', value: false },
     ])
+    expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toEqual({ id: 1 })
     expect(trackEvent).toHaveBeenCalledWith(
       EVENTS.ProUpgrade.Compliance.FilingStatusNotFiled,
     )
@@ -106,5 +112,6 @@ describe('FilingStatusStep', () => {
 
     await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
     expect(goToStep).not.toHaveBeenCalled()
+    expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toBeUndefined()
   })
 })

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
@@ -75,6 +75,10 @@ const FilingStatusStep = (): React.JSX.Element => {
     trackEvent(option.event)
     queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updated)
     goToStep(option.nextStep)
+    // On a successful navigation this component unmounts and the update is
+    // discarded; if router.push fails silently the buttons re-enable so the
+    // candidate can retry instead of being stuck on a disabled screen.
+    setSubmitting(false)
   }
 
   return (

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { ChevronRightIcon } from '@styleguide/components/ui/icons'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { PRO_UPGRADE_STEP, type ProUpgradeStep } from '../proUpgradeStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+interface FilingStatusOption {
+  // Persisted to campaign.details.hasFiledForRace; read back by the wizard
+  // index via filingStatusFromDetails so this answer is respected on return.
+  hasFiled: boolean
+  title: string
+  description: string
+  event: string
+  // "Yes" → the guidance interstitial (task 09); "No" → the filing-instructions
+  // dead-end (task 08). Both are off the linear step order, so we navigate to
+  // them explicitly rather than via goToNextStep.
+  nextStep: ProUpgradeStep
+}
+
+const OPTIONS: FilingStatusOption[] = [
+  {
+    hasFiled: true,
+    title: "Yes, I'm already filed",
+    description: 'I have my campaign EIN and filing documents ready',
+    event: EVENTS.ProUpgrade.Compliance.FilingStatusAlreadyFiled,
+    nextStep: PRO_UPGRADE_STEP.GUIDANCE,
+  },
+  {
+    hasFiled: false,
+    title: 'No, not yet',
+    description: 'I still need to file for this election',
+    event: EVENTS.ProUpgrade.Compliance.FilingStatusNotFiled,
+    nextStep: PRO_UPGRADE_STEP.FILING_INSTRUCTIONS,
+  },
+]
+
+const FilingStatusStep = (): React.JSX.Element => {
+  const { goToStep } = useProUpgradeWizard()
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingStatusViewed)
+  }, [])
+
+  const handleSelect = async (option: FilingStatusOption): Promise<void> => {
+    // Guard against a double-tap firing two updates / navigations.
+    if (submitting) return
+    setSubmitting(true)
+    trackEvent(option.event)
+
+    const updated = await updateCampaign([
+      { key: 'details.hasFiledForRace', value: option.hasFiled },
+    ])
+
+    // updateCampaign swallows API errors and returns false. Navigating anyway
+    // would strand an un-persisted answer, so re-entry would re-ask the
+    // question — surface the failure and let the candidate retry instead.
+    if (!updated) {
+      errorSnackbar('Something went wrong. Please try again.')
+      setSubmitting(false)
+      return
+    }
+
+    queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updated)
+    goToStep(option.nextStep)
+  }
+
+  return (
+    <div>
+      <H2 className="mb-2">Have you already filed for your race?</H2>
+      <Body2 className="text-secondary mb-8">
+        In order to get Pro you need to be officially filed as a candidate to
+        comply with voter data and texting regulations.
+      </Body2>
+
+      <div className="flex flex-col gap-4">
+        {OPTIONS.map((option) => (
+          <button
+            key={option.title}
+            type="button"
+            onClick={() => void handleSelect(option)}
+            disabled={submitting}
+            className="flex w-full items-center justify-between gap-4 rounded-xl border border-gray-200 p-4 text-left transition-colors hover:border-primary hover:bg-gray-50 disabled:pointer-events-none disabled:opacity-60"
+          >
+            <span>
+              <span className="block font-medium">{option.title}</span>
+              <Body2 className="text-secondary">{option.description}</Body2>
+            </span>
+            <ChevronRightIcon className="h-5 w-5 shrink-0 text-secondary" />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default FilingStatusStep

--- a/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingStatusStep.tsx
@@ -56,7 +56,6 @@ const FilingStatusStep = (): React.JSX.Element => {
     // Guard against a double-tap firing two updates / navigations.
     if (submitting) return
     setSubmitting(true)
-    trackEvent(option.event)
 
     const updated = await updateCampaign([
       { key: 'details.hasFiledForRace', value: option.hasFiled },
@@ -71,6 +70,9 @@ const FilingStatusStep = (): React.JSX.Element => {
       return
     }
 
+    // Track the selection only after the write commits, so analytics don't
+    // over-count selections that failed to persist.
+    trackEvent(option.event)
     queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updated)
     goToStep(option.nextStep)
   }
@@ -90,7 +92,7 @@ const FilingStatusStep = (): React.JSX.Element => {
             type="button"
             onClick={() => void handleSelect(option)}
             disabled={submitting}
-            className="flex w-full items-center justify-between gap-4 rounded-xl border border-gray-200 p-4 text-left transition-colors hover:border-primary hover:bg-gray-50 disabled:pointer-events-none disabled:opacity-60"
+            className="flex w-full items-center justify-between gap-4 rounded-xl border border-gray-200 p-4 text-left transition-colors hover:border-primary hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-60"
           >
             <span>
               <span className="block font-medium">{option.title}</span>

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -31,7 +31,7 @@ const queryResult = (
     isPending: overrides.isPending ?? false,
     isError: overrides.isError ?? false,
     refetch: vi.fn(),
-  } as unknown as ReturnType<typeof useQuery>)
+  }) as unknown as ReturnType<typeof useQuery>
 
 describe('ProUpgradeEntry', () => {
   beforeEach(() => {

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -3,6 +3,8 @@ import { screen } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { useQuery } from '@tanstack/react-query'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import type { Campaign } from 'helpers/types'
 import ProUpgradeEntry from './ProUpgradeEntry'
 
 // Mock only useQuery so we control pending vs resolved; keep the real
@@ -12,7 +14,14 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   return { ...actual, useQuery: vi.fn() }
 })
 
+// Mock useCampaign so we can drive the persisted filing-status answer the
+// entry maps into the step derivation.
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: vi.fn(),
+}))
+
 const mockUseQuery = vi.mocked(useQuery)
+const mockUseCampaign = vi.mocked(useCampaign)
 
 const queryResult = (
   overrides: { isPending?: boolean; isError?: boolean } = {},
@@ -22,11 +31,13 @@ const queryResult = (
     isPending: overrides.isPending ?? false,
     isError: overrides.isError ?? false,
     refetch: vi.fn(),
-  }) as unknown as ReturnType<typeof useQuery>
+  } as unknown as ReturnType<typeof useQuery>)
 
 describe('ProUpgradeEntry', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default to no campaign; individual cases override.
+    mockUseCampaign.mockReturnValue([null])
   })
 
   it('renders a spinner and does not redirect while the queries are pending', () => {
@@ -50,6 +61,20 @@ describe('ProUpgradeEntry', () => {
     expect(router.replace).toHaveBeenCalledWith(
       '/dashboard/pro-upgrade/value-prop',
     )
+  })
+
+  it('respects a persisted "already filed" answer and does not redirect back to the filing-status step', () => {
+    // A returning candidate who answered "yes" maps to has-filed, so the
+    // router skips the status step. With no EIN yet, the first incomplete step
+    // is EIN — never the value-prop intro or a re-ask of the filing question.
+    mockUseQuery.mockReturnValue(queryResult())
+    mockUseCampaign.mockReturnValue([
+      { details: { hasFiledForRace: true } } as Campaign,
+    ])
+
+    render(<ProUpgradeEntry />)
+
+    expect(router.replace).toHaveBeenCalledWith('/dashboard/pro-upgrade/ein')
   })
 
   it('shows a recoverable error and does not redirect when a query fails', () => {

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react'
 import { render } from 'helpers/test-utils/render'
 import { router } from 'helpers/test-utils/router-mocking'
 import { useQuery } from '@tanstack/react-query'
-import { useCampaign } from '@shared/hooks/useCampaign'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 import type { Campaign } from 'helpers/types'
 import ProUpgradeEntry from './ProUpgradeEntry'
 
@@ -14,34 +14,41 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   return { ...actual, useQuery: vi.fn() }
 })
 
-// Mock useCampaign so we can drive the persisted filing-status answer the
-// entry maps into the step derivation.
-vi.mock('@shared/hooks/useCampaign', () => ({
-  useCampaign: vi.fn(),
-}))
-
 const mockUseQuery = vi.mocked(useQuery)
-const mockUseCampaign = vi.mocked(useCampaign)
 
 const queryResult = (
-  overrides: { isPending?: boolean; isError?: boolean } = {},
+  overrides: { data?: unknown; isPending?: boolean; isError?: boolean } = {},
 ): ReturnType<typeof useQuery> =>
   ({
-    data: null,
+    data: overrides.data ?? null,
     isPending: overrides.isPending ?? false,
     isError: overrides.isError ?? false,
     refetch: vi.fn(),
   }) as unknown as ReturnType<typeof useQuery>
 
+// The entry runs three queries (campaign, website, TCR). Drive the campaign
+// query independently from the other two so we can exercise its loading state.
+const setQueries = (
+  campaign: ReturnType<typeof useQuery>,
+  other: ReturnType<typeof useQuery>,
+): void => {
+  mockUseQuery.mockImplementation((options) =>
+    (options as { queryKey: unknown }).queryKey === CAMPAIGN_QUERY_KEY
+      ? campaign
+      : other,
+  )
+}
+
 describe('ProUpgradeEntry', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default to no campaign; individual cases override.
-    mockUseCampaign.mockReturnValue([null])
   })
 
   it('renders a spinner and does not redirect while the queries are pending', () => {
-    mockUseQuery.mockReturnValue(queryResult({ isPending: true }))
+    setQueries(
+      queryResult({ isPending: true }),
+      queryResult({ isPending: true }),
+    )
 
     render(<ProUpgradeEntry />)
 
@@ -50,8 +57,20 @@ describe('ProUpgradeEntry', () => {
     expect(router.replace).not.toHaveBeenCalled()
   })
 
+  it('holds on the spinner until the campaign query resolves, even if website/TCR are ready', () => {
+    // The campaign feeds isPro / EIN / filing-status derivation. Deriving while
+    // it is still loading (campaign null) would mis-route a returning candidate
+    // and produce a double-redirect when it later resolves.
+    setQueries(queryResult({ isPending: true }), queryResult())
+
+    render(<ProUpgradeEntry />)
+
+    expect(screen.getByText(/powered by/i)).toBeInTheDocument()
+    expect(router.replace).not.toHaveBeenCalled()
+  })
+
   it('renders nothing once the queries resolve and schedules the redirect', () => {
-    mockUseQuery.mockReturnValue(queryResult())
+    setQueries(queryResult(), queryResult())
 
     const { container } = render(<ProUpgradeEntry />)
 
@@ -67,10 +86,10 @@ describe('ProUpgradeEntry', () => {
     // A returning candidate who answered "yes" maps to has-filed, so the
     // router skips the status step. With no EIN yet, the first incomplete step
     // is EIN — never the value-prop intro or a re-ask of the filing question.
-    mockUseQuery.mockReturnValue(queryResult())
-    mockUseCampaign.mockReturnValue([
-      { details: { hasFiledForRace: true } } as Campaign,
-    ])
+    setQueries(
+      queryResult({ data: { details: { hasFiledForRace: true } } as Campaign }),
+      queryResult(),
+    )
 
     render(<ProUpgradeEntry />)
 
@@ -80,7 +99,7 @@ describe('ProUpgradeEntry', () => {
   it('shows a recoverable error and does not redirect when a query fails', () => {
     // A failed fetch leaves data undefined; redirecting would mis-derive a
     // returning candidate back to the intro as if they had zero progress.
-    mockUseQuery.mockReturnValue(queryResult({ isError: true }))
+    setQueries(queryResult({ isError: true }), queryResult())
 
     render(<ProUpgradeEntry />)
 

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
@@ -6,7 +6,10 @@ import { useQuery } from '@tanstack/react-query'
 import { Button } from '@styleguide'
 import H2 from '@shared/typography/H2'
 import Body2 from '@shared/typography/Body2'
-import { useCampaign } from '@shared/hooks/useCampaign'
+import {
+  CAMPAIGN_QUERY_KEY,
+  fetchCampaign,
+} from '@shared/hooks/CampaignProvider'
 import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
 import {
   USER_WEBSITE_QUERY_KEY,
@@ -29,8 +32,21 @@ import {
 // re-derives, landing a returning candidate on the first incomplete step.
 const ProUpgradeEntry = (): React.JSX.Element | null => {
   const router = useRouter()
-  const [campaign] = useCampaign()
 
+  // Observe the shared campaign query (same key as CampaignProvider, deduped)
+  // so step derivation waits for it. Reading campaign from context instead
+  // would let `ready` flip true while the campaign is still loading (when the
+  // SSR fetch returned null on token/API failure, so initialData is undefined),
+  // mis-deriving a returning candidate and producing a double-redirect.
+  const {
+    data: campaign,
+    isPending: campaignPending,
+    isError: campaignError,
+    refetch: refetchCampaign,
+  } = useQuery({
+    queryKey: CAMPAIGN_QUERY_KEY,
+    queryFn: fetchCampaign,
+  })
   const {
     data: website,
     isPending: websitePending,
@@ -50,8 +66,8 @@ const ProUpgradeEntry = (): React.JSX.Element | null => {
     queryFn: getTcrCompliance,
   })
 
-  const ready = !websitePending && !tcrPending
-  const hasError = websiteError || tcrError
+  const ready = !campaignPending && !websitePending && !tcrPending
+  const hasError = campaignError || websiteError || tcrError
 
   useEffect(() => {
     // Don't derive a step from partial state: a failed fetch leaves data
@@ -88,6 +104,7 @@ const ProUpgradeEntry = (): React.JSX.Element | null => {
         </Body2>
         <Button
           onClick={() => {
+            void refetchCampaign()
             void refetchWebsite()
             void refetchTcr()
           }}

--- a/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
+++ b/app/dashboard/pro-upgrade/components/ProUpgradeEntry.tsx
@@ -20,8 +20,8 @@ import {
 import { isCandidateProfileComplete } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
 import {
   deriveProUpgradeStep,
+  filingStatusFromDetails,
   proUpgradeStepPath,
-  type FilingStatus,
 } from '../proUpgradeStep'
 
 // Wizard index: derives the resume step from canonical state and redirects to
@@ -62,15 +62,9 @@ const ProUpgradeEntry = (): React.JSX.Element | null => {
     const { filingComplete, pinComplete } =
       getTcrComplianceStatusCompletions(tcrCompliance)
 
-    // TODO(task 07): map the candidate's persisted filing-status answer here
-    // once its campaign.details key is decided. Until then it is unanswered,
-    // so a candidate is held at the filing-status step rather than skipped past
-    // it.
-    const filingStatus: FilingStatus = 'unanswered'
-
     const step = deriveProUpgradeStep({
       isPro: Boolean(campaign?.isPro),
-      filingStatus,
+      filingStatus: filingStatusFromDetails(campaign?.details?.hasFiledForRace),
       hasEin: Boolean(campaign?.details?.einNumber),
       filingComplete,
       profileComplete: isCandidateProfileComplete(website),

--- a/app/dashboard/pro-upgrade/proUpgradeStep.test.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   deriveProUpgradeStep,
+  filingStatusFromDetails,
   PRO_UPGRADE_STEP,
   type FilingStatus,
   type ProUpgradeStepInputs,
@@ -168,5 +169,25 @@ describe('deriveProUpgradeStep', () => {
         deriveProUpgradeStep({ ...allComplete, filingStatus }),
       ).not.toThrow()
     }
+  })
+})
+
+describe('filingStatusFromDetails', () => {
+  // The persisted answer is a tri-state boolean on campaign.details: the
+  // candidate has answered yes (true), answered no (false), or not answered
+  // (undefined/null). This is the single mapping both the wizard index (read)
+  // and the filing-status step (write) share, so a "yes" candidate is never
+  // re-asked on return.
+  it('maps a true (already filed) answer to has-filed', () => {
+    expect(filingStatusFromDetails(true)).toBe('has-filed')
+  })
+
+  it('maps a false (not yet filed) answer to not-filed', () => {
+    expect(filingStatusFromDetails(false)).toBe('not-filed')
+  })
+
+  it('treats an unset answer as unanswered', () => {
+    expect(filingStatusFromDetails(undefined)).toBe('unanswered')
+    expect(filingStatusFromDetails(null)).toBe('unanswered')
   })
 })

--- a/app/dashboard/pro-upgrade/proUpgradeStep.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.ts
@@ -48,11 +48,21 @@ export const PRO_UPGRADE_STEP_ORDER: ProUpgradeStep[] = [
 ]
 
 // The candidate's answer to "have you already filed to run for this office?".
-// Task 07 owns where/how this is persisted (a campaign.details key decided
-// there); the router only needs the normalized tri-state, so its caller maps
-// the stored value into this. `unanswered` means the question has not been
-// answered yet.
+// The router only needs the normalized tri-state; its caller maps the stored
+// value into this. `unanswered` means the question has not been answered yet.
 export type FilingStatus = 'unanswered' | 'has-filed' | 'not-filed'
+
+// The answer is persisted as `campaign.details.hasFiledForRace` (task 07).
+// This is the single mapping the wizard index (read) and the filing-status
+// step (write) share, so a candidate who answered "yes" is never re-asked on
+// return. An unset value (never answered) is `unanswered`.
+export const filingStatusFromDetails = (
+  hasFiledForRace: boolean | null | undefined,
+): FilingStatus => {
+  if (hasFiledForRace === true) return 'has-filed'
+  if (hasFiledForRace === false) return 'not-filed'
+  return 'unanswered'
+}
 
 export interface ProUpgradeStepInputs {
   isPro: boolean

--- a/app/dashboard/pro-upgrade/status/page.tsx
+++ b/app/dashboard/pro-upgrade/status/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import FilingStatusStep from '../components/FilingStatusStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Your texting compliance status"
-      taskNote="Filing-status branch — ships in task 07"
-    />
-  )
+  return <FilingStatusStep />
 }

--- a/app/shared/hooks/CampaignProvider.tsx
+++ b/app/shared/hooks/CampaignProvider.tsx
@@ -16,21 +16,26 @@ interface CampaignProviderProps {
 
 export const CAMPAIGN_QUERY_KEY = ['campaign']
 
+// Shared so consumers can observe the same campaign query (deduped by key)
+// rather than redefining the fetch. A 404 means "no campaign yet" (null);
+// other errors propagate so callers can show a recoverable error state.
+export const fetchCampaign = async (): Promise<Campaign | null> => {
+  try {
+    const res = await clientRequest('GET /v1/campaigns/mine', {})
+    return res.data
+  } catch (e) {
+    if (e instanceof FetchError && e.status === 404) return null
+    throw e
+  }
+}
+
 export const CampaignProvider = ({
   children,
   campaign: initCampaign,
 }: CampaignProviderProps): React.JSX.Element => {
   const query = useQuery({
     queryKey: CAMPAIGN_QUERY_KEY,
-    queryFn: async () => {
-      try {
-        const res = await clientRequest('GET /v1/campaigns/mine', {})
-        return res.data
-      } catch (e) {
-        if (e instanceof FetchError && e.status === 404) return null
-        throw e
-      }
-    },
+    queryFn: fetchCampaign,
     initialData: initCampaign ?? undefined,
   })
 

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -338,6 +338,10 @@ export const EVENTS = {
       ValuePropViewed: 'Pro Upgrade - Value Prop Viewed',
       ValuePropGetPro: 'Pro Upgrade - Value Prop: Click Get Pro',
       ValuePropMaybeLater: 'Pro Upgrade - Value Prop: Click Maybe later',
+      FilingStatusViewed: 'Pro Upgrade - Filing Status Viewed',
+      FilingStatusAlreadyFiled:
+        'Pro Upgrade - Filing Status: Click already filed',
+      FilingStatusNotFiled: 'Pro Upgrade - Filing Status: Click not yet filed',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -148,6 +148,7 @@ export interface CampaignDetails {
   tier?: string
   einNumber?: string | null
   einSupportingDocument?: string | null
+  hasFiledForRace?: boolean | null
   wonGeneral?: boolean
   launchStatus?: string
   filedStatement?: string


### PR DESCRIPTION
## ENG-10327 — UI: filing-status branch screen ("Have you already filed?")

Task 07 of the [ENG-7508 Pro Upgrade Phase 3+4 epic](https://app.clickup.com/t/86ah2ezny). Behind the `pro-upgrade3` flag. Builds the second pre-payment wizard screen, matching the Figma "status" frame.

### What it does
Two large clickable option cards (title + description + chevron):
- **"Yes, I'm already filed"** → persists the answer, advances to the guidance interstitial (task 09).
- **"No, not yet"** → persists the answer, routes to the filing-instructions dead-end (task 08).

### The persisted-answer key (the epic's "decide once" gotcha)
The answer is stored as `campaign.details.hasFiledForRace` (tri-state boolean) and mapped into task 01's `FilingStatus` tri-state through a **single shared helper**, `filingStatusFromDetails`:
- `undefined`/`null` → `unanswered`
- `true` → `has-filed`
- `false` → `not-filed`

Both the write (this screen) and the read (`ProUpgradeEntry`, the wizard index) go through that one helper — no second key. This replaces the `TODO(task 07)` hardcoded `'unanswered'` left in `ProUpgradeEntry` by task 01, so a candidate who answered "yes" is no longer re-asked on return (they resume at the EIN step).

### Persistence
`updateCampaign([{ key: 'details.hasFiledForRace', value }])` → `queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updated)` (the `PrimaryResultModal` pattern). `updateCampaign` swallows API errors and returns `false`; that path shows an error snackbar and does **not** navigate, so an un-persisted answer can't be stranded.

### Tests
`npx vitest run app/dashboard/pro-upgrade/` → 35 passing.
- `filingStatusFromDetails` tri-state mapping.
- `FilingStatusStep`: viewed event, yes→persist+guidance, no→persist+filing-instructions, persist-failure→snackbar+no-nav.
- `ProUpgradeEntry`: a persisted "yes" skips the status step (lands on EIN).

`npm run types`, ESLint, and Prettier all clean.

### Notes
- "Yes" navigates to `guidance`; on a later re-entry the router can't derive the guidance interstitial (no persisted "seen" state) and sends a has-filed candidate to EIN — consistent with task 01's design.
- The cards use a raw accessible `<button>` (the pill-shaped styleguide `Button` doesn't fit a card row, and `RadioCardItem` shows radio circles the design omits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Pro upgrade UI and campaign detail field with guarded persistence and test coverage; no auth or payment changes.
> 
> **Overview**
> Adds the Pro upgrade **“Have you already filed?”** screen and wires it into wizard resume logic via **`campaign.details.hasFiledForRace`**.
> 
> **`FilingStatusStep`** replaces the status route placeholder with two option cards. Choosing **Yes** or **No** persists via `updateCampaign`, refreshes the campaign query cache, fires compliance analytics, and navigates to **`guidance`** or **`filing-instructions`**. Failed saves show a snackbar and **do not** navigate.
> 
> **`filingStatusFromDetails`** maps the stored tri-state boolean to `FilingStatus`; **`ProUpgradeEntry`** uses it instead of hardcoded `'unanswered'`, so returning users who already filed skip the status step (e.g. land on EIN). Types add **`hasFiledForRace`** on `CampaignDetails`; three new **`EVENTS.ProUpgrade.Compliance`** filing-status events are added. Tests cover the step, mapper, and entry redirect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d85ad414a0f0b9a241a24cb29cffb112be8fef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->