### PR TITLE
feat(pro-upgrade3): guidance interstitial (ENG-10329)

### DIFF
--- a/app/dashboard/pro-upgrade/components/GuidanceStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/GuidanceStep.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import GuidanceStep from './GuidanceStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const goToStep = vi.fn()
+const goToNextStep = vi.fn()
+
+describe('GuidanceStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'guidance',
+      goToStep,
+      goToNextStep,
+      goToPreviousStep: vi.fn(),
+    })
+  })
+
+  it('fires the viewed analytics event on mount', () => {
+    render(<GuidanceStep />)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.GuidanceViewed,
+    )
+  })
+
+  it('renders the heading and all four numbered checklist items', () => {
+    render(<GuidanceStep />)
+
+    expect(
+      screen.getByText(/we'll need to gather a few things/i),
+    ).toBeInTheDocument()
+
+    for (const label of [
+      'Your campaign EIN',
+      'Your campaign filing details',
+      'Your candidate profile',
+      'Payment',
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+
+    // The four ordinal markers, per the Figma numbered list.
+    for (const ordinal of ['1', '2', '3', '4']) {
+      expect(screen.getByText(ordinal)).toBeInTheDocument()
+    }
+  })
+
+  it('advances explicitly to the EIN step when "Let\'s go!" is clicked', () => {
+    render(<GuidanceStep />)
+
+    screen.getByRole('button', { name: /let's go/i }).click()
+
+    // GUIDANCE is off the linear order, so it must navigate to EIN explicitly
+    // rather than via goToNextStep (which would no-op from an off-order route).
+    expect(goToStep).toHaveBeenCalledWith('ein')
+    expect(goToNextStep).not.toHaveBeenCalled()
+    expect(router.push).not.toHaveBeenCalled()
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.GuidanceContinue,
+    )
+  })
+})

--- a/app/dashboard/pro-upgrade/components/GuidanceStep.tsx
+++ b/app/dashboard/pro-upgrade/components/GuidanceStep.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Button } from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { PRO_UPGRADE_STEP } from '../proUpgradeStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+// The four things the rest of the wizard collects, in the order the candidate
+// encounters them (EIN → filing details → candidate profile → payment). Per
+// the Figma "guidance" frame these are plain labels — the filing window dates
+// live on the not-yet-filed filing-instructions screen, not here. This screen
+// is presentational only: it sets expectations and neither reads nor writes
+// any of these.
+const GATHER_STEPS = [
+  'Your campaign EIN',
+  'Your campaign filing details',
+  'Your candidate profile',
+  'Payment',
+]
+
+const GuidanceStep = (): React.JSX.Element => {
+  const { goToStep } = useProUpgradeWizard()
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.GuidanceViewed)
+  }, [])
+
+  const handleContinue = (): void => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.GuidanceContinue)
+    // GUIDANCE is off the linear step order (the router can't derive an
+    // interstitial with no persisted "seen" state), so advance explicitly to
+    // the EIN step rather than via goToNextStep.
+    goToStep(PRO_UPGRADE_STEP.EIN)
+  }
+
+  return (
+    <div>
+      <H2 className="mb-2">
+        Great! We&apos;ll need to gather a few things to get you set up for
+        texting
+      </H2>
+      <Body2 className="text-secondary mb-8">
+        This is required to access voter data and send texts.
+      </Body2>
+
+      <ol className="rounded-xl border border-gray-200">
+        {GATHER_STEPS.map((label, index) => (
+          <li
+            key={label}
+            className="flex items-center gap-3 border-t border-gray-200 p-4 first:border-t-0"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-50 font-medium text-primary">
+              {index + 1}
+            </span>
+            <span>{label}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-8 flex justify-end">
+        <Button size="large" onClick={handleContinue}>
+          Let&apos;s go!
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default GuidanceStep

--- a/app/dashboard/pro-upgrade/guidance/page.tsx
+++ b/app/dashboard/pro-upgrade/guidance/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import GuidanceStep from '../components/GuidanceStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="What to expect next"
-      taskNote="Guidance interstitial — ships in task 09"
-    />
-  )
+  return <GuidanceStep />
 }

--- a/app/dashboard/pro-upgrade/proUpgradeStep.ts
+++ b/app/dashboard/pro-upgrade/proUpgradeStep.ts
@@ -35,8 +35,10 @@ export const proUpgradeStepPath = (step: ProUpgradeStep): string =>
 // - `filing-instructions`: a dead-end branch off `status` (the candidate has
 //   not yet filed to run), not a resumable step in the linear flow.
 // - `guidance`: an interstitial with no persisted "seen" state, so the router
-//   cannot derive it. TODO(task 09): insert it here once that task defines how
-//   it is reached and advanced past.
+//   cannot derive it. It is reached only by explicit navigation from the
+//   filing-status step ("yes, already filed" → guidance) and advances by
+//   explicit navigation to the EIN step (task 09), so it stays out of the
+//   linear order by design rather than being inserted here.
 export const PRO_UPGRADE_STEP_ORDER: ProUpgradeStep[] = [
   PRO_UPGRADE_STEP.VALUE_PROP,
   PRO_UPGRADE_STEP.STATUS,

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -347,6 +347,8 @@ export const EVENTS = {
         'Pro Upgrade - Filing Instructions: Click email this to me',
       FilingInstructionsExit:
         'Pro Upgrade - Filing Instructions: Click continue to dashboard',
+      GuidanceViewed: 'Pro Upgrade - Guidance Viewed',
+      GuidanceContinue: "Pro Upgrade - Guidance: Click let's go",
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',


### PR DESCRIPTION
## What

Adds the "what we'll gather" guidance interstitial (ENG-10329, task 09 of the Pro Upgrade Phase 3+4 epic). Shown after a candidate confirms they're already filed (filing-status "yes"), before the EIN step.

Presentational only — it sets expectations and neither reads nor writes campaign state:
- Heading + subtext per the Figma `guidance` frame.
- A 4-item numbered checklist: campaign EIN, filing details, candidate profile, payment.
- A single "Let's go!" CTA that advances **explicitly** to the EIN step (`goToStep('ein')`), because `guidance` is off the linear step order.

## Design deviation from the ticket AC

The ticket AC asked for the **filing window dates on item 2**. The current Figma `guidance` frame (`7490:18479` → `7490:18687`) shows item 2 as a plain label with no dates — the dates now live on the not-yet-filed `FilingInstructionsStep` (task 08). Confirmed with the implementer to **match the Figma (no dates)**. The data is available client-side, so this is a design choice, not a limitation. The ticket AC text should be updated to match.

## Notes

- **No footer Back button.** The wizard shell already renders a top Back arrow for off-order routes (`guidance` is orderIndex -1), same call task 08 made for `FilingInstructionsStep`.
- **Resolved a stale TODO** in `proUpgradeStep.ts`: `guidance` stays out of `PRO_UPGRADE_STEP_ORDER` by design — the router can't derive an interstitial with no persisted "seen" state, so it's reached via explicit nav from filing-status and advances via explicit nav to EIN.
- Added `GuidanceViewed` / `GuidanceContinue` analytics events, matching the sibling funnel-event pattern.

## Test plan

- `npx vitest run app/dashboard/pro-upgrade/` → 47 passed (3 new GuidanceStep tests: viewed event, renders heading + 4 items + ordinals, CTA advances to EIN).
- `npm run types` clean, `npm run lint` (eslint + prettier 3.8.3) clean.
- Manual: visual compare to Figma pending — needs the `pro-upgrade3` flag on + an already-filed candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only funnel step with no campaign state reads/writes; navigation behavior is covered by unit tests.
> 
> **Overview**
> Replaces the **guidance** route placeholder with a real **GuidanceStep** interstitial for candidates who already filed, shown after filing-status “yes” and before EIN.
> 
> The screen is **presentational only**: heading, subtext, and a **four-item numbered checklist** (EIN, filing details, candidate profile, payment). **“Let’s go!”** calls **`goToStep('ein')`** instead of linear **`goToNextStep`**, because **`guidance`** stays **out of `PRO_UPGRADE_STEP_ORDER`** (no persisted “seen” state). Comments in **`proUpgradeStep.ts`** document that design.
> 
> Adds **`GuidanceViewed`** / **`GuidanceContinue`** analytics and **three Vitest** cases (mount event, copy/UI, CTA navigation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e8dd99b77197229011b64ec9ba8650627a35c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->