### PR TITLE
feat: refactor Avatar component — remove badge/variant, add shape prop, fix styles

### DIFF
--- a/styleguide/components/ui/avatar.tsx
+++ b/styleguide/components/ui/avatar.tsx
@@ -6,71 +6,52 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@styleguide/lib/utils'
 
-const avatarVariants = cva(
-  'relative flex shrink-0 overflow-hidden rounded-full',
-  {
-    variants: {
-      size: {
-        xSmall: 'size-6',
-        small: 'size-8',
-        medium: 'size-10',
-        large: 'size-12',
-        xLarge: 'size-16',
-      },
-      variant: {
-        default: 'bg-avatar-default-background',
-        brightyellow: 'bg-avatar-brightyellow-background',
-        lavender: 'bg-avatar-lavender-background',
-        halogreen: 'bg-avatar-halogreen-background',
-        blue: 'bg-avatar-blue-background',
-        waxflower: 'bg-avatar-waxflower-background',
-      },
+const avatarVariants = cva('relative flex shrink-0 overflow-hidden', {
+  variants: {
+    size: {
+      xSmall: 'size-6',
+      small: 'size-8',
+      medium: 'size-10',
+      large: 'size-12',
+      xLarge: 'size-16',
     },
-    defaultVariants: {
-      size: 'medium',
-      variant: 'default',
+    shape: {
+      circle: 'rounded-full',
+      square: 'rounded-lg',
     },
   },
-)
+  defaultVariants: {
+    size: 'medium',
+    shape: 'circle',
+  },
+})
 
-const avatarBadgeVariants = cva(
-  'absolute flex items-center justify-center rounded-full bg-brand-cream ring-2 ring-brand-cream',
-  {
-    variants: {
-      size: {
-        small: 'size-3',
-        medium: 'size-4',
-        large: 'size-5',
-      },
-      position: {
-        'top-left': 'top-0 left-0',
-        'top-right': 'top-0 right-0',
-        'bottom-left': 'bottom-0 left-0',
-        'bottom-right': 'bottom-0 right-0',
-      },
-    },
-    defaultVariants: {
-      size: 'medium',
-      position: 'bottom-right',
-    },
-  },
-)
+type AvatarSize = 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge'
+type AvatarShape = 'circle' | 'square'
+
+type AvatarContext = { size: AvatarSize; shape: AvatarShape }
+
+const AvatarCtx = React.createContext<AvatarContext>({
+  size: 'medium',
+  shape: 'circle',
+})
 
 interface AvatarProps
-  extends React.ComponentProps<typeof AvatarPrimitive.Root>,
+  extends
+    React.ComponentProps<typeof AvatarPrimitive.Root>,
     VariantProps<typeof avatarVariants> {}
 
-interface AvatarBadgeProps
-  extends React.ComponentProps<'div'>,
-    VariantProps<typeof avatarBadgeVariants> {}
-
-function Avatar({ className, size, variant, ...props }: AvatarProps) {
+function Avatar({ className, size, shape, ...props }: AvatarProps) {
   return (
-    <AvatarPrimitive.Root
-      data-slot="avatar"
-      className={cn(avatarVariants({ size, variant, className }))}
-      {...props}
-    />
+    <AvatarCtx.Provider
+      value={{ size: size ?? 'medium', shape: shape ?? 'circle' }}
+    >
+      <AvatarPrimitive.Root
+        data-slot="avatar"
+        className={cn(avatarVariants({ size, shape, className }))}
+        {...props}
+      />
+    </AvatarCtx.Provider>
   )
 }
 
@@ -91,11 +72,14 @@ function AvatarFallback({
   className,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  const { size, shape } = React.useContext(AvatarCtx)
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
-        'flex size-full items-center justify-center rounded-full text-sm font-medium',
+        'flex size-full items-center justify-center bg-muted border border-base-border font-medium',
+        shape === 'square' ? 'rounded-lg' : 'rounded-full',
+        size === 'xSmall' ? 'text-xs' : 'text-sm',
         className,
       )}
       {...props}
@@ -108,11 +92,13 @@ function AvatarIcon({
   children,
   ...props
 }: React.ComponentProps<'div'>) {
+  const { shape } = React.useContext(AvatarCtx)
   return (
     <div
       data-slot="avatar-icon"
       className={cn(
-        'flex size-full items-center justify-center rounded-full',
+        'flex size-full items-center justify-center bg-muted border border-base-border',
+        shape === 'square' ? 'rounded-lg' : 'rounded-full',
         className,
       )}
       {...props}
@@ -122,25 +108,9 @@ function AvatarIcon({
   )
 }
 
-function AvatarBadge({
-  className,
-  size,
-  position,
-  ...props
-}: AvatarBadgeProps) {
-  return (
-    <div
-      data-slot="avatar-badge"
-      className={cn(avatarBadgeVariants({ size, position, className }))}
-      {...props}
-    />
-  )
-}
-
 // Compound component pattern
 Avatar.Image = AvatarImage
 Avatar.Fallback = AvatarFallback
 Avatar.Icon = AvatarIcon
-Avatar.Badge = AvatarBadge
 
-export { Avatar, AvatarImage, AvatarFallback, AvatarIcon, AvatarBadge }
+export { Avatar, AvatarImage, AvatarFallback, AvatarIcon }

--- a/styleguide/stories/Avatar.stories.tsx
+++ b/styleguide/stories/Avatar.stories.tsx
@@ -1,12 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import {
   Avatar,
-  AvatarBadge,
   AvatarFallback,
   AvatarIcon,
   AvatarImage,
 } from '../components/ui/avatar'
-import { CheckIcon, StarIcon, UserIcon } from '../components/ui/icons'
+import { UserIcon } from '../components/ui/icons'
 
 const meta: Meta<typeof Avatar> = {
   component: Avatar,
@@ -18,16 +17,9 @@ const meta: Meta<typeof Avatar> = {
       control: 'select',
       options: ['xSmall', 'small', 'medium', 'large', 'xLarge'],
     },
-    variant: {
+    shape: {
       control: 'select',
-      options: [
-        'default',
-        'brightyellow',
-        'lavender',
-        'halogreen',
-        'blue',
-        'waxflower',
-      ],
+      options: ['circle', 'square'],
     },
   },
 }
@@ -37,23 +29,15 @@ type Story = StoryObj<typeof Avatar>
 
 type PlaygroundArgs = {
   size: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge'
-  variant:
-    | 'default'
-    | 'brightyellow'
-    | 'lavender'
-    | 'halogreen'
-    | 'blue'
-    | 'waxflower'
+  shape: 'circle' | 'square'
   showImage: boolean
-  showBadge: boolean
 }
 
 export const Playground: StoryObj<PlaygroundArgs> = {
   args: {
     size: 'medium',
-    variant: 'default',
+    shape: 'circle',
     showImage: false,
-    showBadge: false,
   },
   argTypes: {
     showImage: {
@@ -61,22 +45,13 @@ export const Playground: StoryObj<PlaygroundArgs> = {
       description:
         'Render an image. When false, falls back to the JD initials inside an AvatarFallback.',
     },
-    showBadge: {
-      control: 'boolean',
-      description: 'Render a check badge in the bottom-right corner.',
-    },
   },
-  render: ({ size, variant, showImage, showBadge }) => (
-    <Avatar size={size} variant={variant}>
+  render: ({ size, shape, showImage }) => (
+    <Avatar key={`${String(showImage)}-${shape}`} size={size} shape={shape}>
       {showImage ? (
         <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
       ) : null}
       <AvatarFallback>JD</AvatarFallback>
-      {showBadge ? (
-        <AvatarBadge>
-          <CheckIcon className="h-3 w-3 text-success-main" />
-        </AvatarBadge>
-      ) : null}
     </Avatar>
   ),
 }
@@ -108,17 +83,6 @@ export const WithIcon: Story = {
   ),
 }
 
-export const WithBadge: Story = {
-  render: () => (
-    <Avatar size="large">
-      <AvatarFallback>JD</AvatarFallback>
-      <AvatarBadge>
-        <CheckIcon className="h-3 w-3 text-success-main" />
-      </AvatarBadge>
-    </Avatar>
-  ),
-}
-
 export const Sizes: Story = {
   render: () => (
     <div className="flex items-center gap-4">
@@ -136,118 +100,6 @@ export const Sizes: Story = {
       </Avatar>
       <Avatar size="xLarge">
         <AvatarFallback>XL</AvatarFallback>
-      </Avatar>
-    </div>
-  ),
-}
-
-export const ColorVariants: Story = {
-  render: () => (
-    <div className="flex items-center gap-4">
-      <Avatar variant="default">
-        <AvatarFallback>DF</AvatarFallback>
-      </Avatar>
-      <Avatar variant="brightyellow">
-        <AvatarFallback>BY</AvatarFallback>
-      </Avatar>
-      <Avatar variant="lavender">
-        <AvatarFallback>LV</AvatarFallback>
-      </Avatar>
-      <Avatar variant="halogreen">
-        <AvatarFallback>HG</AvatarFallback>
-      </Avatar>
-      <Avatar variant="blue">
-        <AvatarFallback>BL</AvatarFallback>
-      </Avatar>
-      <Avatar variant="waxflower">
-        <AvatarFallback>WF</AvatarFallback>
-      </Avatar>
-    </div>
-  ),
-}
-
-export const BadgePositions: Story = {
-  render: () => (
-    <div className="flex items-center gap-8">
-      <Avatar size="large">
-        <AvatarFallback>TL</AvatarFallback>
-        <AvatarBadge position="top-left" size="small">
-          <div className="h-2 w-2 rounded-full bg-destructive" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar size="large">
-        <AvatarFallback>TR</AvatarFallback>
-        <AvatarBadge position="top-right" size="small">
-          <div className="h-2 w-2 rounded-full bg-success-main" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar size="large">
-        <AvatarFallback>BL</AvatarFallback>
-        <AvatarBadge position="bottom-left" size="small">
-          <div className="h-2 w-2 rounded-full bg-info-main" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar size="large">
-        <AvatarFallback>BR</AvatarFallback>
-        <AvatarBadge position="bottom-right" size="small">
-          <div className="h-2 w-2 rounded-full bg-warning-main" />
-        </AvatarBadge>
-      </Avatar>
-    </div>
-  ),
-}
-
-export const BadgeSizes: Story = {
-  render: () => (
-    <div className="flex items-center gap-8">
-      <Avatar size="large">
-        <AvatarFallback>S</AvatarFallback>
-        <AvatarBadge size="small">
-          <CheckIcon className="h-2 w-2" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar size="large">
-        <AvatarFallback>M</AvatarFallback>
-        <AvatarBadge size="medium">
-          <CheckIcon className="h-2.5 w-2.5" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar size="large">
-        <AvatarFallback>L</AvatarFallback>
-        <AvatarBadge size="large">
-          <CheckIcon className="h-3 w-3" />
-        </AvatarBadge>
-      </Avatar>
-    </div>
-  ),
-}
-
-export const IconWithColorAndBadge: Story = {
-  render: () => (
-    <div className="flex items-center gap-4">
-      <Avatar variant="brightyellow" size="large">
-        <AvatarIcon>
-          <UserIcon className="h-6 w-6" />
-        </AvatarIcon>
-        <AvatarBadge>
-          <CheckIcon className="h-3 w-3 text-success-main" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar variant="blue" size="large">
-        <AvatarIcon>
-          <UserIcon className="h-6 w-6" />
-        </AvatarIcon>
-        <AvatarBadge position="top-right">
-          <StarIcon className="h-3 w-3 text-warning-main" />
-        </AvatarBadge>
-      </Avatar>
-      <Avatar variant="halogreen" size="large">
-        <AvatarIcon>
-          <UserIcon className="h-6 w-6" />
-        </AvatarIcon>
-        <AvatarBadge position="bottom-left">
-          <div className="h-3 w-3 rounded-full bg-destructive" />
-        </AvatarBadge>
       </Avatar>
     </div>
   ),


### PR DESCRIPTION
feat: refactor Avatar component
Removes unused code, fixes styles to match Figma, and adds shape prop for square variant.
Changes:

Removed AvatarBadge, color variant prop — not in Figma, never worked
Added bg-muted border border-base-border to AvatarFallback and AvatarIcon
Font size: text-xs for xSmall, text-sm for all other sizes (via context)
Added shape prop: circle (default) | square — for sidebar use case
Updated Storybook stories: added shape control to Playground, fixed Radix fallback remount bug

No app/ changes — migration of DashboardMenu, UserAvatar, CandidateAvatar in separate PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking styleguide API (removed variant and AvatarBadge) will break callers until follow-up migrations land; changes are confined to styleguide and Storybook in this PR.
> 
> **Overview**
> Refactors the styleguide **Avatar** to match Figma: drops **color `variant`** and **`AvatarBadge`**, and adds a **`shape`** prop (`circle` | `square`) with context so **Fallback** and **Icon** share border radius and typography.
> 
> **Fallback/Icon** now use `bg-muted` and `border-base-border`; **xSmall** fallbacks use `text-xs`, other sizes `text-sm`. Storybook drops badge/color stories, adds **shape** to Playground, and remounts the avatar on image/shape changes to avoid a Radix fallback bug.
> 
> **Breaking API change** for any consumer still using `variant` or `AvatarBadge` (app migration is planned separately per PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c948d30b80bbc6a143e064656128a5d26754d52e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->