### PR TITLE
Updated the banner heading in WebsiteSunsetBanner.tsx from Website discontinued to Our build your own website feature is being discontinued

### DIFF
--- a/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
+++ b/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
@@ -8,7 +8,9 @@ describe('WebsiteSunsetBanner', () => {
   it('shows the discontinuation notice and a Transfer link to the HubSpot form when the candidate has a website', () => {
     render(<WebsiteSunsetBanner hasWebsite />)
 
-    expect(screen.getByText('Website discontinued')).toBeInTheDocument()
+    expect(
+      screen.getByText('Our build your own website feature is being discontinued'),
+    ).toBeInTheDocument()
     expect(
       screen.getByText(
         'Please transfer your domain to a provider of your choice.',
@@ -25,6 +27,10 @@ describe('WebsiteSunsetBanner', () => {
     const { container } = render(<WebsiteSunsetBanner hasWebsite={false} />)
 
     expect(container).toBeEmptyDOMElement()
-    expect(screen.queryByText('Website discontinued')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Our build your own website feature is being discontinued',
+      ),
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
+++ b/app/dashboard/shared/WebsiteSunsetBanner.test.tsx
@@ -9,7 +9,9 @@ describe('WebsiteSunsetBanner', () => {
     render(<WebsiteSunsetBanner hasWebsite />)
 
     expect(
-      screen.getByText('Our build your own website feature is being discontinued'),
+      screen.getByText(
+        'Our build your own website feature is being discontinued',
+      ),
     ).toBeInTheDocument()
     expect(
       screen.getByText(

--- a/app/dashboard/shared/WebsiteSunsetBanner.tsx
+++ b/app/dashboard/shared/WebsiteSunsetBanner.tsx
@@ -25,7 +25,9 @@ export function WebsiteSunsetBanner({
       className="mb-4 flex items-center gap-3 rounded-lg border border-neutral-400 bg-card px-4 py-3 text-card-foreground"
     >
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold">Website discontinued</p>
+        <p className="text-sm font-semibold">
+          Our build your own website feature is being discontinued
+        </p>
         <p className="text-sm">
           Please transfer your domain to a provider of your choice.
         </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13778,7 +13778,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15566,7 +15566,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -18624,7 +18624,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -18818,7 +18818,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -27036,7 +27036,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -30437,7 +30437,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"


### PR DESCRIPTION
Updated the banner heading in WebsiteSunsetBanner.tsx from "Website discontinued" to "Our
  build your own website feature is being discontinued", and updated the corresponding assertions in
  WebsiteSunsetBanner.test.tsx. Tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and test updates only; no logic, routing, or data changes.
> 
> **Overview**
> Updates the **WebsiteSunsetBanner** alert headline from “Website discontinued” to **“Our build your own website feature is being discontinued”** so the sunset message names the product feature. The body copy, Transfer CTA, and visibility rules are unchanged.
> 
> **WebsiteSunsetBanner.test.tsx** assertions were updated to match the new heading text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae65494ebf8f425371069cb6d86bf4c82c9dc43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->