### PR TITLE
QA <- Dev

### DIFF
--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { render } from 'helpers/test-utils/render'
+import { api } from 'helpers/test-utils/api-mocking'
+import type { TcrCompliance, TcrComplianceStatus } from 'helpers/types'
+import ProUpgrade3Compliance from './ProUpgrade3Compliance'
+
+const mockGetTcrCompliance = vi.fn<() => Promise<TcrCompliance | null>>()
+vi.mock(
+  'app/dashboard/profile/texting-compliance/util/tcrCompliance.util',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('app/dashboard/profile/texting-compliance/util/tcrCompliance.util')
+      >()
+    return {
+      ...actual,
+      getTcrCompliance: () => mockGetTcrCompliance(),
+    }
+  },
+)
+
+const mockSuccessSnackbar = vi.fn()
+const mockErrorSnackbar = vi.fn()
+vi.mock('helpers/useSnackbar', () => ({
+  useSnackbar: () => ({
+    successSnackbar: mockSuccessSnackbar,
+    errorSnackbar: mockErrorSnackbar,
+  }),
+}))
+
+const mockUseUser = vi.fn(() => [{ email: 'jane@example.com' }, vi.fn(), false])
+vi.mock('@shared/hooks/useUser', () => ({
+  useUser: () => mockUseUser(),
+}))
+
+const baseTcrCompliance: TcrCompliance = {
+  id: 'tcr-1',
+  ein: '12-3456789',
+  postalAddress: '123 Main St',
+  committeeName: 'Jane for Council',
+  websiteDomain: 'janeforcouncil.org',
+  filingUrl: 'https://example.com/filing',
+  phone: '5551234567',
+  email: 'jane@example.com',
+  status: 'submitted',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  campaignId: 1,
+}
+
+const tcrWith = (status: TcrComplianceStatus | null): TcrCompliance => ({
+  ...baseTcrCompliance,
+  status,
+})
+
+const getDigitInputs = (): HTMLInputElement[] =>
+  screen
+    .queryAllByRole('textbox')
+    .filter((el) =>
+      (el.getAttribute('aria-label') ?? '').startsWith('Digit '),
+    ) as HTMLInputElement[]
+
+beforeEach(() => {
+  mockGetTcrCompliance.mockReset()
+  mockSuccessSnackbar.mockReset()
+  mockErrorSnackbar.mockReset()
+})
+
+describe('ProUpgrade3Compliance — status → state mapping', () => {
+  it('renders the PIN entry form when status is `submitted`', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+    render(<ProUpgrade3Compliance />)
+
+    await waitFor(() => {
+      expect(getDigitInputs()).toHaveLength(6)
+    })
+    expect(screen.getByText('Enter your PIN')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument()
+  })
+
+  it('renders the in-review state when status is `pending`', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('pending'))
+    render(<ProUpgrade3Compliance />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your candidate profile is being reviewed'),
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: /submit/i })).toBeNull()
+  })
+
+  it('renders the approved state when status is `approved`', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('approved'))
+    render(<ProUpgrade3Compliance />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your profile has been approved!'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('renders the denied state when status is `rejected`', async () => {
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('rejected'))
+    render(<ProUpgrade3Compliance />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your profile needs updates before sending texts'),
+      ).toBeInTheDocument()
+    })
+    // Gives the candidate the concrete next step from the Figma annotation.
+    const supportLink = screen.getByRole('link', {
+      name: 'campaignsuccess@goodparty.org',
+    })
+    expect(supportLink).toHaveAttribute(
+      'href',
+      'mailto:campaignsuccess@goodparty.org',
+    )
+  })
+
+  it.each<[TcrComplianceStatus | null]>([['error'], [null]])(
+    'falls back to the neutral holding state for status %s (no enumerated screen)',
+    async (status) => {
+      mockGetTcrCompliance.mockResolvedValue(
+        status === null ? null : tcrWith(status),
+      )
+      render(<ProUpgrade3Compliance />)
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/your pro upgrade status will appear here/i),
+        ).toBeInTheDocument()
+      })
+      expect(getDigitInputs()).toHaveLength(0)
+      expect(
+        screen.queryByText('Your profile needs updates before sending texts'),
+      ).toBeNull()
+    },
+  )
+
+  it('shows the loading skeleton (not the fallback) while the TCR query is pending', () => {
+    // Never-resolving query keeps the component in the isPending branch.
+    mockGetTcrCompliance.mockReturnValue(
+      new Promise(() => {
+        /* never resolves */
+      }),
+    )
+    render(<ProUpgrade3Compliance />)
+
+    expect(screen.getByText('Texting Compliance')).toBeInTheDocument()
+    expect(
+      screen.queryByText(/your pro upgrade status will appear here/i),
+    ).toBeNull()
+    expect(getDigitInputs()).toHaveLength(0)
+  })
+})
+
+describe('ProUpgrade3Compliance — PIN submit', () => {
+  it('submits the PIN via the existing submit-cv-pin endpoint and reports success', async () => {
+    const user = userEvent.setup()
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    let receivedBody: { pin?: string } = {}
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      ({ body, params }) => {
+        receivedBody = body
+        expect(params.tcrComplianceId).toBe('tcr-1')
+        return { status: 200, data: undefined }
+      },
+    )
+
+    render(<ProUpgrade3Compliance />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    const inputs = getDigitInputs()
+    for (let i = 0; i < 6; i++) {
+      await user.type(inputs[i]!, String(i + 1))
+    }
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(mockSuccessSnackbar).toHaveBeenCalledWith(
+        expect.stringMatching(/PIN submitted/i),
+      )
+    })
+    expect(receivedBody).toEqual({ pin: '123456' })
+    expect(mockErrorSnackbar).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a mismatch error on a 400 without claiming success', async () => {
+    const user = userEvent.setup()
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      { status: 400, data: { message: 'invalid PIN' } },
+    )
+
+    render(<ProUpgrade3Compliance />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    const inputs = getDigitInputs()
+    for (let i = 0; i < 6; i++) {
+      await user.type(inputs[i]!, String(i + 1))
+    }
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /that PIN didn’t match/i,
+      )
+    })
+    expect(mockSuccessSnackbar).not.toHaveBeenCalled()
+    // Form re-enabled so the candidate can retry.
+    expect(screen.getByRole('button', { name: /submit/i })).toBeEnabled()
+  })
+})

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
@@ -160,9 +160,13 @@ describe('ProUpgrade3Compliance — status → state mapping', () => {
 })
 
 describe('ProUpgrade3Compliance — PIN submit', () => {
-  it('submits the PIN via the existing submit-cv-pin endpoint and reports success', async () => {
+  it('submits the PIN via the existing submit-cv-pin endpoint and transitions to in-review', async () => {
     const user = userEvent.setup()
-    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+    // First fetch: mount with `submitted` → PIN form. Every fetch after the
+    // post-submit invalidateQueries returns `pending`, so the test verifies the
+    // card actually transitions off PIN entry (not just that the snackbar fired).
+    mockGetTcrCompliance.mockResolvedValueOnce(tcrWith('submitted'))
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('pending'))
 
     let receivedBody: { pin?: string } = {}
     api.mock(
@@ -190,6 +194,15 @@ describe('ProUpgrade3Compliance — PIN submit', () => {
     })
     expect(receivedBody).toEqual({ pin: '123456' })
     expect(mockErrorSnackbar).not.toHaveBeenCalled()
+
+    // The invalidated query refetches `pending`, so the card must leave PIN
+    // entry for the in-review state — this fails if invalidateQueries is dropped.
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your candidate profile is being reviewed'),
+      ).toBeInTheDocument()
+    })
+    expect(getDigitInputs()).toHaveLength(0)
   })
 
   it('surfaces a mismatch error on a 400 without claiming success', async () => {

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.test.tsx
@@ -205,6 +205,44 @@ describe('ProUpgrade3Compliance — PIN submit', () => {
     expect(getDigitInputs()).toHaveLength(0)
   })
 
+  it('clears and re-enables the PIN form after success when the status has not yet left `submitted`', async () => {
+    const user = userEvent.setup()
+    // Every fetch — including the post-submit refetch — returns `submitted`, the
+    // race where the backend hasn't transitioned yet. The card stays mounted, so
+    // the form must reset (no stale PIN left on screen) and re-enable.
+    mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))
+
+    api.mock(
+      'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+      { status: 200, data: undefined },
+    )
+
+    render(<ProUpgrade3Compliance />)
+    await waitFor(() => expect(getDigitInputs()).toHaveLength(6))
+
+    const inputs = getDigitInputs()
+    for (let i = 0; i < 6; i++) {
+      await user.type(inputs[i]!, String(i + 1))
+    }
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => {
+      expect(mockSuccessSnackbar).toHaveBeenCalledWith(
+        expect.stringMatching(/PIN submitted/i),
+      )
+    })
+
+    // Form remounted: inputs back to empty (no submitted PIN lingering) and
+    // editable rather than frozen disabled in a loading state. The Submit button
+    // is correctly disabled again because the (now empty) form has no PIN.
+    await waitFor(() => {
+      const refreshed = getDigitInputs()
+      expect(refreshed).toHaveLength(6)
+      expect(refreshed.every((input) => input.value === '')).toBe(true)
+    })
+    expect(getDigitInputs()[0]).toBeEnabled()
+  })
+
   it('surfaces a mismatch error on a 400 without claiming success', async () => {
     const user = userEvent.setup()
     mockGetTcrCompliance.mockResolvedValue(tcrWith('submitted'))

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3Compliance.tsx
@@ -1,11 +1,61 @@
 'use client'
 
+import { useQuery } from '@tanstack/react-query'
 import { Card } from '@styleguide'
+import {
+  TCR_COMPLIANCE_QUERY_KEY,
+  TCR_COMPLIANCE_STATUS,
+  getTcrCompliance,
+} from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
+import ProUpgrade3PinEntry from './ProUpgrade3PinEntry'
+import TextingComplianceApproved from './TextingComplianceApproved'
+import TextingComplianceDenied from './TextingComplianceDenied'
+import TextingComplianceInReview from './TextingComplianceInReview'
 
-// Placeholder for the pro-upgrade3 post-payment compliance surface. The
-// precedence wiring in TextingComplianceFeatureFlag routes the pro-upgrade3
-// cohort here now; task 15 replaces this body with the real status states.
+// Post-payment compliance surface for the pro-upgrade3 cohort. The agent
+// provisions the domain/site and submits TCR to Peerly after payment; this
+// card only reflects the TCR record's status, it does not drive the agent.
 export default function ProUpgrade3Compliance(): React.JSX.Element {
+  const { data: tcrCompliance, isPending } = useQuery({
+    queryKey: TCR_COMPLIANCE_QUERY_KEY,
+    queryFn: getTcrCompliance,
+  })
+
+  // Hold a placeholder shell while loading so we don't flash the neutral
+  // fallback to a candidate who is actually awaiting-PIN / in review / etc.
+  if (isPending) {
+    return (
+      <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+        <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+        <div className="h-6 w-2/3 animate-pulse rounded-md bg-slate-200" />
+        <div className="h-4 w-full animate-pulse rounded-md bg-slate-200" />
+      </Card>
+    )
+  }
+
+  if (tcrCompliance) {
+    switch (tcrCompliance.status) {
+      case TCR_COMPLIANCE_STATUS.SUBMITTED:
+        return <ProUpgrade3PinEntry tcrCompliance={tcrCompliance} />
+      case TCR_COMPLIANCE_STATUS.PENDING:
+        return (
+          <TextingComplianceInReview
+            title="Your candidate profile is being reviewed"
+            description="Review takes 3-7 business days. We’ll email you when you’re ready to send texts."
+          />
+        )
+      case TCR_COMPLIANCE_STATUS.APPROVED:
+        return (
+          <TextingComplianceApproved title="Your profile has been approved!" />
+        )
+      case TCR_COMPLIANCE_STATUS.REJECTED:
+        return <TextingComplianceDenied />
+    }
+  }
+
+  // No TCR record yet (or an `error`/unknown status) — the agent kicks off on
+  // payment, so the record may not exist for a beat. Show a neutral holding
+  // state rather than a blank or stuck card.
   return (
     <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
       <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3PinEntry.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3PinEntry.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Card } from '@styleguide'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import { getPinChannels } from 'app/dashboard/profile/texting-compliance/shared/pinChannels'
@@ -20,7 +20,14 @@ interface ProUpgrade3PinEntryProps {
 export default function ProUpgrade3PinEntry({
   tcrCompliance,
 }: ProUpgrade3PinEntryProps): React.JSX.Element {
-  const { submit, submitting, error } = useSubmitCvPin(tcrCompliance)
+  // Remount PinForm on each successful submit (bump its key) so the just-typed
+  // digits are cleared. Unlike EnterPin, this card has no redirect to escape to:
+  // if the post-submit refetch hasn't yet flipped the status off `submitted`,
+  // the form re-enables and would otherwise keep the submitted PIN on screen.
+  const [successKey, setSuccessKey] = useState(0)
+  const { submit, submitting, error } = useSubmitCvPin(tcrCompliance, {
+    onSuccess: () => setSuccessKey((key) => key + 1),
+  })
 
   // Mirror EnterPin's funnel "viewed" signal so the pro-upgrade3 cohort, which
   // sees PIN entry in-place instead of on /enter-pin, still reports it.
@@ -36,6 +43,7 @@ export default function ProUpgrade3PinEntry({
       <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
       <p className="text-lg font-medium">Enter your PIN</p>
       <PinForm
+        key={successKey}
         channels={getPinChannels(tcrCompliance)}
         onSubmit={submit}
         loading={submitting}

--- a/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3PinEntry.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/ProUpgrade3PinEntry.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { Card } from '@styleguide'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { getPinChannels } from 'app/dashboard/profile/texting-compliance/shared/pinChannels'
+import { useSubmitCvPin } from 'app/dashboard/profile/texting-compliance/shared/useSubmitCvPin'
+import PinForm from 'app/dashboard/profile/texting-compliance/shared/PinForm'
+import type { TcrCompliance } from 'helpers/types'
+
+interface ProUpgrade3PinEntryProps {
+  tcrCompliance: TcrCompliance
+}
+
+// The `submitted` (awaiting-PIN) state of the pro-upgrade3 compliance surface.
+// Renders the PIN entry in-place on the profile card rather than routing to the
+// standalone /enter-pin page; the submit path is shared via useSubmitCvPin, so
+// a successful submit invalidates the TCR query and this card re-renders to the
+// in-review state.
+export default function ProUpgrade3PinEntry({
+  tcrCompliance,
+}: ProUpgrade3PinEntryProps): React.JSX.Element {
+  const { submit, submitting, error } = useSubmitCvPin(tcrCompliance)
+
+  // Mirror EnterPin's funnel "viewed" signal so the pro-upgrade3 cohort, which
+  // sees PIN entry in-place instead of on /enter-pin, still reports it.
+  const viewTrackedRef = useRef(false)
+  useEffect(() => {
+    if (viewTrackedRef.current) return
+    viewTrackedRef.current = true
+    trackEvent(EVENTS.ProUpgrade.Compliance.PinEntryViewed)
+  }, [])
+
+  return (
+    <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+      <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+      <p className="text-lg font-medium">Enter your PIN</p>
+      <PinForm
+        channels={getPinChannels(tcrCompliance)}
+        onSubmit={submit}
+        loading={submitting}
+        error={error}
+      />
+    </Card>
+  )
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceApproved.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceApproved.tsx
@@ -1,13 +1,19 @@
 import { BadgeCheck } from 'lucide-react'
 import { Card } from '@styleguide'
 
-export default function TextingComplianceApproved(): React.JSX.Element {
+interface TextingComplianceApprovedProps {
+  title?: string
+}
+
+export default function TextingComplianceApproved({
+  title = 'Your campaign is compliant',
+}: TextingComplianceApprovedProps = {}): React.JSX.Element {
   return (
     <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
       <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
       <div className="flex items-center gap-2">
         <BadgeCheck className="h-6 w-6 text-green-600" aria-hidden />
-        <p className="text-lg font-medium">Your campaign is compliant</p>
+        <p className="text-lg font-medium">{title}</p>
       </div>
     </Card>
   )

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceDenied.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceDenied.tsx
@@ -1,0 +1,33 @@
+import { Card } from '@styleguide'
+import { CircleAlertIcon } from '@styleguide/components/ui/icons'
+
+const SUPPORT_EMAIL = 'campaignsuccess@goodparty.org'
+
+export default function TextingComplianceDenied(): React.JSX.Element {
+  return (
+    <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
+      <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
+      <div className="flex items-start gap-2">
+        <CircleAlertIcon
+          className="h-6 w-6 shrink-0 text-red-600"
+          aria-hidden
+        />
+        <div>
+          <p className="text-lg font-medium">
+            Your profile needs updates before sending texts
+          </p>
+          <p className="text-sm text-secondary">
+            Email{' '}
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              className="text-blue-600 underline"
+            >
+              {SUPPORT_EMAIL}
+            </a>{' '}
+            and we’ll help you fix the issues.
+          </p>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceInReview.tsx
+++ b/app/dashboard/profile/texting-compliance-agentic/components/TextingComplianceInReview.tsx
@@ -1,14 +1,19 @@
 import { Card } from '@styleguide'
 
-export default function TextingComplianceInReview(): React.JSX.Element {
+interface TextingComplianceInReviewProps {
+  title?: string
+  description?: string
+}
+
+export default function TextingComplianceInReview({
+  title = 'Your application is in review',
+  description = 'This can take 3-7 business days. We will send you an email once your campaign is approved, so you can start sending text messages.',
+}: TextingComplianceInReviewProps = {}): React.JSX.Element {
   return (
     <Card className="p-4 md:p-6 mt-4 gap-2" id="texting-compliance">
       <h2 className="text-2xl font-semibold mb-4">Texting Compliance</h2>
-      <p className="text-lg font-medium">Your application is in review</p>
-      <p className="text-sm text-secondary">
-        This can take 3-7 business days. We will send you an email once your
-        campaign is approved, so you can start sending text messages.
-      </p>
+      <p className="text-lg font-medium">{title}</p>
+      <p className="text-sm text-secondary">{description}</p>
     </Card>
   )
 }

--- a/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
+++ b/app/dashboard/profile/texting-compliance/enter-pin/components/EnterPin.tsx
@@ -1,15 +1,11 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { FetchError } from 'ofetch'
+import { useQuery } from '@tanstack/react-query'
 import H2 from '@shared/typography/H2'
 import H5 from '@shared/typography/H5'
-import { clientRequest } from 'gpApi/typed-request'
-import { useUser } from '@shared/hooks/useUser'
-import { useSnackbar } from 'helpers/useSnackbar'
 import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
 import TextingComplianceHeader from 'app/dashboard/profile/texting-compliance/shared/TextingComplianceHeader'
 import {
@@ -18,6 +14,7 @@ import {
   getTcrCompliance,
 } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
 import { getPinChannels } from 'app/dashboard/profile/texting-compliance/shared/pinChannels'
+import { useSubmitCvPin } from 'app/dashboard/profile/texting-compliance/shared/useSubmitCvPin'
 import PinForm from 'app/dashboard/profile/texting-compliance/shared/PinForm'
 
 const PROFILE_ROUTE = '/dashboard/profile'
@@ -27,22 +24,17 @@ const REDIRECT_STATUSES: ReadonlyArray<string> = [
   TCR_COMPLIANCE_STATUS.APPROVED,
 ]
 
-const isPinMismatch = (e: unknown): boolean =>
-  e instanceof FetchError && (e.status === 400 || e.status === 422)
-
 export default function EnterPin(): React.JSX.Element {
   const router = useRouter()
-  const queryClient = useQueryClient()
-  const { successSnackbar } = useSnackbar()
-  const [user] = useUser()
 
   const { data: tcrCompliance, isPending } = useQuery({
     queryKey: TCR_COMPLIANCE_QUERY_KEY,
     queryFn: getTcrCompliance,
   })
 
-  const [submitting, setSubmitting] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { submit, submitting, error } = useSubmitCvPin(tcrCompliance, {
+    onSuccess: () => router.push(PROFILE_ROUTE),
+  })
 
   const status = tcrCompliance?.status ?? null
   const isAwaitingPin = status === TCR_COMPLIANCE_STATUS.SUBMITTED
@@ -57,46 +49,14 @@ export default function EnterPin(): React.JSX.Element {
   // Funnel "viewed" event for the agentic compliance flow (ENG-10294). Fire
   // only once the PIN entry UI is actually shown — this page redirects away for
   // PENDING/APPROVED, so a bare mount event would count users who never see it.
-  // The matching "submitted" signal is the existing PinVerificationCompleted
-  // event in handleSubmit below.
+  // The matching "submitted" signal is the PinVerificationCompleted event
+  // fired by useSubmitCvPin.
   const pinViewTrackedRef = useRef(false)
   useEffect(() => {
     if (isPending || !isAwaitingPin || pinViewTrackedRef.current) return
     pinViewTrackedRef.current = true
     trackEvent(EVENTS.ProUpgrade.Compliance.PinEntryViewed)
   }, [isPending, isAwaitingPin])
-
-  const handleSubmit = async (pin: string): Promise<void> => {
-    if (!tcrCompliance) return
-    setSubmitting(true)
-    setError(null)
-    try {
-      // tcrComplianceId is a path param — typed-request strips it from the
-      // body before sending; only `pin` lands in the POST body.
-      await clientRequest(
-        'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
-        { tcrComplianceId: tcrCompliance.id, pin },
-      )
-
-      trackEvent(EVENTS.Outreach.DlcCompliance.PinVerificationCompleted, {
-        email: user?.email,
-        dlcComplianceStatus: 'Yes',
-      })
-
-      successSnackbar('PIN submitted — your application is in review.')
-      await queryClient.invalidateQueries({
-        queryKey: TCR_COMPLIANCE_QUERY_KEY,
-      })
-      router.push(PROFILE_ROUTE)
-    } catch (e) {
-      setError(
-        isPinMismatch(e)
-          ? 'That PIN didn’t match. Double-check and try again.'
-          : 'We couldn’t verify that PIN. Please try again.',
-      )
-      setSubmitting(false)
-    }
-  }
 
   return (
     <div className="bg-white pt-2 md:pt-0">
@@ -114,7 +74,7 @@ export default function EnterPin(): React.JSX.Element {
         ) : (
           <PinForm
             channels={getPinChannels(tcrCompliance)}
-            onSubmit={handleSubmit}
+            onSubmit={submit}
             loading={submitting}
             error={error}
           />

--- a/app/dashboard/profile/texting-compliance/shared/useSubmitCvPin.ts
+++ b/app/dashboard/profile/texting-compliance/shared/useSubmitCvPin.ts
@@ -63,6 +63,11 @@ export function useSubmitCvPin(
       await queryClient.invalidateQueries({
         queryKey: TCR_COMPLIANCE_QUERY_KEY,
       })
+      // Clear the loading state on success too. EnterPin navigates away via
+      // onSuccess so it never relied on this, but the in-place card stays
+      // mounted: if the refetch hasn't yet flipped the status off `submitted`,
+      // leaving `submitting` true would freeze PinForm with no way to retry.
+      setSubmitting(false)
       onSuccess?.()
     } catch (e) {
       setError(

--- a/app/dashboard/profile/texting-compliance/shared/useSubmitCvPin.ts
+++ b/app/dashboard/profile/texting-compliance/shared/useSubmitCvPin.ts
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { FetchError } from 'ofetch'
+import { clientRequest } from 'gpApi/typed-request'
+import { useUser } from '@shared/hooks/useUser'
+import { useSnackbar } from 'helpers/useSnackbar'
+import { trackEvent, EVENTS } from 'helpers/analyticsHelper'
+import { TCR_COMPLIANCE_QUERY_KEY } from 'app/dashboard/profile/texting-compliance/util/tcrCompliance.util'
+import type { TcrCompliance } from 'helpers/types'
+
+// A 4xx means the PIN itself was wrong (client-correctable); anything else is
+// an upstream/Peerly failure we don't attribute to the candidate's input.
+const isPinMismatch = (e: unknown): boolean =>
+  e instanceof FetchError && (e.status === 400 || e.status === 422)
+
+interface UseSubmitCvPinOptions {
+  // Runs after a successful submit (analytics + snackbar + cache invalidation
+  // have already fired). EnterPin uses it to redirect; the in-place profile
+  // card leaves it unset and lets the invalidated query re-render the surface.
+  onSuccess?: () => void
+}
+
+interface UseSubmitCvPinResult {
+  submit: (pin: string) => Promise<void>
+  submitting: boolean
+  error: string | null
+}
+
+// Shared CampaignVerify PIN submission for both the standalone /enter-pin page
+// and the pro-upgrade3 in-place compliance card, so the endpoint call, error
+// classification, analytics, and cache invalidation can't drift between them.
+export function useSubmitCvPin(
+  tcrCompliance: TcrCompliance | null | undefined,
+  { onSuccess }: UseSubmitCvPinOptions = {},
+): UseSubmitCvPinResult {
+  const queryClient = useQueryClient()
+  const { successSnackbar } = useSnackbar()
+  const [user] = useUser()
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (pin: string): Promise<void> => {
+    if (!tcrCompliance) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      // tcrComplianceId is a path param — typed-request strips it from the
+      // body before sending; only `pin` lands in the POST body.
+      await clientRequest(
+        'POST /v1/campaigns/tcr-compliance/:tcrComplianceId/submit-cv-pin',
+        { tcrComplianceId: tcrCompliance.id, pin },
+      )
+
+      trackEvent(EVENTS.Outreach.DlcCompliance.PinVerificationCompleted, {
+        email: user?.email,
+        dlcComplianceStatus: 'Yes',
+      })
+
+      successSnackbar('PIN submitted — your application is in review.')
+      await queryClient.invalidateQueries({
+        queryKey: TCR_COMPLIANCE_QUERY_KEY,
+      })
+      onSuccess?.()
+    } catch (e) {
+      setError(
+        isPinMismatch(e)
+          ? 'That PIN didn’t match. Double-check and try again.'
+          : 'We couldn’t verify that PIN. Please try again.',
+      )
+      setSubmitting(false)
+    }
+  }
+
+  return { submit, submitting, error }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CampaignVerify PIN submission and compliance gating UX for pro-upgrade3; shared hook reduces drift but both entry paths now depend on one invalidation/submit behavior.
> 
> **Overview**
> Replaces the **pro-upgrade3** profile compliance placeholder with a **TCR-status-driven** card: loading skeleton, in-profile PIN entry, in-review / approved / denied messaging, and a neutral holding state when there is no record or an unknown status.
> 
> PIN submission is centralized in **`useSubmitCvPin`** (submit-cv-pin API, analytics, snackbar, query invalidation, 400/422 mismatch handling). **`EnterPin`** now uses that hook and redirects on success; **`ProUpgrade3PinEntry`** uses it in-place and remounts **`PinForm`** after success so the form clears if status is still `submitted`. **`TextingComplianceApproved`** / **`TextingComplianceInReview`** gain optional copy overrides; **`TextingComplianceDenied`** is new with support email. **`ProUpgrade3Compliance.test.tsx`** covers status mapping and PIN submit flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5714e7930f1c2cf3e8e93ed9c5f0576e3205ecc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->