### PR TITLE
ENG-10332: Pro upgrade candidate-profile step (bio + policy priorities)

### DIFF
--- a/app/dashboard/pro-upgrade/candidate-profile/page.tsx
+++ b/app/dashboard/pro-upgrade/candidate-profile/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import CandidateProfileStep from '../components/CandidateProfileStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Your candidate profile"
-      taskNote="Candidate-profile step — ships in task 12"
-    />
-  )
+  return <CandidateProfileStep />
 }

--- a/app/dashboard/pro-upgrade/components/CandidateProfileStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/CandidateProfileStep.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import type { Website } from 'helpers/types'
+import { EVENTS } from 'helpers/analyticsHelper'
+import { MIN_BIO_LENGTH } from 'app/dashboard/profile/texting-compliance/candidate-profile/candidateProfile.utils'
+import CandidateProfileStep from './CandidateProfileStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+const mockTrackEvent = vi.fn()
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return {
+    ...actual,
+    trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+  }
+})
+
+vi.mock('app/shared/utils/RichEditor', async () => ({
+  default: (await import('helpers/test-utils/RichEditorMock')).RichEditorMock,
+}))
+
+const { getUserWebsite, saveAboutFields } = vi.hoisted(() => ({
+  getUserWebsite: vi.fn(),
+  saveAboutFields: vi.fn(),
+}))
+
+vi.mock('app/dashboard/website/util/website.util', () => ({
+  USER_WEBSITE_QUERY_KEY: ['user-website'],
+  getUserWebsite,
+  saveAboutFields,
+}))
+
+const errorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar, successSnackbar: vi.fn() }),
+}))
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const goToNextStep = vi.fn()
+
+const websiteWith = (bio: string, issueCount: number): Website =>
+  ({
+    content: {
+      about: {
+        bio,
+        issues: Array.from({ length: issueCount }, (_, i) => ({
+          title: `Priority ${i + 1}`,
+          description: 'y'.repeat(MIN_BIO_LENGTH),
+        })),
+      },
+    },
+  }) as unknown as Website
+
+const validBio = 'a'.repeat(MIN_BIO_LENGTH)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseProUpgradeWizard.mockReturnValue({
+    currentStep: 'candidate-profile',
+    goToStep: vi.fn(),
+    goToNextStep,
+    goToPreviousStep: vi.fn(),
+  })
+  // Default: a complete profile on file, save succeeds.
+  getUserWebsite.mockResolvedValue(websiteWith(validBio, 1))
+  saveAboutFields.mockResolvedValue(true)
+})
+
+describe('CandidateProfileStep', () => {
+  it('fires the candidate-profile viewed event on mount', async () => {
+    render(<CandidateProfileStep />)
+    await waitFor(() =>
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        EVENTS.ProUpgrade.Compliance.CandidateProfileViewed,
+      ),
+    )
+  })
+
+  it('renders the bio editor, policy priorities, and a Continue button', async () => {
+    render(<CandidateProfileStep />)
+    expect(await screen.findByTestId('rich-editor')).toBeInTheDocument()
+    expect(screen.getByText('Your policy priorities')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+  })
+
+  it('saves bio and issues and advances to payment on a valid submit', async () => {
+    const user = userEvent.setup()
+    render(<CandidateProfileStep />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await screen.findByTestId('rich-editor')
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    expect(saveAboutFields).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bio: validBio,
+        issues: expect.arrayContaining([
+          expect.objectContaining({ title: 'Priority 1' }),
+        ]),
+      }),
+    )
+    // Advance is the AC: on success the step moves to the payment step.
+    await waitFor(() => expect(goToNextStep).toHaveBeenCalledTimes(1))
+    expect(errorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('blocks advance and surfaces validation messaging for an under-length bio / no priorities', async () => {
+    const user = userEvent.setup()
+    // Empty bio (< 500 chars) and zero policy priorities.
+    getUserWebsite.mockResolvedValue(websiteWith('', 0))
+    render(<CandidateProfileStep />)
+
+    await screen.findByTestId('rich-editor')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    expect(saveAboutFields).not.toHaveBeenCalled()
+    expect(goToNextStep).not.toHaveBeenCalled()
+    expect(screen.getByText('Please add your bio')).toBeInTheDocument()
+    expect(
+      screen.getByText('Please add at least one policy priority'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('rich-editor')).toHaveAttribute(
+      'data-error',
+      'true',
+    )
+  })
+
+  it('does not advance and shows an error when the save fails', async () => {
+    // saveAboutFields resolves false on an API failure; advancing anyway would
+    // strand an un-persisted profile (the next step would derive incomplete).
+    const user = userEvent.setup()
+    saveAboutFields.mockResolvedValue(false)
+    render(<CandidateProfileStep />)
+
+    await waitFor(() => expect(getUserWebsite).toHaveBeenCalled())
+    await screen.findByTestId('rich-editor')
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await waitFor(() => expect(saveAboutFields).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(goToNextStep).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/CandidateProfileStep.tsx
+++ b/app/dashboard/pro-upgrade/components/CandidateProfileStep.tsx
@@ -16,7 +16,10 @@ import { useProUpgradeWizard } from './ProUpgradeWizard'
 // is never asked of the candidate (ENG-10332 product decision).
 const CandidateProfileStep = (): React.JSX.Element => {
   const { goToNextStep } = useProUpgradeWizard()
-  const form = useCandidateProfileForm({ onSaved: goToNextStep })
+  const form = useCandidateProfileForm({
+    onSaved: goToNextStep,
+    trackViewEvent: true,
+  })
 
   return (
     <div>

--- a/app/dashboard/pro-upgrade/components/CandidateProfileStep.tsx
+++ b/app/dashboard/pro-upgrade/components/CandidateProfileStep.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { Button } from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { useCandidateProfileForm } from 'app/dashboard/profile/texting-compliance/candidate-profile/useCandidateProfileForm'
+import CandidateProfileFields from 'app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfileFields'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+// The candidate-profile wizard step. Mounts the shared candidate-profile form
+// (bio + policy priorities) rather than forking it: the bio-length and
+// policy-count validators live in `candidateProfile.utils` and the save path is
+// `useCandidateProfileForm`, both shared with the standalone profile page. On a
+// valid save it advances to the payment step. The campaign image from the Figma
+// is intentionally not collected here — it comes from BallotReady via gp-api and
+// is never asked of the candidate (ENG-10332 product decision).
+const CandidateProfileStep = (): React.JSX.Element => {
+  const { goToNextStep } = useProUpgradeWizard()
+  const form = useCandidateProfileForm({ onSaved: goToNextStep })
+
+  return (
+    <div>
+      <H2 className="mb-2">What is your campaign about?</H2>
+      <Body2 className="text-secondary mb-8">
+        We need to submit your candidate profile to register your campaign.
+        Please be as descriptive as possible to ensure your profile is approved.
+      </Body2>
+
+      <CandidateProfileFields form={form} />
+
+      <div className="mt-8 flex justify-end">
+        <Button
+          size="large"
+          onClick={() => void form.handleSubmit()}
+          loading={form.submitting}
+          loadingText="Saving"
+        >
+          Continue
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default CandidateProfileStep

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.test.tsx
@@ -185,14 +185,18 @@ describe('CandidateProfile — deleting a policy priority persists (ENG-10270)',
   })
 })
 
-describe('CandidateProfile — funnel view event (ENG-10294)', () => {
-  it('fires Candidate Profile Viewed when the step renders', async () => {
+describe('CandidateProfile — funnel view event scoping (ENG-10332)', () => {
+  it('does not fire the Pro-upgrade Candidate Profile Viewed event from the standalone editor', async () => {
+    // The Pro-upgrade funnel "viewed" event is opt-in (trackViewEvent), and the
+    // standalone profile editor — independently routable for editing — does not
+    // opt in. Only the wizard step (CandidateProfileStep) emits it, so the
+    // funnel isn't inflated by non-funnel profile edits.
     getUserWebsite.mockResolvedValue(websiteWith('', 0))
     render(<CandidateProfile />)
-    await waitFor(() => {
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        EVENTS.ProUpgrade.Compliance.CandidateProfileViewed,
-      )
-    })
+    // Let the seeding + any mount effects settle before asserting the negative.
+    await screen.findByTestId('rich-editor')
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.CandidateProfileViewed,
+    )
   })
 })

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfile.tsx
@@ -1,109 +1,16 @@
 'use client'
-import { Alert, AlertDescription, Button, CircleAlertIcon } from '@styleguide'
+import { Button } from '@styleguide'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
-import dynamic from 'next/dynamic'
-import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import {
-  getUserWebsite,
-  saveAboutFields,
-  USER_WEBSITE_QUERY_KEY,
-} from 'app/dashboard/website/util/website.util'
-import { useSnackbar } from 'helpers/useSnackbar'
-import { Website, WebsiteIssue } from 'helpers/types'
-import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
-import {
-  MIN_BIO_LENGTH,
-  getBioError,
-  getBioPlainLength,
-  getPolicyPrioritiesError,
-  normalizeIssues,
-} from '../candidateProfile.utils'
-import PolicyPriorities from './PolicyPriorities'
-
-const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
-  ssr: false,
-  loading: () => (
-    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
-      Loading editor…
-    </div>
-  ),
-})
+import { useCandidateProfileForm } from '../useCandidateProfileForm'
+import CandidateProfileFields from './CandidateProfileFields'
 
 export default function CandidateProfile(): React.JSX.Element {
   const router = useRouter()
-  const queryClient = useQueryClient()
-  const { errorSnackbar } = useSnackbar()
-  const { data: website, isSuccess } = useQuery<Website | null>({
-    queryKey: USER_WEBSITE_QUERY_KEY,
-    queryFn: getUserWebsite,
+  const form = useCandidateProfileForm({
+    onSaved: () => router.push('/dashboard/profile'),
   })
-
-  const [bio, setBio] = useState('')
-  const [bioPlainLength, setBioPlainLength] = useState(0)
-  const [issues, setIssues] = useState<WebsiteIssue[]>([])
-  const [submitting, setSubmitting] = useState(false)
-  // The Submit button is always enabled so the user can attempt to submit and
-  // get a guiding error rather than a silently-disabled button. Errors (alert
-  // + red bio border) only surface once they've tried to submit.
-  const [attemptedSubmit, setAttemptedSubmit] = useState(false)
-  // `initialBio` must be captured exactly once and never change afterward.
-  // RichEditor re-pastes its content whenever `initialText` changes by value,
-  // so deriving it live from the query would clobber the user's in-progress
-  // edits whenever a refetch lands (e.g. the post-submit `invalidateQueries`
-  // or a window-focus refetch). `null` means "not seeded yet" so we defer
-  // mounting the editor until we have the real value.
-  const [initialBio, setInitialBio] = useState<string | null>(null)
-  const seededRef = useRef(false)
-
-  useEffect(() => {
-    // Seed once the website query has settled, not only when `website` is
-    // truthy. A candidate who hasn't created a website yet resolves to `null`
-    // here (saveAboutFields creates the site on submit), so gating on a truthy
-    // `website` would leave `initialBio` null forever and the bio editor would
-    // never mount — the field would be completely absent. Seed from an empty
-    // bio in that case so the editor renders and they can fill it in.
-    if (seededRef.current || !isSuccess) return
-    const initialBioValue = website?.content?.about?.bio ?? ''
-    setBio(initialBioValue)
-    // Seed length up-front so Submit doesn't show a false "add your bio" error
-    // before the dynamically-imported editor emits its first onTextLengthChange.
-    setBioPlainLength(getBioPlainLength(initialBioValue))
-    setInitialBio(initialBioValue)
-    setIssues(normalizeIssues(website?.content?.about?.issues))
-    seededRef.current = true
-  }, [isSuccess, website])
-
-  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
-  // matching "submitted" signal is the existing SubmitSuccess event below.
-  useEffect(() => {
-    trackEvent(EVENTS.ProUpgrade.Compliance.CandidateProfileViewed)
-  }, [])
-
-  const bioError = getBioError(bioPlainLength)
-  const prioritiesError = getPolicyPrioritiesError(issues.length)
-
-  const handleSubmit = async () => {
-    if (submitting) return
-    if (bioError || prioritiesError) {
-      setAttemptedSubmit(true)
-      return
-    }
-    trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
-    setSubmitting(true)
-    const ok = await saveAboutFields({ bio, issues })
-    if (!ok) {
-      trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
-      errorSnackbar('Failed to save candidate profile. Please try again.')
-      setSubmitting(false)
-      return
-    }
-    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
-    await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
-    router.push('/dashboard/profile')
-  }
 
   return (
     <div className="flex h-screen flex-col items-center justify-between pt-2 md:pt-4">
@@ -116,46 +23,8 @@ export default function CandidateProfile(): React.JSX.Element {
           <div>&nbsp;</div>
         </div>
 
-        {attemptedSubmit && (bioError || prioritiesError) && (
-          <Alert
-            variant="destructive"
-            icon={<CircleAlertIcon />}
-            className="mt-6"
-          >
-            <AlertDescription>
-              {bioError && <p>{bioError}</p>}
-              {prioritiesError && <p>{prioritiesError}</p>}
-            </AlertDescription>
-          </Alert>
-        )}
-
         <div className="mt-10">
-          <div className="mb-1.5 block text-sm font-medium">
-            Why are you running?
-          </div>
-          {initialBio !== null && (
-            <RichEditor
-              initialText={initialBio}
-              onChangeCallback={setBio}
-              onTextLengthChange={setBioPlainLength}
-              error={attemptedSubmit && !!bioError}
-            />
-          )}
-          <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
-            <span>{MIN_BIO_LENGTH} character minimum</span>
-            <span>{bioPlainLength}</span>
-          </div>
-        </div>
-
-        <div className="mt-8">
-          <div className="mb-1.5 block text-sm font-medium">
-            Your policy priorities
-          </div>
-          <PolicyPriorities
-            issues={issues}
-            onChange={setIssues}
-            disabled={submitting}
-          />
+          <CandidateProfileFields form={form} />
         </div>
       </div>
 
@@ -163,8 +32,8 @@ export default function CandidateProfile(): React.JSX.Element {
         <Button
           variant="secondary"
           type="button"
-          onClick={handleSubmit}
-          loading={submitting}
+          onClick={() => void form.handleSubmit()}
+          loading={form.submitting}
           loadingText="Submitting"
         >
           Submit

--- a/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfileFields.tsx
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/components/CandidateProfileFields.tsx
@@ -1,0 +1,88 @@
+'use client'
+import { Alert, AlertDescription, CircleAlertIcon } from '@styleguide'
+import dynamic from 'next/dynamic'
+import { MIN_BIO_LENGTH } from '../candidateProfile.utils'
+import type { CandidateProfileForm } from '../useCandidateProfileForm'
+import PolicyPriorities from './PolicyPriorities'
+
+const RichEditor = dynamic(() => import('app/shared/utils/RichEditor'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-md border border-input bg-white px-3 py-2 text-sm text-muted-foreground">
+      Loading editor…
+    </div>
+  ),
+})
+
+interface CandidateProfileFieldsProps {
+  form: CandidateProfileForm
+}
+
+/**
+ * The candidate-profile form body — validation alert, bio editor, and policy
+ * priorities — driven entirely by `useCandidateProfileForm`. Rendered by both
+ * the standalone profile page and the Pro-upgrade wizard step; each supplies its
+ * own heading and submit control around these shared fields.
+ */
+export default function CandidateProfileFields({
+  form,
+}: CandidateProfileFieldsProps): React.JSX.Element {
+  const {
+    bioPlainLength,
+    setBio,
+    setBioPlainLength,
+    issues,
+    setIssues,
+    initialBio,
+    submitting,
+    attemptedSubmit,
+    bioError,
+    prioritiesError,
+  } = form
+
+  return (
+    <>
+      {attemptedSubmit && (bioError || prioritiesError) && (
+        <Alert
+          variant="destructive"
+          icon={<CircleAlertIcon />}
+          className="mb-6"
+        >
+          <AlertDescription>
+            {bioError && <p>{bioError}</p>}
+            {prioritiesError && <p>{prioritiesError}</p>}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div>
+        <div className="mb-1.5 block text-sm font-medium">
+          Why are you running?
+        </div>
+        {initialBio !== null && (
+          <RichEditor
+            initialText={initialBio}
+            onChangeCallback={setBio}
+            onTextLengthChange={setBioPlainLength}
+            error={attemptedSubmit && !!bioError}
+          />
+        )}
+        <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
+          <span>{MIN_BIO_LENGTH} character minimum</span>
+          <span>{bioPlainLength}</span>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <div className="mb-1.5 block text-sm font-medium">
+          Your policy priorities
+        </div>
+        <PolicyPriorities
+          issues={issues}
+          onChange={setIssues}
+          disabled={submitting}
+        />
+      </div>
+    </>
+  )
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/useCandidateProfileForm.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/useCandidateProfileForm.ts
@@ -1,0 +1,143 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getUserWebsite,
+  saveAboutFields,
+  USER_WEBSITE_QUERY_KEY,
+} from 'app/dashboard/website/util/website.util'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { Website, WebsiteIssue } from 'helpers/types'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import {
+  getBioError,
+  getBioPlainLength,
+  getPolicyPrioritiesError,
+  normalizeIssues,
+} from './candidateProfile.utils'
+
+export interface CandidateProfileForm {
+  bio: string
+  setBio: (bio: string) => void
+  bioPlainLength: number
+  setBioPlainLength: (length: number) => void
+  issues: WebsiteIssue[]
+  setIssues: (issues: WebsiteIssue[]) => void
+  // `null` until the website query has settled — the bio editor must defer
+  // mounting until then (see the seeding effect for why).
+  initialBio: string | null
+  submitting: boolean
+  attemptedSubmit: boolean
+  bioError: string | null
+  prioritiesError: string | null
+  handleSubmit: () => Promise<void>
+}
+
+interface UseCandidateProfileFormArgs {
+  // What to do after a successful save. The standalone profile page routes to
+  // /dashboard/profile; the Pro-upgrade wizard advances to the next step. Kept
+  // a callback so the bio/issues state, seeding, and validation live in one
+  // place and neither surface forks the form.
+  onSaved: () => void | Promise<void>
+}
+
+/**
+ * Owns the candidate-profile form: bio + policy-priorities state, one-time
+ * seeding from the saved website, validation (delegated to
+ * `candidateProfile.utils`), and the `saveAboutFields` submit. Consumed by both
+ * the standalone profile page and the Pro-upgrade wizard step so the validators
+ * and the save path can't drift between the two.
+ */
+export const useCandidateProfileForm = ({
+  onSaved,
+}: UseCandidateProfileFormArgs): CandidateProfileForm => {
+  const queryClient = useQueryClient()
+  const { errorSnackbar } = useSnackbar()
+  const { data: website, isSuccess } = useQuery<Website | null>({
+    queryKey: USER_WEBSITE_QUERY_KEY,
+    queryFn: getUserWebsite,
+  })
+
+  const [bio, setBio] = useState('')
+  const [bioPlainLength, setBioPlainLength] = useState(0)
+  const [issues, setIssues] = useState<WebsiteIssue[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  // The Submit button is always enabled so the user can attempt to submit and
+  // get a guiding error rather than a silently-disabled button. Errors (alert
+  // + red bio border) only surface once they've tried to submit.
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false)
+  // `initialBio` must be captured exactly once and never change afterward.
+  // RichEditor re-pastes its content whenever `initialText` changes by value,
+  // so deriving it live from the query would clobber the user's in-progress
+  // edits whenever a refetch lands (e.g. the post-submit `invalidateQueries`
+  // or a window-focus refetch). `null` means "not seeded yet" so we defer
+  // mounting the editor until we have the real value.
+  const [initialBio, setInitialBio] = useState<string | null>(null)
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    // Seed once the website query has settled, not only when `website` is
+    // truthy. A candidate who hasn't created a website yet resolves to `null`
+    // here (saveAboutFields creates the site on submit), so gating on a truthy
+    // `website` would leave `initialBio` null forever and the bio editor would
+    // never mount — the field would be completely absent. Seed from an empty
+    // bio in that case so the editor renders and they can fill it in.
+    if (seededRef.current || !isSuccess) return
+    const initialBioValue = website?.content?.about?.bio ?? ''
+    setBio(initialBioValue)
+    // Seed length up-front so Submit doesn't show a false "add your bio" error
+    // before the dynamically-imported editor emits its first onTextLengthChange.
+    setBioPlainLength(getBioPlainLength(initialBioValue))
+    setInitialBio(initialBioValue)
+    setIssues(normalizeIssues(website?.content?.about?.issues))
+    seededRef.current = true
+  }, [isSuccess, website])
+
+  // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
+  // matching "submitted" signal is the existing SubmitSuccess event below.
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.CandidateProfileViewed)
+  }, [])
+
+  const bioError = getBioError(bioPlainLength)
+  const prioritiesError = getPolicyPrioritiesError(issues.length)
+
+  const handleSubmit = async (): Promise<void> => {
+    if (submitting) return
+    if (bioError || prioritiesError) {
+      setAttemptedSubmit(true)
+      return
+    }
+    trackEvent(EVENTS.Profile.CandidateProfile.ClickSubmit)
+    setSubmitting(true)
+    const ok = await saveAboutFields({ bio, issues })
+    if (!ok) {
+      trackEvent(EVENTS.Profile.CandidateProfile.SubmitError)
+      errorSnackbar('Failed to save candidate profile. Please try again.')
+      setSubmitting(false)
+      return
+    }
+    trackEvent(EVENTS.Profile.CandidateProfile.SubmitSuccess)
+    // Re-derive completeness on both surfaces: the standalone profile reads the
+    // website query, and the wizard's ProUpgradeEntry derives `profileComplete`
+    // from it (so a returning candidate isn't re-prompted). Done before
+    // navigating so the consumer reads fresh data.
+    await queryClient.invalidateQueries({ queryKey: USER_WEBSITE_QUERY_KEY })
+    await onSaved()
+  }
+
+  return {
+    bio,
+    setBio,
+    bioPlainLength,
+    setBioPlainLength,
+    issues,
+    setIssues,
+    initialBio,
+    submitting,
+    attemptedSubmit,
+    bioError,
+    prioritiesError,
+    handleSubmit,
+  }
+}

--- a/app/dashboard/profile/texting-compliance/candidate-profile/useCandidateProfileForm.ts
+++ b/app/dashboard/profile/texting-compliance/candidate-profile/useCandidateProfileForm.ts
@@ -39,6 +39,11 @@ interface UseCandidateProfileFormArgs {
   // a callback so the bio/issues state, seeding, and validation live in one
   // place and neither surface forks the form.
   onSaved: () => void | Promise<void>
+  // Opt in to the Pro-upgrade funnel "viewed" event. Only the wizard step sets
+  // this: the standalone profile editor is an independently-routable settings
+  // surface, so firing the funnel event on every visit there would inflate the
+  // funnel with non-funnel traffic. Defaults to off.
+  trackViewEvent?: boolean
 }
 
 /**
@@ -50,6 +55,7 @@ interface UseCandidateProfileFormArgs {
  */
 export const useCandidateProfileForm = ({
   onSaved,
+  trackViewEvent = false,
 }: UseCandidateProfileFormArgs): CandidateProfileForm => {
   const queryClient = useQueryClient()
   const { errorSnackbar } = useSnackbar()
@@ -95,9 +101,12 @@ export const useCandidateProfileForm = ({
 
   // Funnel "viewed" event for the agentic compliance flow (ENG-10294). The
   // matching "submitted" signal is the existing SubmitSuccess event below.
+  // Only the opted-in wizard step fires it; the standalone profile editor is
+  // not a funnel surface (see trackViewEvent).
   useEffect(() => {
+    if (!trackViewEvent) return
     trackEvent(EVENTS.ProUpgrade.Compliance.CandidateProfileViewed)
-  }, [])
+  }, [trackViewEvent])
 
   const bioError = getBioError(bioPlainLength)
   const prioritiesError = getPolicyPrioritiesError(issues.length)


### PR DESCRIPTION
## What

Wizard step 12 of the Pro-upgrade flow (epic ENG-7508). Collects the candidate profile (bio + policy priorities) used to register the campaign, then advances to payment.

Mounts the **existing** candidate-profile form rather than forking it:
- Extracts `useCandidateProfileForm` (bio/issues state, one-time bio seeding, validation, `saveAboutFields` submit + analytics) and `CandidateProfileFields` (alert + bio editor + policy priorities) from the standalone `CandidateProfile`.
- The standalone profile page and the new `CandidateProfileStep` both consume them, so the bio-length / policy-count validators (`candidateProfile.utils`) and the `PUT /websites/mine` save path can't drift between the two surfaces.

## Behavior
- Valid save (bio ≥ 500 chars + ≥ 1 policy priority) → `saveAboutFields` → invalidate `USER_WEBSITE_QUERY_KEY` → `goToNextStep()` (→ payment). `isCandidateProfileComplete` is satisfied afterward (unchanged shared util).
- Under-length bio / zero priorities → blocks advance with the existing validation messaging.
- Save failure (`saveAboutFields` returns false) → error snackbar, no advance (no stranded un-persisted profile).

## Scope decision
The **campaign image** in the Figma is intentionally **not** collected here. If BallotReady returns an image, gp-api surfaces it on the candidate site; the candidate is never asked for one. `isCandidateProfileComplete` already gates on bio + issues only, so this doesn't affect step derivation.

## Tests
- `CandidateProfileStep.test.tsx` (new, 5): viewed event, renders fields + Continue, valid save advances, under-length/zero-priority blocks, save-failure no-advance.
- Existing standalone `CandidateProfile` / utils / `PolicyForm` suites stay green through the refactor (28 passing in the candidate-profile dir).
- Full `pro-upgrade/` dir: 76 passing. `npm run types` + `npm run lint` clean.

## Not yet
Live walkthrough needs the `pro-upgrade3` flag on + the Amplitude flag created (same state as the other in-review sibling steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compliance campaign registration data (bio/issues persistence) on two surfaces via a shared submit path; behavior is covered by new wizard tests and existing profile tests.
> 
> **Overview**
> Replaces the Pro-upgrade **candidate-profile** placeholder with a real wizard step that collects bio and policy priorities, then moves to payment after a successful save.
> 
> Form behavior is **extracted** into shared `useCandidateProfileForm` and `CandidateProfileFields` so the standalone profile page and `CandidateProfileStep` share the same validation (`candidateProfile.utils`), `saveAboutFields` path, query invalidation, and analytics. The wizard wires `onSaved` to `goToNextStep()`; the profile page still routes back to `/dashboard/profile`. Campaign image is still out of scope for this step.
> 
> Adds **`CandidateProfileStep.test.tsx`** covering viewed analytics, UI, valid save → advance, validation blocks, and save failure without advance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9138597a4fb5a726fedc57e232b697cf09cf256. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->