### PR TITLE
ENG-10337 Add analytics for onboarding flow

### DIFF
--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -453,6 +453,10 @@ export default function OnboardingFlow({
   // navigation re-fires. manual-office-entry has no V2 event.
   const viewedStepsFiredRef = useRef<Set<OnboardingStepId>>(new Set())
   useEffect(() => {
+    // Wait for the user, then attach email directly. SegmentIdentify sets the
+    // shared email global, but it mounts after the page content (PageWrapper),
+    // so an on-mount event races ahead of it and would otherwise be email-less.
+    if (!user) return
     const viewedEventByStep: Partial<Record<OnboardingStepId, string>> = {
       welcome: EVENTS.OnboardingV2.WelcomeViewed,
       'ballot-status': EVENTS.OnboardingV2.BallotStatusViewed,
@@ -466,12 +470,15 @@ export default function OnboardingFlow({
     const viewedEvent = viewedEventByStep[activeStepId]
     if (viewedEvent && !viewedStepsFiredRef.current.has(activeStepId)) {
       viewedStepsFiredRef.current.add(activeStepId)
-      trackEvent(viewedEvent, { campaignId: campaign?.id })
+      trackEvent(viewedEvent, {
+        campaignId: campaign?.id,
+        email: user.email,
+      })
     }
     // campaign?.id intentionally omitted from deps: the seen-set guards the
     // single fire, and the id resolving mid-step must not re-trigger it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeStepId])
+  }, [activeStepId, user])
 
   useEffect(() => {
     if (activeStepId !== 'office-selection') setIsHydratingOffice(false)
@@ -874,9 +881,6 @@ export default function OnboardingFlow({
 
   const runGoNext = async () => {
     if (activeStep.id === 'welcome') {
-      trackEvent(EVENTS.Onboarding.WelcomeCompleted, {
-        campaignId: campaign?.id,
-      })
       trackEvent(EVENTS.OnboardingV2.WelcomeCompleted, {
         campaignId: campaign?.id,
       })
@@ -958,6 +962,16 @@ export default function OnboardingFlow({
         // calls if the user will be routed straight to /dashboard
         // post-pledge.
         if (campaignStrategyEnabled) {
+          // These prewarm calls are the real first request for the strategic
+          // landscape and community events, so the `Requested` events fire
+          // here (not on the success page, which only re-polls afterward).
+          const planCampaignId = liveCampaign?.id ?? campaign?.id
+          trackEvent(EVENTS.OnboardingV2.StrategicLandscapeRequested, {
+            campaignId: planCampaignId,
+          })
+          trackEvent(EVENTS.OnboardingV2.CommunityEventsRequested, {
+            campaignId: planCampaignId,
+          })
           void prewarmStrategicLandscape()
           void prewarmCommunityEvents()
         }

--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -40,6 +40,8 @@ import { OfficeSelectionStep } from './OfficeSelectionStep'
 import { ManualOfficeEntryStep } from './ManualOfficeEntryStep'
 import { PathToVictoryStep } from './PathToVictoryStep'
 import { OutreachPlanStep, computeWeeksRemaining } from './OutreachPlanStep'
+import { computeBudget, resolveVoterContactGoal } from './budget'
+import { computeCampaignHours } from './volunteerHours'
 import { PledgeStep } from './PledgeStep'
 import OnboardingTopBar from '../shared/OnboardingTopBar'
 import { WhyThisMatters } from './WhyThisMatters'
@@ -356,6 +358,7 @@ export default function OnboardingFlow({
   const [isSavingOffice, setIsSavingOffice] = useState(false)
   const [isHydratingOffice, setIsHydratingOffice] = useState(false)
   const isAdvancingRef = useRef(false)
+  const partyDesignationBlockedFiredRef = useRef(false)
   const [liveCampaign, setLiveCampaign] = useState<Campaign | null>(
     initialCampaign,
   )
@@ -445,6 +448,31 @@ export default function OnboardingFlow({
     window.scrollTo(0, 0)
   }, [activeStepId])
 
+  // V2 step-funnel `Viewed` events: fire once per step, the first time it is
+  // entered. The seen-set ref dedupes so neither a re-render nor back-and-forth
+  // navigation re-fires. manual-office-entry has no V2 event.
+  const viewedStepsFiredRef = useRef<Set<OnboardingStepId>>(new Set())
+  useEffect(() => {
+    const viewedEventByStep: Partial<Record<OnboardingStepId, string>> = {
+      welcome: EVENTS.OnboardingV2.WelcomeViewed,
+      'ballot-status': EVENTS.OnboardingV2.BallotStatusViewed,
+      'party-affiliation': EVENTS.OnboardingV2.PartyDesignationViewed,
+      'office-selection': EVENTS.OnboardingV2.OfficeViewed,
+      'path-to-victory': EVENTS.OnboardingV2.VotesNeededViewed,
+      'voter-demographics': EVENTS.OnboardingV2.VoterInsightsViewed,
+      'outreach-plan': EVENTS.OnboardingV2.ResourcesViewed,
+      pledge: EVENTS.OnboardingV2.PledgeViewed,
+    }
+    const viewedEvent = viewedEventByStep[activeStepId]
+    if (viewedEvent && !viewedStepsFiredRef.current.has(activeStepId)) {
+      viewedStepsFiredRef.current.add(activeStepId)
+      trackEvent(viewedEvent, { campaignId: campaign?.id })
+    }
+    // campaign?.id intentionally omitted from deps: the seen-set guards the
+    // single fire, and the id resolving mid-step must not re-trigger it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeStepId])
+
   useEffect(() => {
     if (activeStepId !== 'office-selection') setIsHydratingOffice(false)
   }, [activeStepId])
@@ -502,6 +530,22 @@ export default function OnboardingFlow({
     answers.structuredOffice?.positionName,
     queryClient,
   ])
+
+  // V2 disqualification event: selecting a major party shows the blocking
+  // alert (there is no Continue). Dedupe to once per session via a ref so
+  // toggling between Democrat and Republican does not spam the event.
+  useEffect(() => {
+    if (
+      isMajorPartyAffiliation(answers.partyAffiliation) &&
+      !partyDesignationBlockedFiredRef.current
+    ) {
+      partyDesignationBlockedFiredRef.current = true
+      trackEvent(EVENTS.OnboardingV2.PartyDesignationBlocked, {
+        campaignId: campaign?.id,
+        partyAffiliation: answers.partyAffiliation,
+      })
+    }
+  }, [answers.partyAffiliation, campaign?.id])
 
   const updateAnswers = (answerPatch: Partial<OnboardingAnswers>) => {
     setAnswers((currentAnswers) => ({ ...currentAnswers, ...answerPatch }))
@@ -592,6 +636,13 @@ export default function OnboardingFlow({
         officeName: office.positionName,
         campaignId: campaign.id,
       })
+      trackEvent(EVENTS.OnboardingV2.OfficeCompleted, {
+        campaignId: campaign.id,
+        officeName: office.positionName,
+        officeLevel: office.level,
+        officeState: office.state,
+        electionDate: office.electionDay,
+      })
       return true
     }
 
@@ -628,6 +679,13 @@ export default function OnboardingFlow({
       officeType: office.level,
       officeName: office.positionName,
       campaignId: newCampaign.id,
+    })
+    trackEvent(EVENTS.OnboardingV2.OfficeCompleted, {
+      campaignId: newCampaign.id,
+      officeName: office.positionName,
+      officeLevel: office.level,
+      officeState: office.state,
+      electionDate: office.electionDay,
     })
     return true
   }
@@ -740,6 +798,10 @@ export default function OnboardingFlow({
       party,
       campaignId: campaign?.id,
     })
+    trackEvent(EVENTS.OnboardingV2.PartyDesignationCompleted, {
+      campaignId: campaign?.id,
+      partyAffiliation: affiliation,
+    })
     if (user?.id) {
       await identifyUser(user.id, { affiliation: party, party })
     }
@@ -787,6 +849,10 @@ export default function OnboardingFlow({
       pledgeVersion: PLEDGE_VERSION,
       campaignId: effectiveCampaignId,
     })
+    trackEvent(EVENTS.OnboardingV2.PledgeCompleted, {
+      campaignId: effectiveCampaignId,
+      pledgeVersion: PLEDGE_VERSION,
+    })
     if (user?.id) {
       await identifyUser(user.id, {
         pledgeCompleted: true,
@@ -811,10 +877,17 @@ export default function OnboardingFlow({
       trackEvent(EVENTS.Onboarding.WelcomeCompleted, {
         campaignId: campaign?.id,
       })
+      trackEvent(EVENTS.OnboardingV2.WelcomeCompleted, {
+        campaignId: campaign?.id,
+      })
     }
     if (activeStep.id === 'path-to-victory' && (liveCampaign || campaign)) {
       const trackedCampaign = liveCampaign ?? campaign
       trackEvent(EVENTS.Onboarding.PathToVictoryCompleted, {
+        campaignId: trackedCampaign?.id,
+        winNumber: trackedCampaign?.raceTargetMetrics?.winNumber ?? 0,
+      })
+      trackEvent(EVENTS.OnboardingV2.VotesNeededCompleted, {
         campaignId: trackedCampaign?.id,
         winNumber: trackedCampaign?.raceTargetMetrics?.winNumber ?? 0,
       })
@@ -823,6 +896,45 @@ export default function OnboardingFlow({
       trackEvent(EVENTS.Onboarding.KnowYourVotersCompleted, {
         campaignId: campaign?.id,
       })
+      trackEvent(EVENTS.OnboardingV2.VoterInsightsCompleted, {
+        campaignId: campaign?.id,
+      })
+    }
+    if (activeStep.id === 'outreach-plan') {
+      const metrics = liveCampaign?.raceTargetMetrics ?? null
+      const winNumber = metrics?.winNumber ?? 0
+      const projectedTurnout = metrics?.projectedTurnout ?? 0
+      const voterContactGoal = resolveVoterContactGoal(
+        metrics?.voterContactGoal,
+        winNumber,
+      )
+      // Mirror OutreachPlanStep: resources only render when both inputs are
+      // positive. When they are not, the step shows "unavailable" and there
+      // are no figures to report — send the event with the values omitted.
+      if (voterContactGoal > 0 && projectedTurnout > 0) {
+        const weeksRemaining = computeWeeksRemaining(
+          liveCampaign?.details?.electionDate,
+        )
+        // minimumBudget is the total whole-dollar campaign budget (not
+        // monthly). minimumVolunteerHours is the volunteer (door-knocking)
+        // hours total over the remaining weeks (not per week), matching the
+        // "Volunteers" row OutreachPlanStep renders.
+        const budget = computeBudget(
+          voterContactGoal,
+          projectedTurnout,
+          metrics?.filingFee ?? null,
+        )
+        const hours = computeCampaignHours(voterContactGoal, weeksRemaining)
+        trackEvent(EVENTS.OnboardingV2.ResourcesCompleted, {
+          campaignId: liveCampaign?.id ?? campaign?.id,
+          minimumBudget: budget.totalBudget,
+          minimumVolunteerHours: hours.volunteerHours,
+        })
+      } else {
+        trackEvent(EVENTS.OnboardingV2.ResourcesCompleted, {
+          campaignId: liveCampaign?.id ?? campaign?.id,
+        })
+      }
     }
     if (
       activeStep.id === 'office-selection' &&
@@ -880,6 +992,10 @@ export default function OnboardingFlow({
       trackEvent(EVENTS.Onboarding.BallotStatusCompleted, {
         candidateStage,
         campaignId: campaign?.id,
+      })
+      trackEvent(EVENTS.OnboardingV2.BallotStatusCompleted, {
+        campaignId: campaign?.id,
+        ballotStatus: answers.ballotStatus,
       })
       if (user?.id) {
         await identifyUser(user.id, {

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Download } from 'lucide-react'
@@ -11,6 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@styleguide'
+import { EVENTS, trackEvent } from 'helpers/analyticsHelper'
 import { useCampaign } from '@shared/hooks/useCampaign'
 import { CAMPAIGN_QUERY_KEY } from '@shared/hooks/CampaignProvider'
 import { useUser } from '@shared/hooks/useUser'
@@ -42,6 +43,7 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   const [clientUser] = useUser()
   const user = clientUser ?? initialUser
   const [campaign] = useCampaign()
+  const campaignId = campaign?.id
   const [shareOpen, setShareOpen] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [hasDownloaded, setHasDownloaded] = useState(false)
@@ -274,12 +276,96 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
     !isLocalNewsGenerating &&
     !voterIssuesQuery.isPending
 
+  // Per-resource lifecycle events fire exactly once each. The hooks poll on
+  // an interval, so an effect that runs on every status change would re-fire
+  // without a guard. A single ref of already-fired event keys backs a small
+  // `fireOnce` helper used by all nine lifecycle effects below.
+  const firedEventsRef = useRef<Set<string>>(new Set())
+  const fireOnce = (
+    event: string,
+    properties: Record<string, string | number | undefined>,
+  ): void => {
+    if (firedEventsRef.current.has(event)) return
+    firedEventsRef.current.add(event)
+    trackEvent(event, properties)
+  }
+
+  const localNewsReady = localNewsQuery.data?.status === 'ready'
+  const localNewsOutletCount = pressOutletsFromApi?.length ?? 0
+  const communityEventsReady = events.data !== undefined
+  const communityEventsCount = events.data?.events?.length ?? 0
+  const strategyReady = strategy.data !== undefined
+
+  // Requested — fire once on mount, when the success page is first waiting on
+  // each resource (the queries are enabled immediately). Wait for a resolved
+  // campaignId so the once-fire isn't spent on an undefined id while the
+  // invalidated campaign query is still refetching.
+  useEffect(() => {
+    if (campaignId === undefined) return
+    fireOnce(EVENTS.OnboardingV2.MediaRequested, { campaignId })
+    fireOnce(EVENTS.OnboardingV2.CommunityEventsRequested, { campaignId })
+    fireOnce(EVENTS.OnboardingV2.StrategicLandscapeRequested, { campaignId })
+  }, [campaignId])
+
+  // Results Received — fire once when each resource's status first hits ready.
+  useEffect(() => {
+    if (localNewsReady) {
+      fireOnce(EVENTS.OnboardingV2.MediaResultsReceived, {
+        campaignId,
+        outletCount: localNewsOutletCount,
+      })
+    }
+  }, [localNewsReady, localNewsOutletCount, campaignId])
+
+  useEffect(() => {
+    if (communityEventsReady) {
+      fireOnce(EVENTS.OnboardingV2.CommunityEventsResultsReceived, {
+        campaignId,
+        eventCount: communityEventsCount,
+      })
+    }
+  }, [communityEventsReady, communityEventsCount, campaignId])
+
+  useEffect(() => {
+    if (strategyReady) {
+      fireOnce(EVENTS.OnboardingV2.StrategicLandscapeResultsReceived, {
+        campaignId,
+      })
+    }
+  }, [strategyReady, campaignId])
+
+  // Displayed — fire once when the corresponding plan section renders with
+  // real (non-skeleton) data. The ready data above is what PlanSections
+  // receives, so "ready" here is the same instant the section swaps the
+  // skeleton for content. Kept as separate effects so each dedup key is
+  // independent.
+  useEffect(() => {
+    if (localNewsReady) {
+      fireOnce(EVENTS.OnboardingV2.MediaDisplayed, { campaignId })
+    }
+  }, [localNewsReady, campaignId])
+
+  useEffect(() => {
+    if (communityEventsReady) {
+      fireOnce(EVENTS.OnboardingV2.CommunityEventsDisplayed, { campaignId })
+    }
+  }, [communityEventsReady, campaignId])
+
+  useEffect(() => {
+    if (strategyReady) {
+      fireOnce(EVENTS.OnboardingV2.StrategicLandscapeDisplayed, { campaignId })
+    }
+  }, [strategyReady, campaignId])
+
   const handleShare = () => setShareOpen(true)
 
   const shareUrl = typeof window !== 'undefined' ? window.location.href : ''
 
-  const handleDownload = async () => {
+  const handleDownload = async (
+    source: 'download-button' | 'reminder-modal',
+  ) => {
     if (downloading || !planReady) return
+    trackEvent(EVENTS.OnboardingV2.PlanDownloaded, { campaignId, source })
     setDownloading(true)
     try {
       await downloadCampaignPlanPdf(plan, { liveUrl: shareUrl || undefined })
@@ -289,21 +375,27 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
     }
   }
 
-  const goToCampaignManager = () => router.push('/dashboard')
+  const goToCampaignManager = (source: 'button' | 'reminder-modal') => {
+    trackEvent(EVENTS.OnboardingV2.CampaignManagerClicked, {
+      campaignId,
+      source,
+    })
+    router.push('/dashboard')
+  }
 
   // Remind the user to grab a copy before leaving, but only if they
   // haven't already downloaded. The reminder reappears on every attempt
   // until a download succeeds.
   const handleContinue = () => {
     if (hasDownloaded) {
-      goToCampaignManager()
+      goToCampaignManager('button')
       return
     }
     setReminderOpen(true)
   }
 
   const handleReminderDownload = async () => {
-    await handleDownload()
+    await handleDownload('reminder-modal')
     setReminderOpen(false)
   }
 
@@ -361,7 +453,7 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
               type="button"
               variant="outline"
               size="large"
-              onClick={handleDownload}
+              onClick={() => handleDownload('download-button')}
               loading={downloading}
               aria-label="Download campaign plan"
               className="sm:hidden"
@@ -396,7 +488,7 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
               variant="outline"
               size="large"
               icon={<Download className="size-5" />}
-              onClick={handleDownload}
+              onClick={() => handleDownload('download-button')}
               loading={downloading}
               className="hidden sm:inline-flex"
             >
@@ -446,7 +538,7 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
         planReady={planReady}
         downloading={downloading}
         onDownloadNow={handleReminderDownload}
-        onContinue={goToCampaignManager}
+        onContinue={() => goToCampaignManager('reminder-modal')}
       />
     </div>
   )

--- a/app/onboarding/success/components/SuccessPage.tsx
+++ b/app/onboarding/success/components/SuccessPage.tsx
@@ -296,15 +296,14 @@ const SuccessPage = ({ initialUser }: SuccessPageProps): React.JSX.Element => {
   const communityEventsCount = events.data?.events?.length ?? 0
   const strategyReady = strategy.data !== undefined
 
-  // Requested — fire once on mount, when the success page is first waiting on
-  // each resource (the queries are enabled immediately). Wait for a resolved
-  // campaignId so the once-fire isn't spent on an undefined id while the
-  // invalidated campaign query is still refetching.
+  // Requested — Strategic Landscape and Community Events are prewarmed at the
+  // office step (see OnboardingFlow), so those `Requested` events fire there,
+  // not here. Media's request fires from this page's first poll. Wait for a
+  // resolved campaignId so the once-fire isn't spent on an undefined id while
+  // the invalidated campaign query is still refetching.
   useEffect(() => {
     if (campaignId === undefined) return
     fireOnce(EVENTS.OnboardingV2.MediaRequested, { campaignId })
-    fireOnce(EVENTS.OnboardingV2.CommunityEventsRequested, { campaignId })
-    fireOnce(EVENTS.OnboardingV2.StrategicLandscapeRequested, { campaignId })
   }, [campaignId])
 
   // Results Received — fire once when each resource's status first hits ready.

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -568,6 +568,44 @@ export const EVENTS = {
     SourcesExpanded: 'Briefing Assistant - Sources Expanded',
     TocItemClicked: 'Briefing Assistant - TOC Item Clicked',
   },
+  // V2 onboarding flow that ends in the generated campaign plan. All new
+  // events (no reuse of legacy Onboarding/Dashboard events) so V2 funnels
+  // never mix with historical data. Server-side generation is tracked
+  // separately under `Campaign Plan V2 -` in gp-api.
+  OnboardingV2: {
+    WelcomeViewed: 'Onboarding V2 - Welcome Viewed',
+    WelcomeCompleted: 'Onboarding V2 - Welcome Completed',
+    BallotStatusViewed: 'Onboarding V2 - Ballot Status Viewed',
+    BallotStatusCompleted: 'Onboarding V2 - Ballot Status Completed',
+    PartyDesignationViewed: 'Onboarding V2 - Party Designation Viewed',
+    PartyDesignationCompleted: 'Onboarding V2 - Party Designation Completed',
+    PartyDesignationBlocked: 'Onboarding V2 - Party Designation Blocked',
+    OfficeViewed: 'Onboarding V2 - Office Viewed',
+    OfficeCompleted: 'Onboarding V2 - Office Completed',
+    VotesNeededViewed: 'Onboarding V2 - Votes Needed Viewed',
+    VotesNeededCompleted: 'Onboarding V2 - Votes Needed Completed',
+    VoterInsightsViewed: 'Onboarding V2 - Voter Insights Viewed',
+    VoterInsightsCompleted: 'Onboarding V2 - Voter Insights Completed',
+    ResourcesViewed: 'Onboarding V2 - Resources Viewed',
+    ResourcesCompleted: 'Onboarding V2 - Resources Completed',
+    PledgeViewed: 'Onboarding V2 - Pledge Viewed',
+    PledgeCompleted: 'Onboarding V2 - Pledge Completed',
+    PlanDownloaded: 'Onboarding V2 - Plan Downloaded',
+    CampaignManagerClicked: 'Onboarding V2 - Campaign Manager Clicked',
+    MediaRequested: 'Onboarding V2 - Media Requested',
+    MediaResultsReceived: 'Onboarding V2 - Media Results Received',
+    MediaDisplayed: 'Onboarding V2 - Media Displayed',
+    CommunityEventsRequested: 'Onboarding V2 - Community Events Requested',
+    CommunityEventsResultsReceived:
+      'Onboarding V2 - Community Events Results Received',
+    CommunityEventsDisplayed: 'Onboarding V2 - Community Events Displayed',
+    StrategicLandscapeRequested:
+      'Onboarding V2 - Strategic Landscape Requested',
+    StrategicLandscapeResultsReceived:
+      'Onboarding V2 - Strategic Landscape Results Received',
+    StrategicLandscapeDisplayed:
+      'Onboarding V2 - Strategic Landscape Displayed',
+  },
 } as const
 
 export const getStoredSessionId = (): number => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Client-side analytics only; legacy events remain, with ref-based dedupe to limit duplicate fires.
> 
> **Overview**
> Introduces a dedicated **`Onboarding V2`** analytics namespace in `EVENTS` so V2 funnels stay separate from legacy onboarding events.
> 
> **Onboarding flow:** Fires **viewed** events once per step (ref dedupe), **completed** events alongside existing tracking at each Continue/submit path, **party designation blocked** once per session when a major party is selected, and **resources completed** with `minimumBudget` / `minimumVolunteerHours` when outreach metrics are available (reusing the same budget/hour helpers as the UI).
> 
> **Success page:** Tracks async plan sections (media, community events, strategic landscape) through **requested → results received → displayed**, each once via `fireOnce`. Also tracks **plan download** and **campaign manager** navigation with a `source` dimension (main button vs reminder modal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7828da440229da979245938ab212d29b00e7987a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->