### PR TITLE
ENG-10330: Pro upgrade EIN step (front-end validation)

### DIFF
--- a/app/dashboard/pro-sign-up/committee-check/components/EinCheckInput.tsx
+++ b/app/dashboard/pro-sign-up/committee-check/components/EinCheckInput.tsx
@@ -24,6 +24,11 @@ interface EinCheckInputProps {
   helperText?: React.ReactNode
   name?: string
   error?: boolean
+  // Fired when the help tooltip opens. Defaults to the committee-check
+  // (Phase 1) event so that flow is unchanged; other flows (e.g. the
+  // pro-upgrade EIN step) inject their own so the hover lands in the right
+  // analytics funnel instead of CommitteeCheck's.
+  onTooltipOpen?: () => void
 }
 
 export const EinCheckInput = ({
@@ -31,6 +36,8 @@ export const EinCheckInput = ({
   validated,
   setValidated = noop,
   onChange = noop,
+  onTooltipOpen = () =>
+    trackEvent(EVENTS.ProUpgrade.CommitteeCheck.HoverEinHelp),
   ...restProps
 }: EinCheckInputProps): React.JSX.Element => {
   const handleOnChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -60,9 +67,7 @@ export const EinCheckInput = ({
           <AsyncValidationIcon
             message={EIN_HELP_MESSAGE}
             validated={validated}
-            onTooltipOpen={() => {
-              trackEvent(EVENTS.ProUpgrade.CommitteeCheck.HoverEinHelp)
-            }}
+            onTooltipOpen={onTooltipOpen}
           />
         ),
       }}

--- a/app/dashboard/pro-upgrade/components/EinStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/EinStep.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, testQueryClient } from 'helpers/test-utils/render'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import EinStep from './EinStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: vi.fn(),
+}))
+
+vi.mock('app/onboarding/shared/ajaxActions', () => ({
+  updateCampaign: vi.fn(),
+}))
+
+const errorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar }),
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests. The real
+// EinCheckInput / AsyncValidationIcon also call trackEvent, so a real EVENTS
+// tree keeps those wired without exploding.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const mockUseCampaign = vi.mocked(useCampaign)
+const mockUpdateCampaign = vi.mocked(updateCampaign)
+const goToNextStep = vi.fn()
+
+// A well-formed EIN with an IRS-issued prefix (12) that is not a placeholder.
+const CLEAN_EIN = '12-3456780'
+
+const setEin = (value: string) => {
+  fireEvent.change(screen.getByLabelText('Campaign EIN'), { target: { value } })
+}
+
+const seedCampaign = (einNumber?: string) =>
+  mockUseCampaign.mockReturnValue([
+    einNumber ? ({ details: { einNumber } } as never) : null,
+  ])
+
+describe('EinStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'ein',
+      goToStep: vi.fn(),
+      goToNextStep,
+      goToPreviousStep: vi.fn(),
+    })
+    // Default: no EIN on file yet, persistence succeeds.
+    seedCampaign(undefined)
+    mockUpdateCampaign.mockResolvedValue({ id: 1 } as never)
+  })
+
+  it('fires the viewed analytics event on mount', () => {
+    render(<EinStep />)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.EinViewed,
+    )
+  })
+
+  it('renders the EIN input and the IRS link', () => {
+    render(<EinStep />)
+    expect(screen.getByLabelText('Campaign EIN')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /get a free ein/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('irs.gov'))
+  })
+
+  it('keeps Continue disabled for a format-invalid (incomplete) EIN', () => {
+    render(<EinStep />)
+    setEin('12')
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    expect(mockUpdateCampaign).not.toHaveBeenCalled()
+  })
+
+  it('disables Continue and shows the Phase 1 error copy for a non-IRS-prefix EIN', async () => {
+    render(<EinStep />)
+
+    // 07 is not an IRS-issued prefix, but the value passes the shape-only check.
+    setEin('07-1234567')
+
+    expect(
+      await screen.findByText(/prefix isn't one the IRS issues/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    expect(mockUpdateCampaign).not.toHaveBeenCalled()
+  })
+
+  it('disables Continue and shows the placeholder error copy for a placeholder EIN', async () => {
+    render(<EinStep />)
+
+    // All-same-digit is a classic placeholder the sanity check rejects.
+    setEin('00-0000000')
+
+    expect(
+      await screen.findByText(/looks like a placeholder/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    expect(mockUpdateCampaign).not.toHaveBeenCalled()
+  })
+
+  it('persists einNumber + validatedEin and advances for a clean EIN', async () => {
+    render(<EinStep />)
+
+    setEin(CLEAN_EIN)
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    await waitFor(() => expect(continueButton).toBeEnabled())
+
+    fireEvent.click(continueButton)
+
+    await waitFor(() => expect(goToNextStep).toHaveBeenCalledTimes(1))
+    expect(mockUpdateCampaign).toHaveBeenCalledWith([
+      { key: 'details.einNumber', value: CLEAN_EIN },
+      { key: 'details.validatedEin', value: true },
+    ])
+    // The cache write is load-bearing: ProUpgradeEntry derives the resume step
+    // from the campaign in this cache, so without it a returning candidate is
+    // re-asked for the EIN they just entered.
+    expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toEqual({ id: 1 })
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.EinContinue,
+    )
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('shows an error and does not advance when persistence fails', async () => {
+    // updateCampaign swallows API errors and returns false; advancing anyway
+    // would strand an un-persisted EIN (re-entry would re-prompt).
+    mockUpdateCampaign.mockResolvedValue(false)
+
+    render(<EinStep />)
+
+    setEin(CLEAN_EIN)
+    const continueButton = screen.getByRole('button', { name: 'Continue' })
+    await waitFor(() => expect(continueButton).toBeEnabled())
+
+    fireEvent.click(continueButton)
+
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(goToNextStep).not.toHaveBeenCalled()
+    expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toBeUndefined()
+  })
+
+  it('prefills a previously entered EIN and treats the step as complete', async () => {
+    seedCampaign(CLEAN_EIN)
+
+    render(<EinStep />)
+
+    expect(screen.getByLabelText('Campaign EIN')).toHaveValue(CLEAN_EIN)
+    // A prefilled, valid EIN means the step is already satisfied: Continue is
+    // enabled on mount with no edits.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(),
+    )
+  })
+})

--- a/app/dashboard/pro-upgrade/components/EinStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/EinStep.test.tsx
@@ -153,6 +153,10 @@ describe('EinStep', () => {
     await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
     expect(goToNextStep).not.toHaveBeenCalled()
     expect(testQueryClient.getQueryData(CAMPAIGN_QUERY_KEY)).toBeUndefined()
+    // The continue event must not fire for a write that never committed.
+    expect(trackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.EinContinue,
+    )
   })
 
   it('prefills a previously entered EIN and treats the step as complete', async () => {
@@ -166,5 +170,44 @@ describe('EinStep', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled(),
     )
+  })
+
+  it('syncs a persisted EIN that resolves after first render', async () => {
+    // No SSR initialData: the shared campaign query is still pending on mount,
+    // so useCampaign returns null, then resolves with the saved EIN.
+    seedCampaign(undefined)
+    const { rerender } = render(<EinStep />)
+    expect(screen.getByLabelText('Campaign EIN')).toHaveValue('')
+
+    seedCampaign(CLEAN_EIN)
+    rerender(<EinStep />)
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Campaign EIN')).toHaveValue(CLEAN_EIN),
+    )
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('does not flash an error for a prefilled complete-but-bad EIN', async () => {
+    // A legacy EIN saved before the sanity rules existed: format-valid but a
+    // non-IRS prefix. It must stay neutral on mount (no red error) until the
+    // candidate edits the untouched field, and Continue stays disabled.
+    seedCampaign('07-1234567')
+
+    render(<EinStep />)
+
+    expect(screen.getByLabelText('Campaign EIN')).toHaveValue('07-1234567')
+    expect(
+      screen.queryByText(/prefix isn't one the IRS issues/i),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+
+    // Once the candidate edits it, the sanity verdict (and error) surfaces.
+    fireEvent.change(screen.getByLabelText('Campaign EIN'), {
+      target: { value: '08-1234567' },
+    })
+    expect(
+      await screen.findByText(/prefix isn't one the IRS issues/i),
+    ).toBeInTheDocument()
   })
 })

--- a/app/dashboard/pro-upgrade/components/EinStep.tsx
+++ b/app/dashboard/pro-upgrade/components/EinStep.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@styleguide'
 import H2 from '@shared/typography/H2'
@@ -28,35 +28,53 @@ const EinStep = (): React.JSX.Element => {
   const queryClient = useQueryClient()
   const { errorSnackbar } = useSnackbar()
 
-  // Prefill from the persisted EIN so a returning candidate sees their value and
-  // the step is treated complete (the icon settles to a green check on mount).
   const persistedEin = campaign?.details?.einNumber ?? ''
   const [einInputValue, setEinInputValue] = useState(persistedEin)
+  // Initialize to the sanity-aware verdict, but only surface a green check for a
+  // prefilled value that passes — a complete-but-bad prefilled EIN (e.g. a
+  // legacy save predating the sanity rules) stays neutral until the candidate
+  // edits it, so we never flash a red error on a field they haven't touched.
   const [validatedEin, setValidatedEin] = useState<boolean | null>(() =>
-    einIndicatorState(persistedEin),
+    einIndicatorState(persistedEin) === true ? true : null,
   )
   const [submitting, setSubmitting] = useState(false)
+  // Once the candidate edits the field we stop syncing from the persisted value
+  // and start surfacing the full sanity verdict (including the red error).
+  const hasInteracted = useRef(false)
 
   useEffect(() => {
     trackEvent(EVENTS.ProUpgrade.Compliance.EinViewed)
   }, [])
 
-  // `einIndicatorState` is sanity-aware: true only for a complete, plausible
-  // EIN, false for a complete-but-bad one (placeholder / non-IRS prefix), and
-  // null while still typing — so a partial EIN never flashes an error.
-  const doEinCheck = useCallback(() => {
-    setValidatedEin(einIndicatorState(einInputValue))
+  // Sync the field from the persisted EIN until the candidate edits it. This
+  // also covers a campaign query that resolves *after* first render (no SSR
+  // initialData), which a one-time useState initializer would miss — leaving a
+  // returning candidate's saved EIN unpopulated.
+  useEffect(() => {
+    if (hasInteracted.current) return
+    setEinInputValue(persistedEin)
+  }, [persistedEin])
+
+  // Recompute the verdict whenever the value changes. `einIndicatorState` is
+  // sanity-aware: true for a complete, plausible EIN, false for a
+  // complete-but-bad one (placeholder / non-IRS prefix), null while still
+  // typing. Before the candidate interacts we suppress the `false` verdict so a
+  // prefilled bad EIN shows neutral rather than an error on mount.
+  useEffect(() => {
+    const indicator = einIndicatorState(einInputValue)
+    setValidatedEin(
+      !hasInteracted.current && indicator === false ? null : indicator,
+    )
   }, [einInputValue])
 
-  useEffect(() => {
-    doEinCheck()
-  }, [doEinCheck])
+  const onEinChange = (value: string): void => {
+    hasInteracted.current = true
+    setEinInputValue(value)
+  }
 
   const handleNextClick = async (): Promise<void> => {
     // Guard against a double-tap firing two updates / navigations.
     if (submitting) return
-
-    trackEvent(EVENTS.ProUpgrade.Compliance.EinContinue)
 
     // Defense-in-depth: the button is disabled while the EIN fails sanity
     // (placeholder, non-IRS prefix), but never persist a bad EIN even if that
@@ -78,6 +96,9 @@ const EinStep = (): React.JSX.Element => {
       return
     }
 
+    // Track only after the write commits, so a failed persist isn't counted as
+    // a continue (matching the wizard's other steps).
+    trackEvent(EVENTS.ProUpgrade.Compliance.EinContinue)
     // The cache write is load-bearing: ProUpgradeEntry derives the resume step
     // from the campaign in this cache, so without it a returning candidate is
     // re-asked for the EIN they just entered.
@@ -109,7 +130,10 @@ const EinStep = (): React.JSX.Element => {
         validated={validatedEin}
         setValidated={setValidatedEin}
         error={validatedEin === false}
-        onChange={setEinInputValue}
+        onChange={onEinChange}
+        onTooltipOpen={() =>
+          trackEvent(EVENTS.ProUpgrade.Compliance.EinHoverHelp)
+        }
         helperText={
           <a
             href="https://sa.www4.irs.gov/applyein/legalStructure"

--- a/app/dashboard/pro-upgrade/components/EinStep.tsx
+++ b/app/dashboard/pro-upgrade/components/EinStep.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Button } from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { updateCampaign } from 'app/onboarding/shared/ajaxActions'
+import { EinCheckInput } from 'app/dashboard/pro-sign-up/committee-check/components/EinCheckInput'
+import {
+  checkEinSanity,
+  einIndicatorState,
+} from '@shared/inputs/EinSanityCheck'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+// Front-end EIN collection, Phase 1 style: format + sanity only, no backend /
+// IRS verification (Peerly stays the downstream backstop for a truly bad EIN).
+// Reuses the exact validation the committee-check page uses so the client and
+// server sanity layers can't drift: `einIndicatorState` drives the field icon
+// and `checkEinSanity` gates submit.
+const EinStep = (): React.JSX.Element => {
+  const { goToNextStep } = useProUpgradeWizard()
+  const [campaign] = useCampaign()
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+
+  // Prefill from the persisted EIN so a returning candidate sees their value and
+  // the step is treated complete (the icon settles to a green check on mount).
+  const persistedEin = campaign?.details?.einNumber ?? ''
+  const [einInputValue, setEinInputValue] = useState(persistedEin)
+  const [validatedEin, setValidatedEin] = useState<boolean | null>(() =>
+    einIndicatorState(persistedEin),
+  )
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.EinViewed)
+  }, [])
+
+  // `einIndicatorState` is sanity-aware: true only for a complete, plausible
+  // EIN, false for a complete-but-bad one (placeholder / non-IRS prefix), and
+  // null while still typing — so a partial EIN never flashes an error.
+  const doEinCheck = useCallback(() => {
+    setValidatedEin(einIndicatorState(einInputValue))
+  }, [einInputValue])
+
+  useEffect(() => {
+    doEinCheck()
+  }, [doEinCheck])
+
+  const handleNextClick = async (): Promise<void> => {
+    // Guard against a double-tap firing two updates / navigations.
+    if (submitting) return
+
+    trackEvent(EVENTS.ProUpgrade.Compliance.EinContinue)
+
+    // Defense-in-depth: the button is disabled while the EIN fails sanity
+    // (placeholder, non-IRS prefix), but never persist a bad EIN even if that
+    // gate is somehow bypassed.
+    if (!checkEinSanity(einInputValue).valid) return
+
+    setSubmitting(true)
+    const updated = await updateCampaign([
+      { key: 'details.einNumber', value: einInputValue },
+      { key: 'details.validatedEin', value: true },
+    ])
+
+    // updateCampaign swallows API errors and returns false. Advancing anyway
+    // would strand an un-persisted EIN, so the step would re-prompt on return —
+    // surface the failure and let the candidate retry instead.
+    if (!updated) {
+      errorSnackbar('Something went wrong. Please try again.')
+      setSubmitting(false)
+      return
+    }
+
+    // The cache write is load-bearing: ProUpgradeEntry derives the resume step
+    // from the campaign in this cache, so without it a returning candidate is
+    // re-asked for the EIN they just entered.
+    queryClient.setQueryData(CAMPAIGN_QUERY_KEY, updated)
+    goToNextStep()
+    setSubmitting(false)
+  }
+
+  // `validatedEin` is sanity-aware, so this keeps Continue disabled for a
+  // complete-but-bad EIN (consistent with the red field indicator).
+  const nextDisabled = !validatedEin || submitting
+
+  // When `validatedEin === false` the EIN is complete but failed sanity; surface
+  // the specific reason inline (the disabled button can't be clicked to show it).
+  const einSanity = checkEinSanity(einInputValue)
+
+  return (
+    <div>
+      <H2 className="mb-2">What is your campaign EIN?</H2>
+      <Body2 className="text-secondary mb-8">
+        Every campaign needs one to access voter data and texting. If you
+        don&apos;t have one for your campaign, you can get a free EIN from the
+        IRS in just a few minutes.
+      </Body2>
+
+      <EinCheckInput
+        name="ein-number"
+        value={einInputValue}
+        validated={validatedEin}
+        setValidated={setValidatedEin}
+        error={validatedEin === false}
+        onChange={setEinInputValue}
+        helperText={
+          <a
+            href="https://sa.www4.irs.gov/applyein/legalStructure"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Get a free EIN in 3-5 minutes (irs.gov)
+          </a>
+        }
+      />
+      {validatedEin === false && !einSanity.valid && (
+        <Body2 className="text-error my-4 text-center">
+          {einSanity.message}
+        </Body2>
+      )}
+
+      <div className="mt-8 flex justify-end">
+        <Button
+          size="large"
+          onClick={() => void handleNextClick()}
+          disabled={nextDisabled}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default EinStep

--- a/app/dashboard/pro-upgrade/ein/page.tsx
+++ b/app/dashboard/pro-upgrade/ein/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import EinStep from '../components/EinStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Your EIN"
-      taskNote="EIN step — ships in task 10"
-    />
-  )
+  return <EinStep />
 }

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -351,6 +351,7 @@ export const EVENTS = {
       GuidanceContinue: "Pro Upgrade - Guidance: Click let's go",
       EinViewed: 'Pro Upgrade - EIN Viewed',
       EinContinue: 'Pro Upgrade - EIN: Click continue',
+      EinHoverHelp: 'Pro Upgrade - EIN: Hover help',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -349,6 +349,8 @@ export const EVENTS = {
         'Pro Upgrade - Filing Instructions: Click continue to dashboard',
       GuidanceViewed: 'Pro Upgrade - Guidance Viewed',
       GuidanceContinue: "Pro Upgrade - Guidance: Click let's go",
+      EinViewed: 'Pro Upgrade - EIN Viewed',
+      EinContinue: 'Pro Upgrade - EIN: Click continue',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',


### PR DESCRIPTION
## What

Task 10 of the Pro Upgrade Phase 3 epic ([ENG-10330](https://app.clickup.com/t/86ahxptgd)). Adds the **EIN step** to the `pro-upgrade3` wizard at the `ein` route, replacing the task-01 placeholder.

Validation is **front-end only, exactly as in Phase 1** — format + sanity, no backend / IRS verification. Peerly remains the downstream backstop for a truly bad EIN. Reuses the committee-check building blocks (`EinCheckInput`, `isValidEIN`, `checkEinSanity`/`einIndicatorState`) so the client sanity layer can't drift — no re-implemented validator.

## Behavior

- Renders the EIN input + the IRS "get a free EIN" helper link.
- A format-invalid or sanity-failing EIN (placeholder / non-IRS prefix) keeps **Continue** disabled and shows the existing Phase 1 error copy inline.
- A clean EIN persists `details.einNumber` + `details.validatedEin = true` via `updateCampaign`, writes the returned campaign to the `CAMPAIGN_QUERY_KEY` cache (so `ProUpgradeEntry` resumes correctly), and advances via `goToNextStep()` (→ filing-details).
- `updateCampaign` returning `false` shows an error snackbar and does **not** advance — no stranded un-persisted EIN.
- Prefills from `campaign.details.einNumber` on re-entry; the step is treated complete.
- Adds `EinViewed` / `EinContinue` under `EVENTS.ProUpgrade.Compliance`.

## Deviations from the ticket

- **Committee name not collected here.** The ticket's persist list mentioned `details.campaignCommittee` "if the Figma requires it" — the Figma EIN frame (`7490:18479`) has no committee field (it's gathered elsewhere in the wizard), so only `einNumber` + `validatedEin` are persisted. `ProUpgradeEntry` derives `hasEin` from `einNumber` alone, so re-entry still works.
- **Figma's "OR + accordion" treatment not built.** The ticket scoped this to "EIN input + the IRS link" reusing the committee-check pattern (the IRS link as the input's helper text). The accordion is flagged as a design nicety for a possible follow-up.

## Tests

`npx vitest run app/dashboard/pro-upgrade` → **55 passed** (8 new in `EinStep.test.tsx`). The sanity gate runs against the **real** `checkEinSanity` (non-IRS-prefix and placeholder EINs blocked with the existing copy), and both the persist-success and persist-failure branches plus prefill-on-re-entry are covered.

`npm run types` and `npm run lint` clean.

## Acceptance criteria

- [x] Renders EIN input + IRS link; format-invalid / sanity-failing EINs block submit with the Phase 1 error copy
- [x] Clean EIN persists to `campaign.details.einNumber` (+ `details.validatedEin = true`) and advances
- [x] No backend EIN-verification call (front-end only)
- [x] On re-entry, a previously entered EIN is prefilled and the step is treated complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wizard UI and campaign detail fields only; reuses existing validation and updateCampaign patterns with tests.
> 
> **Overview**
> Replaces the **EIN** route placeholder with a real wizard step that collects the campaign EIN using the same **Phase 1** front-end validation as committee-check (`EinCheckInput`, `einIndicatorState`, `checkEinSanity`)—format and sanity only, no IRS/backend verification.
> 
> **Continue** stays disabled for incomplete or failing EINs (with existing inline error copy); a valid EIN persists `details.einNumber` and `details.validatedEin` via `updateCampaign`, updates the `CAMPAIGN_QUERY_KEY` cache so resume routing works, then calls `goToNextStep`. Failed saves show a snackbar and do not advance. Returning users get a prefilled EIN and an enabled **Continue** when already valid.
> 
> Adds **`EinViewed`** / **`EinContinue`** under `EVENTS.ProUpgrade.Compliance` and **`EinStep.test.tsx`** covering analytics, validation gates, persist success/failure, and prefill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db99fe0c34033f7670dcc0d7b703ce35d065124c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->