### PR TITLE
ENG-10328: filing-instructions dead-end screen (pro-upgrade3)

### DIFF
--- a/app/dashboard/pro-upgrade/components/FilingInstructionsStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingInstructionsStep.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import { router } from 'helpers/test-utils/router-mocking'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import type { Campaign } from 'helpers/types'
+import FilingInstructionsStep from './FilingInstructionsStep'
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: vi.fn(),
+}))
+
+const successSnackbar = vi.fn()
+const errorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ successSnackbar, errorSnackbar }),
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseCampaign = vi.mocked(useCampaign)
+
+const EMAIL_ROUTE = 'POST /v1/campaigns/mine/filing-instructions/email' as const
+
+// A fully-populated campaign: filing window on details, fee/requirements/office
+// on raceTargetMetrics. Individual tests override pieces to exercise omission.
+const fullCampaign = {
+  id: 1,
+  details: {
+    filingPeriodsStart: '2026-06-01',
+    filingPeriodsEnd: '2026-06-30',
+  },
+  raceTargetMetrics: {
+    filingFee: 0,
+    filingRequirementsText:
+      'Signature requirement is between 20 and 100 qualified electors.',
+    filingOfficeAddress: '270 Pleasant St, Rockland, ME 04841',
+    filingPhoneNumber: '(207) 594-8431',
+    paperworkInstructions:
+      'Complete and submit the Declaration of Candidacy form.',
+  },
+} as unknown as Campaign
+
+const setCampaign = (campaign: Campaign | null): void => {
+  mockUseCampaign.mockReturnValue([campaign] as never)
+}
+
+describe('FilingInstructionsStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setCampaign(fullCampaign)
+    api.mock(EMAIL_ROUTE, { status: 200, data: { success: true } })
+  })
+
+  it('fires the viewed analytics event on mount', () => {
+    render(<FilingInstructionsStep />)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingInstructionsViewed,
+    )
+  })
+
+  it('renders the filing window, fee, and requirements from campaign data', () => {
+    render(<FilingInstructionsStep />)
+
+    expect(screen.getByText('Filing window')).toBeInTheDocument()
+    // Both dates rendered and joined — verifies the window composition without
+    // pinning a timezone-sensitive exact day.
+    expect(screen.getByText(/2026.*–.*2026/)).toBeInTheDocument()
+
+    expect(screen.getByText('Filing requirements')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Filing fee is $0. Signature requirement is between 20 and 100 qualified electors.',
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the office-contact block (address + phone) when present', () => {
+    render(<FilingInstructionsStep />)
+
+    expect(screen.getByText('Filing office')).toBeInTheDocument()
+    expect(
+      screen.getByText('270 Pleasant St, Rockland, ME 04841'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('(207) 594-8431')).toBeInTheDocument()
+    expect(screen.getByText('Paperwork')).toBeInTheDocument()
+  })
+
+  it('omits requirements, paperwork, and office blocks when metrics are absent', () => {
+    setCampaign({ id: 1, details: {} } as unknown as Campaign)
+    render(<FilingInstructionsStep />)
+
+    // Window still renders (its own AC); the data-dependent blocks do not.
+    expect(screen.getByText('Filing window')).toBeInTheDocument()
+    expect(screen.queryByText('Filing requirements')).not.toBeInTheDocument()
+    expect(screen.queryByText('Paperwork')).not.toBeInTheDocument()
+    expect(screen.queryByText('Filing office')).not.toBeInTheDocument()
+  })
+
+  it('is a dead-end: offers a dashboard exit and no payment CTA', () => {
+    render(<FilingInstructionsStep />)
+
+    expect(
+      screen.getByRole('button', { name: 'Continue to dashboard' }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/payment/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/continue to payment/i)).not.toBeInTheDocument()
+  })
+
+  it('routes to the dashboard when the exit is clicked', () => {
+    render(<FilingInstructionsStep />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Continue to dashboard' }),
+    )
+
+    expect(router.push).toHaveBeenCalledWith('/dashboard')
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingInstructionsExit,
+    )
+  })
+
+  it('emails the filing instructions and confirms success', async () => {
+    const onRequest = vi.fn()
+    api.mock(EMAIL_ROUTE, () => {
+      onRequest()
+      return { status: 200, data: { success: true } }
+    })
+
+    render(<FilingInstructionsStep />)
+
+    fireEvent.click(screen.getByRole('button', { name: /email this to me/i }))
+
+    await waitFor(() => expect(successSnackbar).toHaveBeenCalled())
+    // The real clientRequest path hit the endpoint, not just a mocked fn.
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingInstructionsEmail,
+    )
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('shows an error snackbar when the email request fails', async () => {
+    api.mock(EMAIL_ROUTE, { status: 500, data: { message: 'boom' } })
+
+    render(<FilingInstructionsStep />)
+
+    fireEvent.click(screen.getByRole('button', { name: /email this to me/i }))
+
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(successSnackbar).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/FilingInstructionsStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingInstructionsStep.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@styleguide'
+import {
+  CalendarIcon,
+  ClipboardListIcon,
+  FileTextIcon,
+  MapPinIcon,
+  SendIcon,
+} from '@styleguide/components/ui/icons'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { dateUsHelper } from 'helpers/dateHelper'
+import { clientRequest } from 'gpApi/typed-request'
+
+// Mirror gp-api's renderFilingInstructionsEmail window logic so the on-screen
+// window and the "email this to me" body can't drift: both → "start – end",
+// else whichever single date exists, else a not-yet-available fallback.
+const formatFilingWindow = (
+  start: string | null | undefined,
+  end: string | null | undefined,
+): string => {
+  const formattedStart = start ? dateUsHelper(start, 'long') : ''
+  const formattedEnd = end ? dateUsHelper(end, 'long') : ''
+  if (formattedStart && formattedEnd) {
+    return `${formattedStart} – ${formattedEnd}`
+  }
+  return formattedStart || formattedEnd || 'Not yet available'
+}
+
+interface InstructionRowProps {
+  icon: React.ReactNode
+  label: string
+  children: React.ReactNode
+}
+
+const InstructionRow = ({
+  icon,
+  label,
+  children,
+}: InstructionRowProps): React.JSX.Element => (
+  <div className="flex gap-3 border-t border-gray-200 p-4 first:border-t-0">
+    <span className="mt-0.5 shrink-0 text-primary">{icon}</span>
+    <div>
+      <span className="block font-medium">{label}</span>
+      <Body2 className="text-secondary">{children}</Body2>
+    </div>
+  </div>
+)
+
+const FilingInstructionsStep = (): React.JSX.Element => {
+  const router = useRouter()
+  const [campaign] = useCampaign()
+  const { errorSnackbar, successSnackbar } = useSnackbar()
+  const [emailing, setEmailing] = useState(false)
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingInstructionsViewed)
+  }, [])
+
+  const metrics = campaign?.raceTargetMetrics
+  const filingFee = metrics?.filingFee ?? null
+  const filingRequirementsText = metrics?.filingRequirementsText ?? null
+  const filingOfficeAddress = metrics?.filingOfficeAddress ?? null
+  const filingPhoneNumber = metrics?.filingPhoneNumber ?? null
+  const paperworkInstructions = metrics?.paperworkInstructions ?? null
+
+  // Compose fee + requirements into one "Filing requirements" detail, matching
+  // the Figma ("Filing fee is $X. <requirements text>"). $-format matches
+  // gp-api's email body (raw dollars) so the two surfaces report the same fee.
+  const requirementsDetail = [
+    filingFee != null ? `Filing fee is $${filingFee}.` : null,
+    filingRequirementsText,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const hasOffice = Boolean(filingOfficeAddress || filingPhoneNumber)
+
+  const handleEmail = async (): Promise<void> => {
+    // Guard against a double-tap firing two sends.
+    if (emailing) return
+    setEmailing(true)
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingInstructionsEmail)
+    try {
+      // No body: gp-api scopes the send to the caller's own campaign + email.
+      await clientRequest(
+        'POST /v1/campaigns/mine/filing-instructions/email',
+        {},
+      )
+      successSnackbar('Filing instructions sent to your email.')
+    } catch (e) {
+      console.error('error emailing filing instructions', e)
+      errorSnackbar('Something went wrong. Please try again.')
+    } finally {
+      setEmailing(false)
+    }
+  }
+
+  const handleExit = (): void => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingInstructionsExit)
+    router.push('/dashboard')
+  }
+
+  return (
+    <div>
+      <H2 className="mb-2">
+        You&apos;re not eligible for Pro yet, but here&apos;s how to file for
+        this election
+      </H2>
+      <Body2 className="text-secondary mb-8">
+        Once done, you can come right back and we&apos;ll have everything ready
+        to go. In the meantime, you still have access to our free campaign
+        tools.
+      </Body2>
+
+      <div className="rounded-xl border border-gray-200">
+        <InstructionRow
+          icon={<CalendarIcon className="h-5 w-5" />}
+          label="Filing window"
+        >
+          {formatFilingWindow(
+            campaign?.details?.filingPeriodsStart,
+            campaign?.details?.filingPeriodsEnd,
+          )}
+        </InstructionRow>
+
+        {requirementsDetail && (
+          <InstructionRow
+            icon={<FileTextIcon className="h-5 w-5" />}
+            label="Filing requirements"
+          >
+            {requirementsDetail}
+          </InstructionRow>
+        )}
+
+        {paperworkInstructions && (
+          <InstructionRow
+            icon={<ClipboardListIcon className="h-5 w-5" />}
+            label="Paperwork"
+          >
+            {paperworkInstructions}
+          </InstructionRow>
+        )}
+
+        {hasOffice && (
+          <InstructionRow
+            icon={<MapPinIcon className="h-5 w-5" />}
+            label="Filing office"
+          >
+            {filingOfficeAddress && (
+              <span className="block">{filingOfficeAddress}</span>
+            )}
+            {filingPhoneNumber && (
+              <span className="block">{filingPhoneNumber}</span>
+            )}
+          </InstructionRow>
+        )}
+
+        <div className="flex justify-center border-t border-gray-200 p-2">
+          <Button
+            variant="ghost"
+            size="small"
+            onClick={() => void handleEmail()}
+            loading={emailing}
+            loadingText="Sending…"
+            icon={<SendIcon className="h-4 w-4" />}
+            iconPosition="right"
+          >
+            Email this to me
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-end">
+        <Button size="large" onClick={handleExit}>
+          Continue to dashboard
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default FilingInstructionsStep

--- a/app/dashboard/pro-upgrade/filing-instructions/page.tsx
+++ b/app/dashboard/pro-upgrade/filing-instructions/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import FilingInstructionsStep from '../components/FilingInstructionsStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="How to file to run for office"
-      taskNote="Filing-instructions screen — ships in task 08"
-    />
-  )
+  return <FilingInstructionsStep />
 }

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -140,6 +140,16 @@ export type APIEndpoints = {
     Response: CampaignVersions
   }
 
+  // Emails the caller their own race's filing instructions (window, fee,
+  // requirements, office contact). No body: gp-api scopes the send to the
+  // authenticated user's campaign + email via @UseCampaign()/@ReqUser().
+  'POST /v1/campaigns/mine/filing-instructions/email': {
+    Request: {}
+    Response: {
+      success: boolean
+    }
+  }
+
   'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin': {
     Request: {
       pin: string

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -342,6 +342,11 @@ export const EVENTS = {
       FilingStatusAlreadyFiled:
         'Pro Upgrade - Filing Status: Click already filed',
       FilingStatusNotFiled: 'Pro Upgrade - Filing Status: Click not yet filed',
+      FilingInstructionsViewed: 'Pro Upgrade - Filing Instructions Viewed',
+      FilingInstructionsEmail:
+        'Pro Upgrade - Filing Instructions: Click email this to me',
+      FilingInstructionsExit:
+        'Pro Upgrade - Filing Instructions: Click continue to dashboard',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -372,6 +372,18 @@ export interface RaceTargetMetrics {
    * text" even when `filingFee` is null.
    */
   filingRequirementsText?: string | null
+  /**
+   * Structured filing-office contact for the race, sourced from BallotReady
+   * via election-api. Powers the "filing office" block on the Pro-upgrade
+   * filing-instructions screen. `filingOfficeAddress` is a single free-text
+   * block (address line 1/2, city, state, zip); `paperworkInstructions` is
+   * BallotReady's narrative on the paperwork a candidate files. All `null`
+   * when BallotReady has no office data for the race. Optional for forward-
+   * compat with API responses that pre-date the field.
+   */
+  filingOfficeAddress?: string | null
+  filingPhoneNumber?: string | null
+  paperworkInstructions?: string | null
   // Fields sourced from election-api's /campaign-strategy-context via gp-api.
   // All nullable — null when the race hash didn't resolve to a
   // Position+District or upstream data is sparse. Optional for forward-compat

--- a/styleguide/components/ui/icons.tsx
+++ b/styleguide/components/ui/icons.tsx
@@ -34,6 +34,7 @@ export {
   LoaderCircle as LoaderCircleIcon,
   LogOut as LogOutIcon,
   Mail as MailIcon,
+  MapPin as MapPinIcon,
   Menu as MenuIcon,
   MessageSquare as MessageSquareIcon,
   Mic as MicIcon,


### PR DESCRIPTION
## What

Replaces the `filing-instructions` placeholder in the pro-upgrade3 wizard with a real `FilingInstructionsStep`. Candidates land here from the filing-status branch (ENG-10327) when they answer **"No, not yet"**. It's a dead-end: it explains how to file and exits to the dashboard — no payment CTA.

Closes ENG-10328 (task 08 of the ENG-7508 epic).

## What renders

- **Filing window** — `campaign.details.filingPeriodsStart/End`
- **Filing requirements** — `raceTargetMetrics.filingFee` + `filingRequirementsText` ("Filing fee is $X. …")
- **Paperwork** — `raceTargetMetrics.paperworkInstructions` (ENG-10325)
- **Filing office** — `filingOfficeAddress` + `filingPhoneNumber` (ENG-10325)
- **Email this to me** — typed `POST /v1/campaigns/mine/filing-instructions/email`
- **Continue to dashboard** — the exit

All sourced from the campaign already in context (no new fetch). Conditional blocks omit cleanly when their data is null.

## Acceptance criteria

- [x] Renders window, fee, and requirements text from existing campaign data, no new fetch
- [x] Renders the office-contact block when available; omits cleanly when not
- [x] "Email this to me" triggers the email and confirms success
- [x] Dead-end: no continue-to-payment; offers an exit to the dashboard

## Notes / deviations

- **API pattern:** ticket said `gpApi/routes.ts`, but `gpApi/CLAUDE.md` forbids new `routes.ts` entries — used the canonical typed `clientRequest` + `api-endpoints.ts`. The gp-api endpoint is already merged, so the contract is coordinated.
- **Anti-drift:** the window/fee formatting mirrors gp-api's `renderFilingInstructionsEmail`, so the screen and the emailed copy report the same values.
- **"Eligibility" row omitted** — the Figma shows it, but there's no backing field (not in the contract or the email renderer). Omitted rather than invent data; worth a design confirm.
- **No footer "Back"** — the wizard shell already renders a top Back arrow on off-order routes, so a footer Back would duplicate it.
- **Email endpoint takes no body** — gp-api scopes the send to the caller's own campaign + email via `@UseCampaign()`/`@ReqUser()`.

## Testing

- `FilingInstructionsStep.test.tsx` — 8 tests (window/fee/requirements render, office present/absent, dead-end + no payment CTA, dashboard exit, email success + error). Email tested through the network boundary (`api.mock`), exercising the real `clientRequest` path.
- Full pro-upgrade suite: 44 passing. `npm run types` + `npm run lint`: clean.
- Not yet walked through live (needs `pro-upgrade3` flag on + a not-yet-filed candidate; real office data needs election-api #191 on dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only pro-upgrade funnel step using existing campaign context and a documented email endpoint; covered by component tests with no auth or payment changes.
> 
> **Overview**
> Replaces the pro-upgrade **filing-instructions** placeholder with **`FilingInstructionsStep`**, a dead-end for candidates who have not filed yet: filing guidance from in-context campaign data, **no payment CTA**, exit via **Continue to dashboard**.
> 
> The step renders filing window (`details.filingPeriodsStart/End`), combined fee + requirements, optional paperwork and filing office (`raceTargetMetrics`), and **Email this to me** via typed `POST /v1/campaigns/mine/filing-instructions/email` (`clientRequest`). Window/fee copy is aligned with gp-api email rendering to avoid drift.
> 
> Supporting updates: **`RaceTargetMetrics`** office/paperwork fields, three **Pro Upgrade compliance** analytics events, **`MapPinIcon`**, and **`FilingInstructionsStep.test.tsx`** (8 tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c853c312b24573256cec8f214e2c773ab3a6ce80. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->