### PR TITLE
fix: show localized voter issues as a ranked list

### DIFF
--- a/app/onboarding/components/TopVoterIssuesSection.test.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.test.tsx
@@ -145,6 +145,21 @@ describe('TopVoterIssuesSection', () => {
     expect(screen.queryByText('Beverly Hills issue')).not.toBeInTheDocument()
   })
 
+  it('renders issues as a numbered ranking without score bars or percentages', async () => {
+    api.mock('GET /v1/onboarding/voter-issues', {
+      status: 200,
+      data: { issues },
+    })
+
+    render(<TopVoterIssuesSection office="Mayor" />)
+
+    expect(await screen.findByText('Public Safety')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.queryByText(/voters care/i)).not.toBeInTheDocument()
+  })
+
   it('collapses to the first three issues and expands on demand', async () => {
     api.mock('GET /v1/onboarding/voter-issues', {
       status: 200,

--- a/app/onboarding/components/TopVoterIssuesSection.tsx
+++ b/app/onboarding/components/TopVoterIssuesSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { Card, CardContent, Badge } from '@styleguide'
+import { Card, CardContent } from '@styleguide'
 import { clientRequest } from 'gpApi/typed-request'
 import { reportErrorToSentry } from '@shared/sentry'
 
@@ -18,12 +18,6 @@ const VOTER_ISSUES_ROUTE = 'GET /v1/onboarding/voter-issues'
 const SENTRY_CONTEXT_FETCH_ISSUES = 'onboarding.voterIssues.fetch'
 const SKELETON_PLACEHOLDER_COUNT = 3
 const COLLAPSED_ISSUES_VISIBLE = 3
-
-const PRIORITY_LABEL: Record<'high' | 'medium' | 'low', string> = {
-  high: 'High priority',
-  medium: 'Medium priority',
-  low: 'Low priority',
-}
 
 // Endpoint derives district from the org cookie, so the request takes no
 // params. We still key the cache by office identity so navigating back and
@@ -123,30 +117,14 @@ export const TopVoterIssuesSection = ({
       ) : (
         <Card className="rounded-2xl shadow-none">
           <CardContent className="flex flex-col gap-3 px-4 py-3">
-            {visibleIssues.map((issue) => (
-              <div key={issue.label} className="space-y-2">
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="text-base font-semibold text-foreground">
-                    {issue.label}
-                  </h3>
-                  {issue.priority === 'high' ? (
-                    <Badge variant="soft">
-                      {PRIORITY_LABEL[issue.priority]}
-                    </Badge>
-                  ) : null}
-                </div>
-
-                <div className="space-y-1">
-                  <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200">
-                    <div
-                      className="h-full rounded-full bg-blue-600"
-                      style={{ width: `${Math.round(issue.score)}%` }}
-                    />
-                  </div>
-                  <p className="text-right text-xs text-slate-500">
-                    {Math.round(issue.score)}% voters care
-                  </p>
-                </div>
+            {visibleIssues.map((issue, index) => (
+              <div key={issue.label} className="flex items-center gap-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+                  {index + 1}
+                </span>
+                <h3 className="text-base font-semibold text-foreground">
+                  {issue.label}
+                </h3>
               </div>
             ))}
             {additionalCount > 0 ? (

--- a/app/onboarding/success/components/planContent.ts
+++ b/app/onboarding/success/components/planContent.ts
@@ -851,12 +851,10 @@ const PRIORITY_PHRASE: Record<'high' | 'medium' | 'low', string> = {
   low: 'lower-priority',
 }
 
-const describeApiIssue = (issue: ApiVoterIssue): string => {
-  const score = Math.round(issue.score)
-  return `Ranks as a ${
+const describeApiIssue = (issue: ApiVoterIssue): string =>
+  `Ranks as a ${
     PRIORITY_PHRASE[issue.priority]
-  } concern for voters in this district — about ${score}% identify it among their top issues.`
-}
+  } concern for voters in this district.`
 
 const buildVoterInsights = (
   customIssues: PlanIssueInput[],


### PR DESCRIPTION
## Context

Pairs with gp-api PR thegoodparty/gp-api#1773, which scopes the onboarding voter-issues endpoint to the candidate's office jurisdiction (no more federal topics on a local race).

## Change

- `TopVoterIssuesSection` now renders the issues as a **numbered ranked list** instead of a per-issue score bar labeled "X% voters care".
- Dropped the matching "about X% identify it among their top issues" clause from the success-page plan prose (`planContent.ts`), keeping the priority-based phrasing.

## Why drop the bar / percentage

The `score` behind that bar is a modeled Haystaq support/propensity average (columns like `hs_charter_schools_support`), **not** a literal share of voters who care. Now that the list is localized, a ranked "top issues, in order" presentation communicates the intent honestly without leaning on a number we can't stand behind.

No API contract change — the response still returns `score`/`priority`; the on-screen display just stops using them. The empty-list → hide behavior and the expand/collapse ("View N more issues") are unchanged.

## Tests

- New test asserts the numbered ranking renders and the "% voters care" copy is gone.
- Existing empty/error/audience-copy/expand-collapse/refetch tests still pass (9/9 in the file, 64/64 across `app/onboarding`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only onboarding and PDF plan copy changes with no API or data-flow changes.
> 
> **Overview**
> **Onboarding voter issues** are shown as a **numbered ranked list** (1, 2, 3…) instead of per-issue progress bars, “X% voters care” copy, and high-priority badges. Expand/collapse and empty/error behavior are unchanged; the API still returns `score`/`priority` but the UI no longer uses them for display.
> 
> **Success-page campaign plan** prose from `describeApiIssue` in `planContent.ts` drops the “about X% identify it among their top issues” sentence and keeps priority-based wording only.
> 
> A new test locks in the ranked UI and asserts the old percentage copy is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78626906e58bf8af135572cdc01c1149c0fb744. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->