### PR TITLE
ENG-10334: Pro upgrade success screen (Welcome to Pro)

### DIFF
--- a/app/dashboard/pro-upgrade/components/SuccessStep.test.tsx
+++ b/app/dashboard/pro-upgrade/components/SuccessStep.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen } from '@testing-library/react'
+import { render } from 'helpers/test-utils/render'
+import { router } from 'helpers/test-utils/router-mocking'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+import SuccessStep from './SuccessStep'
+
+// The confetti overlay paints to a <canvas>, which jsdom can't render — stub it
+// so the test exercises the success content and CTA, not the celebration.
+vi.mock('app/dashboard/questions/components/Confetti', () => ({
+  default: () => null,
+}))
+
+// Keep EVENTS real; stub trackEvent so we don't hit analytics in tests.
+vi.mock('helpers/analyticsHelper', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('helpers/analyticsHelper')>()
+  return { ...actual, trackEvent: vi.fn() }
+})
+
+const mockTrackEvent = vi.mocked(trackEvent)
+
+describe('SuccessStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the Welcome-to-Pro messaging and fires the viewed event', () => {
+    render(<SuccessStep />)
+
+    expect(
+      screen.getByRole('heading', { name: 'Welcome to Pro!' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /your PIN will be sent to your email, phone or address/i,
+      ),
+    ).toBeInTheDocument()
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.SuccessViewed,
+    )
+  })
+
+  it('routes to the post-payment compliance surface when Continue is clicked', () => {
+    render(<SuccessStep />)
+
+    screen.getByRole('button', { name: /continue/i }).click()
+
+    expect(router.push).toHaveBeenCalledWith(
+      '/dashboard/profile#texting-compliance',
+    )
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      EVENTS.ProUpgrade.Compliance.SuccessContinue,
+    )
+  })
+
+  it('does not gate the success content on isPro — it renders with no campaign state', () => {
+    // The screen takes no isPro/campaign input; rendering at all (the assertion
+    // above) proves it can't get stuck waiting on the webhook-driven flip.
+    render(<SuccessStep />)
+
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled()
+  })
+})

--- a/app/dashboard/pro-upgrade/components/SuccessStep.tsx
+++ b/app/dashboard/pro-upgrade/components/SuccessStep.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button, ProBadge } from '@styleguide'
+import H1 from '@shared/typography/H1'
+import Body2 from '@shared/typography/Body2'
+import Confetti from 'app/dashboard/questions/components/Confetti'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
+
+// The post-payment compliance surface (task 15) lives on the profile page in the
+// `texting-compliance` card, which renders once `isPro` flips. We deep-link to it
+// so the candidate lands on their live Pro status.
+const COMPLIANCE_SURFACE_PATH = '/dashboard/profile#texting-compliance'
+
+// Post-payment landing (Stripe embedded-checkout return_url + PaymentStep's
+// on-confirm nav). Purely presentational: `isPro` flips asynchronously via the
+// webhook, so this screen never gates on it — it celebrates and routes onward,
+// and the compliance surface reflects live state once the candidate arrives.
+const SuccessStep = (): React.JSX.Element => {
+  const router = useRouter()
+
+  useEffect(() => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.SuccessViewed)
+  }, [])
+
+  const handleContinue = (): void => {
+    trackEvent(EVENTS.ProUpgrade.Compliance.SuccessContinue)
+    router.push(COMPLIANCE_SURFACE_PATH)
+  }
+
+  return (
+    <>
+      <Confetti />
+      <div className="mx-auto flex max-w-[448px] flex-col items-center gap-6 text-center">
+        <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-blue-100">
+          <ProBadge size="large" />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <H1>Welcome to Pro!</H1>
+          <Body2 className="text-secondary">
+            You can now access voter data, build lists and schedule robocalls!
+            Your PIN will be sent to your email, phone or address within 7
+            business days.
+          </Body2>
+        </div>
+
+        <Button size="large" className="w-full" onClick={handleContinue}>
+          Continue
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default SuccessStep

--- a/app/dashboard/pro-upgrade/success/page.tsx
+++ b/app/dashboard/pro-upgrade/success/page.tsx
@@ -1,12 +1,7 @@
-import ProUpgradeStepPlaceholder from '../components/ProUpgradeStepPlaceholder'
+import SuccessStep from '../components/SuccessStep'
 
 export const dynamic = 'force-dynamic'
 
 export default function Page(): React.JSX.Element {
-  return (
-    <ProUpgradeStepPlaceholder
-      title="You're all set"
-      taskNote="Success / post-payment states — ship in tasks 14–15"
-    />
-  )
+  return <SuccessStep />
 }

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -355,6 +355,8 @@ export const EVENTS = {
       CandidateProfileViewed: 'Pro Upgrade - Candidate Profile Viewed',
       FilingDetailsViewed: 'Pro Upgrade - Filing Details Viewed',
       PaymentViewed: 'Pro Upgrade - Payment Viewed',
+      SuccessViewed: 'Pro Upgrade - Success Viewed',
+      SuccessContinue: 'Pro Upgrade - Success: Click continue',
       PinEntryViewed: 'Pro Upgrade - PIN Entry Viewed',
     },
   },


### PR DESCRIPTION
## What

Post-payment **success screen** for the pro-upgrade3 wizard (epic task 14). Replaces the placeholder at the `success` route — the Stripe embedded-checkout `return_url` landing and `PaymentStep`'s on-confirm target.

Matches the Figma [`success` frame](https://www.figma.com/design/0RyHuhYvyCOhg0LErhO7tb/Pro-upgrade?node-id=7490-18805): confetti, Pro badge in a `blue-100` backdrop, the "Welcome to Pro!" heading, and the PIN / "within 7 business days" copy.

## Acceptance criteria

- [x] Renders the Welcome-to-Pro messaging per the design after payment return.
- [x] Does not get stuck if `isPro` hasn't flipped yet (webhook latency) — the screen takes no `isPro`/campaign input and renders unconditionally; it celebrates and routes onward.
- [x] CTA lands the candidate on the post-payment compliance surface: **Continue** → `/dashboard/profile#texting-compliance`, where `ProUpgrade3Compliance` (task 15) renders once `isPro` flips.

## Decisions / deviations

- **Video CTA dropped.** The Figma shows a "Watch video" primary + video placeholder + "Skip", but there's no Pro onboarding video asset in the codebase and the ticket specifies a single CTA (to the compliance surface). Shipped one **Continue** CTA; the video is a design follow-up. The ticket's CTA AC is fully met.
- **Reuse, no duplication.** Confetti reuses `app/dashboard/questions/components/Confetti.tsx`; the Pro badge reuses the `ProBadge` styleguide component. No new helpers. `bg-blue-100` is a registered design token (maps to `--blue-100`), not the default Tailwind palette.
- Added `SuccessViewed` / `SuccessContinue` under `EVENTS.ProUpgrade.Compliance`.

## Tests

`npx vitest run app/dashboard/pro-upgrade/` → **83 passed** (12 files), including 3 new in `SuccessStep.test.tsx` (renders copy + viewed event; Continue routes to the compliance surface + continue event; renders with no campaign state). `npm run types` + `npm run lint` clean.

## Not yet walked through live

Needs the `pro-upgrade3` flag on + the Amplitude flag created + a Stripe test-mode payment to confirm the return lands here and the compliance surface reflects the `isPro` flip — same state as the sibling in-review tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wizard step with client-side navigation and analytics; no payment, auth, or subscription logic changes.
> 
> **Overview**
> Replaces the **pro-upgrade `success` route placeholder** with a real post-payment **Welcome to Pro** screen (`SuccessStep`), used after Stripe embedded checkout return and payment confirmation.
> 
> The UI shows confetti, a Pro badge, welcome copy (including PIN delivery timing), and a single **Continue** button that navigates to `/dashboard/profile#texting-compliance`. The step is **presentational only**—it does not depend on `isPro` or campaign state so webhook latency cannot block the celebration or CTA.
> 
> Adds `SuccessViewed` and `SuccessContinue` under `EVENTS.ProUpgrade.Compliance`, plus Vitest coverage for copy, analytics, routing, and unconditional render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada9b94cebea9917e3a27c6c375547784669c5d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->