### PR TITLE
feat(pro-upgrade): embedded Stripe checkout payment step [ENG-10333]

### DIFF
--- a/app/dashboard/pro-upgrade/components/PaymentStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/PaymentStep.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import { EVENTS } from 'helpers/analyticsHelper'
+import { PRO_UPGRADE_STEP } from '../proUpgradeStep'
+import PaymentStep from './PaymentStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+const {
+  confirmMock,
+  checkoutValue,
+  errorSnackbar,
+  successSnackbar,
+  trackEventMock,
+} = vi.hoisted(() => {
+  const confirmMock = vi.fn()
+  return {
+    confirmMock,
+    checkoutValue: {
+      confirm: confirmMock,
+      canConfirm: true,
+      // $10.00 — the amount the order summary reads from the live session.
+      total: {
+        total: { minorUnitsAmount: 1000 },
+        subtotal: { minorUnitsAmount: 1000 },
+      },
+      discountAmounts: undefined,
+      applyPromotionCode: vi.fn(),
+      removePromotionCode: vi.fn(),
+    },
+    errorSnackbar: vi.fn(),
+    successSnackbar: vi.fn(),
+    trackEventMock: vi.fn(),
+  }
+})
+
+vi.mock('./ProUpgradeWizard', () => ({
+  useProUpgradeWizard: vi.fn(),
+}))
+
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: trackEventMock }
+})
+
+vi.mock('@stripe/stripe-js', () => ({
+  loadStripe: vi.fn(() => Promise.resolve(null)),
+}))
+
+// The Stripe Custom Checkout SDK is the external dependency; everything else
+// (provider fetch, the reused CheckoutForm, the order summary, navigation) is
+// the real code under test.
+vi.mock('@stripe/react-stripe-js/checkout', () => ({
+  CheckoutProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useCheckout: () => ({ type: 'success', checkout: checkoutValue }),
+  PaymentElement: () => <div data-testid="payment-element" />,
+}))
+
+vi.mock('@shared/utils/Snackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar, successSnackbar }),
+}))
+
+vi.mock('app/shared/sentry', () => ({
+  reportErrorToSentry: vi.fn(),
+}))
+
+const mockUseProUpgradeWizard = vi.mocked(useProUpgradeWizard)
+const goToStep = vi.fn()
+
+const CHECKOUT_SESSION_ROUTE = 'POST /v1/payments/purchase/checkout-session'
+
+describe('PaymentStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmMock.mockResolvedValue({ type: 'success' })
+    mockUseProUpgradeWizard.mockReturnValue({
+      currentStep: 'payment',
+      goToStep,
+      goToNextStep: vi.fn(),
+      goToPreviousStep: vi.fn(),
+    })
+  })
+
+  it('fetches the embedded subscription client secret and mounts the checkout with the order summary', async () => {
+    let requestBody: { embedded?: boolean; returnUrl?: string } | undefined
+    api.mock(CHECKOUT_SESSION_ROUTE, ({ body }) => {
+      requestBody = body
+      return { status: 200, data: { clientSecret: 'cs_test_123' } }
+    })
+
+    render(<PaymentStep />)
+
+    // The embedded checkout (reused CheckoutForm) only mounts once the session
+    // resolves.
+    expect(
+      await screen.findByRole('button', { name: 'Complete upgrade' }),
+    ).toBeInTheDocument()
+
+    expect(requestBody?.embedded).toBe(true)
+    expect(requestBody?.returnUrl).toMatch(/\/dashboard\/pro-upgrade\/success$/)
+
+    // Order summary reads the live amount from the session, not a hardcode.
+    expect(screen.getByText('Pro Plan')).toBeInTheDocument()
+    expect(screen.getByText('$10.00/mo')).toBeInTheDocument()
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.PaymentViewed,
+    )
+  })
+
+  it('confirms the payment and advances to the success step (isPro flips via webhook, not here)', async () => {
+    api.mock(CHECKOUT_SESSION_ROUTE, {
+      status: 200,
+      data: { clientSecret: 'cs_test_123' },
+    })
+
+    render(<PaymentStep />)
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Complete upgrade' }),
+    )
+
+    await waitFor(() =>
+      expect(goToStep).toHaveBeenCalledWith(PRO_UPGRADE_STEP.SUCCESS),
+    )
+    expect(confirmMock).toHaveBeenCalledWith({ redirect: 'if_required' })
+  })
+
+  it('keeps the candidate on the payment form to retry when the payment fails', async () => {
+    confirmMock.mockResolvedValue({
+      type: 'error',
+      error: { message: 'Your card was declined' },
+    })
+    api.mock(CHECKOUT_SESSION_ROUTE, {
+      status: 200,
+      data: { clientSecret: 'cs_test_123' },
+    })
+
+    render(<PaymentStep />)
+
+    const submit = await screen.findByRole('button', {
+      name: 'Complete upgrade',
+    })
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(errorSnackbar).toHaveBeenCalled())
+    expect(goToStep).not.toHaveBeenCalled()
+    // Still on the form — the candidate can fix their card and retry.
+    expect(
+      screen.getByRole('button', { name: 'Complete upgrade' }),
+    ).toBeInTheDocument()
+  })
+
+  it('shows a hard error when the checkout session cannot be created', async () => {
+    api.mock(CHECKOUT_SESSION_ROUTE, {
+      status: 500,
+      data: { error: 'stripe down' },
+    })
+
+    render(<PaymentStep />)
+
+    expect(await screen.findByText('Purchase Error')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Complete upgrade' }),
+    ).not.toBeInTheDocument()
+    expect(goToStep).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/PaymentStep.tsx
+++ b/app/dashboard/pro-upgrade/components/PaymentStep.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import { useCheckout } from '@stripe/react-stripe-js/checkout'
+import { ProBadge } from '@styleguide'
+import H2 from '@shared/typography/H2'
+import Body2 from '@shared/typography/Body2'
+import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import { APP_BASE } from 'appEnv'
+import { CheckoutSessionProvider } from 'app/dashboard/purchase/components/CheckoutSessionProvider'
+import { useCheckoutSession } from 'app/dashboard/purchase/components/CheckoutSessionProvider'
+import CheckoutPayment from 'app/dashboard/purchase/components/CheckoutPayment'
+import PurchaseError from 'app/dashboard/purchase/components/PurchaseError'
+import { createProSubscriptionCheckoutSession } from 'app/dashboard/purchase/utils/purchaseFetch.utils'
+import { PRO_UPGRADE_STEP, proUpgradeStepPath } from '../proUpgradeStep'
+import { useProUpgradeWizard } from './ProUpgradeWizard'
+
+// Stripe sends the candidate here when a confirm requires a redirect (e.g.
+// 3DS). The success step (task 14) reads the post-payment state; isPro is
+// flipped by the webhook, never client-side.
+const SUCCESS_RETURN_URL = `${APP_BASE}${proUpgradeStepPath(
+  PRO_UPGRADE_STEP.SUCCESS,
+)}`
+
+// Reads the live total from the mounted Stripe checkout so the amount can't
+// drift from the configured Stripe price. Rendered inside CheckoutProvider.
+const OrderSummary = (): React.JSX.Element => {
+  const checkoutResult = useCheckout()
+  const monthly =
+    checkoutResult.type === 'loading' || checkoutResult.type === 'error'
+      ? null
+      : checkoutResult.checkout.total.total.minorUnitsAmount / 100
+  const amountLabel = monthly === null ? null : `$${monthly.toFixed(2)}`
+
+  return (
+    <aside className="rounded-xl border border-gray-200 p-6">
+      <div className="flex items-center justify-between">
+        <span className="font-medium">Pro Plan</span>
+        <ProBadge />
+      </div>
+      <Body2 className="text-secondary mt-1">Billed monthly</Body2>
+
+      <div className="mt-6 flex items-baseline justify-between">
+        <span className="text-secondary">Monthly</span>
+        <span className="font-medium">
+          {amountLabel === null ? '—' : `${amountLabel}/mo`}
+        </span>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-gray-200 pt-4">
+        <span className="font-semibold">Total</span>
+        <span className="font-semibold">{amountLabel ?? '—'}</span>
+      </div>
+    </aside>
+  )
+}
+
+const PaymentContent = ({
+  onConfirmed,
+}: {
+  onConfirmed: () => void
+}): React.JSX.Element => {
+  const { checkoutSession, error, fetchClientSecret } = useCheckoutSession()
+  const hasFetchedSession = useRef(false)
+
+  useEffect(() => {
+    if (!hasFetchedSession.current) {
+      hasFetchedSession.current = true
+      fetchClientSecret().catch(() => {
+        // Surfaced via the provider's `error` state below.
+      })
+    }
+  }, [fetchClientSecret])
+
+  // Only a failed session fetch (no checkout to show) is a dead-end. Once the
+  // checkout has mounted, a failed/declined payment also sets `error`, but we
+  // keep the form so the candidate can fix their card and retry rather than
+  // being bounced to an error screen.
+  if (error && !checkoutSession) {
+    return <PurchaseError error={error} serverError={undefined} />
+  }
+
+  if (!checkoutSession) {
+    return <LoadingAnimation />
+  }
+
+  return (
+    <CheckoutPayment
+      onPaymentConfirmed={onConfirmed}
+      submitLabel="Complete upgrade"
+      orderSummary={<OrderSummary />}
+    />
+  )
+}
+
+const PaymentStep = (): React.JSX.Element => {
+  const { goToStep } = useProUpgradeWizard()
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.PaymentViewed)
+  }, [])
+
+  const createSession = useCallback(
+    () => createProSubscriptionCheckoutSession(SUCCESS_RETURN_URL),
+    [],
+  )
+
+  const handleConfirmed = useCallback(() => {
+    goToStep(PRO_UPGRADE_STEP.SUCCESS)
+  }, [goToStep])
+
+  return (
+    <div>
+      <H2 className="mb-6">Complete your upgrade</H2>
+      <CheckoutSessionProvider createSession={createSession}>
+        <PaymentContent onConfirmed={handleConfirmed} />
+      </CheckoutSessionProvider>
+    </div>
+  )
+}
+
+export default PaymentStep

--- a/app/dashboard/pro-upgrade/payment/page.tsx
+++ b/app/dashboard/pro-upgrade/payment/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import PaymentStep from '../components/PaymentStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="Complete your upgrade"
-      taskNote="Payment step (embedded) — ships in task 13"
-    />
-  )
+  return <PaymentStep />
 }

--- a/app/dashboard/purchase/components/CheckoutForm.test.tsx
+++ b/app/dashboard/purchase/components/CheckoutForm.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import CheckoutForm from './CheckoutForm'
+
+const { confirmMock, checkoutValue, errorSnackbar, successSnackbar, setError } =
+  vi.hoisted(() => {
+    const confirmMock = vi.fn()
+    return {
+      confirmMock,
+      checkoutValue: {
+        confirm: confirmMock,
+        canConfirm: true,
+        total: {
+          total: { minorUnitsAmount: 1000 },
+          subtotal: { minorUnitsAmount: 1000 },
+        },
+        discountAmounts: undefined,
+        applyPromotionCode: vi.fn(),
+        removePromotionCode: vi.fn(),
+      },
+      errorSnackbar: vi.fn(),
+      successSnackbar: vi.fn(),
+      setError: vi.fn(),
+    }
+  })
+
+vi.mock('@stripe/react-stripe-js/checkout', () => ({
+  useCheckout: () => ({ type: 'success', checkout: checkoutValue }),
+  PaymentElement: () => <div data-testid="payment-element" />,
+}))
+
+vi.mock('@shared/utils/Snackbar', () => ({
+  useSnackbar: () => ({ errorSnackbar, successSnackbar }),
+}))
+
+vi.mock('app/shared/sentry', () => ({
+  reportErrorToSentry: vi.fn(),
+}))
+
+vi.mock('./CheckoutSessionProvider', () => ({
+  useCheckoutSession: () => ({ setError }),
+}))
+
+const clickSubmit = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Complete Purchase' }))
+
+describe('CheckoutForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    confirmMock.mockResolvedValue({ type: 'success' })
+  })
+
+  it('completes a one-time purchase via onSuccess with the session id', async () => {
+    const onSuccess = vi.fn()
+
+    render(<CheckoutForm onSuccess={onSuccess} sessionId="cs_one_time" />)
+    clickSubmit()
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('cs_one_time'))
+    expect(confirmMock).toHaveBeenCalledWith({ redirect: 'if_required' })
+  })
+
+  it('signals confirmation via onConfirmed (not onSuccess) when there is no session id', async () => {
+    const onSuccess = vi.fn()
+    const onConfirmed = vi.fn()
+
+    render(
+      <CheckoutForm
+        onSuccess={onSuccess}
+        onConfirmed={onConfirmed}
+        submitLabel="Complete Purchase"
+      />,
+    )
+    clickSubmit()
+
+    await waitFor(() => expect(onConfirmed).toHaveBeenCalled())
+    expect(confirmMock).toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('fails before charging when a one-time session has no id and no onConfirmed fallback', async () => {
+    // Guards the regression the type change opened up: confirming first would
+    // charge the card and then silently skip fulfillment.
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    render(<CheckoutForm onSuccess={onSuccess} onError={onError} />)
+    clickSubmit()
+
+    await waitFor(() => expect(onError).toHaveBeenCalled())
+    expect(confirmMock).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/app/dashboard/purchase/components/CheckoutForm.tsx
+++ b/app/dashboard/purchase/components/CheckoutForm.tsx
@@ -118,6 +118,14 @@ function CheckoutFormContent({
 
   const mutation = useMutation({
     mutationFn: async () => {
+      // One-time purchases complete via `onSuccess(sessionId)`. Without a
+      // session id and without an `onConfirmed` fallback we'd charge the card
+      // and then silently skip fulfillment, so fail before confirming. (The
+      // subscription path passes `onConfirmed` and no session id.)
+      if (!sessionId && !onConfirmed) {
+        throw new Error('Missing checkout session ID')
+      }
+
       if (!hasConfirmedPayment) {
         const result = await checkout.confirm({ redirect: 'if_required' })
 

--- a/app/dashboard/purchase/components/CheckoutForm.tsx
+++ b/app/dashboard/purchase/components/CheckoutForm.tsx
@@ -16,15 +16,24 @@ import { LoadingAnimation } from '@shared/utils/LoadingAnimation'
 import PromoCodeSection, { usePromoCode } from './PromoCodeSection'
 
 interface CheckoutFormProps {
-  onSuccess: (sessionId: string) => void
+  // Fired after a successful confirm when there is a Stripe session id to act
+  // on (one-time purchases call completeCheckoutSession with it).
+  onSuccess?: (sessionId: string) => void
+  // Fired after a successful confirm when there is no session id (the Pro
+  // subscription flow, where gp-api returns only a clientSecret and fulfillment
+  // happens via the Stripe webhook).
+  onConfirmed?: () => void | Promise<void>
   onError?: (error: string) => void
   sessionId?: string
+  submitLabel?: string
 }
 
 export default function CheckoutForm({
   onSuccess,
+  onConfirmed,
   onError,
   sessionId,
+  submitLabel,
 }: CheckoutFormProps): React.JSX.Element {
   const { setError } = useCheckoutSession()
   const checkoutResult = useCheckout()
@@ -65,6 +74,8 @@ export default function CheckoutForm({
       checkout={checkout}
       sessionId={sessionId}
       onSuccess={onSuccess}
+      onConfirmed={onConfirmed}
+      submitLabel={submitLabel}
       onError={(error) => {
         let msg: string
         if (error instanceof Error) {
@@ -91,11 +102,15 @@ function CheckoutFormContent({
   checkout,
   sessionId,
   onSuccess,
+  onConfirmed,
+  submitLabel = 'Complete Purchase',
   onError,
 }: {
   checkout: StripeCheckoutValue
   sessionId?: string
-  onSuccess: (sessionId: string) => void
+  onSuccess?: (sessionId: string) => void
+  onConfirmed?: () => void | Promise<void>
+  submitLabel?: string
   onError: (error: Error | StripeError) => void
 }): React.JSX.Element {
   const promo = usePromoCode(checkout)
@@ -103,10 +118,6 @@ function CheckoutFormContent({
 
   const mutation = useMutation({
     mutationFn: async () => {
-      if (!sessionId) {
-        throw new Error('Missing checkout session ID')
-      }
-
       if (!hasConfirmedPayment) {
         const result = await checkout.confirm({ redirect: 'if_required' })
 
@@ -117,9 +128,14 @@ function CheckoutFormContent({
         setHasConfirmedPayment(true)
       }
 
-      await onSuccess(sessionId)
-
-      return sessionId
+      // One-time purchases complete via the session id; the Pro subscription
+      // has no session id client-side and finalizes through the webhook, so it
+      // just signals confirmation.
+      if (sessionId) {
+        await onSuccess?.(sessionId)
+      } else {
+        await onConfirmed?.()
+      }
     },
     onError,
   })
@@ -172,7 +188,7 @@ function CheckoutFormContent({
         className="mt-6 w-full whitespace-nowrap"
         size="large"
       >
-        Complete Purchase
+        {submitLabel}
       </Button>
     </form>
   )

--- a/app/dashboard/purchase/components/CheckoutPayment.tsx
+++ b/app/dashboard/purchase/components/CheckoutPayment.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ReactNode } from 'react'
 import { CheckoutProvider } from '@stripe/react-stripe-js/checkout'
 import { loadStripe } from '@stripe/stripe-js'
 import CheckoutForm from './CheckoutForm'
@@ -9,28 +10,51 @@ import { useCheckoutSession } from './CheckoutSessionProvider'
 const stripePromise = loadStripe(NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
 
 export type CheckoutPaymentProps = {
-  onPaymentSuccess: (sessionId: string) => void
+  onPaymentSuccess?: (sessionId: string) => void
+  // Used when there is no Stripe session id client-side (the Pro subscription),
+  // where fulfillment happens via the webhook and the form just confirms.
+  onPaymentConfirmed?: () => void | Promise<void>
   onPaymentError?: (errorMessage: string) => void
+  submitLabel?: string
+  // Rendered inside the CheckoutProvider (alongside the form) so it can read the
+  // live total via Stripe's useCheckout — e.g. the Pro plan order summary.
+  orderSummary?: ReactNode
 }
 
 const CheckoutPayment: React.FC<CheckoutPaymentProps> = ({
   onPaymentSuccess,
+  onPaymentConfirmed,
   onPaymentError,
+  submitLabel,
+  orderSummary,
 }) => {
   const { checkoutSession } = useCheckoutSession()
 
   if (!checkoutSession?.clientSecret) return null
+
+  const form = (
+    <CheckoutForm
+      onSuccess={onPaymentSuccess}
+      onConfirmed={onPaymentConfirmed}
+      onError={onPaymentError}
+      sessionId={checkoutSession.id}
+      submitLabel={submitLabel}
+    />
+  )
 
   return (
     <CheckoutProvider
       stripe={stripePromise}
       options={{ clientSecret: checkoutSession.clientSecret }}
     >
-      <CheckoutForm
-        onSuccess={onPaymentSuccess}
-        onError={onPaymentError}
-        sessionId={checkoutSession.id}
-      />
+      {orderSummary ? (
+        <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[1fr_360px] lg:items-start">
+          {form}
+          {orderSummary}
+        </div>
+      ) : (
+        form
+      )}
     </CheckoutProvider>
   )
 }

--- a/app/dashboard/purchase/components/CheckoutSessionProvider.tsx
+++ b/app/dashboard/purchase/components/CheckoutSessionProvider.tsx
@@ -35,6 +35,12 @@ interface CheckoutSessionProviderProps {
   purchaseMetaData?: Record<string, string | number | boolean | undefined>
   receiptEmail?: string
   returnUrl?: string
+  // When provided, the session is created by this function instead of the
+  // typed one-time `createCheckoutSession(type, ...)` path. Used by the Pro
+  // upgrade wizard to mount the subscription checkout while reusing the rest of
+  // the provider (caching, in-flight dedupe, error state). It must throw on
+  // failure; the provider surfaces the message via `error`.
+  createSession?: () => Promise<CheckoutSessionResponse>
 }
 
 export const CheckoutSessionProvider = ({
@@ -43,6 +49,7 @@ export const CheckoutSessionProvider = ({
   purchaseMetaData = {},
   receiptEmail,
   returnUrl,
+  createSession,
 }: CheckoutSessionProviderProps) => {
   const [checkoutSession, setCheckoutSession] =
     useState<CheckoutSessionResponse | null>(null)
@@ -66,7 +73,10 @@ export const CheckoutSessionProvider = ({
       return pendingRequestRef.current
     }
 
-    if (!type || !PURCHASE_TYPES[type as keyof typeof PURCHASE_TYPES]) {
+    if (
+      !createSession &&
+      !PURCHASE_TYPES[type as keyof typeof PURCHASE_TYPES]
+    ) {
       setError('Invalid purchase type')
       reportErrorToSentry(new Error('CheckoutSessionProvider error'), {
         message: 'Invalid purchase type',
@@ -77,6 +87,24 @@ export const CheckoutSessionProvider = ({
     setIsLoading(true)
     const request = (async () => {
       try {
+        if (createSession) {
+          try {
+            const session = await createSession()
+            setCheckoutSession(session)
+            return session.clientSecret
+          } catch (err) {
+            const errorMessage =
+              err instanceof Error
+                ? err.message
+                : 'Failed to create checkout session'
+            setError(errorMessage)
+            reportErrorToSentry(new Error('CheckoutSessionProvider error'), {
+              message: errorMessage,
+            })
+            throw err
+          }
+        }
+
         const response = await createCheckoutSession(
           type,
           purchaseMetaDataRef.current,
@@ -104,7 +132,7 @@ export const CheckoutSessionProvider = ({
 
     pendingRequestRef.current = request
     return request
-  }, [checkoutSession, type, receiptEmail, returnUrl])
+  }, [checkoutSession, type, receiptEmail, returnUrl, createSession])
 
   return (
     <CheckoutSessionContext.Provider

--- a/app/dashboard/purchase/utils/purchaseFetch.utils.ts
+++ b/app/dashboard/purchase/utils/purchaseFetch.utils.ts
@@ -1,14 +1,19 @@
 import { apiRoutes } from 'gpApi/routes'
 import { clientFetch, ApiResponse } from 'gpApi/clientFetch'
+import { clientRequest } from 'gpApi/typed-request'
 
 interface CompletePurchaseResponse {
   success: boolean
 }
 
 export interface CheckoutSessionResponse {
-  id: string
+  // `id` and `amount` come back for the one-time Custom Checkout sessions but
+  // not for the Pro subscription session (gp-api returns only `clientSecret`),
+  // so both are optional. Consumers already default `amount` and treat `id` as
+  // an optional Stripe session id.
+  id?: string
   clientSecret: string
-  amount: number
+  amount?: number
 }
 
 export function createCheckoutSession(
@@ -25,6 +30,27 @@ export function createCheckoutSession(
     returnUrl,
     allowPromoCodes,
   })
+}
+
+// Pro $10/mo subscription. Mounts the same embedded Stripe Custom Checkout as
+// the one-time flow, but the session is created by gp-api's
+// `createProCheckoutSession` (embedded mode) which returns only a
+// `clientSecret`. `returnUrl` is where Stripe sends the candidate when a
+// confirm requires a redirect (e.g. 3DS). `isPro` is flipped by the Stripe
+// webhook, not here.
+export async function createProSubscriptionCheckoutSession(
+  returnUrl?: string,
+): Promise<CheckoutSessionResponse> {
+  const { data } = await clientRequest(
+    'POST /v1/payments/purchase/checkout-session',
+    { embedded: true, returnUrl },
+  )
+
+  if (!data.clientSecret) {
+    throw new Error('Missing client secret for Pro subscription checkout')
+  }
+
+  return { clientSecret: data.clientSecret }
 }
 
 export function completeCheckoutSession(

--- a/gpApi/api-endpoints.ts
+++ b/gpApi/api-endpoints.ts
@@ -438,6 +438,22 @@ export type APIEndpoints = {
     Request: {}
     Response: void
   }
+
+  // Pro $10/mo subscription checkout (gp-api createProCheckoutSession).
+  // `embedded: true` returns a Stripe Custom Checkout `clientSecret` to mount
+  // in-app; omitting it returns a hosted `redirectUrl` (legacy off-cohort
+  // path). `returnUrl` is where Stripe sends the candidate when a confirm
+  // requires a redirect (e.g. 3DS); gp-api defaults it when omitted.
+  'POST /v1/payments/purchase/checkout-session': {
+    Request: {
+      embedded?: boolean
+      returnUrl?: string
+    }
+    Response: {
+      clientSecret?: string
+      redirectUrl?: string
+    }
+  }
 }
 
 // Backend (snake_case) annotation types. Mirrors @goodparty_org/contracts

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -354,6 +354,7 @@ export const EVENTS = {
       EinHoverHelp: 'Pro Upgrade - EIN: Hover help',
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
+      PaymentViewed: 'Pro Upgrade - Payment Viewed',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',
     },
   },


### PR DESCRIPTION
## What

The pre-payment Pro upgrade wizard's **payment step** (task 13 of the ENG-7508 Phase 3 epic), behind the `pro-upgrade3` cohort. Renders an embedded Stripe Custom Checkout next to a Pro plan order summary — no redirect away from the app — replacing the legacy redirect-to-Stripe step for this cohort. On a successful confirm the candidate advances to the wizard success step. `isPro` is flipped only by the Stripe webhook, never client-side.

ClickUp: https://app.clickup.com/t/86ahxpthj

## How

Reuses the existing Custom Checkout machinery (`CheckoutSessionProvider` + `CheckoutPayment` + `CheckoutForm`, `ui_mode: 'custom'`) rather than building a second Stripe integration. The shared components were generalized **additively** so the three existing callers (purchase, polls, outreach) are behaviorally unchanged:

- `CheckoutSessionProvider` gains an optional `createSession` injector (the subscription fetch; skips `PURCHASE_TYPES` validation, reuses caching / in-flight dedupe / error state).
- `CheckoutForm` gains optional `onConfirmed` (fires after confirm when there is **no** session id — the subscription case, fulfilled by the webhook) and `submitLabel`; `onSuccess` is now optional.
- `CheckoutSessionResponse.id`/`amount` made optional — the subscription session returns only `clientSecret`. Existing `amount` consumers already default it; `id` is only the optional Stripe `sessionId`.

Calls the task-03 embedded subscription endpoint through the **typed** client: a new `'POST /v1/payments/purchase/checkout-session'` entry in `gpApi/api-endpoints.ts` + `clientRequest` (the ticket said `routes.ts`, but `gpApi/CLAUDE.md` forbids new `routes.ts` entries — same call task 08 made). The gp-api side is already merged on `develop`.

- The order-summary amount reads the **live** Stripe total (`useCheckout().checkout.total`) instead of a hardcoded `$10`.
- `return_url` → `${APP_BASE}/dashboard/pro-upgrade/success` for redirect-required confirms (e.g. 3DS).
- A declined/failed payment keeps the candidate on the form to retry; a failed session creation shows a hard error.
- New analytics event `PaymentViewed`.

## Testing

`PaymentStep.test.tsx` — 4 integration-style tests exercising the real `CheckoutForm`/`CheckoutPayment`/order summary with only the Stripe SDK + the typed endpoint mocked:
- fetches the embedded `clientSecret` with `{ embedded: true, returnUrl }` and mounts the checkout + reads `$10.00/mo` from the session
- confirm success → navigates to the success step (`isPro` via webhook, no client-side completion)
- declined payment keeps the candidate on the form to retry
- session-create failure → `PurchaseError`

`npm run types` clean; ESLint + Prettier clean; **111 pass** across `pro-upgrade` / `purchase` / `polls`.

## Notes / follow-ups

- **Design confirm:** the Figma node in the ticket resolves to the whole flow board, not the payment sub-frame, so the order-summary layout follows the ticket's described content rather than a pixel match.
- **Tasks 14/15 seam:** this step navigates to `/success` before the webhook flips `isPro`; the success surface (task 14/15) must handle that window without bouncing a just-paid candidate back through the index (where `deriveProUpgradeStep` still returns `PAYMENT` until `isPro` is true).
- Not yet walked through live — needs the `pro-upgrade3` flag + the Amplitude flag, and a Stripe test-mode end-to-end (confirm `isPro` flips via webhook and the agent run launches, cross-check task 02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared payment checkout paths used by purchase/outreach/polls; changes are additive but subscription fulfillment depends on webhook timing vs. navigating to success before `isPro` flips.
> 
> **Overview**
> Replaces the Pro upgrade **payment** placeholder with an **in-app embedded Stripe Custom Checkout** (form + Pro order summary). Candidates stay in the wizard; on successful confirm they advance to the success step while **`isPro` is only set by the Stripe webhook**, not client-side completion.
> 
> The implementation **reuses** `CheckoutSessionProvider` / `CheckoutPayment` / `CheckoutForm` with **additive** changes: optional `createSession` for the Pro subscription API (`embedded: true`, `returnUrl` → pro-upgrade success for 3DS), optional `onConfirmed` when there is no Stripe session id, customizable submit label, optional order summary layout, and optional `id`/`amount` on checkout session responses. A typed **`POST /v1/payments/purchase/checkout-session`** entry and `createProSubscriptionCheckoutSession` wire the subscription fetch; the order summary reads the **live** Stripe total via `useCheckout`.
> 
> Declined payments keep the user on the form to retry; failed session creation shows `PurchaseError`. Adds **`PaymentViewed`** analytics and **`PaymentStep.test.tsx`** (session fetch, confirm → success step, decline retry, session error).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312d1902f875770714142c088a24949d99c2327a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->