### PR TITLE
ENG-10331: Pro upgrade filing-details step

### DIFF
--- a/app/dashboard/pro-upgrade/components/FilingDetailsStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingDetailsStep.test.tsx
@@ -101,11 +101,20 @@ const fillValidNonFederalForm = () => {
 }
 
 describe('ballotLevelToOfficeLevel', () => {
-  it('maps the four onboarding office-level strings to the backend enum', () => {
+  it('maps the capitalized manual-entry office-level labels to the backend enum', () => {
     expect(ballotLevelToOfficeLevel('Federal')).toBe('federal')
     expect(ballotLevelToOfficeLevel('State')).toBe('state')
     expect(ballotLevelToOfficeLevel('Local/Township/City')).toBe('local')
     expect(ballotLevelToOfficeLevel('County/Regional')).toBe('local')
+  })
+
+  it('maps the lowercase BallotReady position.level values case-insensitively', () => {
+    // BallotReady search stores lowercase levels (e.g. onboarding fixtures use
+    // `level: 'local'`); these must not fall through to the local default for
+    // federal/state, which would hide the FEC fields and submit a wrong level.
+    expect(ballotLevelToOfficeLevel('federal')).toBe('federal')
+    expect(ballotLevelToOfficeLevel('state')).toBe('state')
+    expect(ballotLevelToOfficeLevel('local')).toBe('local')
   })
 
   it('defaults an unknown or missing ballot level to local', () => {
@@ -239,5 +248,61 @@ describe('FilingDetailsStep', () => {
     render(<FilingDetailsStep />)
     expect(screen.getByLabelText('FEC Committee ID')).toBeInTheDocument()
     expect(screen.getByText('Committee type *')).toBeInTheDocument()
+  })
+
+  it('submits fecCommitteeId + the chosen committeeType verbatim for a federal candidate', async () => {
+    seedCampaign({ einNumber: CLEAN_EIN, ballotLevel: 'Federal' })
+    render(<FilingDetailsStep />)
+
+    fireEvent.change(screen.getByLabelText('Campaign committee name'), {
+      target: { value: 'Friends of Jane' },
+    })
+    // Federal validation requires the filing link to be a fec.gov URL.
+    fireEvent.change(screen.getByLabelText('Campaign filing link'), {
+      target: { value: 'https://www.fec.gov/data/committee/C00123456' },
+    })
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'jane@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Phone'), {
+      target: { value: '4155551234' },
+    })
+    fireEvent.click(screen.getByTestId('select-address'))
+    fireEvent.change(screen.getByLabelText('FEC Committee ID'), {
+      target: { value: 'C00123456' },
+    })
+    // Committee type is the only Radix Select rendered (office level is hidden).
+    fireEvent.click(screen.getByRole('combobox'))
+    fireEvent.click(screen.getByRole('option', { name: 'House' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1))
+    const [, payload] = mockSubmit.mock.calls[0]!
+    // The federal branch must NOT strip the FEC id nor force CANDIDATE — that
+    // distinction is the whole contract with the backend's federal branch.
+    expect(payload).toEqual(
+      expect.objectContaining({
+        officeLevel: 'federal',
+        fecCommitteeId: 'C00123456',
+        committeeType: 'HOUSE',
+      }),
+    )
+    expect(payload.committeeType).not.toBe('CANDIDATE')
+    await waitFor(() => expect(goToNextStep).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not double-submit on two rapid clicks', async () => {
+    render(<FilingDetailsStep />)
+    fillValidNonFederalForm()
+
+    // Two synchronous clicks before the async `loading` prop can re-render: the
+    // synchronous ref guard must block the second so only one TCR registration
+    // is created.
+    const button = screen.getByRole('button', { name: 'Continue' })
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1))
   })
 })

--- a/app/dashboard/pro-upgrade/components/FilingDetailsStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingDetailsStep.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { apiRoutes } from 'gpApi/routes'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { submitTcrCompliance } from 'app/dashboard/profile/texting-compliance/util/registrationFormData.util'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import FilingDetailsStep, {
+  ballotLevelToOfficeLevel,
+  getInitialFilingDetailsState,
+} from './FilingDetailsStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+vi.mock('@shared/hooks/useCampaign', () => ({
+  useCampaign: vi.fn(),
+}))
+
+// Keep toRegistrationFormData real (the test asserts the mapped payload shape);
+// only stub the network submit so we can assert what it was called with and
+// drive the success / failure branches.
+vi.mock(
+  'app/dashboard/profile/texting-compliance/util/registrationFormData.util',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('app/dashboard/profile/texting-compliance/util/registrationFormData.util')
+      >()
+    return { ...actual, submitTcrCompliance: vi.fn() }
+  },
+)
+
+const errorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar }),
+}))
+
+// AddressAutocomplete pulls in the Google Places widget; stub it with a button
+// that fires onSelect so a test can supply a valid filing address.
+vi.mock('@shared/AddressAutocomplete', () => ({
+  default: ({
+    onSelect,
+  }: {
+    onSelect: (place: { formatted_address: string; place_id: string }) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="select-address"
+      onClick={() =>
+        onSelect({ formatted_address: '123 Main St', place_id: 'place-123' })
+      }
+    >
+      select address
+    </button>
+  ),
+}))
+
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const mockUseCampaign = vi.mocked(useCampaign)
+const mockSubmit = vi.mocked(submitTcrCompliance)
+const goToNextStep = vi.fn()
+
+// A well-formed, non-placeholder EIN with an IRS-issued prefix.
+const CLEAN_EIN = '12-3456780'
+
+type CampaignDetails = {
+  einNumber?: string
+  campaignCommittee?: string
+  ballotLevel?: string
+}
+
+const seedCampaign = (details: CampaignDetails | null) =>
+  mockUseCampaign.mockReturnValue([
+    details === null ? null : ({ details } as never),
+  ])
+
+// Fill every field a non-federal candidate must provide for a valid submit.
+const fillValidNonFederalForm = () => {
+  fireEvent.change(screen.getByLabelText('Campaign committee name'), {
+    target: { value: 'Friends of Jane' },
+  })
+  fireEvent.change(screen.getByLabelText('Campaign filing link'), {
+    target: { value: 'https://example.com/filing' },
+  })
+  fireEvent.change(screen.getByLabelText('Email'), {
+    target: { value: 'jane@example.com' },
+  })
+  fireEvent.change(screen.getByLabelText('Phone'), {
+    target: { value: '4155551234' },
+  })
+  fireEvent.click(screen.getByTestId('select-address'))
+}
+
+describe('ballotLevelToOfficeLevel', () => {
+  it('maps the four onboarding office-level strings to the backend enum', () => {
+    expect(ballotLevelToOfficeLevel('Federal')).toBe('federal')
+    expect(ballotLevelToOfficeLevel('State')).toBe('state')
+    expect(ballotLevelToOfficeLevel('Local/Township/City')).toBe('local')
+    expect(ballotLevelToOfficeLevel('County/Regional')).toBe('local')
+  })
+
+  it('defaults an unknown or missing ballot level to local', () => {
+    expect(ballotLevelToOfficeLevel(undefined)).toBe('local')
+    expect(ballotLevelToOfficeLevel(null)).toBe('local')
+    expect(ballotLevelToOfficeLevel('Something else')).toBe('local')
+  })
+})
+
+describe('getInitialFilingDetailsState', () => {
+  it('prefills committee + EIN and derives officeLevel, leaving contact info blank', () => {
+    const state = getInitialFilingDetailsState({
+      details: {
+        einNumber: CLEAN_EIN,
+        campaignCommittee: 'Friends of Jane',
+        ballotLevel: 'State',
+      },
+    } as never)
+    expect(state.ein).toBe(CLEAN_EIN)
+    expect(state.campaignCommitteeName).toBe('Friends of Jane')
+    expect(state.officeLevel).toBe('state')
+    // Filing contact info must be entered fresh to match the official filing.
+    expect(state.email).toBe('')
+    expect(state.phone).toBe('')
+  })
+})
+
+describe('FilingDetailsStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'filing-details',
+      goToStep: vi.fn(),
+      goToNextStep,
+      goToPreviousStep: vi.fn(),
+    })
+    // Default: a local candidate with EIN already collected at the prior step.
+    seedCampaign({ einNumber: CLEAN_EIN, ballotLevel: 'Local/Township/City' })
+    mockSubmit.mockResolvedValue(undefined)
+  })
+
+  it('fires the viewed analytics event once the form is shown', () => {
+    render(<FilingDetailsStep />)
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+    )
+  })
+
+  it('shows a loading placeholder (and no view event) until the campaign loads', () => {
+    seedCampaign(null)
+    render(<FilingDetailsStep />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(trackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.FilingDetailsViewed,
+    )
+  })
+
+  it('renders the filing-details fields and the mismatch warning copy', () => {
+    render(<FilingDetailsStep />)
+    expect(
+      screen.getByText('What are your campaign filing details?'),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/it will take much longer/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Campaign committee name')).toBeInTheDocument()
+    expect(screen.getByLabelText('Campaign filing link')).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Phone')).toBeInTheDocument()
+    expect(screen.getByTestId('select-address')).toBeInTheDocument()
+  })
+
+  it('submits the mapped payload to createAgentic and advances on success', async () => {
+    render(<FilingDetailsStep />)
+    fillValidNonFederalForm()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1))
+    expect(mockSubmit).toHaveBeenCalledWith(
+      apiRoutes.campaign.tcrCompliance.createAgentic,
+      expect.objectContaining({
+        campaignCommitteeName: 'Friends of Jane',
+        electionFilingLink: 'https://example.com/filing',
+        officeLevel: 'local',
+        ein: CLEAN_EIN,
+        email: 'jane@example.com',
+        phone: '4155551234',
+        address: { formatted_address: '123 Main St', place_id: 'place-123' },
+        // Non-federal committees submit as CANDIDATE.
+        committeeType: 'CANDIDATE',
+      }),
+      expect.any(String),
+    )
+    await waitFor(() => expect(goToNextStep).toHaveBeenCalledTimes(1))
+    expect(trackEvent).toHaveBeenCalledWith(
+      EVENTS.Outreach.DlcCompliance.RegistrationSubmitted,
+      expect.objectContaining({ email: 'jane@example.com' }),
+    )
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('does not submit or advance when the form is invalid', () => {
+    // No fields filled (and no EIN on file) → invalid form.
+    seedCampaign({ ballotLevel: 'Local/Township/City' })
+    render(<FilingDetailsStep />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(mockSubmit).not.toHaveBeenCalled()
+    expect(goToNextStep).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error and does not advance when the submit fails', async () => {
+    mockSubmit.mockRejectedValue(new Error('boom'))
+    render(<FilingDetailsStep />)
+    fillValidNonFederalForm()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(goToNextStep).not.toHaveBeenCalled()
+  })
+
+  it('hides the FEC fields for a non-federal candidate', () => {
+    render(<FilingDetailsStep />)
+    expect(screen.queryByLabelText('FEC Committee ID')).not.toBeInTheDocument()
+    expect(screen.queryByText('Committee type *')).not.toBeInTheDocument()
+  })
+
+  it('shows the FEC fields for a federal candidate', () => {
+    seedCampaign({ einNumber: CLEAN_EIN, ballotLevel: 'Federal' })
+    render(<FilingDetailsStep />)
+    expect(screen.getByLabelText('FEC Committee ID')).toBeInTheDocument()
+    expect(screen.getByText('Committee type *')).toBeInTheDocument()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/FilingDetailsStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingDetailsStep.tsx
@@ -43,24 +43,24 @@ import { useProUpgradeWizard } from './ProUpgradeWizard'
 // The backend createAgentic endpoint validates officeLevel against the
 // federal/state/local enum, and the federal branch additionally requires FEC
 // fields. The candidate already chose an office in onboarding, so we derive the
-// level from `details.ballotLevel` rather than re-asking. Onboarding persists
-// exactly the four option strings below (OfficeStepForm); anything else
-// (including a missing value on a pre-structured-office campaign) falls back to
-// `local`, which is the safest default for our overwhelmingly down-ballot
-// audience and keeps the candidate from stalling on a hidden field.
+// level from `details.ballotLevel` rather than re-asking. That value comes from
+// two paths with different casing: BallotReady search stores lowercase
+// `local` / `state` / `federal` (per `position.level`), while manual entry
+// stores the capitalized labels `Federal` / `State` / `County/Regional` /
+// `Local/Township/City` (OfficeStepForm). Match case-insensitively on the only
+// two levels that change behavior; everything else — county/city/township,
+// regional, and any missing value on a pre-structured-office campaign — maps to
+// `local`, the safe default for our overwhelmingly down-ballot audience that
+// keeps the candidate from stalling on a hidden field.
 type OfficeLevel = 'federal' | 'state' | 'local'
 
 export const ballotLevelToOfficeLevel = (
   ballotLevel: string | null | undefined,
 ): OfficeLevel => {
-  switch (ballotLevel) {
-    case 'Federal':
-      return 'federal'
-    case 'State':
-      return 'state'
-    default:
-      return 'local'
-  }
+  const normalized = ballotLevel?.trim().toLowerCase()
+  if (normalized === 'federal') return 'federal'
+  if (normalized === 'state') return 'state'
+  return 'local'
 }
 
 // EIN and committee come from `campaign.details` (the EIN was collected and
@@ -140,13 +140,24 @@ const FilingDetailsForm = ({
     handleChange({ fecCommitteeId: value })
   }
 
+  // Synchronous double-submit guard. `loading` is a parent prop that only
+  // reflects the submission after a re-render, so a second click in the same
+  // render cycle would slip past `if (loading)` and create a second TCR
+  // registration. A ref flips immediately. Mirrors the shared
+  // TextingComplianceRegistrationForm.
+  const submittingRef = useRef(false)
+  useEffect(() => {
+    if (!loading) submittingRef.current = false
+  }, [loading])
+
   const handleContinue = () => {
     if (!isValid) {
       setAttemptedSubmit(true)
       window.scrollTo({ top: 0, behavior: 'smooth' })
       return
     }
-    if (loading) return
+    if (submittingRef.current || loading) return
+    submittingRef.current = true
     // Non-federal committees submit as CANDIDATE and must not carry an FEC id
     // (the backend rejects a stray fecCommitteeId on non-federal). Federal keeps
     // the entered FEC id + committee type as-is. Mirrors the shared

--- a/app/dashboard/pro-upgrade/components/FilingDetailsStep.tsx
+++ b/app/dashboard/pro-upgrade/components/FilingDetailsStep.tsx
@@ -1,0 +1,354 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  Button,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import TextField from '@shared/inputs/TextField'
+import AddressAutocomplete from '@shared/AddressAutocomplete'
+import {
+  FormDataProvider,
+  useFormData,
+  type FormDataState,
+} from '@shared/hooks/useFormData'
+import { useCampaign } from '@shared/hooks/useCampaign'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { apiRoutes } from 'gpApi/routes'
+import { USER_WEBSITE_QUERY_KEY } from 'app/dashboard/website/util/website.util'
+import { TCR_COMPLIANCE_QUERY_KEY } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
+import {
+  submitTcrCompliance,
+  toRegistrationFormData,
+} from 'app/dashboard/profile/texting-compliance/util/registrationFormData.util'
+import {
+  validateRegistrationForm,
+  type ValidationField,
+} from 'app/dashboard/profile/texting-compliance/register/components/TextingComplianceRegistrationForm'
+import {
+  FecCommitteeIdInput,
+  getFecCommitteeIdValidation,
+} from 'app/dashboard/profile/texting-compliance/register/components/FecCommitteeIdInput'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+// The backend createAgentic endpoint validates officeLevel against the
+// federal/state/local enum, and the federal branch additionally requires FEC
+// fields. The candidate already chose an office in onboarding, so we derive the
+// level from `details.ballotLevel` rather than re-asking. Onboarding persists
+// exactly the four option strings below (OfficeStepForm); anything else
+// (including a missing value on a pre-structured-office campaign) falls back to
+// `local`, which is the safest default for our overwhelmingly down-ballot
+// audience and keeps the candidate from stalling on a hidden field.
+type OfficeLevel = 'federal' | 'state' | 'local'
+
+export const ballotLevelToOfficeLevel = (
+  ballotLevel: string | null | undefined,
+): OfficeLevel => {
+  switch (ballotLevel) {
+    case 'Federal':
+      return 'federal'
+    case 'State':
+      return 'state'
+    default:
+      return 'local'
+  }
+}
+
+// EIN and committee come from `campaign.details` (the EIN was collected and
+// validated at the previous step). Email/phone/address are left blank: account
+// contact info frequently does not match the official filing, and a PIN is only
+// delivered if these match the filing exactly (mirrors ElectionFiling's
+// getInitialFormState / ENG-10290).
+export const getInitialFilingDetailsState = (
+  campaign: ReturnType<typeof useCampaign>[0],
+): FormDataState => {
+  const details = (campaign?.details ?? {}) as {
+    einNumber?: string | null
+    campaignCommittee?: string
+    ballotLevel?: string | null
+  }
+  return {
+    electionFilingLink: '',
+    campaignCommitteeName: details.campaignCommittee || '',
+    officeLevel: ballotLevelToOfficeLevel(details.ballotLevel),
+    ein: details.einNumber || '',
+    phone: '',
+    address: { formatted_address: '', place_id: '' },
+    website: '',
+    email: '',
+  }
+}
+
+const validateFilingDetails = (data: FormDataState) =>
+  validateRegistrationForm(data, { requireWebsite: false })
+
+const getStringValue = (value: FormDataState[keyof FormDataState]): string =>
+  typeof value === 'string' ? value : ''
+
+interface FilingDetailsFormProps {
+  onSubmit: (formData: FormDataState) => void
+  loading: boolean
+}
+
+const FilingDetailsForm = ({
+  onSubmit,
+  loading,
+}: FilingDetailsFormProps): React.JSX.Element => {
+  const { formData, handleChange } = useFormData()
+  const {
+    officeLevel,
+    campaignCommitteeName,
+    electionFilingLink,
+    email,
+    phone,
+  } = formData
+  const isFederal = getStringValue(officeLevel) === 'federal'
+
+  const { validations, isValid } = validateRegistrationForm(formData, {
+    requireWebsite: false,
+  })
+
+  // Always-enabled button so the candidate can attempt submit and get guiding
+  // errors; field errors only surface after the first invalid attempt.
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false)
+  const showError = (field: ValidationField): boolean =>
+    attemptedSubmit && !validations[field]
+
+  const addressValue = formData.address
+  const initialAddress =
+    addressValue &&
+    typeof addressValue === 'object' &&
+    'formatted_address' in addressValue
+      ? (addressValue as { formatted_address: string }).formatted_address
+      : ''
+  const [addressInput, setAddressInput] = useState(initialAddress)
+
+  const [validFecCommitteeId, setValidFecCommitteeId] = useState(
+    getFecCommitteeIdValidation(getStringValue(formData.fecCommitteeId)),
+  )
+  const handleFecCommitteeIdChange = (value: string) => {
+    setValidFecCommitteeId(getFecCommitteeIdValidation(value))
+    handleChange({ fecCommitteeId: value })
+  }
+
+  const handleContinue = () => {
+    if (!isValid) {
+      setAttemptedSubmit(true)
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+      return
+    }
+    if (loading) return
+    // Non-federal committees submit as CANDIDATE and must not carry an FEC id
+    // (the backend rejects a stray fecCommitteeId on non-federal). Federal keeps
+    // the entered FEC id + committee type as-is. Mirrors the shared
+    // TextingComplianceRegistrationForm submit shaping.
+    if (isFederal) {
+      onSubmit(formData)
+      return
+    }
+    const { fecCommitteeId: _fec, ...rest } = formData
+    onSubmit({ ...rest, committeeType: 'CANDIDATE' })
+  }
+
+  return (
+    <div>
+      <H2 className="mb-2">What are your campaign filing details?</H2>
+      <Body2 className="text-secondary mb-8">
+        If these do not match the details you submitted on your campaign filing
+        or registration, it will take much longer before you can send text
+        messages.
+      </Body2>
+
+      <div className="flex flex-col gap-6">
+        <TextField
+          label="Campaign committee name"
+          placeholder="Jane for Council"
+          fullWidth
+          required
+          error={showError('campaignCommitteeName')}
+          value={getStringValue(campaignCommitteeName)}
+          onChange={(e) =>
+            handleChange({ campaignCommitteeName: e.target.value })
+          }
+        />
+        <TextField
+          label="Campaign filing link"
+          placeholder="https://"
+          fullWidth
+          required
+          error={showError('electionFilingLink')}
+          helperText="Get approved quicker by providing your filing link."
+          value={getStringValue(electionFilingLink)}
+          onChange={(e) => handleChange({ electionFilingLink: e.target.value })}
+        />
+
+        {isFederal && (
+          <>
+            <FecCommitteeIdInput
+              value={getStringValue(formData.fecCommitteeId)}
+              validated={validFecCommitteeId}
+              onChange={handleFecCommitteeIdChange}
+              error={showError('fecCommitteeId')}
+            />
+            <div className="flex w-full flex-col gap-1.5">
+              <Label>Committee type *</Label>
+              <Select
+                value={getStringValue(formData.committeeType)}
+                onValueChange={(val) => handleChange({ committeeType: val })}
+              >
+                <SelectTrigger
+                  className="w-full"
+                  aria-invalid={showError('committeeType') || undefined}
+                >
+                  <SelectValue placeholder="Select committee type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="HOUSE">House</SelectItem>
+                  <SelectItem value="SENATE">Senate</SelectItem>
+                  <SelectItem value="PRESIDENTIAL">Presidential</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </>
+        )}
+
+        <div>
+          <div className="font-medium">
+            Which of these appear on your campaign filing?
+          </div>
+          <Body2 className="text-secondary mt-1 mb-4">
+            Enter them exactly as they appear on your campaign filing. You will
+            receive a PIN within 7 business days to one of these to verify your
+            campaign.
+          </Body2>
+          <div className="flex flex-col gap-6">
+            <TextField
+              label="Email"
+              placeholder="jane@gmail.com"
+              fullWidth
+              required
+              error={showError('email')}
+              value={getStringValue(email)}
+              onChange={(e) => handleChange({ email: e.target.value })}
+            />
+            <TextField
+              label="Phone"
+              placeholder="(555) 555-5555"
+              fullWidth
+              required
+              error={showError('phone')}
+              value={getStringValue(phone)}
+              onChange={(e) => handleChange({ phone: e.target.value })}
+            />
+            <AddressAutocomplete
+              value={addressInput}
+              onChange={(value) => {
+                setAddressInput(value)
+                if (!value) handleChange({ address: null })
+              }}
+              onSelect={(place) => {
+                setAddressInput(place.formatted_address || '')
+                handleChange({
+                  address: {
+                    formatted_address: place.formatted_address || '',
+                    place_id: place.place_id || '',
+                  },
+                })
+              }}
+              placeholder="Address *"
+              variant="outlined"
+              error={showError('address')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-end">
+        <Button
+          size="large"
+          onClick={handleContinue}
+          loading={loading}
+          disabled={loading}
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Pre-payment wizard filing-details step (task 11). Collects the TCR
+// registration data and submits it via the same createAgentic call the
+// election-filing form uses, so the two flows can't drift. The submit no longer
+// dispatches the compliance agent for a non-Pro candidate — that moved to the
+// payment-success webhook (task 02, ENG-10323) — so there is nothing to gate
+// client-side; using createAgentic is enough.
+const FilingDetailsStep = (): React.JSX.Element => {
+  const { goToNextStep } = useProUpgradeWizard()
+  const [campaign] = useCampaign()
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+  const [loading, setLoading] = useState(false)
+
+  const ready = Boolean(campaign)
+
+  // Fire the funnel view event once the form is actually shown (gated behind
+  // `ready`), not while the Loading… placeholder is up.
+  const viewTrackedRef = useRef(false)
+  useEffect(() => {
+    if (!ready || viewTrackedRef.current) return
+    viewTrackedRef.current = true
+    trackEvent(EVENTS.ProUpgrade.Compliance.FilingDetailsViewed)
+  }, [ready])
+
+  const handleSubmit = async (formData: FormDataState) => {
+    if (loading) return
+    setLoading(true)
+    try {
+      await submitTcrCompliance(
+        apiRoutes.campaign.tcrCompliance.createAgentic,
+        toRegistrationFormData(formData),
+        'Failed to submit filing details',
+      )
+      trackEvent(EVENTS.Outreach.DlcCompliance.RegistrationSubmitted, {
+        email: getStringValue(formData.email),
+        dlcComplianceStatus: 'Pending',
+      })
+      // The TCR record now drives filingComplete in ProUpgradeEntry's step
+      // derivation; invalidate so a returning candidate resumes past this step.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY }),
+        queryClient.invalidateQueries({ queryKey: TCR_COMPLIANCE_QUERY_KEY }),
+      ])
+      goToNextStep()
+    } catch {
+      errorSnackbar('Failed to submit filing details. Please try again later.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!ready) {
+    return <div className="text-sm text-muted-foreground">Loading…</div>
+  }
+
+  return (
+    <FormDataProvider
+      initialState={getInitialFilingDetailsState(campaign)}
+      validator={validateFilingDetails}
+    >
+      <FilingDetailsForm onSubmit={handleSubmit} loading={loading} />
+    </FormDataProvider>
+  )
+}
+
+export default FilingDetailsStep

--- a/app/dashboard/pro-upgrade/filing-details/page.tsx
+++ b/app/dashboard/pro-upgrade/filing-details/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import FilingDetailsStep from '../components/FilingDetailsStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Your filing details"
-      taskNote="Filing-details step — ships in task 11"
-    />
-  )
+  return <FilingDetailsStep />
 }


### PR DESCRIPTION
## ENG-10331 — UI: filing-details step (committee, filing link, PIN contact methods)

Task 11 of the Pro Upgrade epic (ENG-7508). Adds the pre-payment wizard's filing-details step.

[ClickUp ENG-10331](https://app.clickup.com/t/86ahxptgq) · [Figma "campaign details" frame](https://www.figma.com/design/0RyHuhYvyCOhg0LErhO7tb/Pro-upgrade?node-id=7490-18748)

### What shipped
- New `FilingDetailsStep.tsx` at the `filing-details` route (replaces the placeholder). Collects campaign committee name, filing link, and the email / phone / address contact methods, then submits via the **same** `submitTcrCompliance` + `toRegistrationFormData` + `POST /campaigns/tcr-compliance/agentic` path the existing election-filing form uses — no fork of the validator/mapper/submit, so the two flows can't drift.
- **Office level is derived** from `details.ballotLevel` (chosen in onboarding) and seeded into form state instead of being re-asked. EIN is **prefilled** from the prior EIN step (task 10) and carried in the payload, not shown.
- **FEC committee id + committee type render only for a federal candidate**, so a federal submit still satisfies the backend's federal branch; non-federal (the common case) never sees them and submits as `CANDIDATE`.
- Inline validation reuses `validateRegistrationForm`. On submit failure an error snackbar shows and the step does **not** advance. On success it invalidates the TCR + website queries (so step derivation marks filing complete on return) and advances to the candidate-profile step.
- The submit **does not** dispatch the compliance agent for a non-Pro candidate — that moved to the payment-success webhook in ENG-10323 (merged) — so there's nothing to gate client-side.

### Decisions / deviations (vs the ticket + Figma)
1. Email/phone/address are rendered as **three required inputs** under the "Which of these appear on your campaign filing?" heading, rather than a "select all that apply" checkbox group — all three are required, so the checkbox affordance is moot.
2. Office level is **derived, not asked** (`Federal`→federal, `State`→state, `Local/Township/City` & `County/Regional`→local; unknown/missing → `local`).
3. **No FEC fields except for federal candidates** (per product decision); federal candidates still get them so their submit works.
4. Filing link kept **required** (backend requires `filingUrl`); the Figma helper copy reads as optional — flagged as a copy/design nit.

### Tests
`npx vitest run app/dashboard/pro-upgrade` → 68 passed. New file: 11 tests covering the `ballotLevel→officeLevel` mapping, initial-state derivation, valid non-federal submit (asserts the mapped createAgentic payload), invalid-submit blocking, submit-failure snackbar + no-nav, and federal vs non-federal FEC field visibility. `npm run types` + `npm run lint` clean.

### Not yet done
- Not walked through live (needs the `pro-upgrade3` flag + the Amplitude `pro-upgrade3` flag created).
- The non-Pro "agent not dispatched on submit" guarantee still wants the manual gp-api/QA cross-check per the ticket's test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Submits campaign filing and compliance registration data via createAgentic; risk is moderated because validation, mapping, and API calls reuse the existing texting-compliance path rather than new backend logic.
> 
> **Overview**
> Replaces the Pro upgrade **filing-details** placeholder with a real wizard step that collects committee name, filing link, and filing contact info (email, phone, address), then posts TCR registration through the same `submitTcrCompliance` / `toRegistrationFormData` / **createAgentic** path as the existing election-filing flow.
> 
> **Office level** is derived from onboarding `ballotLevel` (not shown); **EIN** and committee name are prefilled from campaign details while contact fields start empty. **FEC committee ID and committee type** appear only for federal candidates; non-federal submits strip FEC data and set `committeeType: 'CANDIDATE'`. On success the step invalidates TCR and website queries and advances the wizard; failures show a snackbar and block navigation. Analytics cover funnel view (after campaign loads) and registration submitted.
> 
> Adds **Vitest coverage** for mapping helpers, initial state, submit payload shape, validation blocking, error handling, and federal vs non-federal field visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0791234e012281013597d3f5de272cd96e90893d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->