### PR TITLE
feat(success): use SOS-curated voter deadlines for registration + absentee

### DIFF
--- a/app/onboarding/success/components/planContent.test.ts
+++ b/app/onboarding/success/components/planContent.test.ts
@@ -63,7 +63,7 @@ describe('buildPlanData voter-registration deadline — no-deadline states', () 
     )
   })
 
-  it('renders the no-deadline copy for VT (same-day registration through ED)', () => {
+  it('renders the no-deadline copy for VT (same-day registration through ED) and also suppresses the absentee row (VT is universal VBM)', () => {
     const plan = buildPlanData(makeInput({ state: 'VT' }))
 
     expect(
@@ -75,10 +75,42 @@ describe('buildPlanData voter-registration deadline — no-deadline states', () 
       (row) => row.milestone === 'Voter registration',
     )
     expect(regRow).toBeDefined()
+    // VT's tier note is "Online ED; Mail ED; In-person ED" — redundant
+    // with the same-day-voting sentence, so it should NOT be appended.
     expect(regRow?.notes).toBe(NO_DEADLINE_COPY)
     expect(plan.keyDates.some((d) => d.description === NO_DEADLINE_COPY)).toBe(
       true,
     )
+
+    // VT is the only state that hits BOTH `voterRegHasNoDeadline` and
+    // `absenteeOmitted` (universal VBM). Without this assertion a
+    // regression on the absentee suppression branch for VT-shaped data
+    // would slip through unnoticed.
+    expect(
+      plan.timeline.some(
+        (row) => row.milestone === 'Absentee ballot request deadline',
+      ),
+    ).toBe(false)
+    expect(
+      plan.keyDates.some((d) =>
+        d.description.startsWith('Absentee ballot request deadline'),
+      ),
+    ).toBe(false)
+  })
+
+  it('appends the local pre-registration tier note for NH', () => {
+    const plan = buildPlanData(makeInput({ state: 'NH' }))
+
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration',
+    )
+    expect(regRow).toBeDefined()
+    // NH has a meaningful tier note (locally-set deadlines) — the
+    // pre-registration context should be surfaced after the
+    // same-day-voting sentence rather than silently dropped.
+    expect(regRow?.notes).toContain(NO_DEADLINE_COPY)
+    expect(regRow?.notes).toContain('Local pre-registration')
+    expect(regRow?.notes).toContain('Set locally')
   })
 })
 
@@ -98,15 +130,30 @@ describe('buildPlanData absentee-request deadline omission', () => {
     ).toBe(false)
   })
 
-  it('still renders the voter registration deadline for CA (using curated Oct 19 date)', () => {
-    const plan = buildPlanData(makeInput({ state: 'CA' }))
+  it('uses the curated CA voter registration date (Oct 19) and ignores a conflicting BR milestone (Nov 2)', () => {
+    // The real-world regression this guards: BR returned Nov 2 for CA
+    // registration; the curated table has the correct Oct 19. Passing
+    // the wrong BR value here proves the curated lookup wins — without
+    // the conflicting BR value the E-offset fallback (electionDate-15 =
+    // Oct 19) would produce the same date and the test would be
+    // tautological.
+    const plan = buildPlanData(
+      makeInput({
+        state: 'CA',
+        milestones: {
+          voter_registration: { start: null, end: '2026-11-02' },
+          early_voting: null,
+          request_ballot: null,
+        },
+      }),
+    )
 
     const regRow = plan.timeline.find(
       (row) => row.milestone === 'Voter registration deadline',
     )
     expect(regRow).toBeDefined()
-    // Curated date is 2026-10-19. dateUsHelper formats as "Oct 19, 2026".
     expect(regRow?.date).toContain('Oct 19, 2026')
+    expect(regRow?.date).not.toContain('Nov 2, 2026')
     expect(regRow?.notes).toContain('Per state SOS data')
   })
 })

--- a/app/onboarding/success/components/planContent.test.ts
+++ b/app/onboarding/success/components/planContent.test.ts
@@ -34,14 +34,14 @@ const makeInput = (overrides: Partial<PlanInput> = {}): PlanInput => ({
 })
 
 describe('buildPlanData voter-registration deadline — no-deadline states', () => {
-  const NO_DEADLINE_COPY =
+  const ND_COPY =
+    'There is no registration deadline as North Dakota has no voter registration requirement.'
+  const SDR_COPY =
     'There is no registration deadline as there is same day voting.'
 
-  it('renders the no-deadline copy for ND (no voter registration at all)', () => {
+  it('renders the ND-specific copy (no registration requirement, not same-day registration)', () => {
     const plan = buildPlanData(makeInput({ state: 'ND' }))
 
-    // The standard "deadline" milestone label must NOT appear (the row
-    // has been replaced with the explanatory copy keyed to Election Day).
     expect(
       plan.timeline.some(
         (row) => row.milestone === 'Voter registration deadline',
@@ -51,16 +51,17 @@ describe('buildPlanData voter-registration deadline — no-deadline states', () 
       (row) => row.milestone === 'Voter registration',
     )
     expect(regRow).toBeDefined()
-    expect(regRow?.notes).toBe(NO_DEADLINE_COPY)
+    // ND has no voter registration system — the SDR copy would be a
+    // wrong legal basis.
+    expect(regRow?.notes).toBe(ND_COPY)
+    expect(regRow?.notes).not.toContain('same day voting')
 
     expect(
       plan.keyDates.some((d) =>
         d.description.startsWith('Voter registration deadline'),
       ),
     ).toBe(false)
-    expect(plan.keyDates.some((d) => d.description === NO_DEADLINE_COPY)).toBe(
-      true,
-    )
+    expect(plan.keyDates.some((d) => d.description === ND_COPY)).toBe(true)
   })
 
   it('renders the no-deadline copy for VT (same-day registration through ED) and also suppresses the absentee row (VT is universal VBM)', () => {
@@ -77,10 +78,8 @@ describe('buildPlanData voter-registration deadline — no-deadline states', () 
     expect(regRow).toBeDefined()
     // VT's tier note is "Online ED; Mail ED; In-person ED" — redundant
     // with the same-day-voting sentence, so it should NOT be appended.
-    expect(regRow?.notes).toBe(NO_DEADLINE_COPY)
-    expect(plan.keyDates.some((d) => d.description === NO_DEADLINE_COPY)).toBe(
-      true,
-    )
+    expect(regRow?.notes).toBe(SDR_COPY)
+    expect(plan.keyDates.some((d) => d.description === SDR_COPY)).toBe(true)
 
     // VT is the only state that hits BOTH `voterRegHasNoDeadline` and
     // `absenteeOmitted` (universal VBM). Without this assertion a
@@ -108,7 +107,7 @@ describe('buildPlanData voter-registration deadline — no-deadline states', () 
     // NH has a meaningful tier note (locally-set deadlines) — the
     // pre-registration context should be surfaced after the
     // same-day-voting sentence rather than silently dropped.
-    expect(regRow?.notes).toContain(NO_DEADLINE_COPY)
+    expect(regRow?.notes).toContain(SDR_COPY)
     expect(regRow?.notes).toContain('Local pre-registration')
     expect(regRow?.notes).toContain('Set locally')
   })
@@ -194,5 +193,46 @@ describe('buildPlanData fallback for unknown state', () => {
     // suppressed and neither claims SOS data attribution.
     expect(regRow?.notes).not.toContain('Per state SOS data')
     expect(absenteeRow?.notes).not.toContain('Per state SOS data')
+  })
+
+  it('documents that universal-VBM absentee suppression is year-tied: CA in 2027 shows the absentee row', () => {
+    // `isUniversalVbm` is logically a state characteristic, but the
+    // year guard makes the curated lookup miss for non-2026-general
+    // elections — so the absentee row reappears for CA/CO/HI/etc. in
+    // 2027+ even though they are still universal-VBM states. The fix
+    // is to separate year-agnostic state facts from the dated deadline
+    // data; until then this test pins the current behavior so a
+    // regression elsewhere doesn't quietly change it.
+    const plan = buildPlanData(
+      makeInput({ state: 'CA', electionDateIso: '2027-11-02' }),
+    )
+
+    const absenteeRow = plan.timeline.find(
+      (row) => row.milestone === 'Absentee ballot request deadline',
+    )
+    expect(absenteeRow).toBeDefined()
+    expect(absenteeRow?.notes).not.toContain('Per state SOS data')
+  })
+
+  it('does not claim SOS authority for a 2026 primary (curated table covers the Nov general only)', () => {
+    // A CA June primary has year=2026 but doesn't share the November
+    // deadlines. The month gate keeps it on the BR / E-offset path so
+    // the wrong dates aren't labeled as SOS-verified.
+    const plan = buildPlanData(
+      makeInput({ state: 'CA', electionDateIso: '2026-06-02' }),
+    )
+
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration deadline',
+    )
+    expect(regRow).toBeDefined()
+    expect(regRow?.notes).not.toContain('Per state SOS data')
+    // And the absentee row is back in play for the same reason —
+    // universal-VBM suppression depends on the curated lookup, which
+    // is gated to the Nov 2026 general.
+    const absenteeRow = plan.timeline.find(
+      (row) => row.milestone === 'Absentee ballot request deadline',
+    )
+    expect(absenteeRow).toBeDefined()
   })
 })

--- a/app/onboarding/success/components/planContent.test.ts
+++ b/app/onboarding/success/components/planContent.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { buildPlanData, type PlanInput } from './planContent'
+
+// Minimum-viable PlanInput fixture. Tests override only the fields under
+// test (state, milestones). Election date is fixed at a known Tue in the
+// future so date math is stable.
+const ELECTION_DATE_ISO = '2026-11-03'
+
+const makeInput = (overrides: Partial<PlanInput> = {}): PlanInput => ({
+  candidateName: 'Test Candidate',
+  race: 'Test Office',
+  district: '',
+  city: '',
+  state: 'CA',
+  partisanType: 'nonpartisan',
+  electionDateIso: ELECTION_DATE_ISO,
+  filingDateStartIso: '2026-07-01',
+  filingDateEndIso: '2026-08-07',
+  winNumber: 1000,
+  projectedTurnout: 2000,
+  voterContactGoal: 5000,
+  runningAgainst: [],
+  customIssues: [],
+  stances: [],
+  hubspotIncumbent: null,
+  filingFee: null,
+  filingRequirementsText: null,
+  registeredVoters: null,
+  uniqueCellphones: null,
+  uniqueLandlines: null,
+  raceCandidates: [],
+  milestones: null,
+  ...overrides,
+})
+
+describe('buildPlanData voter-registration deadline omission', () => {
+  it('omits the registration deadline for ND (no voter registration at all)', () => {
+    const plan = buildPlanData(makeInput({ state: 'ND' }))
+
+    expect(
+      plan.timeline.some(
+        (row) => row.milestone === 'Voter registration deadline',
+      ),
+    ).toBe(false)
+    expect(
+      plan.keyDates.some((d) =>
+        d.description.startsWith('Voter registration deadline'),
+      ),
+    ).toBe(false)
+  })
+
+  it('omits the registration deadline for VT (same-day registration through ED)', () => {
+    const plan = buildPlanData(makeInput({ state: 'VT' }))
+
+    expect(
+      plan.timeline.some(
+        (row) => row.milestone === 'Voter registration deadline',
+      ),
+    ).toBe(false)
+    expect(
+      plan.keyDates.some((d) =>
+        d.description.startsWith('Voter registration deadline'),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('buildPlanData absentee-request deadline omission', () => {
+  it('omits the absentee request deadline for universal-VBM states (CA)', () => {
+    const plan = buildPlanData(makeInput({ state: 'CA' }))
+
+    expect(
+      plan.timeline.some(
+        (row) => row.milestone === 'Absentee ballot request deadline',
+      ),
+    ).toBe(false)
+    expect(
+      plan.keyDates.some((d) =>
+        d.description.startsWith('Absentee ballot request deadline'),
+      ),
+    ).toBe(false)
+  })
+
+  it('still renders the voter registration deadline for CA (using curated Oct 19 date)', () => {
+    const plan = buildPlanData(makeInput({ state: 'CA' }))
+
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration deadline',
+    )
+    expect(regRow).toBeDefined()
+    // Curated date is 2026-10-19. dateUsHelper formats as "Oct 19, 2026".
+    expect(regRow?.date).toContain('Oct 19, 2026')
+    expect(regRow?.notes).toContain('Per state SOS data')
+  })
+})
+
+describe('buildPlanData tier-note rendering', () => {
+  it('renders the curated tier-note in the absentee row notes for AK', () => {
+    const plan = buildPlanData(makeInput({ state: 'AK' }))
+
+    const absenteeRow = plan.timeline.find(
+      (row) => row.milestone === 'Absentee ballot request deadline',
+    )
+    expect(absenteeRow).toBeDefined()
+    expect(absenteeRow?.notes).toContain('Per state SOS data')
+    expect(absenteeRow?.notes).toContain(
+      'Method differences — Online Oct 19; Mail Oct 24',
+    )
+  })
+})
+
+describe('buildPlanData fallback for unknown state', () => {
+  it('renders both deadline rows using the E-offset fallback when the state is not in the curated table', () => {
+    // 'XX' is intentionally not in VOTER_DEADLINES_2026. The curated
+    // lookup should miss and both rows should fall back to the
+    // BR/E-offset path that previously drove everything.
+    const plan = buildPlanData(makeInput({ state: 'XX' }))
+
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration deadline',
+    )
+    const absenteeRow = plan.timeline.find(
+      (row) => row.milestone === 'Absentee ballot request deadline',
+    )
+
+    expect(regRow).toBeDefined()
+    expect(absenteeRow).toBeDefined()
+    // E-offset fallback notes start with "Approximate." (no BR milestone
+    // data passed in this test). The point is just that neither row is
+    // suppressed and neither claims SOS data attribution.
+    expect(regRow?.notes).not.toContain('Per state SOS data')
+    expect(absenteeRow?.notes).not.toContain('Per state SOS data')
+  })
+})

--- a/app/onboarding/success/components/planContent.test.ts
+++ b/app/onboarding/success/components/planContent.test.ts
@@ -33,23 +33,37 @@ const makeInput = (overrides: Partial<PlanInput> = {}): PlanInput => ({
   ...overrides,
 })
 
-describe('buildPlanData voter-registration deadline omission', () => {
-  it('omits the registration deadline for ND (no voter registration at all)', () => {
+describe('buildPlanData voter-registration deadline — no-deadline states', () => {
+  const NO_DEADLINE_COPY =
+    'There is no registration deadline as there is same day voting.'
+
+  it('renders the no-deadline copy for ND (no voter registration at all)', () => {
     const plan = buildPlanData(makeInput({ state: 'ND' }))
 
+    // The standard "deadline" milestone label must NOT appear (the row
+    // has been replaced with the explanatory copy keyed to Election Day).
     expect(
       plan.timeline.some(
         (row) => row.milestone === 'Voter registration deadline',
       ),
     ).toBe(false)
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration',
+    )
+    expect(regRow).toBeDefined()
+    expect(regRow?.notes).toBe(NO_DEADLINE_COPY)
+
     expect(
       plan.keyDates.some((d) =>
         d.description.startsWith('Voter registration deadline'),
       ),
     ).toBe(false)
+    expect(plan.keyDates.some((d) => d.description === NO_DEADLINE_COPY)).toBe(
+      true,
+    )
   })
 
-  it('omits the registration deadline for VT (same-day registration through ED)', () => {
+  it('renders the no-deadline copy for VT (same-day registration through ED)', () => {
     const plan = buildPlanData(makeInput({ state: 'VT' }))
 
     expect(
@@ -57,11 +71,14 @@ describe('buildPlanData voter-registration deadline omission', () => {
         (row) => row.milestone === 'Voter registration deadline',
       ),
     ).toBe(false)
-    expect(
-      plan.keyDates.some((d) =>
-        d.description.startsWith('Voter registration deadline'),
-      ),
-    ).toBe(false)
+    const regRow = plan.timeline.find(
+      (row) => row.milestone === 'Voter registration',
+    )
+    expect(regRow).toBeDefined()
+    expect(regRow?.notes).toBe(NO_DEADLINE_COPY)
+    expect(plan.keyDates.some((d) => d.description === NO_DEADLINE_COPY)).toBe(
+      true,
+    )
   })
 })
 

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -354,7 +354,16 @@ const buildTimeline = (
   // request deadline" rendered even though CA is universal vote-by-mail
   // and there is no request). Falls back to BR / E-offset only when the
   // state isn't in the curated table.
-  const curated = VOTER_DEADLINES_2026[stateCode.toUpperCase()]
+  //
+  // Year guard: the curated table is for the 2026 cycle only. For any
+  // other election year (special elections, 2027 primaries, future
+  // cycles) fall through to BR — better to show BR's date than to claim
+  // SOS authority for the wrong year's deadlines. Update by regenerating
+  // the data file for the next cycle.
+  const curated =
+    electionDate.getFullYear() === 2026
+      ? VOTER_DEADLINES_2026[stateCode.toUpperCase()]
+      : undefined
 
   const voterRegDeadline =
     parseDateIso(curated?.registration.date ?? null) ??
@@ -378,6 +387,21 @@ const buildTimeline = (
     curated != null && curated.registration.date === null
   const NO_DEADLINE_COPY =
     'There is no registration deadline as there is same day voting.'
+  // NH (and any other no-deadline state with a non-trivial tier note)
+  // has locally-set pre-registration windows that supplement the
+  // same-day-voting option. Append them so the candidate still sees the
+  // pre-registration context; skip when tier note is null (ND) or just
+  // restates "Election Day" for all methods (VT). The split-by-"; "
+  // check matches the format `tier_note` emits in the generated data.
+  const tierNoteAddsInfo =
+    voterRegTierNote !== null &&
+    !voterRegTierNote
+      .split('; ')
+      .every((part) => /\bElection Day\b/i.test(part))
+  const noDeadlineNotes =
+    voterRegHasNoDeadline && tierNoteAddsInfo
+      ? `${NO_DEADLINE_COPY} Local pre-registration: ${voterRegTierNote}.`
+      : NO_DEADLINE_COPY
 
   // Universal VBM states (CA, CO, etc.) have no real request deadline —
   // ballots auto-mail to all active voters. Drop the milestone entirely
@@ -462,7 +486,7 @@ const buildTimeline = (
         ? {
             date: electionDate,
             milestone: 'Voter registration',
-            notes: NO_DEADLINE_COPY,
+            notes: noDeadlineNotes,
           }
         : {
             date: voterRegDeadline,
@@ -524,7 +548,7 @@ const buildTimeline = (
     voterRegHasNoDeadline
       ? {
           date: electionDate,
-          description: NO_DEADLINE_COPY,
+          description: noDeadlineNotes,
         }
       : {
           date: voterRegDeadline,

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -19,6 +19,7 @@ import {
   CONTACTS_PER_VOLUNTEER_HOUR,
   resolveWeeksRemaining,
 } from '../../components/volunteerHours'
+import { VOTER_DEADLINES_2026 } from '../data/voterDeadlines2026'
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
@@ -305,6 +306,7 @@ const buildTimeline = (
   filingDateEnd: Date | null,
   milestones: RaceMilestones | null,
   eventCount: number,
+  stateCode: string,
 ): {
   timeline: TimelineRow[]
   keyDates: KeyDate[]
@@ -344,17 +346,61 @@ const buildTimeline = (
   const voterRegOpen = parseDateIso(
     milestones?.voter_registration?.start ?? null,
   )
+
+  // Voter registration deadline + absentee request deadline pull from a
+  // curated SOS-verified table per state (see voterDeadlines2026.ts) rather
+  // than BallotReady. BR's data for these two has been wrong on enough
+  // states (CA registration showed Nov 2 vs actual Oct 19; CA "absentee
+  // request deadline" rendered even though CA is universal vote-by-mail
+  // and there is no request). Falls back to BR / E-offset only when the
+  // state isn't in the curated table.
+  const curated = VOTER_DEADLINES_2026[stateCode.toUpperCase()]
+
   const voterRegDeadline =
+    parseDateIso(curated?.registration.date ?? null) ??
     parseDateIso(milestones?.voter_registration?.end ?? null) ??
     addDays(electionDate, -15)
-  const voterRegDeadlineIsReal = milestones?.voter_registration?.end != null
+  const voterRegSource: 'curated' | 'ballotReady' | 'approximate' = curated
+    ?.registration.date
+    ? 'curated'
+    : milestones?.voter_registration?.end != null
+      ? 'ballotReady'
+      : 'approximate'
+  const voterRegTierNote = curated?.registration.tierNote ?? null
+
+  // Universal VBM states (CA, CO, etc.) have no real request deadline —
+  // ballots auto-mail to all active voters. Drop the milestone entirely
+  // for those rather than render a misleading row.
+  const absenteeOmitted = curated?.absentee.isUniversalVbm === true
   const requestBallotEnd =
+    parseDateIso(curated?.absentee.date ?? null) ??
     parseDateIso(milestones?.request_ballot?.end ?? null) ??
     addDays(electionDate, -7)
-  const requestBallotEndIsReal = milestones?.request_ballot?.end != null
+  const requestBallotEndSource: 'curated' | 'ballotReady' | 'approximate' =
+    curated?.absentee.date
+      ? 'curated'
+      : milestones?.request_ballot?.end != null
+        ? 'ballotReady'
+        : 'approximate'
+  const requestBallotTierNote = curated?.absentee.tierNote ?? null
 
   const sourceNote = (isReal: boolean, baseNote: string): string =>
     isReal ? `Per BallotReady. ${baseNote}` : `Approximate. ${baseNote}`
+
+  // For deadlines pulled from the curated table, attribute to SOS data and
+  // append the tier breakdown when methods differ (e.g. ID online vs mail).
+  const curatedNote = (
+    source: 'curated' | 'ballotReady' | 'approximate',
+    tierNote: string | null,
+    baseNote: string,
+  ): string => {
+    if (source === 'curated') {
+      const prefix = 'Per state SOS data.'
+      const tiers = tierNote ? ` Method differences — ${tierNote}.` : ''
+      return `${prefix}${tiers} ${baseNote}`
+    }
+    return sourceNote(source === 'ballotReady', baseNote)
+  }
 
   const timelineRows: Array<{ date: Date; milestone: string; notes: string }> =
     [
@@ -404,16 +450,25 @@ const buildTimeline = (
       {
         date: voterRegDeadline,
         milestone: 'Voter registration deadline',
-        notes: sourceNote(
-          voterRegDeadlineIsReal,
+        notes: curatedNote(
+          voterRegSource,
+          voterRegTierNote,
           'Push via robocall campaign.',
         ),
       },
-      {
-        date: requestBallotEnd,
-        milestone: 'Absentee ballot request deadline',
-        notes: sourceNote(requestBallotEndIsReal, 'Push via text campaign.'),
-      },
+      ...(absenteeOmitted
+        ? []
+        : [
+            {
+              date: requestBallotEnd,
+              milestone: 'Absentee ballot request deadline',
+              notes: curatedNote(
+                requestBallotEndSource,
+                requestBallotTierNote,
+                'Push via text campaign.',
+              ),
+            },
+          ]),
       {
         date: electionDate,
         milestone: 'Election Day, polls open; absentee ballots due',
@@ -453,10 +508,14 @@ const buildTimeline = (
       date: voterRegDeadline,
       description: 'Voter registration deadline.',
     },
-    {
-      date: requestBallotEnd,
-      description: 'Absentee ballot request deadline.',
-    },
+    ...(absenteeOmitted
+      ? []
+      : [
+          {
+            date: requestBallotEnd,
+            description: 'Absentee ballot request deadline.',
+          },
+        ]),
     {
       date: electionDate,
       description: 'Election Day.',
@@ -1076,6 +1135,7 @@ export const buildPlanData = (input: PlanInput): PlanData => {
     filingDateEnd,
     input.milestones,
     eventCount,
+    input.state,
   )
   const contactSchedule = buildContactSchedule(electionDateValid)
 

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -355,15 +355,25 @@ const buildTimeline = (
   // and there is no request). Falls back to BR / E-offset only when the
   // state isn't in the curated table.
   //
-  // Year guard: the curated table is for the 2026 cycle only. For any
-  // other election year (special elections, 2027 primaries, future
-  // cycles) fall through to BR — better to show BR's date than to claim
-  // SOS authority for the wrong year's deadlines. Update by regenerating
-  // the data file for the next cycle.
-  const curated =
-    electionDate.getFullYear() === 2026
-      ? VOTER_DEADLINES_2026[stateCode.toUpperCase()]
-      : undefined
+  // Year-and-month guard: the curated table covers the Nov 3, 2026
+  // general election only. Every `date` in there is in Oct/Nov 2026 (or
+  // null for SDR states). A 2026 primary (e.g. CA's June primary) would
+  // also have year === 2026 but render the general-election deadlines —
+  // off by months and labeled as authoritative SOS data. Restrict to
+  // the Oct/Nov 2026 window so primaries fall through to BR / E-offset
+  // like every other non-2026-general election.
+  //
+  // Known limitation: `isUniversalVbm` is a state characteristic, not a
+  // year-tied date — for CA/CO/etc. in 2027+ elections this guard makes
+  // the curated lookup miss and the absentee-request row reappears. The
+  // test in planContent.test.ts documents that behavior; resolving it
+  // properly means separating year-agnostic state facts from the dated
+  // deadline data, which is a larger refactor.
+  const isCuratedWindow =
+    electionDate.getFullYear() === 2026 && electionDate.getMonth() >= 9
+  const curated = isCuratedWindow
+    ? VOTER_DEADLINES_2026[stateCode.toUpperCase()]
+    : undefined
 
   const voterRegDeadline =
     parseDateIso(curated?.registration.date ?? null) ??
@@ -385,8 +395,14 @@ const buildTimeline = (
   // electionDate-15-days row that doesn't apply).
   const voterRegHasNoDeadline =
     curated != null && curated.registration.date === null
+  // The legal basis differs: VT/NH allow same-day registration at the
+  // polls; ND has no voter-registration requirement at all (eligible
+  // residents just vote). Same outcome — no deadline — but the
+  // explanation has to be accurate.
   const NO_DEADLINE_COPY =
-    'There is no registration deadline as there is same day voting.'
+    stateCode.toUpperCase() === 'ND'
+      ? 'There is no registration deadline as North Dakota has no voter registration requirement.'
+      : 'There is no registration deadline as there is same day voting.'
   // NH (and any other no-deadline state with a non-trivial tier note)
   // has locally-set pre-registration windows that supplement the
   // same-day-voting option. Append them so the candidate still sees the

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -368,10 +368,15 @@ const buildTimeline = (
       : 'approximate'
   const voterRegTierNote = curated?.registration.tierNote ?? null
 
-  // States with same-day registration through Election Day (ND, VT, NH,
-  // etc.) have no fixed deadline — the curated table sets `date: null`.
-  // Drop the milestone rather than fabricate one from the E-offset
-  // fallback. North Dakota in particular has no voter registration at all.
+  // Drop the registration-deadline milestone for states with no fixed
+  // cutoff. The semantics differ by state but the curated table sets
+  // `date: null` for all of them:
+  //   - VT, NH — same-day registration through Election Day; voters can
+  //     register at the polls. No deadline to display.
+  //   - ND — no voter registration system at all; eligible residents
+  //     just show up to vote.
+  // Without this guard the E-offset fallback would fabricate a
+  // (electionDate - 15 days) row that doesn't apply.
   const voterRegOmitted = curated != null && curated.registration.date === null
 
   // Universal VBM states (CA, CO, etc.) have no real request deadline —

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -368,16 +368,16 @@ const buildTimeline = (
       : 'approximate'
   const voterRegTierNote = curated?.registration.tierNote ?? null
 
-  // Drop the registration-deadline milestone for states with no fixed
-  // cutoff. The semantics differ by state but the curated table sets
-  // `date: null` for all of them:
-  //   - VT, NH — same-day registration through Election Day; voters can
-  //     register at the polls. No deadline to display.
-  //   - ND — no voter registration system at all; eligible residents
-  //     just show up to vote.
-  // Without this guard the E-offset fallback would fabricate a
-  // (electionDate - 15 days) row that doesn't apply.
-  const voterRegOmitted = curated != null && curated.registration.date === null
+  // States with no fixed registration cutoff (VT, NH = same-day reg
+  // through Election Day; ND = no registration system at all) have
+  // `registration.date: null` in the curated table. Render the milestone
+  // with an explanatory note keyed to Election Day rather than falling
+  // through to the E-offset fallback (which would invent a
+  // electionDate-15-days row that doesn't apply).
+  const voterRegHasNoDeadline =
+    curated != null && curated.registration.date === null
+  const NO_DEADLINE_COPY =
+    'There is no registration deadline as there is same day voting.'
 
   // Universal VBM states (CA, CO, etc.) have no real request deadline —
   // ballots auto-mail to all active voters. Drop the milestone entirely
@@ -458,19 +458,21 @@ const buildTimeline = (
             },
           ]
         : []),
-      ...(voterRegOmitted
-        ? []
-        : [
-            {
-              date: voterRegDeadline,
-              milestone: 'Voter registration deadline',
-              notes: curatedNote(
-                voterRegSource,
-                voterRegTierNote,
-                'Push via robocall campaign.',
-              ),
-            },
-          ]),
+      voterRegHasNoDeadline
+        ? {
+            date: electionDate,
+            milestone: 'Voter registration',
+            notes: NO_DEADLINE_COPY,
+          }
+        : {
+            date: voterRegDeadline,
+            milestone: 'Voter registration deadline',
+            notes: curatedNote(
+              voterRegSource,
+              voterRegTierNote,
+              'Push via robocall campaign.',
+            ),
+          },
       ...(absenteeOmitted
         ? []
         : [
@@ -519,14 +521,15 @@ const buildTimeline = (
             } that you should personally attend.`
           : 'Identify community events in your area to attend in person.',
     },
-    ...(voterRegOmitted
-      ? []
-      : [
-          {
-            date: voterRegDeadline,
-            description: 'Voter registration deadline.',
-          },
-        ]),
+    voterRegHasNoDeadline
+      ? {
+          date: electionDate,
+          description: NO_DEADLINE_COPY,
+        }
+      : {
+          date: voterRegDeadline,
+          description: 'Voter registration deadline.',
+        },
     ...(absenteeOmitted
       ? []
       : [

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -368,6 +368,12 @@ const buildTimeline = (
       : 'approximate'
   const voterRegTierNote = curated?.registration.tierNote ?? null
 
+  // States with same-day registration through Election Day (ND, VT, NH,
+  // etc.) have no fixed deadline — the curated table sets `date: null`.
+  // Drop the milestone rather than fabricate one from the E-offset
+  // fallback. North Dakota in particular has no voter registration at all.
+  const voterRegOmitted = curated != null && curated.registration.date === null
+
   // Universal VBM states (CA, CO, etc.) have no real request deadline —
   // ballots auto-mail to all active voters. Drop the milestone entirely
   // for those rather than render a misleading row.
@@ -447,15 +453,19 @@ const buildTimeline = (
             },
           ]
         : []),
-      {
-        date: voterRegDeadline,
-        milestone: 'Voter registration deadline',
-        notes: curatedNote(
-          voterRegSource,
-          voterRegTierNote,
-          'Push via robocall campaign.',
-        ),
-      },
+      ...(voterRegOmitted
+        ? []
+        : [
+            {
+              date: voterRegDeadline,
+              milestone: 'Voter registration deadline',
+              notes: curatedNote(
+                voterRegSource,
+                voterRegTierNote,
+                'Push via robocall campaign.',
+              ),
+            },
+          ]),
       ...(absenteeOmitted
         ? []
         : [
@@ -504,10 +514,14 @@ const buildTimeline = (
             } that you should personally attend.`
           : 'Identify community events in your area to attend in person.',
     },
-    {
-      date: voterRegDeadline,
-      description: 'Voter registration deadline.',
-    },
+    ...(voterRegOmitted
+      ? []
+      : [
+          {
+            date: voterRegDeadline,
+            description: 'Voter registration deadline.',
+          },
+        ]),
     ...(absenteeOmitted
       ? []
       : [

--- a/app/onboarding/success/data/voterDeadlines2026.ts
+++ b/app/onboarding/success/data/voterDeadlines2026.ts
@@ -1,0 +1,694 @@
+// AUTO-GENERATED from ~/Downloads/voter_deadlines_2026_by_state.xlsx.
+// Source workbook is the SOS-verified curated set of 2026 voter
+// registration + absentee-request deadlines per state, addressing the
+// BallotReady data quality issues (e.g. CA registration showing Nov 2
+// instead of the actual Oct 19, CA absentee 'request deadline' even
+// though CA is universal vote-by-mail).
+//
+// Update for the next election cycle by regenerating this file from
+// the next year's workbook. Do NOT hand-edit dates here.
+
+export type Confidence = 'High' | 'Medium' | 'Low'
+
+export interface RegistrationDeadline {
+  date: string | null // ISO YYYY-MM-DD; null when no fixed cutoff (e.g. SDR through ED)
+  tierNote: string | null // human note when methods differ; null when uniform
+  confidence: Confidence
+}
+
+export interface AbsenteeDeadline extends RegistrationDeadline {
+  isUniversalVbm: boolean // when true the milestone is omitted entirely
+}
+
+export interface StateVoterDeadlines2026 {
+  registration: RegistrationDeadline
+  absentee: AbsenteeDeadline
+}
+
+export const VOTER_DEADLINES_2026: Record<string, StateVoterDeadlines2026> = {
+  AK: {
+    registration: {
+      date: '2026-10-04',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-24',
+      tierNote: 'Online Oct 19; Mail Oct 24',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  AL: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: 'Mail Oct 27; In-person Oct 29',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  AR: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: 'Mail Oct 27; In-person Oct 30',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  AZ: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  CA: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  CO: {
+    registration: {
+      date: '2026-10-26',
+      tierNote: 'Online Oct 26; Mail Oct 26; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  CT: {
+    registration: {
+      date: '2026-10-16',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  DC: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: 'Online Oct 13; Mail Oct 13; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  DE: {
+    registration: {
+      date: '2026-10-10',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-30',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  FL: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-22',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  GA: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  HI: {
+    registration: {
+      date: '2026-10-24',
+      tierNote: 'Online Election Day; Mail Oct 24; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  IA: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  ID: {
+    registration: {
+      date: '2026-10-23',
+      tierNote: 'Online Oct 23; Mail Oct 9; In-person Oct 9',
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  IL: {
+    registration: {
+      date: '2026-10-18',
+      tierNote: 'Online Oct 18; Mail Oct 6; In-person Oct 6',
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-29',
+      tierNote: 'Online Oct 29; Mail Oct 29; In-person Nov 2',
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  IN: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-22',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  KS: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  KY: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-20',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  LA: {
+    registration: {
+      date: '2026-10-14',
+      tierNote: 'Online Oct 14; Mail Oct 5; In-person Oct 5',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-30',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MA: {
+    registration: {
+      date: '2026-10-24',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MD: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: 'Online Oct 13; Mail Oct 13; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: 'Online Oct 30; Mail Oct 27; In-person Election Day',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  ME: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: 'Online Oct 13; Mail Oct 13; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-29',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MI: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: 'Online Oct 19; Mail Oct 19; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-30',
+      tierNote: 'Online Oct 30; Mail Oct 30; In-person Nov 2',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MN: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: 'Online Oct 13; Mail Oct 13; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MO: {
+    registration: {
+      date: '2026-10-07',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-21',
+      tierNote: 'Mail Oct 21; In-person Nov 2',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MS: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-31',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  MT: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: 'Mail Oct 5; In-person Election Day',
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NC: {
+    registration: {
+      date: '2026-10-09',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-20',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  ND: {
+    registration: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NE: {
+    registration: {
+      date: '2026-10-16',
+      tierNote: 'Online Oct 16; Mail Oct 16; In-person Oct 23',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: 'Mail Oct 23; In-person Oct 30',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NH: {
+    registration: {
+      date: null,
+      tierNote:
+        'Mail Set locally; In-person Supervisors of Checklist session 6-13 days before',
+      confidence: 'Low' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NJ: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: 'Online Oct 27; Mail Oct 27; In-person Nov 2',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NM: {
+    registration: {
+      date: '2026-10-06',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-20',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  NV: {
+    registration: {
+      date: '2026-10-29',
+      tierNote: 'Online Oct 29; Mail Oct 6; In-person Oct 6',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  NY: {
+    registration: {
+      date: '2026-10-24',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-24',
+      tierNote: 'Online Oct 24; Mail Oct 24; In-person Nov 2',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  OH: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: 'Mail Oct 27; In-person Nov 2',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  OK: {
+    registration: {
+      date: '2026-10-09',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  OR: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  PA: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-27',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  RI: {
+    registration: {
+      date: '2026-10-04',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-13',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  SC: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  SD: {
+    registration: {
+      date: '2026-10-19',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  TN: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-24',
+      tierNote: null,
+      confidence: 'Medium' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  TX: {
+    registration: {
+      date: '2026-10-05',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  UT: {
+    registration: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  VA: {
+    registration: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-23',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  VT: {
+    registration: {
+      date: null,
+      tierNote:
+        'Online Election Day; Mail Election Day; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  WA: {
+    registration: {
+      date: '2026-10-26',
+      tierNote: 'Online Oct 26; Mail Oct 26; In-person Election Day',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: null,
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: true,
+    },
+  },
+  WI: {
+    registration: {
+      date: '2026-10-14',
+      tierNote: 'Online Oct 14; Mail Oct 14; In-person Oct 30',
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-29',
+      tierNote: 'Online Oct 29; Mail Oct 29; In-person Through Sun before',
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  WV: {
+    registration: {
+      date: '2026-10-13',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-10-28',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+  WY: {
+    registration: {
+      date: '2026-10-20',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+    },
+    absentee: {
+      date: '2026-11-02',
+      tierNote: null,
+      confidence: 'High' as Confidence,
+      isUniversalVbm: false,
+    },
+  },
+}


### PR DESCRIPTION
## Summary
Addresses two P1 data-quality issues on the campaign-plan timeline that traced back to BallotReady:

1. **Voter registration deadline wrong on multiple states.** Example: CA showed *"Nov 2, 2026"* as the standard registration deadline. The actual California deadline is **Oct 19** (15 days before the election). BR's date conflates the standard cutoff with same-day conditional registration.
2. **Absentee ballot request deadline rendered in universal-vote-by-mail states.** Example: CA showed *"Nov 3, 2026 — Absentee ballot request deadline"* even though CA mails ballots to every active voter and there is no request to make. Same for CO, DC, HI, IL, NV, OR, UT, VT, WA.

Per Terry's decision, this PR replaces those two milestones with an SOS-verified curated dataset for the 2026 cycle.

## What changes

- **New file** `app/onboarding/success/data/voterDeadlines2026.ts` — auto-generated from `voter_deadlines_2026_by_state.xlsx`. Typed per-state record with resolved registration deadline, resolved absentee-request deadline, per-method tier note when methods differ (e.g. ID: online Oct 23 vs mail Oct 9), and `isUniversalVbm` flag. Confidence label preserved from the workbook.
- `buildTimeline` now takes a `stateCode` and consults the curated table first. Falls back to BR / E-offset only when the state is unknown (defense in depth — all 50 states + DC are in the table).
- For universal-VBM states, the *Absentee ballot request deadline* milestone is **omitted entirely** rather than rendered with misleading copy. The candidate sees one fewer row, not a wrong row.
- When method tiers differ, the timeline's *Notes* column appends e.g. `"Method differences — Online Oct 23; Mail Oct 9."` and the earliest date is used as the primary. Per request: surface alternatives when present, default to earliest otherwise.
- `keyDates` (Executive Summary bullets) inherits both fixes — same shared variables.

## Specific milestones affected

The spreadsheet covers two of the eight timeline milestones:

| Milestone | Source today | After |
|---|---|---|
| Voter registration deadline | BR `voter_registration.end` | **Curated SOS data** |
| Absentee ballot request deadline | BR `request_ballot.end` | **Curated SOS data**, OMITTED for universal-VBM states |

The other six (filing, early-voting begins/ends, absentee-request opens, registration opens, Election Day) are unchanged.

## Stale-data note

The data is hardcoded for the 2026 cycle. For 2027/2028, regenerate the file from the next year's workbook (Source workbook lives in Daniel's Downloads — to be moved to a shared location). Do not hand-edit dates in the TS file.

## Test plan

- [ ] `npm run dev` and pull up a CA campaign on the success page
- [ ] PDF timeline: voter registration deadline shows **Oct 19, 2026** (not Nov 2)
- [ ] PDF timeline: NO row for "Absentee ballot request deadline"
- [ ] Executive Summary Key Dates: voter registration deadline = Oct 19, no absentee request row
- [ ] Spot-check a non-VBM state (e.g. AL, FL, TX): both rows still present, dates per curated table
- [ ] Spot-check a state with method tiers (e.g. ID): primary date is earliest, Notes column includes tier breakdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Candidates see registration and absentee dates in PDFs and key dates; incorrect curated data or stale 2026 hardcoding could misdirect GOTV timing, though the change fixes known BallotReady errors.
> 
> **Overview**
> Replaces BallotReady-sourced **voter registration** and **absentee ballot request** deadlines on the onboarding success campaign plan with a new SOS-verified **2026** per-state dataset (`voterDeadlines2026.ts`), wired through `buildTimeline` via `input.state`.
> 
> **Registration deadline** and **absentee request deadline** now resolve curated dates first (with BallotReady / election-day offsets as fallback). Timeline **Notes** attribute curated rows to state SOS data and append method **tier** copy when online/mail/in-person differ. **Universal vote-by-mail** states drop the absentee request milestone entirely from both the Section 6 timeline and executive **key dates** instead of showing a bogus request deadline.
> 
> Other timeline milestones (filing, early voting, ballot request opens, registration opens, Election Day) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88316963a077427f234c166123667b7e7f5a4eca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->