### PR TITLE
Make all events in onboarding "V2"

### DIFF
--- a/app/onboarding/components/OnboardingFlow.tsx
+++ b/app/onboarding/components/OnboardingFlow.tsx
@@ -422,7 +422,7 @@ export default function OnboardingFlow({
         if (officeIdentityKey) {
           setResolvedP2vOfficeKey(officeIdentityKey)
         }
-        trackEvent(EVENTS.Onboarding.PathToVictoryUpdated, {
+        trackEvent(EVENTS.OnboardingV2.VotesNeededCalculated, {
           campaignId,
           projectedTurnout: result.projectedTurnout,
           winNumber: result.winNumber,
@@ -435,7 +435,7 @@ export default function OnboardingFlow({
           void identifyUser(user.id, { hasWinNumber: true })
         }
       } else {
-        trackEvent(EVENTS.Onboarding.PathToVictoryErrored, {
+        trackEvent(EVENTS.OnboardingV2.VotesNeededFailed, {
           campaignId,
           reason: result.reason,
         })
@@ -633,16 +633,6 @@ export default function OnboardingFlow({
         ...trackingProperties,
         officeType: office.level,
       })
-      trackEvent(EVENTS.Onboarding.OfficeStep.OfficeCompleted, {
-        ...trackingProperties,
-        officeManuallyInput: false,
-      })
-      trackEvent(EVENTS.Onboarding.OfficeSelectionCompleted, {
-        zipCode: answers.officeZip,
-        officeType: office.level,
-        officeName: office.positionName,
-        campaignId: campaign.id,
-      })
       trackEvent(EVENTS.OnboardingV2.OfficeCompleted, {
         campaignId: campaign.id,
         officeName: office.positionName,
@@ -676,16 +666,6 @@ export default function OnboardingFlow({
     await identifyUser(user?.id, {
       ...trackingProperties,
       officeType: office.level,
-    })
-    trackEvent(EVENTS.Onboarding.OfficeStep.OfficeCompleted, {
-      ...trackingProperties,
-      officeManuallyInput: false,
-    })
-    trackEvent(EVENTS.Onboarding.OfficeSelectionCompleted, {
-      zipCode: answers.officeZip,
-      officeType: office.level,
-      officeName: office.positionName,
-      campaignId: newCampaign.id,
     })
     trackEvent(EVENTS.OnboardingV2.OfficeCompleted, {
       campaignId: newCampaign.id,
@@ -745,16 +725,6 @@ export default function OnboardingFlow({
         ...trackingProperties,
         officeType: 'manual',
       })
-      trackEvent(EVENTS.Onboarding.OfficeStep.OfficeCompleted, {
-        ...trackingProperties,
-        officeManuallyInput: true,
-      })
-      trackEvent(EVENTS.Onboarding.OfficeSelectionCompleted, {
-        zipCode: answers.officeZip,
-        officeType: 'manual',
-        officeName: form.office,
-        campaignId: campaign.id,
-      })
       return true
     }
 
@@ -777,16 +747,6 @@ export default function OnboardingFlow({
       ...trackingProperties,
       officeType: 'manual',
     })
-    trackEvent(EVENTS.Onboarding.OfficeStep.OfficeCompleted, {
-      ...trackingProperties,
-      officeManuallyInput: true,
-    })
-    trackEvent(EVENTS.Onboarding.OfficeSelectionCompleted, {
-      zipCode: answers.officeZip,
-      officeType: 'manual',
-      officeName: form.office,
-      campaignId: newCampaign.id,
-    })
     return true
   }
 
@@ -800,11 +760,6 @@ export default function OnboardingFlow({
       ])
       if (updated === false) return false
     }
-    trackEvent(EVENTS.Onboarding.PartyStep.Completed, { affiliation: party })
-    trackEvent(EVENTS.Onboarding.PartySelectionCompleted, {
-      party,
-      campaignId: campaign?.id,
-    })
     trackEvent(EVENTS.OnboardingV2.PartyDesignationCompleted, {
       campaignId: campaign?.id,
       partyAffiliation: affiliation,
@@ -817,7 +772,9 @@ export default function OnboardingFlow({
 
   const persistPledgeAndComplete = async (): Promise<boolean> => {
     const effectiveCampaignId = liveCampaign?.id ?? campaign?.id
-    trackEvent(EVENTS.Onboarding.PledgeStep.ClickSubmit)
+    trackEvent(EVENTS.OnboardingV2.PledgeSubmitClicked, {
+      campaignId: effectiveCampaignId,
+    })
     const updated = await updateCampaign([
       { key: 'details.pledged', value: true },
       { key: 'data.currentStep', value: ONBOARDING_STEP_COMPLETE },
@@ -851,11 +808,6 @@ export default function OnboardingFlow({
     // campaign instead of serving the stale (or missing-metrics) entry that
     // was cached earlier in this session.
     void queryClient.invalidateQueries({ queryKey: CAMPAIGN_QUERY_KEY })
-    trackEvent(EVENTS.Onboarding.PledgeStep.Completed)
-    trackEvent(EVENTS.Onboarding.PledgeCompleted, {
-      pledgeVersion: PLEDGE_VERSION,
-      campaignId: effectiveCampaignId,
-    })
     trackEvent(EVENTS.OnboardingV2.PledgeCompleted, {
       campaignId: effectiveCampaignId,
       pledgeVersion: PLEDGE_VERSION,
@@ -887,19 +839,12 @@ export default function OnboardingFlow({
     }
     if (activeStep.id === 'path-to-victory' && (liveCampaign || campaign)) {
       const trackedCampaign = liveCampaign ?? campaign
-      trackEvent(EVENTS.Onboarding.PathToVictoryCompleted, {
-        campaignId: trackedCampaign?.id,
-        winNumber: trackedCampaign?.raceTargetMetrics?.winNumber ?? 0,
-      })
       trackEvent(EVENTS.OnboardingV2.VotesNeededCompleted, {
         campaignId: trackedCampaign?.id,
         winNumber: trackedCampaign?.raceTargetMetrics?.winNumber ?? 0,
       })
     }
     if (activeStep.id === 'voter-demographics') {
-      trackEvent(EVENTS.Onboarding.KnowYourVotersCompleted, {
-        campaignId: campaign?.id,
-      })
       trackEvent(EVENTS.OnboardingV2.VoterInsightsCompleted, {
         campaignId: campaign?.id,
       })
@@ -947,7 +892,9 @@ export default function OnboardingFlow({
     ) {
       setIsSavingOffice(true)
       try {
-        trackEvent(EVENTS.Onboarding.OfficeStep.ClickNext)
+        trackEvent(EVENTS.OnboardingV2.OfficeNextClicked, {
+          campaignId: liveCampaign?.id ?? campaign?.id,
+        })
         const ok = await persistStructuredOffice(answers.structuredOffice)
         if (!ok) return
         // Pre-warm the success-page LLM sections now that raceId +
@@ -987,7 +934,9 @@ export default function OnboardingFlow({
     ) {
       setIsSavingOffice(true)
       try {
-        trackEvent(EVENTS.Onboarding.OfficeStep.ClickNext)
+        trackEvent(EVENTS.OnboardingV2.OfficeNextClicked, {
+          campaignId: liveCampaign?.id ?? campaign?.id,
+        })
         const ok = await persistManualOffice(answers.manualOfficeForm)
         if (!ok) return
         router.refresh()
@@ -1003,10 +952,6 @@ export default function OnboardingFlow({
         if (updated === false) return
       }
       const candidateStage = ballotStatusToCandidateStage[answers.ballotStatus]
-      trackEvent(EVENTS.Onboarding.BallotStatusCompleted, {
-        candidateStage,
-        campaignId: campaign?.id,
-      })
       trackEvent(EVENTS.OnboardingV2.BallotStatusCompleted, {
         campaignId: campaign?.id,
         ballotStatus: answers.ballotStatus,

--- a/helpers/analyticsHelper.ts
+++ b/helpers/analyticsHelper.ts
@@ -608,6 +608,10 @@ export const EVENTS = {
       'Onboarding V2 - Strategic Landscape Results Received',
     StrategicLandscapeDisplayed:
       'Onboarding V2 - Strategic Landscape Displayed',
+    VotesNeededCalculated: 'Onboarding V2 - Votes Needed Calculated',
+    VotesNeededFailed: 'Onboarding V2 - Votes Needed Failed',
+    OfficeNextClicked: 'Onboarding V2 - Office Next Clicked',
+    PledgeSubmitClicked: 'Onboarding V2 - Pledge Submit Clicked',
   },
 } as const
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Analytics-only rename and deduplication in the V2 onboarding UI; no auth, persistence, or launch logic changes beyond which Segment events fire.
> 
> **Overview**
> **Onboarding V2 analytics** in `OnboardingFlow` now owns the funnel: legacy `EVENTS.Onboarding.*` `trackEvent` calls are removed or replaced so each step emits a single **Onboarding V2** event with updated names and payloads.
> 
> Path-to-victory metrics use **`VotesNeededCalculated`** / **`VotesNeededFailed`** instead of Path To Victory Updated/Errored. Step completion drops paired legacy events (e.g. `OfficeStep.OfficeCompleted` + `OfficeSelectionCompleted`) in favor of one **`OfficeCompleted`** with `officeName`, `officeLevel`, `officeState`, and `electionDate`. Party, pledge, ballot status, and “continue” flows align to V2 names (`PartyDesignationCompleted`, `PledgeSubmitClicked`, `PledgeCompleted`, `BallotStatusCompleted`, `VotesNeededCompleted`, `VoterInsightsCompleted`, etc.).
> 
> **`OfficeNextClicked`** (with `campaignId`) replaces the office step Click Next event on structured and manual office continue. **`analyticsHelper`** adds the four new Onboarding V2 event string constants; legacy `EVENTS.Onboarding` entries are unchanged for other routes still on the old flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd114c9bb69d06270f1372cc52ba4dca3477b83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->