### PR TITLE
feat(success): add AI disclaimer to campaign plan page and PDF

### DIFF
--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -348,6 +348,13 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
             }}
           />
         </div>
+
+        <p className="mt-12 text-sm text-muted-foreground">
+          Campaign plans are AI-generated and still in beta, so double-check
+          anything you&apos;ll act on against the sources. Your feedback shapes
+          how we can improve our product moving forward, and we enjoy hearing
+          from all our users.
+        </p>
       </main>
 
       <div className="fixed inset-x-0 bottom-0 z-40 border-t border-base-border bg-base-surface">

--- a/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
+++ b/app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx
@@ -1374,6 +1374,12 @@ export const CampaignPlanPdfDocument = ({
             </View>
           ))}
         </View>
+        <Text style={styles.transition}>
+          Campaign plans are AI-generated and still in beta, so double-check
+          anything you&apos;ll act on against the sources. Your feedback shapes
+          how we can improve our product moving forward, and we enjoy hearing
+          from all our users.
+        </Text>
       </SectionPage>
     </Document>
   )


### PR DESCRIPTION
## Summary
Adds the team's standard AI-beta disclaimer to two places:

1. **Bottom of the success page** ([SuccessPage.tsx](app/onboarding/success/components/SuccessPage.tsx)) — placed inside `<main>` directly after `<PlanSections>` so it scrolls with the content. Small muted text (`text-sm text-muted-foreground`) matching the briefings-page treatment shown in the reference screenshot.
2. **End of the PDF** ([CampaignPlanPdfDocument.tsx](app/onboarding/success/pdf/CampaignPlanPdfDocument.tsx)) — appended after the Glossary table on the final section page, reusing the existing `styles.transition` (italic muted, top divider) so it reads as a closing note. Lands on the last page of the rendered PDF.

## Copy

> Campaign plans are AI-generated and still in beta, so double-check anything you'll act on against the sources. Your feedback shapes how we can improve our product moving forward, and we enjoy hearing from all our users.

**Wording note:** the source disclaimer (from the meetings briefings page) starts with "Briefings are…". Swapped to "Campaign plans are…" since this is the campaign-plan page, not the briefings page. If you'd rather keep it verbatim, easy one-line revert.

## Test plan
- [ ] `npm run dev`, go to onboarding success page
- [ ] Scroll to the bottom; verify the disclaimer is present below the plan sections
- [ ] Hit Download PDF; verify the disclaimer appears at the end of the Glossary (last) section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI/PDF changes with no logic, data, or auth impact.
> 
> **Overview**
> Adds a shared **AI beta disclaimer** so users see the same notice on the onboarding success campaign plan and in the downloadable PDF.
> 
> On **`SuccessPage`**, a muted paragraph is inserted at the bottom of `<main>`, directly under **`PlanSections`**, so it scrolls with the plan content above the fixed footer.
> 
> In **`CampaignPlanPdfDocument`**, the same copy is appended after the Glossary on the final section page, styled with **`styles.transition`** (divider, italic, muted) as a closing note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18c4bd5ba8e31791ad2c99e288dd6780f346060. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->